### PR TITLE
Revert `SC_PAGESIZE` monkey-patch

### DIFF
--- a/src/stdlib/libc.cr
+++ b/src/stdlib/libc.cr
@@ -8,11 +8,6 @@ lib LibC
 
   {% if flag?(:darwin) %}
     SC_PHYS_PAGES = 200
-    {% if flag?(:aarch64) %}
-    # Monkey-patch
-    # Remove once https://github.com/crystal-lang/crystal/pull/12037/files is released
-    SC_PAGESIZE = 29
-    {% end %}
   {% elsif flag?(:freebsd) || flag?(:dragonfly) || flag?(:netbsd) %}
     SC_PHYS_PAGES = 121
   {% elsif flag?(:openbsd) %}


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/pull/12037 has been released with Crystal 1.5.0.

Reverts 75a98093936cbcf4eae80fb6cd68f7954a7dad35, ab259698315cde29d94cd0454b2c293c3c5ccc75