### PR TITLE
Automatically remove the container when it exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ It is possible to run AvalancheMQ using docker. To build the image run:
 This will create a docker image tagged as avalanchemq:latest that we then can use to launch an
 instance of AvalancheMQ by executing:
 
-`docker run -p 15672:15672 -p 5672:5672 -v data:/data --name avalanchemq avalanchemq:latest`
+`docker run --rm -p 15672:15672 -p 5672:5672 -v data:/data --name avalanchemq avalanchemq:latest`
 
 You are now able to visit the management UI at [http://localhost:15672](http://localhost:15672) and
 start publishing/consuming messages. The container can be killed


### PR DESCRIPTION
Otherwise you will get this annoying error message next time you try to
start it:

    $ docker run -p 15672:15672 -p 5672:5672 -v data:/data --name avalanchemq avalanchemq:latest
    docker: Error response from daemon: Conflict. The container name "/avalanchemq" is already in use by container "cd3dfb7f0234f71ed073337313e040eb877a6c4d550aabf823aa34260f98e288". You have to remove (or rename) that container to be able to reuse that name.
    See 'docker run --help'.

This does not remove your data volume.