### PR TITLE
Ack is always flushed to disk

### DIFF
--- a/src/avalanchemq/client/channel.cr
+++ b/src/avalanchemq/client/channel.cr
@@ -448,7 +448,7 @@ module AvalancheMQ
         if c = unack.consumer
           c.ack(unack.sp)
         end
-        unack.queue.ack(unack.sp, persistent: unack.persistent)
+        unack.queue.ack(unack.sp)
         @events.send(EventType::ClientAck)
         @ack_count += 1
       end

--- a/src/avalanchemq/http/controller/queues.cr
+++ b/src/avalanchemq/http/controller/queues.cr
@@ -192,7 +192,7 @@ module AvalancheMQ
                 end
                 sps.each do |sp|
                   if ack
-                    q.ack(sp, true)
+                    q.ack(sp)
                   else
                     q.reject(sp, requeue)
                   end

--- a/src/avalanchemq/queue/durable_queue.cr
+++ b/src/avalanchemq/queue/durable_queue.cr
@@ -101,7 +101,7 @@ module AvalancheMQ
       true
     end
 
-    protected def delete_message(sp : SegmentPosition, persistent = false) : Nil
+    protected def delete_message(sp : SegmentPosition) : Nil
       super
       @ack_lock.synchronize do
         @log.debug { "writing #{sp} to ack" }

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -383,7 +383,7 @@ module AvalancheMQ
         # @log.debug { "Delivering #{sp} to consumer" }
         if c.deliver(env.message, sp, env.redelivered)
           if c.no_ack
-            delete_message(sp, false)
+            delete_message(sp)
           else
             @unacked.push(sp, env.message.persistent?, c)
           end
@@ -602,7 +602,7 @@ module AvalancheMQ
           end
         end
       end
-      delete_message sp, msg.persistent?
+      delete_message sp
     end
 
     # checks if the message has been dead lettered to the same queue
@@ -706,7 +706,7 @@ module AvalancheMQ
       @get_count += 1
       if env = get(no_ack)
         if no_ack
-          delete_message(env.segment_position, false)
+          delete_message(env.segment_position)
         else
           @unacked.push(env.segment_position, env.message.persistent?, nil)
         end
@@ -761,16 +761,16 @@ module AvalancheMQ
       @requeued.delete(sp) if redelivered
     end
 
-    def ack(sp : SegmentPosition, persistent : Bool) : Nil
+    def ack(sp : SegmentPosition) : Nil
       return if @deleted
       @log.debug { "Acking #{sp}" }
       @ack_count += 1
       @unacked.delete(sp)
-      delete_message(sp, persistent)
+      delete_message(sp)
       consumer_available
     end
 
-    protected def delete_message(sp : SegmentPosition, persistent = false) : Nil
+    protected def delete_message(sp : SegmentPosition) : Nil
       @deliveries.delete(sp) if @delivery_limit
       @vhost.dirty = true
     end


### PR DESCRIPTION
The ack file is always flushed to disk after write, no need to have
the extra persistent argument for the method
The same goes for delete_message method