### PR TITLE
Label bug occurs due to two reasons 1: UI becoming idle and stop poll…

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -8,10 +8,7 @@
 
   const POLLING_RATE = 5000
   const X_AXIS_LENGTH = 600000 //10 min
-
-  function maxDataLength () {
-    return X_AXIS_LENGTH/POLLING_RATE
-  }
+  const MAX_TICKS = X_AXIS_LENGTH/POLLING_RATE
 
   function render (id, unit, options = {}, stacked = false) {
     const el = document.getElementById(id)
@@ -66,7 +63,7 @@
             },
             ticks: {
               min: 0,
-              max: maxDataLength(),
+              max: MAX_TICKS,
               source: 'auto'
             }
           }],
@@ -174,7 +171,7 @@
       x: date,
       y: value(data)
     }
-    if (dataset.data.length >= maxDataLength()) {
+    if (dataset.data.length >= MAX_TICKS) {
       dataset.data.shift()
     }
     dataset.data.push(point)


### PR DESCRIPTION
Label bug occurs due to two reasons 

1. UI becoming idle and stop polling for data.
2: Avalanche do not have data saved every 5th second due to some reason. 

Both issues creates gaps in the graph data, making the labels go ham. This fix fill these gaps with timestamps having null value on y-axis to always keep the graphs showing 10 mins of data. 
A rework of this to instead always replace the frontend-saved with the "log" data coming from the response request might be better? However, that approach will only solve the first reason, but I think thats the most common one.

<img width="586" alt="Screenshot 2020-11-30 at 12 20 29" src="https://user-images.githubusercontent.com/25172381/100605506-4f697b80-3308-11eb-8646-4a45cfcc32dd.png">
