### PR TITLE
Improve compatibility for PUT /api/queues/vhost/name

### DIFF
--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -76,7 +76,7 @@ describe AvalancheMQ::HTTP::QueuesController do
         }
       })
       response = put("/api/queues/%2f/putqueue", body: body)
-      response.status_code.should eq 204
+      response.status_code.should eq 201
       response = get("/api/queues/%2f/putqueue")
       response.status_code.should eq 200
     ensure
@@ -85,7 +85,7 @@ describe AvalancheMQ::HTTP::QueuesController do
 
     it "should not require any body" do
       response = put("/api/queues/%2f/okq")
-      response.status_code.should eq 204
+      response.status_code.should eq 201
     ensure
       s.vhosts["/"].delete_queue("okq")
     end
@@ -95,7 +95,7 @@ describe AvalancheMQ::HTTP::QueuesController do
         "durable": true
       })
       response = put("/api/queues/%2f/q1d", body: body)
-      response.status_code.should eq 204
+      response.status_code.should eq 201
       body = %({
         "durable": false
       })

--- a/src/avalanchemq/http/controller/queues.cr
+++ b/src/avalanchemq/http/controller/queues.cr
@@ -68,13 +68,13 @@ module AvalancheMQ
               unless q.match?(durable, false, auto_delete, tbl)
                 bad_request(context, "Existing queue declared with other arguments arg")
               end
-              context.response.status_code = 200
+              context.response.status_code = 204
             elsif name.starts_with? "amq."
               bad_request(context, "Not allowed to use the amq. prefix")
             else
               @amqp_server.vhosts[vhost]
                 .declare_queue(name, durable, auto_delete, tbl)
-              context.response.status_code = 204
+              context.response.status_code = 201
             end
           end
         end


### PR DESCRIPTION
Before this change, AvalancheMQ responded with 400 Bad Request for `PUT /api/queues/vhost/name` without body.

    $ curl -s -v -X PUT -u guest:guest http://127.0.0.1:15675/api/queues/tut/beep
    *   Trying 127.0.0.1:15675...
    * Connected to 127.0.0.1 (127.0.0.1) port 15675 (#0)
    * Server auth using Basic with user 'guest'
    > PUT /api/queues/tut/beep HTTP/1.1
    > Host: 127.0.0.1:15675
    > Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
    > User-Agent: curl/7.72.0
    > Accept: */*
    >
    * Mark bundle as not supporting multiuse
    < HTTP/1.1 400 Bad Request
    < Connection: keep-alive
    < Strict-Transport-Security: max-age=31536000
    < Content-Type: application/json
    < Referrer-Policy: same-origin
    < Transfer-Encoding: chunked
    <
    { [60 bytes data]
    * Connection #0 to host 127.0.0.1 left intact
    {
      "error": "bad_request",
      "reason": "Argument error"
    }

Now we handle the empty body and also respond with HTTP status 201/204 instead of 204/200 (to further improve compatibility):

    $ curl -i -X PUT -u guest:guest http://127.0.0.1:15675/api/queues/tut/bar
    HTTP/1.1 201 Created
    Connection: keep-alive
    Strict-Transport-Security: max-age=31536000
    Content-Type: application/json
    Referrer-Policy: same-origin
    Content-Length: 0

    $ curl -i -X PUT -u guest:guest http://127.0.0.1:15675/api/queues/tut/bar
    HTTP/1.1 204 No Content
    Connection: keep-alive
    Strict-Transport-Security: max-age=31536000
    Content-Type: application/json
    Referrer-Policy: same-origin
    Content-Length: 0