### PR TITLE
Number of persistent messages in queue response

### DIFF
--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -439,6 +439,7 @@ module LavinMQ
         consumers:                   @consumers.size,
         vhost:                       @vhost.name,
         messages:                    @ready.size + @unacked.size,
+        messages_persistent:         @durable ? @ready.size + @unacked.size : 0,
         ready:                       @ready.size,
         ready_bytes:                 @ready.bytesize,
         ready_avg_bytes:             @ready.avg_bytesize,


### PR DESCRIPTION
Expand the `api/queues` response with number of persistent messages for durable queues. 

Enough to just add all messages in a durable queue regardless of delivery mode?

Next release, revert hidden diagnostic check.
https://github.com/84codes/cloudamqp-api/commit/698a2f418c822cdb22ade1e3eb18dfd5933833d7