### PR TITLE
Include timestamp and TTL in SegmentPosition metadata

### DIFF
--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -89,7 +89,7 @@ describe "Delayed Message Exchange" do
       x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
       queue = s.vhosts["/"].queues[q_name]
       queue.message_count.should eq 0
-      wait_for(15.milliseconds) { queue.message_count == 1 }
+      wait_for(200.milliseconds) { queue.message_count == 1 }
       queue.message_count.should eq 1
     end
   ensure

--- a/spec/segment_position_spec.cr
+++ b/spec/segment_position_spec.cr
@@ -96,12 +96,13 @@ describe LavinMQ::SegmentPosition do
     end
 
     it "should always be sorted (ExpirationReadyQueue)" do
+      flags = LavinMQ::SegmentPosition::SPFlags::HasTTL
       sps = [
-        LavinMQ::SegmentPosition.new(0, 0, expiration_ts: 1_i64),
-        LavinMQ::SegmentPosition.new(0, 1, expiration_ts: 3_i64),
-        LavinMQ::SegmentPosition.new(0, 2, expiration_ts: 1_i64),
-        LavinMQ::SegmentPosition.new(0, 3, expiration_ts: 5_i64),
-        LavinMQ::SegmentPosition.new(0, 4, expiration_ts: 4_i64),
+        LavinMQ::SegmentPosition.new(0, 0, ttl: 1_i64, flags: flags),
+        LavinMQ::SegmentPosition.new(0, 1, ttl: 3_i64, flags: flags),
+        LavinMQ::SegmentPosition.new(0, 2, ttl: 1_i64, flags: flags),
+        LavinMQ::SegmentPosition.new(0, 3, ttl: 5_i64, flags: flags),
+        LavinMQ::SegmentPosition.new(0, 4, ttl: 4_i64, flags: flags),
       ]
       ready = LavinMQ::Queue::ExpirationReadyQueue.new(sps.size)
       ready.insert(sps)

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -464,7 +464,7 @@ module LavinMQ
       sp = @ready.first? || return
       @log.debug { "Checking if message #{sp} has to be expired" }
       if expire_at = expire_at(sp)
-        expire_in = expire_at - RoughTime.utc.to_unix_ms
+        expire_in = expire_at - RoughTime.unix_ms
         if expire_in > 0
           expire_in.milliseconds
         else
@@ -477,10 +477,10 @@ module LavinMQ
       if ttl = @message_ttl
         ttl = Math.min(ttl, sp.ttl) if sp.flags.has_ttl?
         return false if ttl.zero? && !requeue && !@consumers.empty?
-        sp.timestamp + ttl < RoughTime.utc.to_unix_ms
+        sp.timestamp + ttl < RoughTime.unix_ms
       elsif sp.flags.has_ttl?
         return false if sp.ttl.zero? && !requeue && !@consumers.empty?
-        sp.timestamp + sp.ttl < RoughTime.utc.to_unix_ms
+        sp.timestamp + sp.ttl < RoughTime.unix_ms
       else
         false
       end
@@ -499,11 +499,10 @@ module LavinMQ
 
     private def expire_messages : Nil
       i = 0
-      now = RoughTime.utc.to_unix_ms
       @ready.shift do |sp|
         @log.debug { "Checking if next message #{sp} has to be expired" }
         if expire_at = expire_at(sp)
-          expire_in = expire_at - now
+          expire_in = expire_at - RoughTime.unix_ms
           @log.debug { "expire sp=#{sp} expire_in=#{expire_in}" }
           if expire_in <= 0
             expire_msg(sp, :expired)
@@ -642,7 +641,7 @@ module LavinMQ
         props, msg.size, IO::Memory.new(msg.body))
     end
 
-    private def expire_queue(now = Time.monotonic) : Bool
+    private def expire_queue : Bool
       @log.debug { "Trying to expire queue" }
       return false unless @consumers.empty?
       @log.debug { "Queue expired" }

--- a/src/lavinmq/rough_time.cr
+++ b/src/lavinmq/rough_time.cr
@@ -1,14 +1,26 @@
-class RoughTime
-  @@t = Time.utc
+module RoughTime
+  @@utc = Time.utc
+  @@unix_ms : Int64 = @@utc.to_unix_ms // 100 * 100
+  @@monotonic = Time.monotonic
 
   spawn(name: "RoughTime") do
     loop do
       sleep 0.1
-      @@t = Time.utc
+      @@utc = Time.utc
+      @@unix_ms = @@utc.to_unix_ms // 100 * 100
+      @@monotonic = Time.monotonic
     end
   end
 
   def self.utc : Time
-    @@t
+    @@utc
+  end
+
+  def self.unix_ms : Int64
+    @@unix_ms
+  end
+
+  def self.monotonic : Time::Span
+    @@monotonic
   end
 end

--- a/src/lavinmq/segment_position.cr
+++ b/src/lavinmq/segment_position.cr
@@ -20,7 +20,7 @@ module LavinMQ
 
     def_equals_and_hash @segment, @position
 
-    def initialize(@segment : UInt32, @position : UInt32, @bytesize = 0_u32, @timestamp = 0_i64, @ttl = 0u32, @priority = 0_u8, @flags = SPFlags.new(0_u8))
+    def initialize(@segment : UInt32, @position : UInt32, @bytesize = 0_u32, @timestamp = 0_i64, @ttl = 0u32, @priority = 0_u8, @flags = SPFlags::None)
     end
 
     def self.zero


### PR DESCRIPTION
Uses 6 more bytes but one less disk lookup is then required when a queue
has a queue TTL (as the timestamp then have to be read from disk). Also
improves the situation for TTL=0 messages which requires special
handling (in the event of or lack of consumers, and on requeue).