### PR TITLE
Do not allow requeue=true on ack from HTTP API

### DIFF
--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -197,7 +197,7 @@ describe AvalancheMQ::HTTP::QueuesController do
         sleep 0.05
         body = %({
           "count": 2,
-          "ack_mode": "ack",
+          "ack_mode": "get",
           "encoding": "auto"
         })
         response = post("/api/queues/%2f/q5/get", body: body)
@@ -212,7 +212,7 @@ describe AvalancheMQ::HTTP::QueuesController do
         ch.queue("q6")
         body = %({
           "count": 1,
-          "ack_mode": "ack",
+          "ack_mode": "get",
           "encoding": "auto"
         })
         response = post("/api/queues/%2f/q6/get", body: body)
@@ -231,7 +231,7 @@ describe AvalancheMQ::HTTP::QueuesController do
         sleep 0.05
         body = %({
           "count": 1,
-          "ack_mode": "ack",
+          "ack_mode": "get",
           "encoding": "base64"
         })
         response = post("/api/queues/%2f/q7/get", body: body)
@@ -243,21 +243,21 @@ describe AvalancheMQ::HTTP::QueuesController do
       s.vhosts["/"].delete_queue("q7")
     end
 
-    it "should not allow ack and requeue" do
+    it "should not allow get and requeue" do
       with_channel do |ch|
         q = ch.queue("q8")
         q.publish "m1"
         sleep 0.05
         body = %({
           "count": 1,
-          "ack_mode": "ack",
+          "ack_mode": "get",
           "requeue": true,
           "encoding": "base64"
         })
         response = post("/api/queues/%2f/q8/get", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
-        body["reason"].should eq "Cannot requeue message on ack"
+        body["reason"].should eq "Cannot requeue message on get"
       end
     ensure
       s.vhosts["/"].delete_queue("q8")

--- a/src/avalanchemq/http/controller/queues.cr
+++ b/src/avalanchemq/http/controller/queues.cr
@@ -151,12 +151,12 @@ module AvalancheMQ
             end
             body = parse_body(context)
             get_count = body["count"]?.try(&.as_i) || 1
-            ack_mode = body["ack_mode"]?.try(&.as_s) || "ack"
+            ack_mode = body["ack_mode"]?.try(&.as_s) || "get"
             encoding = body["encoding"]?.try(&.as_s) || "auto"
             truncate = body["truncate"]?.try(&.as_i)
             requeue = body["requeue"]?.try(&.as_bool) || ack_mode == "reject_requeue_true"
-            ack = {"ack", "get"}.includes? ack_mode
-            bad_request(context, "Cannot requeue message on ack") if ack && requeue
+            ack = ack_mode == "get"
+            bad_request(context, "Cannot requeue message on get") if ack && requeue
             JSON.build(context.response) do |j|
               j.array do
                 sps = Array(SegmentPosition).new(get_count)

--- a/static/queue.html
+++ b/static/queue.html
@@ -172,8 +172,7 @@
           <label>
             <span>Mode</span>
             <select name="mode">
-              <option value="ack_requeue_true">Ack and requeue</option>
-              <option value="ack_requeue_false">Ack</option>
+              <option value="get">Get</option>
               <option value="reject_requeue_true">Reject and requeue</option>
               <option value="reject_requeue_false">Reject</option>
             </select>


### PR DESCRIPTION
Requeue on ack is not supported, the way it was done before caused issues with
the ordering of SegmentPositions and GC