### PR TITLE
Updated repo name of powertools after change in centos

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           yum install dnf-plugins-core
-          yum config-manager --set-enabled PowerTools
+          yum config-manager --set-enabled powertools
           yum install -y git rpmlint rpm-build openssl-devel zlib-devel help2man systemd-devel
 
       - name: Checkout


### PR DESCRIPTION
Master RPM build failes with: Error: No matching repo to modify: PowerTools. Just changing name might fix? 

https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes