### PR TITLE
Update user access controller

### DIFF
--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -204,7 +204,8 @@ module LavinMQ
       end
 
       private def refuse_unless_management(context, user, vhost = nil)
-        unless user.tags.any?
+        unless user.tags.any? { |t| t.administrator? || t.monitoring? ||
+               t.policy_maker? || t.management? }
           @log.warn { "user=#{user.name} does not have management access on vhost=#{vhost}" }
           access_refused(context)
         end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -196,6 +196,7 @@ module LavinMQ
       end
 
       private def refuse_unless_vhost_access(context, user, vhost)
+        return if user.tags.any? &.administrator?
         unless user.permissions.has_key?(vhost)
           @log.warn { "user=#{user.name} does not have permissions to access vhost=#{vhost}" }
           access_refused(context)
@@ -203,14 +204,13 @@ module LavinMQ
       end
 
       private def refuse_unless_management(context, user, vhost = nil)
-        unless user.tags.any? { |t| t.management? || t.administrator? || t.policy_maker? || t.monitoring? }
+        unless user.tags.any?
           @log.warn { "user=#{user.name} does not have management access on vhost=#{vhost}" }
           access_refused(context)
         end
       end
 
       private def refuse_unless_policymaker(context, user, vhost = nil)
-        refuse_unless_management(context, user, vhost)
         unless user.tags.any? { |t| t.policy_maker? || t.administrator? }
           @log.warn { "user=#{user.name} does not have policymaker access on vhost=#{vhost}" }
           access_refused(context)
@@ -218,7 +218,6 @@ module LavinMQ
       end
 
       private def refuse_unless_monitoring(context, user)
-        refuse_unless_management(context, user)
         unless user.tags.any? { |t| t.administrator? || t.monitoring? }
           @log.warn { "user=#{user.name} does not have monitoring access" }
           access_refused(context)
@@ -226,8 +225,6 @@ module LavinMQ
       end
 
       private def refuse_unless_administrator(context, user : User)
-        refuse_unless_policymaker(context, user)
-        refuse_unless_monitoring(context, user)
         unless user.tags.any? &.administrator?
           @log.warn { "user=#{user.name} does not have administrator access" }
           access_refused(context)

--- a/src/lavinmq/user.cr
+++ b/src/lavinmq/user.cr
@@ -8,6 +8,7 @@ module LavinMQ
     Monitoring
     Management
     PolicyMaker
+    Impersonator
 
     def to_json(json : JSON::Builder)
       to_s.downcase.to_json(json)

--- a/static/user.html
+++ b/static/user.html
@@ -91,7 +91,12 @@
           <input type="text" name="tags">
         </label>
         <div id="dataTags" class="label">
-          <a data-tag="administrator">Administrator</a> | <a data-tag="policymaker">Policymaker</a> | <a data-tag="monitoring">Monitoring</a> | <a data-tag="management">Management</a> | <a data-tag="">None</a>
+          <a data-tag="administrator">Administrator</a> |
+          <a data-tag="policymaker">Policymaker</a> |
+          <a data-tag="monitoring">Monitoring</a> |
+          <a data-tag="management">Management</a> |
+          <a data-tag="impersonator">Impersonator</a> |
+          <a data-tag="">None</a>
         </div>
         <button type="submit" class="btn-primary">Update user</button>
       </form>

--- a/static/users.html
+++ b/static/users.html
@@ -53,7 +53,12 @@
           <input type="text" name="tags">
         </label>
         <div id="dataTags" class="label">
-          <a data-tag="administrator">Administrator</a> | <a data-tag="policymaker">Policymaker</a> | <a data-tag="monitoring">Monitoring</a> | <a data-tag="management">Management</a> | <a data-tag="">None</a>
+          <a data-tag="administrator">Administrator</a> |
+          <a data-tag="policymaker">Policymaker</a> |
+          <a data-tag="monitoring">Monitoring</a> |
+          <a data-tag="management">Management</a> |
+          <a data-tag="impersonator">Impersonator</a> |
+          <a data-tag="">None</a>
         </div>
         <button type="submit" class="btn-primary">Add user</button>
       </form>


### PR DESCRIPTION
From detected issue regarding uploading definitions from the UI. 

Previous user tag access check also combined lesser access. Instead of just making sure the user have the correct access for any given tag.

E.g. check for administrative rights, also used the policymaker and monitoring check. While the tags it self was repeated in those checks. Enough to just control that the user have the correct tags assigned.