### PR TITLE
HTTP API: make PUT /api/users/:name more robust

### DIFF
--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -110,6 +110,13 @@ describe AvalancheMQ::HTTP::UsersController do
       body = JSON.parse(response.body)
       body["reason"].as_s.should match(/Field .+ is required/)
     end
+
+    it "should handle unexpected input" do
+      response = put("/api/users/foo", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field .+ is required/)
+    end
   end
 
   describe "GET /api/users/user/permissions" do


### PR DESCRIPTION
Addresses the following scenarios:

Do not crash on bad input

    $ curl -si -u guest:guest -X PUT -H 'Content-Type: application/json' --data '"{}"' http://localhost:15672/api/users/foo
    HTTP/1.1 500 Internal Server Error
    Connection: keep-alive
    Strict-Transport-Security: max-age=31536000
    Content-Type: application/json
    Referrer-Policy: same-origin
    Transfer-Encoding: chunked

    {"error":"internal_server_error","reason":"Internal Server Error"}

Better error message on empty body (hard to reproduce with spec)

    $ curl -si -u guest:guest -X PUT -H 'Content-Type: application/json' http://localhost:15672/api/users/foo
    HTTP/1.1 400 Bad Request
    Connection: keep-alive
    Strict-Transport-Security: max-age=31536000
    Content-Type: application/json
    Referrer-Policy: same-origin
    Transfer-Encoding: chunked

    {"error":"bad_request","reason":"Argument error"}

They all now respond with "400 Bad Request" and `{"error":"bad_request","reason":"Field 'password_hash' or 'password' is required when creating new user"}`.