### PR TITLE
Push to cloudamqp/avalanchemq-head repo only for master

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -76,7 +76,7 @@ jobs:
         run: package_cloud push cloudamqp/avalanchemq-head/ubuntu/${{ env.CODENAME }} builds/debian/${{ env.CODENAME }}/avalanchemq_${{ env.VERSION }}-1_${{ matrix.arch }}.deb
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/master'
 
       - name: Upload to packagecloud release repo
         run: package_cloud push cloudamqp/avalanchemq/ubuntu/${{ env.CODENAME }} builds/debian/${{ env.CODENAME }}/avalanchemq_${{ env.VERSION }}-1_${{ matrix.arch }}.deb


### PR DESCRIPTION
Since this workflow is run twice when we push a commit on master
that has a tag the upload to packagecloud for
cloudamqp/avalanchemq-head fails with error that artifact already
exists.

So now we only push to  cloudamqp/avalanchemq-head repo only for
master and push to cloudamqp/avalanchemq repo for tags