### PR TITLE
HTTP API: handle bad and unexpected input

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -174,9 +174,23 @@ describe AvalancheMQ::HTTP::Server do
       s.delete_parameter(nil, "global_p1")
     end
 
-    it "handles empty body" do
+    it "should handle request with empty body" do
       response = post("/api/definitions", body: "")
       response.status_code.should eq 200
+    end
+
+    it "should handle unexpected input" do
+      response = post("/api/definitions", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = post("/api/definitions", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
     end
   end
 
@@ -419,9 +433,23 @@ describe AvalancheMQ::HTTP::Server do
       s.vhosts["/"].delete_policy("import_p1")
     end
 
-    it "handles empty body" do
+    it "should handle request with empty body" do
       response = post("/api/definitions/%2f", body: "")
       response.status_code.should eq 200
+    end
+
+    it "should handle unexpected input" do
+      response = post("/api/definitions/%2f", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = post("/api/definitions/%2f", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
     end
   end
 

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -75,6 +75,20 @@ describe AvalancheMQ::HTTP::ExchangesController do
       body["reason"].as_s.should match(/Missing required argument/)
     end
 
+    it "should handle unexpected input" do
+      response = put("/api/exchanges/%2f/faulty", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/exchanges/%2f/faulty", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
+    end
+
     it "should require durable to be the same when overwriting" do
       body = %({
         "type": "topic",

--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -98,6 +98,20 @@ describe AvalancheMQ::HTTP::ParametersController do
       body = JSON.parse(response.body)
       body["reason"].as_s.should match(/Field .+ is required/)
     end
+
+    it "should handle unexpected input" do
+      response = put("/api/parameters/test/%2f/name", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/parameters/test/%2f/name", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
+    end
   end
 
   describe "DELETE /api/parameters/component/vhost/name" do
@@ -167,6 +181,20 @@ describe AvalancheMQ::HTTP::ParametersController do
       response.status_code.should eq 400
       body = JSON.parse(response.body)
       body["reason"].as_s.should match(/Field .+ is required/)
+    end
+
+    it "should handle unexpected input" do
+      response = put("/api/global-parameters/name", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/global-parameters/name", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
     end
   end
 
@@ -265,6 +293,20 @@ describe AvalancheMQ::HTTP::ParametersController do
       response.status_code.should eq 400
       body = JSON.parse(response.body)
       body["reason"].as_s.should match(/Fields .+ are required/)
+    end
+
+    it "should handle unexpected input" do
+      response = put("/api/policies/%2f/name", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/policies/%2f/name", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
     end
   end
 

--- a/spec/api/permissions_spec.cr
+++ b/spec/api/permissions_spec.cr
@@ -70,6 +70,20 @@ describe AvalancheMQ::HTTP::PermissionsController do
       body = JSON.parse(response.body)
       body["reason"].as_s.should match(/Fields .+ are required/)
     end
+
+    it "should handle unexpected input" do
+      response = put("/api/permissions/%2f/guest", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/permissions/%2f/guest", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
+    end
   end
 
   describe "DELETE /api/permissions/vhost/user" do

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -53,6 +53,20 @@ describe AvalancheMQ::HTTP::UsersController do
       body = JSON.parse(response.body)
       body["reason"].as_s.should match(/Field .+ is required/)
     end
+
+    it "should handle unexpected input" do
+      response = put("/api/users/bulk-delete", body: "\"{}\"")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/users/bulk-delete", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
+    end
   end
 
   describe "GET /api/users/name" do
@@ -125,10 +139,17 @@ describe AvalancheMQ::HTTP::UsersController do
     end
 
     it "should handle unexpected input" do
-      response = put("/api/users/foo", body: "\"{}\"")
+      response = put("/api/users/alice", body: "\"{}\"")
       response.status_code.should eq 400
       body = JSON.parse(response.body)
-      body["reason"].as_s.should eq "Bad request"
+      body["reason"].as_s.should eq "Input needs to be a JSON object."
+    end
+
+    it "should handle invalid JSON" do
+      response = put("/api/users/alice", body: "a")
+      response.status_code.should eq 400
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Malformed JSON.")
     end
   end
 

--- a/src/avalanchemq/http/controller/users.cr
+++ b/src/avalanchemq/http/controller/users.cr
@@ -68,7 +68,6 @@ module AvalancheMQ
           name = params["name"]
           bad_request(context, "Illegal user name") if UserStore.hidden?(name)
           body = parse_body(context)
-          bad_request(context) unless body.as_h?
           password_hash = body["password_hash"]?.try &.as_s?
           password = body["password"]?.try &.as_s?
           tags = Tag.parse_list(body["tags"]?.try(&.as_s).to_s)


### PR DESCRIPTION
This PR handles two cases:

1) If you made a POST or PUT request with invalid JSON, we did handle it
(returning 400 Bad Request) but the error message in the `reason` field
was a bit cryptic:

        "unexpected token '<EOF>' at 1:1"

we also [logged it](https://github.com/84codes/avalanchemq/blob/edffb36c83c7be940c9f2d9c17e5d6c0cf13be25/src/avalanchemq/http/handler/error_handler.cr#L23-L28), now we don't.

2) You could make a request with valid JSON that would be returned as a
String and not a Hash, and then the following unhandled exception would
happen. This is now handled.

        2020-10-28 17:28:40 +01:00 [ERROR] vhost=/: Parameter shovel/tut could not be applied with value=myvalue error='Expected Hash for #[]?(key : String), not String'
        2020-10-28 17:28:40 +01:00 [ERROR] httpserver: method=PUT path=/api/parameters/shovel/%2F/tut status=500 error=Expected Hash for #[]?(key : String), not String (Exception)
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/json/any.cr:116:7 in '[]?'
          from src/avalanchemq/shovel/shovel_store.cr:15:26 in 'create'
          from src/avalanchemq/vhost.cr:503:11 in 'apply_parameters'
          from src/avalanchemq/vhost.cr:423:7 in 'add_parameter'
          from src/avalanchemq/http/controller/parameters.cr:77:13 in '->'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/primitives.cr:255:3 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/router/src/router/handler/handler.cr:25:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from src/avalanchemq/http/handler/basic_auth.cr:31:26 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from src/avalanchemq/http/controller/static.cr:20:11 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from src/avalanchemq/http/handler/error_handler.cr:12:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from src/avalanchemq/http/handler/defaults_handler.cr:13:9 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/http-protection/src/http-protection/frame_options.cr:23:7 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/handler.cr:28:7 in 'call_next'
          from lib/http-protection/src/http-protection/strict_transport.cr:24:7 in 'call'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server/request_processor.cr:50:11 in 'process'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server.cr:513:5 in 'handle_client'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/http/server.cr:468:13 in '->'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/primitives.cr:255:3 in 'run'
          from ../../../../usr/local/Cellar/crystal/0.35.1_1/src/fiber.cr:92:34 in '->'