### PR TITLE
Added perf for channel-churn

### DIFF
--- a/src/avalanchemqperf.cr
+++ b/src/avalanchemqperf.cr
@@ -313,12 +313,27 @@ class ConnectionChurn < Perf
   end
 end
 
+class ChannelChurn < Perf
+  def run
+    super
+    c = AMQP::Client.new(@uri)
+    conn = c.connect
+    Benchmark.ips do |x|
+      x.report("open-close channel") do
+        ch = conn.channel
+        ch.close
+      end
+    end
+  end
+end
+
 mode = ARGV.shift?
 case mode
 when "throughput"       then Throughput.new.run
 when "bind-churn"       then BindChurn.new.run
 when "queue-churn"      then QueueChurn.new.run
 when "connection-churn" then ConnectionChurn.new.run
+when "channel-churn"    then ChannelChurn.new.run
 when /^.+$/             then Perf.new.run([mode.not_nil!])
 else                         abort Perf.new.banner
 end


### PR DESCRIPTION
output: `open-close channel   2.56k (390.39µs) (±19.57%)  659kB/op  fastest`