### PR TITLE
Config option to show all sockets of type UNIXSocket as tls terminated

### DIFF
--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -10,6 +10,7 @@ require "../sortable_json"
 require "../rough_time"
 require "../error"
 require "./amqp_connection"
+require "../config"
 
 module AvalancheMQ
   class Client
@@ -98,9 +99,9 @@ module AvalancheMQ
         peer_port:         @remote_address.port,
         name:              @name,
         pid:               @name,
-        ssl:               @socket.is_a?(OpenSSL::SSL::Socket),
-        tls_version:       @socket.is_a?(OpenSSL::SSL::Socket) ? @socket.as(OpenSSL::SSL::Socket).tls_version : nil,
-        cipher:            @socket.is_a?(OpenSSL::SSL::Socket) ? @socket.as(OpenSSL::SSL::Socket).cipher : nil,
+        ssl:               tls_terminated?,
+        tls_version:       tls_version,
+        cipher:            cipher,
         state:             state,
       }.merge(stats_details)
     end
@@ -813,6 +814,23 @@ module AvalancheMQ
       # yield so that msg expiration, consumer delivery etc gets priority
       Fiber.yield
       with_channel frame, &.basic_get(frame)
+    end
+
+    private def tls_terminated?()
+      @socket.is_a?(OpenSSL::SSL::Socket) ||
+      (@socket.is_a?(UNIXSocket) && Config.instance.unix_socket_tls_terminated)
+    end
+
+    private def tls_version()
+      return @socket.as(OpenSSL::SSL::Socket).tls_version if @socket.is_a?(OpenSSL::SSL::Socket)
+      return "Unknown" if @socket.is_a?(UNIXSocket) && Config.instance.unix_socket_tls_terminated
+      nil
+    end
+
+    private def cipher()
+      return @socket.as(OpenSSL::SSL::Socket).cipher if @socket.is_a?(OpenSSL::SSL::Socket)
+      return "Unknown" if @socket.is_a?(UNIXSocket) && Config.instance.unix_socket_tls_terminated
+      nil
     end
   end
 end

--- a/src/avalanchemq/config.cr
+++ b/src/avalanchemq/config.cr
@@ -13,6 +13,7 @@ module AvalancheMQ
     property unix_path = ""
     property unix_proxy_protocol = true # PROXY protocol on unix domain socket connections
     property tcp_proxy_protocol = false  # PROXY protocol on amqp tcp connections
+    property unix_socket_tls_terminated = false
     property tls_cert_path = ""
     property tls_key_path = ""
     property tls_ciphers = ""


### PR DESCRIPTION
Introduced in order to show connections as TLS in UI when using nginx proxy infront of avalanchemq.
Couldn't find a way to extract the TLS version and Cipher from nginx or the socket, do you know of one? 