### PR TITLE
Dont expire messages when the queue has been closed

### DIFF
--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -333,6 +333,7 @@ module AvalancheMQ
         when @refresh_ttl_timeout.receive
           @log.debug "Queue#consumer_or_expire Refresh TTL timeout"
         when timeout ttl
+          return true if @state == QueueState::Closed
           case ttl
           when q_ttl
             expire_queue && return false


### PR DESCRIPTION
Since the deliver loop is running in it's own fiber, when we are
waiting to expire messages we use a timeout, from that when we start
to wait for the timeout until it's time to expire the message the
queue could have been closed.
The result of this is that the `@ack` file is closed and we cannot
delete the message (meaning write the segement position to `@ack`)

fixes #195