### PR TITLE
Bugfix: Ensure receive_or_expire returns bool

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -706,10 +706,10 @@ describe LavinMQ::Server do
   it "does not expire queue when consumer are still there" do
     with_channel do |ch|
       args = AMQP::Client::Arguments.new
-      args["x-expires"] = 5
+      args["x-expires"] = 50
       q = ch.queue("test", args: args)
       q.subscribe(no_ack: true) { |_| }
-      sleep 5.milliseconds
+      sleep 50.milliseconds
       Fiber.yield
       s.vhosts["/"].queues.has_key?("test").should be_true
     end

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -706,7 +706,7 @@ describe LavinMQ::Server do
   it "does not expire queue when consumer are still there" do
     with_channel do |ch|
       args = AMQP::Client::Arguments.new
-      args["x-expires"] = 1
+      args["x-expires"] = 5
       q = ch.queue("test", args: args)
       q.subscribe(no_ack: true) { |_| }
       sleep 5.milliseconds

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -316,12 +316,12 @@ module LavinMQ
       end
     end
 
-    private def receive_or_expire
+    private def receive_or_expire : Bool
       @log.debug { "Waiting for msgs" }
       unless @consumers.empty?
         select
         when @message_available.receive
-          return
+          return true
         when @consumers_empty.receive
           @log.debug { "Consumers empty" }
         end
@@ -339,7 +339,7 @@ module LavinMQ
       true
     end
 
-    private def consumer_or_expire
+    private def consumer_or_expire : Bool
       @log.debug { "No consumer available" }
       q_ttl = time_to_expiration
       m_ttl = time_to_message_expiration


### PR DESCRIPTION
This caused the deliver_loop to stop, introduced in 09c426ad7cb240d9342b6b61b54a277e49bf8451, never released

Set return type to avoid similar issues.