### PR TITLE
Support PROXY protocol V1 for AMQP connections

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -94,7 +94,7 @@ module TestHelpers
     @@s = AvalancheMQ::Server.new(dir, log.dup)
     @@h = AvalancheMQ::HTTP::Server.new(@@s.not_nil!, log.dup)
     @@h.not_nil!.bind_tcp(cfg.http_bind, cfg.http_port)
-    spawn { @@s.try &.listen(cfg.amqp_bind, cfg.amqp_port) }
+    spawn { @@s.try &.listen(cfg.amqp_bind, cfg.amqp_port, cfg.proxy_protocol) }
     cert = Dir.current + "/spec/resources/server_certificate.pem"
     key = Dir.current + "/spec/resources/server_key.pem"
     ctx = OpenSSL::SSL::Context::Server.new

--- a/src/avalanchemq.cr
+++ b/src/avalanchemq.cr
@@ -22,6 +22,9 @@ p = OptionParser.parse do |parser|
   parser.on("--amqps-port=PORT", "AMQPS port to listen on (default: -1)") do |v|
     config.amqps_port = v.to_i
   end
+  parser.on("--proxy-protocol=PROTOCOL", "which PROXY protocol version to use (default: none)") do |v|
+    config.proxy_protocol = v.to_i
+  end
   parser.on("--amqp-bind=BIND", "IP address that the AMQP server will listen on (default: 127.0.0.1)") do |v|
     config.amqp_bind = v
   end
@@ -136,7 +139,7 @@ end
 
 if config.amqp_port > 0
   spawn(name: "AMQP listening on #{config.amqp_port}") do
-    amqp_server.try &.listen(config.amqp_bind, config.amqp_port)
+    amqp_server.try &.listen(config.amqp_bind, config.amqp_port, config.proxy_protocol)
   end
 end
 

--- a/src/avalanchemq/config.cr
+++ b/src/avalanchemq/config.cr
@@ -7,6 +7,7 @@ module AvalancheMQ
     property amqp_bind = "127.0.0.1"
     property amqp_port = 5672
     property amqps_port = -1
+    property proxy_protocol = 0
     property unix_path = ""
     property tls_cert_path = ""
     property tls_key_path = ""
@@ -80,15 +81,16 @@ module AvalancheMQ
     private def parse_amqp(settings)
       settings.each do |config, v|
         case config
-        when "bind"        then @amqp_bind = v
-        when "port"        then @amqp_port = v.to_i32
-        when "tls_port"    then @amqps_port = v.to_i32
-        when "tls_cert"    then @tls_cert_path = v # backward compatibility
-        when "tls_key"     then @tls_key_path = v  # backward compatibility
-        when "unix_path"   then @unix_path = v
-        when "heartbeat"   then @heartbeat = v.to_u16
-        when "channel_max" then @channel_max = v.to_u16
-        when "frame_max"   then @frame_max = v.to_u32
+        when "bind"           then @amqp_bind = v
+        when "port"           then @amqp_port = v.to_i32
+        when "tls_port"       then @amqps_port = v.to_i32
+        when "tls_cert"       then @tls_cert_path = v # backward compatibility
+        when "tls_key"        then @tls_key_path = v  # backward compatibility
+        when "proxy_protocol" then @proxy_protocol = v.to_i32
+        when "unix_path"      then @unix_path = v
+        when "heartbeat"      then @heartbeat = v.to_u16
+        when "channel_max"    then @channel_max = v.to_u16
+        when "frame_max"      then @frame_max = v.to_u32
         else
           STDERR.puts "WARNING: Unrecognized configuration 'amqp/#{config}'"
         end


### PR DESCRIPTION
I've tested manually using HAProxy locally with this config:

    global
        maxconn 100
        log 127.0.0.1 local0

    defaults
        timeout connect 10s
        timeout client  1m
        timeout server  1m

    listen proxy_v1
        mode tcp
        log global
        option tcplog
        bind *:20000
        server amq 127.0.0.1:5675 send-proxy

When the proxy protocol is enabled, direct connections to the broker will time out.