### PR TITLE
Autocomplete of queue and exchanges input fields

### DIFF
--- a/static/exchange.html
+++ b/static/exchange.html
@@ -72,11 +72,12 @@
       <form method="post" id="addBinding" class="form card cols-6">
         <h3>Add a binding from this exchange</h3>
         <label>
-          <select name="dest-type" required>
+          <select name="dest-type" required onchange="updateAutocomplete(this.value)">
             <option value="q">To queue</option>
             <option value="e">To exchange</option>
           </select>
-          <input name="destination" type="text" required>
+          <input name="destination" type="text" required list="exchange-dest-list">
+          <datalist id="exchange-dest-list"></datalist>
         </label>
         <label>
           <span>Routing key</span>
@@ -263,6 +264,12 @@
             .catch(avalanchemq.http.standardErrorHandler)
         }
       })
+
+      function updateAutocomplete(e) {
+        type = e === 'q' ? 'queues' : 'exchanges'
+        avalanchemq.helpers.autoCompleteDatalist("exchange-dest-list", type)
+      }
+      updateAutocomplete('q')
     </script>
   </body>
 </html>

--- a/static/federation.html
+++ b/static/federation.html
@@ -13,6 +13,7 @@
     <link rel="apple-touch-icon" sizes="114x114" href="/img/apple-touch-icon-iphone4.png" />
     <script src="/js/auth.js"></script>
     <script src="/js/http.js"></script>
+    <script src="/js/helpers.js"></script>
   </head>
   <body>
     <header>
@@ -106,7 +107,8 @@
           <legend>Federated exchange parameters</legend>
           <label>
             <span>Exchange</span>
-            <input type="text" name="exchange">
+            <input type="text" name="exchange" list="exchange-datalist">
+            <datalist id="exchange-datalist"></datalist>
           </label>
           <!-- <label>
             <span>Max hops</span>
@@ -125,7 +127,8 @@
           <legend>Federated queue parameters</legend>
           <label>
             <span>Queue</span>
-            <input type="text" name="queue">
+            <input type="text" name="queue" list="queue-datalist">
+            <datalist id="queue-datalist"></datalist>
           </label>
           <label>
             <span>Consumer tag</span>
@@ -220,6 +223,8 @@
             evt.target.reset()
           }).catch(avalanchemq.http.standardErrorHandler)
       })
+      avalanchemq.helpers.autoCompleteDatalist("queue-datalist", "queues")
+      avalanchemq.helpers.autoCompleteDatalist("exchange-datalist", "exchanges")
     </script>
   </body>
 </html>

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -73,6 +73,25 @@
     }
   }
 
+  /**
+  * @param datalistID id of the datalist element linked to input
+  * @param type input content, accepts: queues, exchanges, vhosts, users
+  */
+  function autoCompleteDatalist(datalistID, type) {
+    avalanchemq.http.request('GET',`/api/${type}`).then(res => {
+      datalist = document.getElementById(datalistID);
+      while (datalist.firstChild) {
+        datalist.removeChild(datalist.lastChild);
+      }
+      values = res.map(val => val.name)
+      uniqValues = [...new Set(values)];
+      uniqValues.forEach(val => {
+        option = document.createElement("option")
+        option.value = val
+        datalist.appendChild(option)
+      });
+    })
+  }
 
   Object.assign(window.avalanchemq, {
     helpers: {
@@ -80,7 +99,8 @@
       nFormatter,
       duration,
       argumentHelper,
-      argumentHelperJSON
+      argumentHelperJSON,
+      autoCompleteDatalist
     }
   })
 })()

--- a/static/queue.html
+++ b/static/queue.html
@@ -125,7 +125,8 @@
         <h3>Add a binding to this queue</h3>
         <label>
           <span>From exchange</span>
-          <input name="source" type="text" required>
+          <input name="source" type="text" required list="exchange-list">
+          <datalist id="exchange-list"></datalist>
         </label>
         <label>
           <span>Routing key</span>
@@ -195,7 +196,9 @@
         <h3>Move messages</h3>
         <label>
           <span>Destination queue</span>
-          <input type="text" name="shovel-destination">
+          <input type="text" name="shovel-destination" list="queue-list">
+          <datalist id="queue-list">
+          </datalist>
         </label>
         <button type="submit" class="btn-primary">Move messages</button>
       </form>
@@ -555,6 +558,9 @@
             .catch(avalanchemq.http.standardErrorHandler)
         }
       })
+
+      avalanchemq.helpers.autoCompleteDatalist("exchange-list", 'exchanges')
+      avalanchemq.helpers.autoCompleteDatalist("queue-list", 'queues')
     </script>
   </body>
 

--- a/static/shovels.html
+++ b/static/shovels.html
@@ -13,6 +13,7 @@
     <link rel="apple-touch-icon" sizes="114x114" href="/img/apple-touch-icon-iphone4.png" />
     <script src="/js/auth.js"></script>
     <script src="/js/http.js"></script>
+    <script src="/js/helpers.js"></script>
   </head>
   <body>
     <header>
@@ -76,14 +77,15 @@
           </label>
           <label>
             <span>Type</span>
-            <select name="src-type" required>
+            <select name="src-type" required onchange="updateAutocomplete(this.value,'shovel-src-list')">
               <option value="queue">Queue</option>
               <option value="exchange">Exchange</option>
             </select>
           </label>
           <label>
             <span>Endpoint</span>
-            <input type="text" name="src-endpoint" required>
+            <input type="text" name="src-endpoint" required list="shovel-src-list">
+            <datalist id="shovel-src-list"></datalist>
           </label>
           <label id="srcRoutingKey" class="hide">
             <span>Routing key</span>
@@ -109,14 +111,15 @@
           </label>
           <label class="amqp-dest-field">
             <span>Type</span>
-            <select name="dest-type" required>
+            <select name="dest-type" required onchange="updateAutocomplete(this.value,'shovel-dest-list')">
               <option value="queue">Queue</option>
               <option value="exchange">Exchange</option>
             </select>
           </label>
           <label class="amqp-dest-field">
             <span>Endpoint</span>
-            <input type="text" name="dest-endpoint">
+            <input type="text" name="dest-endpoint" list="shovel-dest-list">
+            <datalist id="shovel-dest-list"></datalist>
           </label>
         </fieldset>
         <label>
@@ -269,6 +272,13 @@
             avalanchemq.dom.toast('Shovel ' + name + ' created')
           }).catch(avalanchemq.http.standardErrorHandler)
       })
+
+      function updateAutocomplete(e, id) {
+        type = e === 'queue' ? 'queues' : 'exchanges'
+        avalanchemq.helpers.autoCompleteDatalist(id, type)
+      }
+      updateAutocomplete('queue',"shovel-src-list")
+      updateAutocomplete('queue',"shovel-dest-list")
     </script>
   </body>
 </html>


### PR DESCRIPTION
Appends fetched data from avalanches API to the default browsers autocomplete datalist. In case of errors, just ignore, as it doesn't affect core functionality, just UX.

Is there cases when you would like to enter a non-existing queue/exchange? Otherwise inputs of type select might be preferable, just as it is done for vhosts in a couple of other places.
<img width="569" alt="Screenshot 2021-01-13 at 10 19 43" src="https://user-images.githubusercontent.com/25172381/104432030-df961400-5588-11eb-9ba4-0e0b5cd3dca7.png">
