### PR TITLE
Fix name filter pagination bug

### DIFF
--- a/static/js/table.js
+++ b/static/js/table.js
@@ -21,7 +21,7 @@
     const keyColumns = options.keyColumns
     const interval = options.interval
     let timer = null
-    let searchTerm = getQueryVariable('filter')
+    let searchTerm = getQueryVariable('name')
     const currentPage = getQueryVariable('page') || 1
     let pageSize = getQueryVariable('page_size') || 100
 
@@ -192,7 +192,7 @@
 
     function renderSearch () {
       const debouncedUpdate = debounce(() => {
-        updateQueryState({ filter: searchTerm })
+        updateQueryState({ name: searchTerm })
         fetchAndUpdate()
       })
       const str = `<form class="form" action="javascript:void(0);">


### PR DESCRIPTION
HTTP API and queryBuilder use key name, thus that's what we should use
here.

This was changed not too long ago, but we can't figure out what the
issue was, so we'll try this solution anyway. 28a4e75b342d28816f79e1a32ebdabad67cec005