### PR TITLE
Removed redundant close

### DIFF
--- a/src/avalanchemq/client/channel.cr
+++ b/src/avalanchemq/client/channel.cr
@@ -353,7 +353,6 @@ module AvalancheMQ
           end
         else
           @client.send_not_found(frame, "No queue '#{frame.queue}' in vhost '#{@client.vhost.name}'")
-          close
         end
       end
 


### PR DESCRIPTION
Duplicate calls to close. We are already sending a`Close` frame and waits for the `CloseOk` frame before actually closing the connection.

https://github.com/84codes/avalanchemq/blob/15dff4ca9391c2a02662247f16a4c7a8ecaa94bf/src/avalanchemq/client/client.cr#L461-L464

https://github.com/84codes/avalanchemq/blob/15dff4ca9391c2a02662247f16a4c7a8ecaa94bf/src/avalanchemq/client/client.cr#L422-L444