### PR TITLE
Remove \n and \r from the exchange name

### DIFF
--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -486,7 +486,7 @@ module AvalancheMQ
     end
 
     private def declare_exchange(frame)
-      exchange_name = frame.exchange_name.gsub(/\n|\t|\r/, "")
+      exchange_name = Exchange.trim_name(frame.exchange_name)
       if !valid_entity_name(exchange_name)
         send_precondition_failed(frame, "Exchange name isn't valid")
       elsif frame.exchange_name.empty?

--- a/src/avalanchemq/exchange/exchange.cr
+++ b/src/avalanchemq/exchange/exchange.cr
@@ -29,6 +29,10 @@ module AvalancheMQ
     rate_stats(%w(publish_in publish_out unroutable))
     property publish_in_count, publish_out_count, unroutable_count
 
+    def self.trim_name(name)
+      name.gsub(/\n|\r/, "")
+    end
+
     def initialize(@vhost : VHost, @name : String, @durable = false,
                    @auto_delete = false, @internal = false,
                    @arguments = Hash(String, AMQP::Field).new)

--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -334,7 +334,7 @@ module AvalancheMQ
       Fiber.yield if (@apply_count += 1) % 128 == 0
       case f
       when AMQP::Frame::Exchange::Declare
-        exchange_name = f.exchange_name.gsub(/\n|\t|\r/, "")
+        exchange_name = Exchange.trim_name(f.exchange_name)
         return false if @exchanges.has_key? exchange_name
         e = @exchanges[exchange_name] =
           make_exchange(self, exchange_name, f.exchange_type, f.durable, f.auto_delete, f.internal, f.arguments.to_h)


### PR DESCRIPTION
Previously we discarded as invalid name but rabbitmq-java-client
has tests that validate that newline and carriage return is stripped

Tests: https://github.com/rabbitmq/rabbitmq-java-client/blob/master/src/test/java/com/rabbitmq/client/test/functional/ExchangeDeclare.java#L59