### PR TITLE
Queue size metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Queue size metric snapshot to present expensive queue metrics calculation ([#362](https://github.com/cloudamqp/lavinmq/pull/362))
+- Queue size metric details to present expensive queue metrics calculation ([#362](https://github.com/cloudamqp/lavinmq/pull/362))
 
 ## [1.0.0-beta.2] - 2022-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Queue size metric snapshot to present expensive queue metrics calculation ([#362](https://github.com/cloudamqp/lavinmq/pull/362))
+
 ## [1.0.0-beta.2] - 2022-06-30
 
 ### Fixed

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -108,6 +108,8 @@ components:
       "$ref": "./schemas/queues.yaml#/PutQueueRequestBody"
     queues-GetQueueMessagesRequestBody:
       "$ref": "./schemas/queues.yaml#/GetQueueMessagesRequestBody"
+    size-details:
+      "$ref": "./schemas/queues.yaml#/size-details"
     user:
       "$ref": "./schemas/users.yaml#/user"
     users:
@@ -229,6 +231,8 @@ paths:
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1contents"
   "/queues/{vhost}/{name}/get":
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1get"
+  "/queues/{vhost}/{name}/size-details":
+    "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1size-details"
   "/users":
     "$ref": "./paths/users.yaml#/~1users"
   "/users/without-permissions":

--- a/openapi/paths/queues.yaml
+++ b/openapi/paths/queues.yaml
@@ -345,3 +345,42 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/queues/{vhost}/{name}/size-snapshot":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  - in: path
+    name: name
+    required: true
+    schema:
+      type: string
+      description: Name of queue.
+  get:
+    tags:
+    - queues
+    description: Get queue size metrics snapshot with detailed information of message sizes
+    summary: Get queue size metrics snapshot
+    operationId: GetQueueSizeSnapshot
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/size-snapshot"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"

--- a/openapi/paths/queues.yaml
+++ b/openapi/paths/queues.yaml
@@ -345,7 +345,7 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
-"/queues/{vhost}/{name}/size-snapshot":
+"/queues/{vhost}/{name}/size-details":
   parameters:
   - in: path
     name: vhost
@@ -362,16 +362,16 @@
   get:
     tags:
     - queues
-    description: Get queue size metrics snapshot with detailed information of message sizes
-    summary: Get queue size metrics snapshot
-    operationId: GetQueueSizeSnapshot
+    description: List size details for a specific queue.
+    summary: List queue size details
+    operationId: GetQueueSizeDetails
     responses:
       '200':
         description: OK
         content:
           application/json:
             schema:
-              "$ref": "../openapi.yaml#/components/schemas/size-snapshot"
+              "$ref": "../openapi.yaml#/components/schemas/size-details"
       4XX:
         description: Client Error
         content:

--- a/openapi/schemas/queues.yaml
+++ b/openapi/schemas/queues.yaml
@@ -234,7 +234,7 @@ GetQueueMessagesRequestBody:
       type: string
     requeue:
       type: boolean
-size-snapshot:
+size-details:
   type: object
   properties:
     messages:

--- a/openapi/schemas/queues.yaml
+++ b/openapi/schemas/queues.yaml
@@ -32,11 +32,19 @@ queue:
       description: Number of ready messages in the queue.
     ready_bytes:
       type: integer
+      description: Total size of ready messages in the queue.
+    ready_avg_bytes:
+      type: integer
+      description: Average size of ready messages in the queue.
     unacked:
       type: integer
       description: Number of unacknowledged messages in the queue.
     unacked_bytes:
       type: integer
+      description: Total size of unacknowledged messages in the queue.
+    unacked_avg_bytes:
+      type: integer
+      description: Average size of unacknowledged messages in the queue.
     policy:
       type: string
       nullable: true
@@ -61,6 +69,12 @@ queue:
     internal:
       type: boolean
       description: If the queue is internal (meaning clients can't publish directly to it).
+    first_message_timestamp:
+      type: integer
+      description: Epoch timestamp of the first message in the queue.
+    last_message_timestamp:
+      type: integer
+      description: Epoch timestamp of the last message in the queue.
 consumer_details:
   type: object
   properties:
@@ -220,3 +234,45 @@ GetQueueMessagesRequestBody:
       type: string
     requeue:
       type: boolean
+size-snapshot:
+  type: object
+  properties:
+    messages:
+      type: integer
+      description: Number of messages in the queue.
+    ready:
+      type: integer
+      description: Number of ready messages in the queue.
+    ready_bytes:
+      type: integer
+      description: Total size of ready messages in the queue.
+    ready_avg_bytes:
+      type: integer
+      description: Average size of ready messages in the queue.
+    ready_max_bytes:
+      type: integer
+      description: Maximum size of ready messages in the queue.
+    ready_min_bytes:
+      type: integer
+      description: Minimum size of ready messages in the queue.
+    unacked:
+      type: integer
+      description: Number of unacknowledged messages in the queue.
+    unacked_bytes:
+      type: integer
+      description: Total size of unacknowledged messages in the queue.
+    unacked_avg_bytes:
+      type: integer
+      description: Average size of unacknowledged messages in the queue.
+    unacked_max_bytes:
+      type: integer
+      description: Maximum size of unacknowledged messages in the queue.
+    unacked_min_bytes:
+      type: integer
+      description: Minimum size of unacknowledged messages in the queue.
+    first_message_timestamp:
+      type: integer
+      description: Epoch timestamp of the first message in the queue.
+    last_message_timestamp:
+      type: integer
+      description: Epoch timestamp of the last message in the queue.

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -54,6 +54,24 @@ describe LavinMQ::HTTP::QueuesController do
     end
   end
 
+  describe "GET /api/queues/vhost/name/size-snapshot" do
+    it "should return message size snapshot stats" do
+      with_channel do |ch|
+        q = ch.queue("stats_q")
+        q.publish "m1"
+      end
+      response = get("/api/queues/%2f/stats_q/size-snapshot")
+      response.status_code.should eq 200
+      body = JSON.parse(response.body)
+      body["ready_max_bytes"].nil?.should be_false
+      body["ready_min_bytes"].nil?.should be_false
+      body["unacked_max_bytes"].nil?.should be_false
+      body["unacked_min_bytes"].nil?.should be_false
+    ensure
+      s.vhosts["/"].delete_queue("stats_q")
+    end
+  end
+
   describe "GET /api/queues/vhost/name/bindings" do
     it "should return queue bindings" do
       s.vhosts["/"].declare_queue("q0", false, false)

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -54,13 +54,13 @@ describe LavinMQ::HTTP::QueuesController do
     end
   end
 
-  describe "GET /api/queues/vhost/name/size-snapshot" do
-    it "should return message size snapshot stats" do
+  describe "GET /api/queues/vhost/name/size-details" do
+    it "should return message size details stats" do
       with_channel do |ch|
         q = ch.queue("stats_q")
         q.publish "m1"
       end
-      response = get("/api/queues/%2f/stats_q/size-snapshot")
+      response = get("/api/queues/%2f/stats_q/size-details")
       response.status_code.should eq 200
       body = JSON.parse(response.body)
       body["ready_max_bytes"].nil?.should be_false

--- a/spec/ready_queue_spec.cr
+++ b/spec/ready_queue_spec.cr
@@ -73,11 +73,11 @@ describe LavinMQ::Queue::ReadyQueue do
   it "should calculate message sizes" do
     rq = LavinMQ::Queue::ReadyQueue.new
     sps = [
-      LavinMQ::SegmentPosition.new(10,10,5u32),
-      LavinMQ::SegmentPosition.new(10,10,1u32),
-      LavinMQ::SegmentPosition.new(10,10,10u32),
-      LavinMQ::SegmentPosition.new(10,10,3u32),
-      LavinMQ::SegmentPosition.new(10,10,1u32)
+      LavinMQ::SegmentPosition.new(10, 10, 5u32),
+      LavinMQ::SegmentPosition.new(10, 10, 1u32),
+      LavinMQ::SegmentPosition.new(10, 10, 10u32),
+      LavinMQ::SegmentPosition.new(10, 10, 3u32),
+      LavinMQ::SegmentPosition.new(10, 10, 1u32),
     ]
     sps.each { |sp| rq.insert(sp) }
     rq.bytesize.should eq 20u32

--- a/spec/ready_queue_spec.cr
+++ b/spec/ready_queue_spec.cr
@@ -84,5 +84,10 @@ describe LavinMQ::Queue::ReadyQueue do
     rq.avg_bytesize.should eq 4u32
     rq.max_bytesize(&.bytesize).should eq 10u32
     rq.min_bytesize(&.bytesize).should eq 1u32
+    rq.purge
+    rq.bytesize.should eq 0u32
+    rq.avg_bytesize.should eq 0u32
+    rq.max_bytesize(&.bytesize).should eq 0u32
+    rq.min_bytesize(&.bytesize).should eq 0u32
   end
 end

--- a/spec/ready_queue_spec.cr
+++ b/spec/ready_queue_spec.cr
@@ -69,4 +69,20 @@ describe LavinMQ::Queue::ReadyQueue do
     rq.purge
     rq.bytesize.should eq 0
   end
+
+  it "should calculate message sizes" do
+    rq = LavinMQ::Queue::ReadyQueue.new
+    sps = [
+      LavinMQ::SegmentPosition.new(10,10,5u32),
+      LavinMQ::SegmentPosition.new(10,10,1u32),
+      LavinMQ::SegmentPosition.new(10,10,10u32),
+      LavinMQ::SegmentPosition.new(10,10,3u32),
+      LavinMQ::SegmentPosition.new(10,10,1u32)
+    ]
+    sps.each { |sp| rq.insert(sp) }
+    rq.bytesize.should eq 20u32
+    rq.avg_bytesize.should eq 4u32
+    rq.max_bytesize(&.bytesize).should eq 10u32
+    rq.min_bytesize(&.bytesize).should eq 1u32
+  end
 end

--- a/spec/unacked_queue_spec.cr
+++ b/spec/unacked_queue_spec.cr
@@ -33,11 +33,11 @@ describe LavinMQ::Queue::UnackQueue do
   it "should calculate message sizes" do
     q = LavinMQ::Queue::UnackQueue.new
     sps = [
-      LavinMQ::SegmentPosition.new(10,10,5u32),
-      LavinMQ::SegmentPosition.new(10,10,1u32),
-      LavinMQ::SegmentPosition.new(10,10,10u32),
-      LavinMQ::SegmentPosition.new(10,10,3u32),
-      LavinMQ::SegmentPosition.new(10,10,1u32)
+      LavinMQ::SegmentPosition.new(10, 10, 5u32),
+      LavinMQ::SegmentPosition.new(10, 10, 1u32),
+      LavinMQ::SegmentPosition.new(10, 10, 10u32),
+      LavinMQ::SegmentPosition.new(10, 10, 3u32),
+      LavinMQ::SegmentPosition.new(10, 10, 1u32),
     ]
     sps.each { |sp| q.push(sp, nil) }
     q.bytesize.should eq 20u32

--- a/spec/unacked_queue_spec.cr
+++ b/spec/unacked_queue_spec.cr
@@ -1,6 +1,35 @@
 require "./spec_helper"
 
-describe LavinMQ::Queue::ReadyQueue do
+describe LavinMQ::Queue::UnackQueue do
+  it "keeps track of bytesize" do
+    q = LavinMQ::Queue::UnackQueue.new
+    q.bytesize.should eq 0
+
+    sp1 = LavinMQ::SegmentPosition.new(0u32, 0u32, bytesize: 1u32)
+    sp2 = LavinMQ::SegmentPosition.new(1u32, 0u32, bytesize: 3u32)
+    sp3 = LavinMQ::SegmentPosition.new(0u32, 1u32, bytesize: 2u32)
+
+    q.push(sp1, nil)
+    q.push(sp2, nil)
+    q.push(sp3, nil)
+    q.bytesize.should eq 6
+
+    q.delete(sp1)
+    q.bytesize.should eq 5
+
+    q.delete(sp2)
+    q.bytesize.should eq 2
+
+    q.push(sp1, nil)
+    q.bytesize.should eq 3
+
+    q.push(sp2, nil)
+    q.bytesize.should eq 6
+
+    q.purge
+    q.bytesize.should eq 0
+  end
+
   it "should calculate message sizes" do
     q = LavinMQ::Queue::UnackQueue.new
     sps = [
@@ -15,7 +44,7 @@ describe LavinMQ::Queue::ReadyQueue do
     q.avg_bytesize.should eq 4u32
     q.max_bytesize(&.sp.bytesize).should eq 10u32
     q.min_bytesize(&.sp.bytesize).should eq 1u32
-    sps.each { |sp| q.purge }
+    q.purge
     q.bytesize.should eq 0u32
     q.avg_bytesize.should eq 0u32
     q.max_bytesize(&.sp.bytesize).should eq 0u32

--- a/spec/unacked_queue_spec.cr
+++ b/spec/unacked_queue_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+describe LavinMQ::Queue::ReadyQueue do
+  it "should calculate message sizes" do
+    q = LavinMQ::Queue::UnackQueue.new
+    sps = [
+      LavinMQ::SegmentPosition.new(10,10,5u32),
+      LavinMQ::SegmentPosition.new(10,10,1u32),
+      LavinMQ::SegmentPosition.new(10,10,10u32),
+      LavinMQ::SegmentPosition.new(10,10,3u32),
+      LavinMQ::SegmentPosition.new(10,10,1u32)
+    ]
+    sps.each { |sp| q.push(sp, nil) }
+    q.bytesize.should eq 20u32
+    q.avg_bytesize.should eq 4u32
+    q.max_bytesize(&.sp.bytesize).should eq 10u32
+    q.min_bytesize(&.sp.bytesize).should eq 1u32
+    sps.each { |sp| q.purge }
+    q.bytesize.should eq 0u32
+    q.avg_bytesize.should eq 0u32
+    q.max_bytesize(&.sp.bytesize).should eq 0u32
+    q.min_bytesize(&.sp.bytesize).should eq 0u32
+  end
+end

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -93,12 +93,12 @@ module LavinMQ
           end
         end
 
-        get "/api/queues/:vhost/:name/size-snapshot" do |context, params|
+        get "/api/queues/:vhost/:name/size-details" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
             consumer_count = context.request.query_params["consumer_list_length"]?.try &.to_i || -1
             JSON.build(context.response) do |builder|
-              queue(context, params, vhost).snapshot_to_json(builder, consumer_count)
+              queue(context, params, vhost).size_details_to_json(builder, consumer_count)
             end
           end
         end

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -93,6 +93,16 @@ module LavinMQ
           end
         end
 
+        get "/api/queues/:vhost/:name/size-snapshot" do |context, params|
+          with_vhost(context, params) do |vhost|
+            refuse_unless_management(context, user(context), vhost)
+            consumer_count = context.request.query_params["consumer_list_length"]?.try &.to_i || -1
+            JSON.build(context.response) do |builder|
+              queue(context, params, vhost).to_json2(builder, consumer_count)
+            end
+          end
+        end
+
         delete "/api/queues/:vhost/:name" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -98,7 +98,7 @@ module LavinMQ
             refuse_unless_management(context, user(context), vhost)
             consumer_count = context.request.query_params["consumer_list_length"]?.try &.to_i || -1
             JSON.build(context.response) do |builder|
-              queue(context, params, vhost).to_json2(builder, consumer_count)
+              queue(context, params, vhost).snapshot_to_json(builder, consumer_count)
             end
           end
         end

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -460,8 +460,8 @@ module LavinMQ
       })
     end
 
-    def snapshot_tuple
-      snapshot = {
+    def size_details_tuple
+      details = {
         messages:                @ready.size + @unacked.size,
         ready:                   @ready.size,
         ready_bytes:             @ready.bytesize,
@@ -476,10 +476,10 @@ module LavinMQ
         first_message_timestamp: 0,
         last_message_timestamp:  0,
       }
-      return snapshot if @ready.size.zero?
+      return details if @ready.size.zero?
       first_message = read(@ready.first?.not_nil!).message
       last_message = read(@ready.last?.not_nil!).message
-      snapshot.merge({
+      details.merge({
         first_message_timestamp: first_message.timestamp,
         last_message_timestamp:  last_message.timestamp,
       })
@@ -962,9 +962,9 @@ module LavinMQ
       end
     end
 
-    def snapshot_to_json(builder : JSON::Builder, limit : Int32 = -1)
+    def size_details_to_json(builder : JSON::Builder, limit : Int32 = -1)
       builder.object do
-        snapshot_tuple.each do |k, v|
+        size_details_tuple.each do |k, v|
           builder.field(k, v) unless v.nil?
         end
       end

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -460,7 +460,7 @@ module LavinMQ
       })
     end
 
-    def queue_size_snapshot
+    def snapshot_tuple
       snapshot = details_tuple()
       snapshot.merge({
         ready_max_bytes:    @ready.max_bytesize &.bytesize,
@@ -947,10 +947,9 @@ module LavinMQ
       end
     end
 
-    # Todo: Temporary, fix this!
-    def to_json2(builder : JSON::Builder, limit : Int32 = -1)
+    def snapshot_to_json(builder : JSON::Builder, limit : Int32 = -1)
       builder.object do
-        queue_size_snapshot.each do |k, v|
+        snapshot_tuple.each do |k, v|
           builder.field(k, v) unless v.nil?
         end
         builder.field("consumer_details") do

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -870,7 +870,7 @@ module LavinMQ
 
     def rm_consumer(consumer : Client::Channel::Consumer, basic_cancel = false)
       deleted = @consumers.delete_consumer consumer
-      consumer_unacked_size = @unacked.bytesize # { |u| u.consumer == consumer ? 1 : 0 }
+      consumer_unacked_size = @unacked.sum { |u| u.consumer == consumer ? 1 : 0 }
       unless basic_cancel
         requeue_many(@unacked.delete(consumer))
       end

--- a/src/lavinmq/queue/ready.cr
+++ b/src/lavinmq/queue/ready.cr
@@ -234,13 +234,13 @@ module LavinMQ
         @bytesize // @ready.size
       end
 
-      # expensive calculation used for ready queue snapshot
+      # expensive calculation used for ready queue details
       def max_bytesize(&blk : SegmentPosition -> _) : UInt32
         return 0u32 if @ready.size.zero?
         @ready.max_of(&blk)
       end
 
-      # expensive calculation used for ready queue snapshot
+      # expensive calculation used for ready queue details
       def min_bytesize(&blk : SegmentPosition -> _) : UInt32
         return 0u32 if @ready.size.zero?
         @ready.min_of(&blk)

--- a/src/lavinmq/queue/ready.cr
+++ b/src/lavinmq/queue/ready.cr
@@ -228,6 +228,23 @@ module LavinMQ
       def to_a
         @ready.to_a
       end
+
+      def avg_bytesize
+        return 0u64 if @ready.size.zero?
+        @bytesize // @ready.size
+      end
+
+      # expensive calculation used for ready queue snapshot
+      def max_bytesize(&blk : SegmentPosition -> _) : UInt32
+        return 0u32 if @ready.size.zero?
+        @ready.max_of(&blk)
+      end
+
+      # expensive calculation used for ready queue snapshot
+      def min_bytesize(&blk : SegmentPosition -> _) : UInt32
+        return 0u32 if @ready.size.zero?
+        @ready.min_of(&blk)
+      end
     end
 
     abstract class SortedReadyQueue < ReadyQueue

--- a/src/lavinmq/queue/unacked.cr
+++ b/src/lavinmq/queue/unacked.cr
@@ -66,6 +66,10 @@ module LavinMQ
         @unacked[index]?
       end
 
+      def sum(&blk : Unack -> _) : UInt64
+        @unacked.sum(0_u64, &blk)
+      end
+
       def avg_bytesize
         return 0u64 if @unacked.size.zero?
         @bytesize // @unacked.size

--- a/src/lavinmq/queue/unacked.cr
+++ b/src/lavinmq/queue/unacked.cr
@@ -75,13 +75,13 @@ module LavinMQ
         @bytesize // @unacked.size
       end
 
-      # expensive calculation used for unacked queue snapshot
+      # expensive calculation used for unacked queue details
       def max_bytesize(&blk : Unack -> _) : UInt32
         return 0u32 if @unacked.size.zero?
         @unacked.max_of(&blk)
       end
 
-      # expensive calculation used for unacked queue snapshot
+      # expensive calculation used for unacked queue details
       def min_bytesize(&blk : Unack -> _) : UInt32
         return 0u32 if @unacked.size.zero?
         @unacked.min_of(&blk)

--- a/src/lavinmq/queue/unacked.cr
+++ b/src/lavinmq/queue/unacked.cr
@@ -66,8 +66,21 @@ module LavinMQ
         @unacked[index]?
       end
 
-      def sum(&blk : Unack -> _) : UInt64
-        @unacked.sum(0_u64, &blk)
+      def avg_bytesize
+        return 0u64 if @unacked.size.zero?
+        @bytesize // @unacked.size
+      end
+
+      # expensive calculation used for unacked queue snapshot
+      def max_bytesize(&blk : Unack -> _) : UInt32
+        return 0u32 if @unacked.size.zero?
+        @unacked.max_of(&blk)
+      end
+
+      # expensive calculation used for unacked queue snapshot
+      def min_bytesize(&blk : Unack -> _) : UInt32
+        return 0u32 if @unacked.size.zero?
+        @unacked.min_of(&blk)
       end
 
       def capacity

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -272,6 +272,8 @@
       lavinmq.http.request('DELETE', url)
         .then(() => { lavinmq.dom.toast('Queue purged!') })
         .catch(lavinmq.http.standardErrorHandler)
+      document.getElementById('ms-date-time').textContent = "-"
+      document.getElementById('snapshotTable').setAttribute("hidden", null)
     }
   })
 
@@ -359,6 +361,7 @@
             document.getElementById('q-last-timestamp').textContent = " - "
           }
           document.getElementById('ms-date-time').textContent = lavinmq.helpers.formatTimestamp(new Date())
+          document.getElementById('snapshotTable').removeAttribute("hidden")
         })
         .catch(lavinmq.http.standardErrorHandler)
     }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -315,9 +315,29 @@
     const url = '/api/queues/' + urlEncodedVhost + '/' + urlEncodedQueue + '/size-snapshot'
     if (window.confirm('Are you sure? This will take a snapshot of queue message sizes.')) {
       lavinmq.http.request('GET', url)
-        .then(() => {
+        .then(item => {
           lavinmq.dom.toast('Queue size snapshot')
           handleQueueState('running')
+          document.getElementById('ms-q-unacked').textContent = item.unacked
+          document.getElementById('ms-q-unacked-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_bytes) + 'B'
+          document.getElementById('ms-q-unacked-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_avg_bytes) + 'B'
+          document.getElementById('ms-q-unacked-min-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_min_bytes) + 'B'
+          document.getElementById('ms-q-unacked-max-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_max_bytes) + 'B'
+          document.getElementById('ms-q-total').textContent = lavinmq.helpers.formatNumber(item.messages)
+          document.getElementById('ms-q-total-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_bytes + item.ready_bytes) + 'B'
+          document.getElementById('ms-q-ready').textContent = lavinmq.helpers.formatNumber(item.ready)
+          document.getElementById('ms-q-ready-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_bytes) + 'B'
+          document.getElementById('ms-q-ready-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_avg_bytes) + 'B'
+          document.getElementById('ms-q-ready-min-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_min_bytes) + 'B'
+          document.getElementById('ms-q-ready-max-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_max_bytes) + 'B'
+          if (item.first_message_timestamp !== undefined && item.first_message_timestamp !== 0) {
+            document.getElementById('ms-q-first-timestamp').textContent = lavinmq.helpers.formatTimestamp(item.first_message_timestamp)
+            document.getElementById('ms-q-last-timestamp').textContent = lavinmq.helpers.formatTimestamp(item.last_message_timestamp)
+          } else {
+            document.getElementById('q-first-timestamp').textContent = " - "
+            document.getElementById('q-last-timestamp').textContent = " - "
+          }
+          document.getElementById('ms-date-time').textContent = lavinmq.helpers.formatTimestamp(new Date())
         })
         .catch(lavinmq.http.standardErrorHandler)
     }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -76,7 +76,8 @@
         document.getElementById('q-unacked-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_avg_bytes) + 'B'
         document.getElementById('q-total').textContent = lavinmq.helpers.formatNumber(item.messages)
         document.getElementById('q-total-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_bytes + item.ready_bytes) + 'B'
-        document.getElementById('q-total-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_avg_bytes + item.ready_avg_bytes) + 'B'
+        const total_avg_bytes = item.messages != 0 ? (item.unacked_bytes + item.ready_bytes)/item.messages : 0
+        document.getElementById('q-total-avg-bytes').textContent = lavinmq.helpers.nFormatter(total_avg_bytes) + 'B'
         document.getElementById('q-ready').textContent = lavinmq.helpers.formatNumber(item.ready)
         document.getElementById('q-ready-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_bytes) + 'B'
         document.getElementById('q-ready-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_avg_bytes) + 'B'
@@ -325,6 +326,26 @@
           document.getElementById('ms-q-unacked-max-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_max_bytes) + 'B'
           document.getElementById('ms-q-total').textContent = lavinmq.helpers.formatNumber(item.messages)
           document.getElementById('ms-q-total-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_bytes + item.ready_bytes) + 'B'
+          const total_avg_bytes = item.messages != 0 ? (item.unacked_bytes + item.ready_bytes)/item.messages : 0
+          document.getElementById('ms-q-total-avg-bytes').textContent = lavinmq.helpers.nFormatter(total_avg_bytes) + 'B'
+          document.getElementById('ms-q-total-max-bytes').textContent = lavinmq.helpers.nFormatter(0) + 'B'
+          if (item.ready_max_bytes > item.unacked_max_bytes) {
+            document.getElementById('ms-q-total-max-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_max_bytes) + 'B'
+          } else if (item.unacked_max_bytes > item.ready_max_bytes) {
+            document.getElementById('ms-q-total-max-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_max_bytes) + 'B'
+          }
+          document.getElementById('ms-q-total-min-bytes').textContent = lavinmq.helpers.nFormatter(0) + 'B'
+          var total_min_bytes = 0
+          if (item.ready_min_bytes != 0 && item.unacked_min_bytes == 0) {
+            total_min_bytes = item.ready_min_bytes
+          } else if (item.unacked_min_bytes != 0 && item.ready_min_bytes == 0) {
+            total_min_bytes = item.unacked_min_bytes
+          } else if (item.ready_min_bytes < item.unacked_min_bytes) {
+            total_min_bytes = item.ready_min_bytes
+          } else if (item.unacked_min_bytes < item.ready_min_bytes) {
+            total_min_bytes = item.unacked_min_bytes
+          }
+          document.getElementById('ms-q-total-min-bytes').textContent = lavinmq.helpers.nFormatter(total_min_bytes) + 'B'
           document.getElementById('ms-q-ready').textContent = lavinmq.helpers.formatNumber(item.ready)
           document.getElementById('ms-q-ready-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_bytes) + 'B'
           document.getElementById('ms-q-ready-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_avg_bytes) + 'B'

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -315,7 +315,7 @@
 
   messageSnapshotForm.addEventListener('submit', function (evt) {
     evt.preventDefault()
-    const url = '/api/queues/' + urlEncodedVhost + '/' + urlEncodedQueue + '/size-snapshot'
+    const url = '/api/queues/' + urlEncodedVhost + '/' + urlEncodedQueue + '/size-details'
     if (window.confirm('Are you sure? This will take a snapshot of queue message sizes.')) {
       lavinmq.http.request('GET', url)
         .then(item => {

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -6,6 +6,7 @@
   const escapeHTML = lavinmq.dom.escapeHTML
   const pauseQueueForm = document.querySelector('#pauseQueue')
   const resumeQueueForm = document.querySelector('#resumeQueue')
+  const messageSnapshotForm = document.querySelector('#messageSnapshot')
   document.title = queue + ' | LavinMQ'
   let consumerListLength = 20
   const consumersTable = lavinmq.table.renderTable('table', { keyColumns: [] }, function (tr, item) {
@@ -72,10 +73,13 @@
         handleQueueState(item.state)
         document.getElementById('q-unacked').textContent = item.unacked
         document.getElementById('q-unacked-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_bytes) + 'B'
+        document.getElementById('q-unacked-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_avg_bytes) + 'B'
         document.getElementById('q-total').textContent = lavinmq.helpers.formatNumber(item.messages)
         document.getElementById('q-total-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_bytes + item.ready_bytes) + 'B'
+        document.getElementById('q-total-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.unacked_avg_bytes + item.ready_avg_bytes) + 'B'
         document.getElementById('q-ready').textContent = lavinmq.helpers.formatNumber(item.ready)
         document.getElementById('q-ready-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_bytes) + 'B'
+        document.getElementById('q-ready-avg-bytes').textContent = lavinmq.helpers.nFormatter(item.ready_avg_bytes) + 'B'
         document.getElementById('q-consumers').textContent = lavinmq.helpers.formatNumber(item.consumers)
         if (item.first_message_timestamp !== undefined && item.first_message_timestamp !== 0) {
           document.getElementById('q-first-timestamp').textContent = lavinmq.helpers.formatTimestamp(item.first_message_timestamp)
@@ -300,6 +304,19 @@
       lavinmq.http.request('PUT', url)
         .then(() => {
           lavinmq.dom.toast('Queue resumed!')
+          handleQueueState('running')
+        })
+        .catch(lavinmq.http.standardErrorHandler)
+    }
+  })
+
+  messageSnapshotForm.addEventListener('submit', function (evt) {
+    evt.preventDefault()
+    const url = '/api/queues/' + urlEncodedVhost + '/' + urlEncodedQueue + '/size-snapshot'
+    if (window.confirm('Are you sure? This will take a snapshot of queue message sizes.')) {
+      lavinmq.http.request('GET', url)
+        .then(() => {
+          lavinmq.dom.toast('Queue size snapshot')
           handleQueueState('running')
         })
         .catch(lavinmq.http.standardErrorHandler)

--- a/static/queue.html
+++ b/static/queue.html
@@ -300,8 +300,8 @@
             <td id="ms-q-total">-</td>
             <td id="ms-q-total-bytes">-</td>
             <td id="ms-q-total-avg-bytes">-</td>
-            <td> - </td>
-            <td> - </td>
+            <td id="ms-q-total-max-bytes"> - </td>
+            <td id="ms-q-total-min-bytes"> - </td>
           </tr>
           <tr>
             <th>Ready</th>

--- a/static/queue.html
+++ b/static/queue.html
@@ -288,7 +288,7 @@
           </label>
         </form>
         <p>Snapshot taken at: <span id="ms-date-time"></span></p>
-        <table class="details-table cols-6">
+        <table class="details-table cols-6" id="snapshotTable" hidden>
           <tr>
             <th></th>
             <th>Count</th>

--- a/static/queue.html
+++ b/static/queue.html
@@ -53,31 +53,37 @@
             <th></th>
             <th>Count</th>
             <th>Bytesize</th>
+            <th>Average</th>
           </tr>
           <tr>
             <th>Total</th>
             <td id="q-total"></td>
             <td id="q-total-bytes"></td>
+            <td id="q-total-avg-bytes"></td>
           </tr>
           <tr>
             <th>Ready</th>
             <td id="q-ready"></td>
             <td id="q-ready-bytes"></td>
+            <td id="q-ready-avg-bytes"></td>
           </tr>
           <tr>
             <th>Unacked</th>
             <td id="q-unacked"></td>
             <td id="q-unacked-bytes"></td>
+            <td id="q-unacked-avg-bytes"></td>
           </tr>
           <tr>
             <th>Timestamps</th>
             <th>First</th>
             <th>Last</th>
+            <th></th>
           </tr>
           <tr>
             <td></td>
             <td id="q-first-timestamp"> - </td>
             <td id="q-last-timestamp"> - </td>
+            <td></td>
           </tr>
         </table>
       </section>
@@ -273,6 +279,14 @@
         <form method="delete" id="deleteQueue" class="form">
           <label>
             <button type="submit" class="btn-danger">Delete queue</button>
+          </label>
+        </form>
+      </section>
+      <section class="card cols-3">
+        <h3>Message snapshot</h3>
+        <form method="get" id="messageSnapshot" class="form">
+          <label>
+            <button type="submit" class="btn-warn">Msg snapshot</button>
           </label>
         </form>
       </section>

--- a/static/queue.html
+++ b/static/queue.html
@@ -287,7 +287,7 @@
             <button type="submit" class="btn-warn">Size Snapshot</button>
           </label>
         </form>
-        <p>Snapshot taken at: <span id="ms-date-time"></span></p>
+        <p>Snapshot taken at: <span id="ms-date-time">-</span></p>
         <table class="details-table cols-6" id="snapshotTable" hidden>
           <tr>
             <th></th>

--- a/static/queue.html
+++ b/static/queue.html
@@ -74,16 +74,12 @@
             <td id="q-unacked-avg-bytes"></td>
           </tr>
           <tr>
-            <th>Timestamps</th>
-            <th>First</th>
-            <th>Last</th>
-            <th></th>
+            <th colspan="2">First timestamp</th>
+            <th colspan="2">Last timestamp</th>
           </tr>
           <tr>
-            <td></td>
-            <td id="q-first-timestamp"> - </td>
-            <td id="q-last-timestamp"> - </td>
-            <td></td>
+            <td id="q-first-timestamp" colspan="2"> - </td>
+            <td id="q-last-timestamp" colspan="2"> - </td>
           </tr>
         </table>
       </section>

--- a/static/queue.html
+++ b/static/queue.html
@@ -278,13 +278,56 @@
           </label>
         </form>
       </section>
-      <section class="card cols-3">
-        <h3>Message snapshot</h3>
+      <section class="card cols-6">
+        <h3>Message size snapshot</h3>
         <form method="get" id="messageSnapshot" class="form">
           <label>
-            <button type="submit" class="btn-warn">Msg snapshot</button>
+            <button type="submit" class="btn-warn">Size Snapshot</button>
           </label>
         </form>
+        <p>Snapshot taken at: <span id="ms-date-time"></span></p>
+        <table class="details-table cols-6">
+          <tr>
+            <th></th>
+            <th>Count</th>
+            <th>Bytesize</th>
+            <th>Average</th>
+            <th>Max</th>
+            <th>Min</th>
+          </tr>
+          <tr>
+            <th>Total</th>
+            <td id="ms-q-total">-</td>
+            <td id="ms-q-total-bytes">-</td>
+            <td id="ms-q-total-avg-bytes">-</td>
+            <td> - </td>
+            <td> - </td>
+          </tr>
+          <tr>
+            <th>Ready</th>
+            <td id="ms-q-ready">-</td>
+            <td id="ms-q-ready-bytes">-</td>
+            <td id="ms-q-ready-avg-bytes">-</td>
+            <td id="ms-q-ready-max-bytes">-</td>
+            <td id="ms-q-ready-min-bytes">-</td>
+          </tr>
+          <tr>
+            <th>Unacked</th>
+            <td id="ms-q-unacked">-</td>
+            <td id="ms-q-unacked-bytes">-</td>
+            <td id="ms-q-unacked-avg-bytes">-</td>
+            <td id="ms-q-unacked-max-bytes">-</td>
+            <td id="ms-q-unacked-min-bytes">-</td>
+          </tr>
+          <tr>
+            <th colspan="2">First timestamp</th>
+            <td id="ms-q-first-timestamp" colspan="4">-</td>
+          </tr>
+          <tr>
+            <th colspan="2">Last timestamp</th>
+            <td id="ms-q-last-timestamp" colspan="4">-</td>
+          </tr>
+        </table>
       </section>
     </main>
     <footer></footer>

--- a/static/queue.html
+++ b/static/queue.html
@@ -268,7 +268,9 @@
           <span>Number of messages</span>
           <input type="number" name="count" min="1" placeholder="All">
         </label>
-        <button type="submit" class="btn-danger">Purge queue</button>
+        <label>
+          <button type="submit" class="btn-danger">Purge queue</button>
+        </label>
       </form>
       <section class="card cols-3">
         <h3>Delete queue</h3>


### PR DESCRIPTION
Expand messages size rates in queue view, with average sizes. Introduce message size snapshot, with manual trigger expensive calculation of max/min over ready and unacked queues. Only display this data upon user/debug action.

- Adds counter for unacked bytesize, same as [#317](https://github.com/cloudamqp/lavinmq/pull/317)
- Adds average calculation on queue (ready, unacked, total). "queue.counter / queue.size"
- Updates "Messages" card in queue view.
- Adds max/min calculation on queue (ready, unacked, total)
   - Separated endpoint and only calculated when invoked.
- Displayed snapshot in separated card in queue view.

Messags card:
![Screenshot 2022-06-07 at 14 52 25](https://user-images.githubusercontent.com/47317658/172563248-197e4ca2-0a03-4ee8-8f92-99e0caebc2d5.png)

Message size snapshot:
![Screenshot 2022-06-08 at 09 58 54](https://user-images.githubusercontent.com/47317658/172563792-3a0cca97-68fa-4c32-90a8-175336e562e6.png)


