### PR TITLE
HTTP API: handle unknown exchange type in input

### DIFF
--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -59,6 +59,22 @@ describe AvalancheMQ::HTTP::ExchangesController do
       body["reason"].as_s.should match(/Field 'type' is required/)
     end
 
+    it "should require a known type" do
+      body = %({ "type": "tut" })
+      response = put("/api/exchanges/%2f/faulty", body: body)
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Unknown exchange type/)
+    end
+
+    it "should require arguments if the type demands it" do
+      body = %({ "type": "x-delayed-message" })
+      response = put("/api/exchanges/%2f/faulty", body: body)
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Missing required argument/)
+    end
+
     it "should require durable to be the same when overwriting" do
       body = %({
         "type": "topic",

--- a/src/avalanchemq/error.cr
+++ b/src/avalanchemq/error.cr
@@ -24,5 +24,8 @@ module AvalancheMQ
 
     class PreconditionFailed < Error
     end
+
+    class ExchangeTypeError < Error
+    end
   end
 end

--- a/src/avalanchemq/http/controller/exchanges.cr
+++ b/src/avalanchemq/http/controller/exchanges.cr
@@ -79,6 +79,8 @@ module AvalancheMQ
                 .declare_exchange(name, type.not_nil!, durable, auto_delete, internal, tbl)
               context.response.status_code = 204
             end
+          rescue ex : Error::ExchangeTypeError
+            bad_request(context, ex.message)
           end
         end
 

--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -841,14 +841,14 @@ module AvalancheMQ
         HeadersExchange.new(vhost, name, durable, auto_delete, internal, arguments)
       when "x-delayed-message"
         type = arguments.delete("x-delayed-type")
-        raise "Missing required argument 'x-delayed-type'" unless type
+        raise Error::ExchangeTypeError.new("Missing required argument 'x-delayed-type'") unless type
         arguments["x-delayed-message"] = true
         make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)
       when "x-federation-upstream"
         FederationExchange.new(vhost, name, arguments)
       when "x-consistent-hash"
         ConsistentHashExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      else raise "Cannot make exchange type #{type}"
+      else raise Error::ExchangeTypeError.new("Unknown exchange type #{type}")
       end
     end
   end


### PR DESCRIPTION
Also

- handle missing argument for exchange type "x-delayed-message"
- spec: no need to remove exchange that was never created

Before this change, the API responded with 500 Internal Server Error and logs printed the stacktrace

    httpserver: method=PUT path=/api/exchanges/%2F/myex status=500 error=Cannot make exchange type  (Exception)
      from src/avalanchemq/vhost.cr:847:12 in 'make_exchange'
      from src/avalanchemq/vhost.cr:344:11 in 'apply'
      from src/avalanchemq/vhost.cr:338:5 in 'apply'
      from src/avalanchemq/vhost.cr:307:7 in 'declare_exchange'
      from src/avalanchemq/http/controller/exchanges.cr:78:15 in '->'
      from ../usr/share/crystal/src/primitives.cr:255:3 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/router/src/router/handler/handler.cr:25:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/router/src/router/handler/handler.cr:25:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/router/src/router/handler/handler.cr:25:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/router/src/router/handler/handler.cr:25:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/router/src/router/handler/handler.cr:25:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/handler/basic_auth.cr:31:26 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/controller/static.cr:20:11 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/handler/error_handler.cr:12:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/handler/defaults_handler.cr:13:9 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/http-protection/src/http-protection/frame_options.cr:23:7 in 'call'
      from ../usr/share/crystal/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/http-protection/src/http-protection/strict_transport.cr:24:7 in 'call'
      from ../usr/share/crystal/src/http/server/request_processor.cr:50:11 in 'process'
      from ../usr/share/crystal/src/http/server.cr:513:5 in 'handle_client'
      from ../usr/share/crystal/src/http/server.cr:468:13 in '->'
      from ../usr/share/crystal/src/primitives.cr:255:3 in 'run'
      from ../usr/share/crystal/src/fiber.cr:92:34 in '->'
      from ???