### PR TITLE
HTTP API: be able to upload definitions

### DIFF
--- a/openapi/paths/definitions.yaml
+++ b/openapi/paths/definitions.yaml
@@ -70,10 +70,8 @@
           schema:
             "$ref": "../openapi.yaml#/components/schemas/definitions-UploadDefinitionsRequestBody"
     responses:
-      # FIXME: should be 200 OK when used outside the UI
-      # to address "Operation must have at least one `2xx` response." warning
-      '302':
-        description: Found.
+      '200':
+        description: OK
       4XX:
         description: Client Error
         content:

--- a/src/avalanchemq/http/controller/definitions.cr
+++ b/src/avalanchemq/http/controller/definitions.cr
@@ -29,7 +29,8 @@ module AvalancheMQ
               import_definitions(body)
             end
           end
-          redirect_back(context)
+          redirect_back(context) if context.request.headers["Referer"]?
+          context
         end
 
         get "/api/definitions/:vhost" do |context, params|


### PR DESCRIPTION
This route is mostly used by the mgmt UI (where it works), but it is also exposed as part of the HTTP API, so let's make it work without the `Referer` header too.

Only added a small sanity check to the test cases, as the implementation is the same as for the JSON API (and it will probably stay that way).

Addresses this crash:

    2020-10-28 15:26:41 +01:00 [ERROR] httpserver: method=POST path=/api/definitions/upload status=500 error=Missing hash key: HTTP::Headers::Key(@name="Referer") (KeyError)
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/hash.cr:1030:9 in '[]'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/headers.cr:71:5 in '[]'
      from src/avalanchemq/http/controller.cr:101:9 in 'redirect_back'
      from src/avalanchemq/http/controller/definitions.cr:32:11 in '->'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/primitives.cr:255:3 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/router/src/router/handler/handler.cr:25:9 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/handler/basic_auth.cr:31:26 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/controller/static.cr:20:11 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/handler/error_handler.cr:12:9 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from src/avalanchemq/http/handler/defaults_handler.cr:13:9 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/http-protection/src/http-protection/frame_options.cr:23:7 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
      from lib/http-protection/src/http-protection/strict_transport.cr:24:7 in 'call'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/request_processor.cr:50:11 in 'process'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server.cr:513:5 in 'handle_client'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server.cr:468:13 in '->'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/primitives.cr:255:3 in 'run'
      from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/fiber.cr:92:34 in '->'