### PR TITLE
A start of spec when disk is full

### DIFF
--- a/spec/disk_full_spec.cr
+++ b/spec/disk_full_spec.cr
@@ -2,37 +2,36 @@ require "./spec_helper"
 
 describe "when disk is full" do
   before_each do
-    close_servers
     system "mkdir -p /tmp/tmpfs"
   end
 
   after_each do
-    close_servers
-    system "umount /tmp/tmpfs"
+    system "umount /tmp/tmpfs 2> /dev/null"
   end
 
   it "should raise error on start server" do
     system("mount -t tmpfs -o size=500k lavinmq-spec /tmp/tmpfs") || pending! "Root required for tmpfs"
     expect_raises(File::Error) do
-      TestHelpers.create_servers("/tmp/tmpfs")
+      LavinMQ::Server.new("/tmp/tmpfs")
     end
   end
 
   it "should raise error on publish" do
     system("mount -t tmpfs -o size=1m lavinmq-spec /tmp/tmpfs") || pending! "Root required for tmpfs"
-    TestHelpers.create_servers("/tmp/tmpfs")
+    s = LavinMQ::Server.new("/tmp/tmpfs")
+    spawn { s.listen("127.0.0.2", 5672) }
     message = "m"
-    with_channel do |ch|
+    with_channel(host: "127.0.0.2") do |ch|
       q = ch.queue("queue")
       expect_raises(AMQP::Client::Error) do
         q.publish message * 134_217_728
       end
     end
+    s.close
   end
 
   pending "should raise error on close server" do
     expect_raises(File::Error) do
-      close_servers
     end
   end
 end

--- a/spec/disk_full_spec.cr
+++ b/spec/disk_full_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-describe "when disk is full" do
+describe LavinMQ::Server do
   before_each do
     system "mkdir -p /tmp/tmpfs"
   end
@@ -9,14 +9,14 @@ describe "when disk is full" do
     system "umount /tmp/tmpfs 2> /dev/null"
   end
 
-  it "should raise error on start server" do
+  it "will raise error on start server when out of disk" do
     system("mount -t tmpfs -o size=500k lavinmq-spec /tmp/tmpfs") || pending! "Root required for tmpfs"
     expect_raises(File::Error) do
       LavinMQ::Server.new("/tmp/tmpfs")
     end
   end
 
-  it "should raise error on publish" do
+  it "will raise error on publish when out of disk" do
     system("mount -t tmpfs -o size=1m lavinmq-spec /tmp/tmpfs") || pending! "Root required for tmpfs"
     s = LavinMQ::Server.new("/tmp/tmpfs")
     spawn { s.listen("127.0.0.2", 5672) }
@@ -30,7 +30,7 @@ describe "when disk is full" do
     s.close
   end
 
-  pending "should raise error on close server" do
+  pending "will raise error on close server when out of disk" do
     expect_raises(File::Error) do
     end
   end

--- a/spec/disk_full_spec.cr
+++ b/spec/disk_full_spec.cr
@@ -1,17 +1,26 @@
 require "./spec_helper"
 
-# To run these specs you need to create a small RAM-disk, see https://gist.github.com/htr3n/344f06ba2bb20b1056d7d5570fe7f596.
-
 describe "when disk is full" do
+  before_each do
+    close_servers
+    system "mkdir -p /tmp/tmpfs"
+  end
+
+  after_each do
+    close_servers
+    system "umount /tmp/tmpfs"
+  end
+
   it "should raise error on start server" do
+    system("mount -t tmpfs -o size=500k lavinmq-spec /tmp/tmpfs") || pending! "Root required for tmpfs"
     expect_raises(File::Error) do
-      TestHelpers.create_servers("/Volumes/TinyDisk-0.5MB")
+      TestHelpers.create_servers("/tmp/tmpfs")
     end
   end
 
   it "should raise error on publish" do
-    close_servers
-    TestHelpers.create_servers("/Volumes/TinyDisk-1MB")
+    system("mount -t tmpfs -o size=1m lavinmq-spec /tmp/tmpfs") || pending! "Root required for tmpfs"
+    TestHelpers.create_servers("/tmp/tmpfs")
     message = "m"
     with_channel do |ch|
       q = ch.queue("queue")
@@ -21,7 +30,7 @@ describe "when disk is full" do
     end
   end
 
-  it "should raise error on close server" do
+  pending "should raise error on close server" do
     expect_raises(File::Error) do
       close_servers
     end

--- a/spec/disk_full_spec.cr
+++ b/spec/disk_full_spec.cr
@@ -1,4 +1,4 @@
-require "../spec/spec_helper"
+require "./spec_helper"
 
 # To run these specs you need to create a small RAM-disk, see https://gist.github.com/htr3n/344f06ba2bb20b1056d7d5570fe7f596.
 

--- a/special_spec/disk_full_spec.cr
+++ b/special_spec/disk_full_spec.cr
@@ -1,0 +1,29 @@
+require "../spec/spec_helper"
+
+# To run these specs you need to create a small RAM-disk, see https://gist.github.com/htr3n/344f06ba2bb20b1056d7d5570fe7f596.
+
+describe "when disk is full" do
+  it "should raise error on start server" do
+    expect_raises(File::Error) do
+      TestHelpers.create_servers("/Volumes/TinyDisk-0.5MB")
+    end
+  end
+
+  it "should raise error on publish" do
+    close_servers
+    TestHelpers.create_servers("/Volumes/TinyDisk-1MB")
+    message = "m"
+    with_channel do |ch|
+      q = ch.queue("queue")
+      expect_raises(AMQP::Client::Error) do
+        q.publish message * 134_217_728
+      end
+    end
+  end
+
+  it "should raise error on close server" do
+    expect_raises(File::Error) do
+      close_servers
+    end
+  end
+end


### PR DESCRIPTION
Tests start of server and publish of message when disk gets full. A small RAM-disk is needed and therefore the spec is put in a different spec folder. 