### PR TITLE
fixes chart shrinking when browser not at 100% zoom

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -36,6 +36,7 @@ function render (id, unit, options = {}, stacked = false) {
     },
     options: Object.assign({
       responsive: true,
+      maintainAspectRatio: false,
       aspectRatio: 4,
       tooltips: {
         mode: 'x',


### PR DESCRIPTION
Strange resizing bug for Chart.js where chart resizes when at specifically 90% zoom in chrome web browser. 
Possibly related to [this issue](https://github.com/chartjs/Chart.js/issues/10890), added same fix as discussed in the thread. 

https://user-images.githubusercontent.com/85930202/205579361-7fd8c69e-2878-4c41-b297-34b79d6fe5e1.mov

