### PR TITLE
Spec: Keep same Logger for server restarts

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -121,7 +121,7 @@ module TestHelpers
   end
 
   def self.create_servers(dir = "/tmp/spec", level = LOG_LEVEL)
-    Log.setup(level)
+    Log.setup(level) unless @@s
     cfg = LavinMQ::Config.instance
     cfg.gc_segments_interval = 1
     cfg.queue_max_acks = 10


### PR DESCRIPTION
When we run `Log.setup` the second time we'd loose logging in specs.

I'm not sure exactly why logging stops working, but needed a fix to debug some other specs and this worked ...