### PR TITLE
Clear the response buffer before writing error

### DIFF
--- a/src/lavinmq/http/handler/error_handler.cr
+++ b/src/lavinmq/http/handler/error_handler.cr
@@ -9,7 +9,12 @@ module LavinMQ
       end
 
       def call(context)
-        call_next(context)
+        begin
+          call_next(context)
+        rescue e
+          context.response.flush
+          raise e
+        end
       rescue ex : Server::UnknownContentType
         context.response.content_type = "text/plain"
         context.response.status_code = 415


### PR DESCRIPTION
So errors while writing paginated responses don't get wrapped like 
```
{"items":[{"error":"internal_server_error","reason":"Internal Server Error"}
```