### PR TITLE
Run specs on ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libsystemd-dev
+          sudo apt-get install -y libsystemd-dev libyaml-dev
 
       - name: Install Crystal
         run: |


### PR DESCRIPTION
Addresses https://github.com/84codes/avalanchemq/runs/1287362503

`/usr/bin/ld: cannot find -lsystemd (this usually means you need to install the development package for libsystemd)
collect2: error: ld returned 1 exit status`

Since https://github.com/84codes/avalanchemq/commit/5c7ed787687cc5ff3fec0937eb0b284a63d86397 we need to run on a OS with systemd.