### PR TITLE
Docker: Copy base static, then add/override docbuilder files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y make curl
 WORKDIR /tmp
 COPY Makefile shard.yml shard.lock .
 RUN make js lib
+COPY ./static ./static
 COPY --from=docbuilder /tmp/openapi/openapi.yaml openapi/openapi.yaml
 COPY --from=docbuilder /tmp/static/docs/index.html static/docs/index.html
-COPY ./static ./static
 COPY ./src ./src
 ARG TARGETARCH
 RUN make objects target=$TARGETARCH-unknown-linux-gnu -j2


### PR DESCRIPTION
At least on my machine something acts up sometime and "builder" tries to build docs (which it can't do, no npx).