### PR TITLE
Bugfix -  Correct sorting on page refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Remember table sorting option until session ends + correct sorting on page refresh
 - Bugfix - Refresh last used time on queue when policy with expire applies to it
 - Autofill of update policy form when click on policy name in the queue, exchange or policies views.
 

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -14,7 +14,12 @@
 
   function renderTable (id, options = {}, renderRow) {
     let sortKey = getQueryVariable('sort')
-    let reverseOrder = getQueryVariable('sort_reverse')
+    let reverseOrder = strToBool(getQueryVariable('reverseOrder'))
+    const view = window.location.pathname.split("/").pop()
+    if (!sortKey || reverseOrder === null) {
+      sortKey = window.sessionStorage.getItem(view + '-sortkey')
+      reverseOrder = strToBool(window.sessionStorage.getItem(view + '-reverseorder'))
+    }
     const url = options.url
     const table = document.getElementById(id)
     const container = table.parentElement
@@ -63,6 +68,10 @@
       }
     }
 
+    function strToBool(str){
+      return str === 'true' ? true : false
+    }
+
     function makeHeadersSortable () {
       const sortHeader = table.querySelector(`th[data-sort-key="${sortKey}"]`)
       if (sortHeader) {
@@ -87,6 +96,8 @@
             e.target.classList.add('sorting_desc')
             e.target.classList.remove('sorting_asc')
           }
+          window.sessionStorage.setItem(view + '-sortkey', sortKey)
+          window.sessionStorage.setItem(view + '-reverseorder', reverseOrder)
           updateQueryState({ sort: sortKey, reverseOrder })
           const t = table.tBodies[0]
           clearRows(t)


### PR DESCRIPTION
Storing with last path in url as identifier to the specific table. Feels a bit unstable, but couldn't see any other way as the tables got the same id="table". WDYT?