### PR TITLE
Only send referrer on same-site to avoid data leak

### DIFF
--- a/src/avalanchemq/http/handler/defaults_handler.cr
+++ b/src/avalanchemq/http/handler/defaults_handler.cr
@@ -9,6 +9,7 @@ module AvalancheMQ
         if context.request.path.starts_with?("/api/")
           context.response.content_type = "application/json"
         end
+        context.response.headers.add("Referrer-Policy", "same-origin")
         call_next(context)
       end
     end


### PR DESCRIPTION
> The Referrer-Policy HTTP header controls how much referrer information
> (sent via the Referer header) should be included with requests.
>
> same-origin
>
> A referrer will be sent for same-site origins, but cross-origin
> requests will send no referrer information.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy