### PR TITLE
Sort Queues by rates

### DIFF
--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -97,7 +97,6 @@
       policyLink.href = '/policies?name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
       policyLink.textContent = item.policy
     }
-    console.log(item.message_stats)
     lavinmq.table.renderCell(tr, 4, policyLink, 'center')
     lavinmq.table.renderCell(tr, 5, item.consumers, 'right')
     lavinmq.table.renderCell(tr, 6, null, 'center ' + 'state-' + item.state)

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -106,8 +106,8 @@
     lavinmq.table.renderCell(tr, 9, lavinmq.helpers.formatNumber(item.messages), 'right')
     lavinmq.table.renderCell(tr, 10, lavinmq.helpers.formatNumber(item.message_stats.publish_details.rate), 'right')
     lavinmq.table.renderCell(tr, 11, lavinmq.helpers.formatNumber(item.message_stats.deliver_details.rate), 'right')
-    // lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.redeliver_details.rate), 'right')
-    lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
+    lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.redeliver_details.rate), 'right')
+    lavinmq.table.renderCell(tr, 13, lavinmq.helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
   })
 
   document.querySelector('#declare').addEventListener('submit', function (evt) {

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -106,8 +106,8 @@
     lavinmq.table.renderCell(tr, 9, lavinmq.helpers.formatNumber(item.messages), 'right')
     lavinmq.table.renderCell(tr, 10, lavinmq.helpers.formatNumber(item.message_stats.publish_details.rate), 'right')
     lavinmq.table.renderCell(tr, 11, lavinmq.helpers.formatNumber(item.message_stats.deliver_details.rate), 'right')
-    lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.redeliver_details.rate), 'right')
-    lavinmq.table.renderCell(tr, 13, lavinmq.helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
+    // lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.redeliver_details.rate), 'right')
+    lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
   })
 
   document.querySelector('#declare').addEventListener('submit', function (evt) {

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -97,6 +97,7 @@
       policyLink.href = '/policies?name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
       policyLink.textContent = item.policy
     }
+    console.log(item.message_stats)
     lavinmq.table.renderCell(tr, 4, policyLink, 'center')
     lavinmq.table.renderCell(tr, 5, item.consumers, 'right')
     lavinmq.table.renderCell(tr, 6, null, 'center ' + 'state-' + item.state)
@@ -105,7 +106,8 @@
     lavinmq.table.renderCell(tr, 9, lavinmq.helpers.formatNumber(item.messages), 'right')
     lavinmq.table.renderCell(tr, 10, lavinmq.helpers.formatNumber(item.message_stats.publish_details.rate), 'right')
     lavinmq.table.renderCell(tr, 11, lavinmq.helpers.formatNumber(item.message_stats.deliver_details.rate), 'right')
-    lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
+    lavinmq.table.renderCell(tr, 12, lavinmq.helpers.formatNumber(item.message_stats.redeliver_details.rate), 'right')
+    lavinmq.table.renderCell(tr, 13, lavinmq.helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
   })
 
   document.querySelector('#declare').addEventListener('submit', function (evt) {

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -117,7 +117,7 @@
       if (searchTerm) {
         q += `&name=${searchTerm}&use_regex=true`
       }
-      if (sortKey !== '') {
+      if (sortKey > "") {
         q += `&sort=${sortKey}&sort_reverse=${reverseOrder}`
       }
       return q

--- a/static/queues.html
+++ b/static/queues.html
@@ -48,6 +48,7 @@
                 <th data-sort-key="messages">Total</th>
                 <th data-sort-key="publish">Publish rate</th>
                 <th data-sort-key="deliver">Deliver rate</th>
+                <th data-sort-key="redeliver">Redeliver rate</th>
                 <th data-sort-key="ack">Ack rate</th>
               </tr>
             </thead>

--- a/static/queues.html
+++ b/static/queues.html
@@ -46,10 +46,10 @@
                 <th data-sort-key="ready">Ready</th>
                 <th data-sort-key="unacked">Unacked</th>
                 <th data-sort-key="messages">Total</th>
-                <th data-sort-key="publish">Publish rate</th>
-                <th data-sort-key="deliver">Deliver rate</th>
-                <th data-sort-key="redeliver">Redeliver rate</th>
-                <th data-sort-key="ack">Ack rate</th>
+                <th data-sort-key='publish_details.message_stats'>Publish rate</th>
+                <th data-sort-key="deliver_details.message_stats">Deliver rate</th>
+                <th data-sort-key="redeliver_details.message_stats">Redeliver rate</th>
+                <th data-sort-key="ack_details.message_stats">Ack rate</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/static/queues.html
+++ b/static/queues.html
@@ -48,7 +48,7 @@
                 <th data-sort-key="messages">Total</th>
                 <th data-sort-key="publish">Publish rate</th>
                 <th data-sort-key="deliver">Deliver rate</th>
-                <th data-sort-key="redeliver">Redeliver rate</th>
+                <!-- <th data-sort-key="redeliver">Redeliver rate</th> -->
                 <th data-sort-key="ack">Ack rate</th>
               </tr>
             </thead>

--- a/static/queues.html
+++ b/static/queues.html
@@ -46,10 +46,10 @@
                 <th data-sort-key="ready">Ready</th>
                 <th data-sort-key="unacked">Unacked</th>
                 <th data-sort-key="messages">Total</th>
-                <th data-sort-key='publish_details.message_stats'>Publish rate</th>
-                <th data-sort-key="deliver_details.message_stats">Deliver rate</th>
-                <th data-sort-key="redeliver_details.message_stats">Redeliver rate</th>
-                <th data-sort-key="ack_details.message_stats">Ack rate</th>
+                <th data-sort-key="message_stats.publish_details.rate">Publish rate</th>
+                <th data-sort-key="message_stats.deliver_details.rate">Deliver rate</th>
+                <th data-sort-key="message_stats.redeliver_details.rate">Redeliver rate</th>
+                <th data-sort-key="message_stats.ack_details.rate">Ack rate</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/static/queues.html
+++ b/static/queues.html
@@ -48,7 +48,7 @@
                 <th data-sort-key="messages">Total</th>
                 <th data-sort-key="publish">Publish rate</th>
                 <th data-sort-key="deliver">Deliver rate</th>
-                <!-- <th data-sort-key="redeliver">Redeliver rate</th> -->
+                <th data-sort-key="redeliver">Redeliver rate</th>
                 <th data-sort-key="ack">Ack rate</th>
               </tr>
             </thead>

--- a/static/queues.html
+++ b/static/queues.html
@@ -46,9 +46,9 @@
                 <th data-sort-key="ready">Ready</th>
                 <th data-sort-key="unacked">Unacked</th>
                 <th data-sort-key="messages">Total</th>
-                <th>Publish rate</th>
-                <th>Deliver rate</th>
-                <th>Ack rate</th>
+                <th data-sort-key="publish">Publish rate</th>
+                <th data-sort-key="deliver">Deliver rate</th>
+                <th data-sort-key="ack">Ack rate</th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
This update allows users to sort queues by message rates. 
It also adds Redelivery rate to the queues table, and lets users sort by redelivery rate as well. 

#342 
![sort_by_rates](https://user-images.githubusercontent.com/85930202/180210473-bded3997-59ac-4b4f-bf5d-28a9aeddc209.png)
