### PR TITLE
WIP: spec to test index corruption at startup after crash

### DIFF
--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -105,34 +105,27 @@ describe LavinMQ::DurableQueue do
     queue.@ready.size.should eq msg_count
   end
 
-  # TODO: we know this works as expected although logs dont show
-  # next step is to shut down hard in order to try and trigger faulty index recovery
-  it "it should not insert zeros to enq/ack files" do
+  # Index corruption bug
+  # https://github.com/cloudamqp/lavinmq/pull/384
+  it "must find messages written after a uncompacted hole" do
+    enq_path = ""
     with_channel do |ch|
       q = ch.queue("corruption_test", durable: true)
       q.publish_confirm "Hello world"
-      # enq_path = queue.@enq.path
-    end
-    queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
-    queue.@ready.size.should eq 1
-    # close_servers
-    # emulate the file was preallocated after server crash
-    # File.open(enq_path, "r+") { |f| f.truncate(f.size + 24 * 1024**2) }
-    # TestHelpers.setup
-    puts "GETS HERE 1"
-    sleep 2
-    with_channel do |ch|
-      puts "GETS HERE 2"
-      q = ch.queue("corruption_test", durable: true)
-      pp q
-      puts "publishing"
-      q.publish_confirm "Hello world"
-      puts "published"
       queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
-      # enq_path = queue.@enq.path
+      enq_path = queue.@enq.path
     end
-    sleep 2
-    puts "GETS HERE 3"
+    close_servers
+    # Emulate the file was preallocated after server crash
+    File.open(enq_path, "r+") { |f| f.truncate(f.size + 24 * 1024**2) }
+    TestHelpers.setup
+    # Write another message after the prealloced space
+    with_channel do |ch|
+      q = ch.queue("corruption_test", durable: true)
+      q.publish_confirm "Hello world"
+    end
+    close_servers
+    TestHelpers.setup
     queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
     queue.@ready.size.should eq 2
   end


### PR DESCRIPTION
Begining of spec to recreate and test the index corruption bug. 

https://84codes.slack.com/archives/CKPHUKCF6/p1666302566839169
"the message loss happens at the second start after a crash, not at shutdown
a crash needs to happen so that the index files was preallocated, then we used lseek SEEK_HOLE to find the end, but that wasn't the true end, it was rounded up 4096 bytes, filling the rest will null bytes, and then we started to append after that "hole". that meant that at the second start, when restoring the index, we stopped reading when we encountured the first null bytes, and didn't read the ack/enqs that been written during the session after the crash. so those messages were lost, or at least as soon as a GC of segments ran (every 60s)."