### PR TITLE
Don't log if client EOF on connect, such as healthchecks

### DIFF
--- a/src/avalanchemq/server.cr
+++ b/src/avalanchemq/server.cr
@@ -212,17 +212,8 @@ module AvalancheMQ
 
     def handle_connection(socket, connection_info)
       client = Client.start(socket, connection_info, @vhosts, @users, @log, @events)
-      if client.nil?
-        socket.close
-        @log.info { "Connection failed for remote_address=#{connection_info.src}" }
-      end
-    rescue ex : IO::Error | OpenSSL::SSL::Error
-      @log.debug { "HandleConnection exception: #{ex.inspect}" }
-      begin
-        socket.close
-      rescue
-        nil
-      end
+    ensure
+      socket.close if client.nil?
     end
 
     private def handle_proxied_v1_connection(client)


### PR DESCRIPTION
Typically generic TCP healthchecks just opens a TCP connection and then
closes it, without sending anything. That causes a lot of noise the
logs. This prevents that.

Now it just logs these errors:

```
amqpserver: Error accepting TLS connection from 127.0.0.1:52232: #<OpenSSL::SSL::Error:SSL_accept: error:1408F10B:SSL routines:ssl3_get_record:wrong version number>
amqpserver client=127.0.0.1:42180: Unexpected protocol '', closing socket
amqpserver client=127.0.0.1:42182: VHost "vhost2" not found
amqpserver client=127.0.0.1:42184: User "guest2" not found
amqpserver client=127.0.0.1:42186: Authentication failure for user "guest"
```