### PR TITLE
Fix OverflowError in Ready/Unacked#sum (uint32 -> uint64)

### DIFF
--- a/src/avalanchemq/queue/ready.cr
+++ b/src/avalanchemq/queue/ready.cr
@@ -189,8 +189,8 @@ module AvalancheMQ
         @ready.capacity
       end
 
-      def sum(&blk : SegmentPosition -> _)
-        @ready.sum(&blk)
+      def sum(&blk : SegmentPosition -> _) : UInt64
+        @ready.sum(0_u64, &blk)
       end
 
       def compact

--- a/src/avalanchemq/queue/unacked.cr
+++ b/src/avalanchemq/queue/unacked.cr
@@ -64,8 +64,8 @@ module AvalancheMQ
         @unacked[index]?
       end
 
-      def sum(&blk : Unack -> _)
-        @unacked.sum(&blk)
+      def sum(&blk : Unack -> _) : UInt64
+        @unacked.sum(0_u64, &blk)
       end
 
       def capacity


### PR DESCRIPTION
Fixes Arithmetic overflow (OverflowError) when counting sum of SP sizes,
which can easily be >4G thus overflowing an uint32.