### PR TITLE
Overwrite user on import definitions if used already exist

### DIFF
--- a/src/avalanchemq/user_store.cr
+++ b/src/avalanchemq/user_store.cr
@@ -44,7 +44,6 @@ module AvalancheMQ
     end
 
     def add(name, password_hash, password_algorithm, tags = Array(Tag).new, save = true)
-      return if has_key?(name)
       user = User.new(name, password_hash, password_algorithm, tags)
       @users[name] = user
       save! if save


### PR DESCRIPTION
user_store#add only called from one other location than import_definitions (https://github.com/84codes/avalanchemq/blob/master/src/avalanchemq/http/controller/users.cr#L86), so should not affect any other action. 