### PR TITLE
Set tcp_defer_accept on listening sockets

### DIFF
--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -45,6 +45,7 @@ module LavinMQ
     end
 
     def listen(s : TCPServer)
+      s.tcp_defer_accept = true
       @listeners[s] = :amqp
       @log.info { "Listening on #{s.local_address}" }
       loop do
@@ -104,6 +105,7 @@ module LavinMQ
 
     def listen_tls(bind, port, context)
       s = TCPServer.new(bind, port)
+      s.tcp_defer_accept = true
       @listeners[s] = :amqps
       @log.info { "Listening on #{s.local_address} (TLS)" }
       while client = s.accept?

--- a/src/stdlib/socket.cr
+++ b/src/stdlib/socket.cr
@@ -19,6 +19,30 @@ class Socket
   end
 end
 
+lib LibC
+  TCP_DEFER_ACCEPT = 9
+end
+
+class TCPSocket
+  # Returns `true` if quick acks are enabled. Only available in Linux.
+  def tcp_defer_accept? : Bool
+    {% if flag?(:linux) %}
+      getsockopt_bool LibC::TCP_DEFER_ACCEPT, level: Protocol::TCP
+    {% else %}
+      false
+    {% end %}
+  end
+
+  # Enables TCP quick acks when set to `true`, otherwise disables it. Only available in Linux.
+  def tcp_defer_accept=(val : Bool)
+    {% if flag?(:linux) %}
+      setsockopt_bool LibC::TCP_DEFER_ACCEPT, val, level: Protocol::TCP
+    {% else %}
+      raise NotImplementedError.new("TCPSocket#tcp_defer_accept=")
+    {% end %}
+  end
+end
+
 module IO::Evented
   def evented_sendfile(limit : Int, errno_msg : String) : Int64
     limit = limit.to_i64


### PR DESCRIPTION
This PR makes the `accept` syscall not return until the client has sent a data packet too. Works as AMQP requires the client to speak first. Unfortunately benchmarking shows a drop in connection acception rate with this patch.

```
✗ bin/lavinmqperf connection-churn --uri amqp://127.0.0.1
```

with this patch:
```
open-close connection and channel   5.19k (192.84µs) (± 7.39%)  37.1kB/op  fastest
```
without:
```
open-close connection and channel   5.38k (185.87µs) (± 6.86%)  37.1kB/op  fastest
```

Can't really explain why it's slower but there it is. Opening and closing this PR FYI only. 
