### PR TITLE
Allow shared user to download its vhost definition.

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -424,23 +424,6 @@ describe LavinMQ::HTTP::Server do
         s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
         s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
       end
-
-      it "should refuse user tag access" do
-        s.users.delete("guest")
-        s.users.create("other_name", "guest", [LavinMQ::Tag::Http], save: false) # Will be the new default_user
-        s.vhosts.create("new")
-        s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)
-        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
-        response = get("/api/definitions/new", headers: headers)
-        response.status_code.should eq 401
-        body = JSON.parse(response.body)
-        body["reason"].should eq "Access refused"
-      ensure
-        s.users.delete("other_name", save: false)
-        s.vhosts.delete("new")
-        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
-        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
-      end
     end
   end
 

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -433,10 +433,9 @@ describe LavinMQ::HTTP::Server do
         s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)
         headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
         response = get("/api/definitions/new", headers: headers)
-        # Should Http have more access than management?
-        # response.status_code.should eq 401
-        # body = JSON.parse(response.body)
-        # body["reason"].should eq "Access refused"
+        response.status_code.should eq 401
+        body = JSON.parse(response.body)
+        body["reason"].should eq "Access refused"
       ensure
         s.users.delete("other_name", save: false)
         s.vhosts.delete("new")

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -392,6 +392,58 @@ describe LavinMQ::HTTP::Server do
     ensure
       s.vhosts["/"].delete_policy("export_p2")
     end
+
+    describe "user tags and vhost access" do
+      it "export vhost definitions as management user" do
+        s.users.delete("guest")
+        s.users.create("other_name", "guest", [LavinMQ::Tag::Management], save: false) # Will be the new default_user
+        s.vhosts.create("new")
+        s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)
+        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
+        response = get("/api/definitions/new", headers: headers)
+        response.status_code.should eq 200
+      ensure
+        s.users.delete("other_name", save: false)
+        s.vhosts.delete("new")
+        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
+        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
+      end
+
+      it "should refuse vhost access" do
+        s.users.delete("guest")
+        s.users.create("other_name", "guest", [LavinMQ::Tag::Management], save: false) # Will be the new default_user
+        s.vhosts.create("new")
+        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
+        response = get("/api/definitions/new", headers: headers)
+        response.status_code.should eq 401
+        body = JSON.parse(response.body)
+        body["reason"].should eq "Access refused"
+      ensure
+        s.users.delete("other_name", save: false)
+        s.vhosts.delete("new")
+        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
+        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
+      end
+
+      it "should refuse user tag access" do
+        s.users.delete("guest")
+        # Http tag override refuse_unless_management
+        s.users.create("other_name", "guest", [LavinMQ::Tag::Http], save: false) # Will be the new default_user
+        s.vhosts.create("new")
+        s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)
+        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
+        response = get("/api/definitions/new", headers: headers)
+        # Should Http have more access than management?
+        # response.status_code.should eq 401
+        # body = JSON.parse(response.body)
+        # body["reason"].should eq "Access refused"
+      ensure
+        s.users.delete("other_name", save: false)
+        s.vhosts.delete("new")
+        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
+        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
+      end
+    end
   end
 
   describe "POST /api/definitions/vhost" do
@@ -487,6 +539,61 @@ describe LavinMQ::HTTP::Server do
       response.status_code.should eq 400
       body = JSON.parse(response.body)
       body["reason"].as_s.should eq("Malformed JSON.")
+    end
+
+    describe "user tags and vhost access" do
+      it "import vhost definitions as policymaker user" do
+        s.users.delete("guest")
+        s.users.create("other_name", "guest", [LavinMQ::Tag::PolicyMaker], save: false) # Will be the new default_user
+        s.vhosts.create("new")
+        s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)
+        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
+        body = %({ "queues": [{ "name": "import_q1", "vhost": "new", "durable": true, "auto_delete": false, "arguments": {} }] })
+        response = post("/api/definitions/new", headers: headers, body: body)
+        response.status_code.should eq 200
+        s.vhosts["new"].queues.has_key?("import_q1").should be_true
+      ensure
+        s.vhosts["new"].delete_queue("import_q1")
+        s.users.delete("other_name", save: false)
+        s.vhosts.delete("new")
+        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
+        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
+      end
+
+      it "should refuse vhost access" do
+        s.users.delete("guest")
+        s.users.create("other_name", "guest", [LavinMQ::Tag::Management], save: false) # Will be the new default_user
+        s.vhosts.create("new")
+        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
+        body = %({ "queues": [{ "name": "import_q1", "vhost": "new", "durable": true, "auto_delete": false, "arguments": {} }] })
+        response = post("/api/definitions/new", headers: headers, body: body)
+        response.status_code.should eq 401
+        body = JSON.parse(response.body)
+        body["reason"].should eq "Access refused"
+      ensure
+        s.users.delete("other_name", save: false)
+        s.vhosts.delete("new")
+        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
+        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
+      end
+
+      it "should refuse user tag access" do
+        s.users.delete("guest")
+        s.users.create("other_name", "guest", [LavinMQ::Tag::Management], save: false) # Will be the new default_user
+        s.vhosts.create("new")
+        s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)
+        headers = HTTP::Headers{"Authorization" => "Basic b3RoZXJfbmFtZTpndWVzdA=="}
+        body = %({ "queues": [{ "name": "import_q1", "vhost": "new", "durable": true, "auto_delete": false, "arguments": {} }] })
+        response = post("/api/definitions/new", headers: headers, body: body)
+        response.status_code.should eq 401
+        body = JSON.parse(response.body)
+        body["reason"].should eq "Access refused"
+      ensure
+        s.users.delete("other_name", save: false)
+        s.vhosts.delete("new")
+        s.users.create("guest", "guest", [LavinMQ::Tag::Administrator])
+        s.vhosts.each_key { |name| s.users.add_permission("guest", name, /.*/, /.*/, /.*/) }
+      end
     end
   end
 

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -427,7 +427,6 @@ describe LavinMQ::HTTP::Server do
 
       it "should refuse user tag access" do
         s.users.delete("guest")
-        # Http tag override refuse_unless_management
         s.users.create("other_name", "guest", [LavinMQ::Tag::Http], save: false) # Will be the new default_user
         s.vhosts.create("new")
         s.users.add_permission("other_name", "new", /.*/, /.*/, /.*/)

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -198,7 +198,7 @@ module LavinMQ
       end
 
       private def refuse_unless_management(context, user, vhost = nil)
-        if user.tags.empty?
+        unless user.tags.any? { |t| t.management? || t.administrator? || t.policy_maker? }
           @log.warn { "user=#{user.name} does not have management access on vhost=#{vhost}" }
           access_refused(context)
         end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -198,7 +198,7 @@ module LavinMQ
       end
 
       private def refuse_unless_management(context, user, vhost = nil)
-        unless user.tags.any? { |t| t.management? || t.administrator? || t.policy_maker? }
+        unless user.tags.any? { |t| t.management? || t.administrator? || t.policy_maker? || t.monitoring? }
           @log.warn { "user=#{user.name} does not have management access on vhost=#{vhost}" }
           access_refused(context)
         end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -190,6 +190,13 @@ module LavinMQ
         end
       end
 
+      private def refuse_unless_vhost_access(context, user, vhost)
+        unless user.permissions.has_key?(vhost)
+          @log.warn { "user=#{user.name} does not have permissions to access vhost=#{vhost}" }
+          access_refused(context)
+        end
+      end
+
       private def refuse_unless_management(context, user, vhost = nil)
         if user.tags.empty?
           @log.warn { "user=#{user.name} does not have management access on vhost=#{vhost}" }

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -35,7 +35,7 @@ module LavinMQ
 
         get "/api/definitions/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
-            refuse_unless_policymaker(context, user(context), vhost)
+            refuse_unless_management(context, user(context), vhost)
             refuse_unless_vhost_access(context, user(context), vhost)
             export_vhost_definitions(vhost, context.response)
           end

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -34,8 +34,9 @@ module LavinMQ
         end
 
         get "/api/definitions/:vhost" do |context, params|
-          refuse_unless_administrator(context, user(context))
           with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
+            refuse_unless_vhost_access(context, user(context), vhost)
             export_vhost_definitions(vhost, context.response)
           end
         end

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -42,9 +42,10 @@ module LavinMQ
         end
 
         post "/api/definitions/:vhost" do |context, params|
-          refuse_unless_administrator(context, user(context))
-          body = parse_body(context)
           with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
+            refuse_unless_vhost_access(context, user(context), vhost)
+            body = parse_body(context)
             import_vhost_definitions(vhost, body)
           end
         end


### PR DESCRIPTION
Allow user with policymaker permission be able to download vhost definition. As long as the user also have access to that vhost.