### PR TITLE
BasicRecover w/ requeue should return all unacked messages to the queues

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -761,14 +761,16 @@ describe LavinMQ::Server do
 
   it "supports recover requeue" do
     with_channel do |ch|
-      q = ch.queue
-      q.publish "m1"
+      q = ch.queue("recover", exclusive: true)
+      5.times { q.publish "" }
       delivered = 0
-      q.subscribe(no_ack: false) { |_m| delivered += 1 }
+      tag = q.subscribe(no_ack: false) { |_m| delivered += 1 }
+      sleep 0.05
+      q.unsubscribe(tag)
       sleep 0.05
       ch.basic_recover(requeue: true)
       sleep 0.05
-      delivered.should eq 2
+      q.delete[:message_count].should eq 5
     end
   end
 

--- a/src/lavinmq/client/channel/consumer.cr
+++ b/src/lavinmq/client/channel/consumer.cr
@@ -58,19 +58,6 @@ module LavinMQ
           @unacked -= 1
         end
 
-        def recover(requeue)
-          @channel.recover(self) do |sp|
-            if requeue
-              reject(sp)
-              @queue.reject(sp, requeue: true)
-            else
-              # redeliver to the original recipient
-              env = @queue.read(sp)
-              deliver(env.message, sp, true, recover: true)
-            end
-          end
-        end
-
         def cancel
           @channel.send AMQP::Frame::Basic::Cancel.new(@channel.id, @tag, true)
           @channel.consumers.delete self

--- a/src/lavinmq/client/channel/consumer.cr
+++ b/src/lavinmq/client/channel/consumer.cr
@@ -35,10 +35,7 @@ module LavinMQ
         end
 
         def deliver(msg, sp, redelivered = false, recover = false)
-          unless @no_ack || recover
-            @unacked += 1
-          end
-
+          @unacked += 1 unless @no_ack || recover
           persistent = msg.properties.delivery_mode == 2_u8
           # @log.debug { "Getting delivery tag" }
           delivery_tag = @channel.next_delivery_tag(@queue, sp, persistent, @no_ack, self)


### PR DESCRIPTION
And BasicRecover without requeue should redeliver them to the same consumers (and
messages retrived by basic_get and cancelled consumers should be
requeued).