### PR TITLE
CI: Start all binaries to ensure everything is working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Spec
         run: crystal spec --no-color --order random
 
-  spec:
+  test-binaries:
     name: Test binaries
     runs-on: ubuntu-latest
     container: crystallang/crystal:0.35.1


### PR DESCRIPTION
These files are generally not covered by our specs.