### PR TITLE
HTTP API: handle empty PUT/POST body

### DIFF
--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -71,6 +71,19 @@ describe AvalancheMQ::HTTP::BindingsController do
       s.vhosts["/"].delete_queue("bindings_q1")
     end
 
+    it "should inform about required fields" do
+      s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+      s.vhosts["/"].declare_queue("bindings_q1", false, false)
+
+      response = post("/api/bindings/%2f/e/be1/q/bindings_q1", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field .+ is required/)
+    ensure
+      s.vhosts["/"].delete_exchange("be1")
+      s.vhosts["/"].delete_queue("bindings_q1")
+    end
+
     it "should return 404 if exchange does not exist" do
       response = get("/api/bindings/%2f/e/404/q/404")
       response.status_code.should eq 404

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -173,6 +173,11 @@ describe AvalancheMQ::HTTP::Server do
     ensure
       s.delete_parameter(nil, "global_p1")
     end
+
+    it "handles empty body" do
+      response = post("/api/definitions", body: "")
+      response.status_code.should eq 200
+    end
   end
 
   describe "GET /api/definitions" do
@@ -412,6 +417,11 @@ describe AvalancheMQ::HTTP::Server do
       s.vhosts["/"].policies.has_key?("import_p1").should be_true
     ensure
       s.vhosts["/"].delete_policy("import_p1")
+    end
+
+    it "handles empty body" do
+      response = post("/api/definitions/%2f", body: "")
+      response.status_code.should eq 200
     end
   end
 end

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -53,11 +53,10 @@ describe AvalancheMQ::HTTP::ExchangesController do
     end
 
     it "should require type" do
-      body = %({})
-      response = put("/api/exchanges/%2f/faulty", body: body)
+      response = put("/api/exchanges/%2f/faulty", body: "")
       response.status_code.should eq 400
-    ensure
-      s.vhosts["/"].delete_exchange("faulty")
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field 'type' is required/)
     end
 
     it "should require durable to be the same when overwriting" do
@@ -186,9 +185,10 @@ describe AvalancheMQ::HTTP::ExchangesController do
 
     it "should require all args" do
       s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      body = %({})
-      response = post("/api/exchanges/%2f/spechange/publish", body: body)
+      response = post("/api/exchanges/%2f/spechange/publish", body: "")
       response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Fields .+ are required/)
     ensure
       s.vhosts["/"].delete_exchange("spechange")
     end

--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -77,6 +77,13 @@ describe AvalancheMQ::HTTP::ParametersController do
     ensure
       s.vhosts["/"].delete_parameter("test", "name")
     end
+
+    it "should handle request with empty body" do
+      response = put("/api/parameters/test/%2f/name", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field .+ is required/)
+    end
   end
 
   describe "DELETE /api/parameters/component/vhost/name" do
@@ -126,6 +133,13 @@ describe AvalancheMQ::HTTP::ParametersController do
       response.status_code.should eq 204
     ensure
       s.delete_parameter(nil, "name")
+    end
+
+    it "should handle request with empty body" do
+      response = put("/api/global-parameters/name", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field .+ is required/)
     end
   end
 
@@ -200,6 +214,13 @@ describe AvalancheMQ::HTTP::ParametersController do
       response.status_code.should eq 204
     ensure
       s.vhosts["/"].delete_policy("name")
+    end
+
+    it "should handle request with empty body" do
+      response = put("/api/policies/%2f/name", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Fields .+ are required/)
     end
   end
 

--- a/spec/api/permissions_spec.cr
+++ b/spec/api/permissions_spec.cr
@@ -40,6 +40,15 @@ describe AvalancheMQ::HTTP::PermissionsController do
       })
       response = put("/api/permissions/test/guest", body: body)
       response.status_code.should eq 204
+    ensure
+      s.vhosts.delete("test")
+    end
+
+    it "should handle request with empty body" do
+      response = put("/api/permissions/%2f/guest", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Fields .+ are required/)
     end
   end
 

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -46,6 +46,13 @@ describe AvalancheMQ::HTTP::UsersController do
       delete("/api/users/alan1")
       delete("/api/users/alan2")
     end
+
+    it "should handle request with empty body" do
+      response = put("/api/users/bulk-delete", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field .+ is required/)
+    end
   end
 
   describe "GET /api/users/name" do
@@ -95,6 +102,13 @@ describe AvalancheMQ::HTTP::UsersController do
       response.status_code.should eq 401
     ensure
       delete("/api/users/alan")
+    end
+
+    it "should handle request with empty body" do
+      response = put("/api/users/alice", body: "")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should match(/Field .+ is required/)
     end
   end
 

--- a/src/avalanchemq/http/controller.cr
+++ b/src/avalanchemq/http/controller.cr
@@ -106,7 +106,11 @@ module AvalancheMQ
         raise Server::ExpectedBodyError.new if context.request.body.nil?
         ct = context.request.headers["Content-Type"]? || nil
         if ct.nil? || ct.empty? || ct == "application/json"
-          JSON.parse(context.request.body.not_nil!)
+          if context.request.content_length == 0
+            JSON.parse(%({}))
+          else
+            JSON.parse(context.request.body.not_nil!)
+          end
         else
           raise Server::UnknownContentType.new("Unknown Content-Type: #{ct}")
         end

--- a/src/avalanchemq/http/controller/queues.cr
+++ b/src/avalanchemq/http/controller/queues.cr
@@ -49,11 +49,7 @@ module AvalancheMQ
             user = user(context)
             name = URI.decode_www_form(params["name"])
             name = Queue.generate_name if name.empty?
-            body = if context.request.content_length == 0
-                     JSON.parse(%({}))
-                   else
-                     parse_body(context)
-                   end
+            body = parse_body(context)
             durable = body["durable"]?.try(&.as_bool?) || false
             auto_delete = body["auto_delete"]?.try(&.as_bool?) || false
             arguments = parse_arguments(body)


### PR DESCRIPTION
Improves the error messages returned from the API and avoids stack traces in broker logs (in some cases).