### PR TITLE
Show total ready and unacked messages

### DIFF
--- a/spec/api/node_spec.cr
+++ b/spec/api/node_spec.cr
@@ -9,7 +9,7 @@ describe LavinMQ::HTTP::NodesController do
       body = JSON.parse(response.body)
       body.as_a.empty?.should be_false
       data = body.as_a.first.as_h
-      keys = ["connection_created", "connection_closed"]
+      keys = ["connection_created", "connection_closed", "messages_ready", "messages_unacknowledged"]
       keys.each do |key|
         data.has_key?(key).should be_true
       end

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -11,28 +11,20 @@
   let updateTimer = null
 
   function update (cb) {
-    const statsPromise = lavinmq.http.request('GET', url)
-    Promise.all([
-      statsPromise
-    ]).then(function (responses) {
-      const statsData = responses[0]
-      render(statsData)
+    lavinmq.http.request('GET', url).then(function (response) {
+      render(response)
       if (cb) {
-        cb(statsData)
+        cb(response)
       }
     }).catch(lavinmq.http.standardErrorHandler).catch(stop)
   }
 
-  function render (data, queueData) {
+  function render (data) {
     document.querySelector('#version').innerText = data[0].applications[0].version
 
     for (const node of data) {
       updateDetails(node)
-      if (queueData instanceof Object) {
-        updateStats({ ...node, ...queueData })
-      } else {
-        updateStats(node)
-      }
+      updateStats(node)
     }
   }
 
@@ -46,22 +38,6 @@
     if (updateTimer) {
       clearInterval(updateTimer)
     }
-  }
-
-  function get (key) {
-    return new Promise(function (resolve, reject) {
-      try {
-        if (data) {
-          resolve(data[key])
-        } else {
-          update(data => {
-            resolve(data[key])
-          })
-        }
-      } catch (e) {
-        reject(e.message)
-      }
-    })
   }
 
   const updateDetails = (nodeStats) => {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -21,7 +21,6 @@
 
   function render (data) {
     document.querySelector('#version').innerText = data[0].applications[0].version
-
     for (const node of data) {
       updateDetails(node)
       updateStats(node)

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -12,19 +12,11 @@
 
   function update (cb) {
     const statsPromise = lavinmq.http.request('GET', url)
-    const queueStatsPromise = lavinmq.http.request('GET', '/api/queues')
     Promise.all([
-      statsPromise,
-      queueStatsPromise
+      statsPromise
     ]).then(function (responses) {
       const statsData = responses[0]
-      const queueData = responses[1]
-      const msgSums = (queueData ?? [])?.reduce((agg, queue) => {
-        agg.msg_ready += queue.ready
-        agg.msg_unacked += queue.unacked
-        return agg
-      }, { msg_ready: 0, msg_unacked: 0 })
-      render(statsData, msgSums)
+      render(statsData)
       if (cb) {
         cb(statsData)
       }
@@ -163,11 +155,11 @@
       content: [
         {
           heading: 'Ready',
-          key: 'msg_ready'
+          key: 'messages_ready'
         },
         {
           heading: 'Unacked',
-          key: 'msg_unacked'
+          key: 'messages_unacknowledged'
         }
       ]
     }

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -11,7 +11,7 @@
   let updateTimer = null
 
   function update (cb) {
-    lavinmq.http.request('GET', url).then(function (response) {
+    lavinmq.http.request('GET', url).then((response) => {
       render(response)
       if (cb) {
         cb(response)


### PR DESCRIPTION
Adds total number of ready and unacked messages for all queues to **stats** on **nodes page**

<img width="588" alt="image" src="https://user-images.githubusercontent.com/85930202/180849791-1a759f80-131c-4cda-8263-14fdb84c56f0.png">

