### PR TITLE
Push the "latest" tag to Docker Hub when we tag a release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,10 @@ name: docker
 
 on:
   push:
-    branches: master
+    branches:
+      - master
+    tags:
+      - 'v*.*.*'
 
 jobs:
   main:
@@ -41,7 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
We want to move the `latest` tag when we do a new release:

https://github.com/84codes/avalanchemq/blob/f43cdba0342e57cff11b986289432d125be5dd1e/.github/workflows/docker.yml#L30-L32

It is currently 2 months old: https://hub.docker.com/layers/cloudamqp/avalanchemq/latest/images/sha256-c0f8a19a3b0948389e85331daff46af755601f7353832b84d43616512846a5e9?context=explore