### PR TITLE
On USR1 print segments referenced by each queue

### DIFF
--- a/src/avalanchemq.cr
+++ b/src/avalanchemq.cr
@@ -183,6 +183,7 @@ Signal::USR1.trap do
     STDOUT.puts "Dumping string pool to #{f.path}"
     AvalancheMQ::Reporter.dump_string_pool(f)
   end
+  AvalancheMQ::Reporter.print_queue_segments(amqp_server, STDOUT)
   STDOUT.flush
 end
 

--- a/src/avalanchemq/reporter.cr
+++ b/src/avalanchemq/reporter.cr
@@ -32,6 +32,17 @@ module AvalancheMQ
       end
     end
 
+    def self.print_queue_segments(amqp_server, io)
+      amqp_server.vhosts.each_value do |vhost|
+        vhost.queues.each_value do |q|
+          s = Set(UInt32).new
+          q.unacked.each_sp {|sp| s << sp.segment }
+          q.ready.each {|sp| s << sp.segment }
+          io.puts "queue=\"#{vhost.name}/#{q.name}\" segments=#{s}"
+        end
+      end
+    end
+
     def self.dump_string_pool(io)
       pool = AMQ::Protocol::ShortString::POOL
       io.puts "# size=#{pool.size} capacity=#{pool.@capacity}"


### PR DESCRIPTION
Outputs
```
queue="//my_queue" segments=Set{2}
queue="my_vhost/my_queue" segments=Set{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
```
This can help in discover if and why some segments aren't released