### PR TITLE
Fix error in npm_postinstall

### DIFF
--- a/build/npm_postinstall
+++ b/build/npm_postinstall
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
+
 [[ -d static/js/lib ]] && cp node_modules/chart.js/dist/Chart.bundle.min.js static/js/lib/chart.js
 
 echo "Linting HTTP API documentation..."


### PR DESCRIPTION
Address this issue: https://github.com/84codes/avalanchemq/runs/1740957293?check_suite_focus=true#step:3:12

    ./build/npm_postinstall: 2: ./build/npm_postinstall: [[: not found

Exit on errors so we don't miss them.