### PR TITLE
Chartjs configuration

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -82,9 +82,9 @@
       import * as Vhosts from './js/vhosts.js'
       import * as HTTP from './js/http.js'
 
-      const msgChart = Chart.render('msgChart', 'msgs', { aspectRatio: 2 }, true)
-      const dataChart = Chart.render('dataChart', 'bytes/s', { aspectRatio: 2 })
-      const rateChart = Chart.render('rateChart', 'msgs/s', { aspectRatio: 2 })
+      const msgChart = Chart.render('msgChart', 'msgs', true)
+      const dataChart = Chart.render('dataChart', 'bytes/s')
+      const rateChart = Chart.render('rateChart', 'msgs/s')
 
       function updateCharts (response) {
         let msgStats = {

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -24,9 +24,6 @@ function render (id, unit, options = {}, stacked = false) {
   const ctx = document.createElement('canvas')
   graphContainer.append(ctx)
   el.append(graphContainer)
-  const legendEl = document.createElement('div')
-  legendEl.classList.add('legend')
-  el.append(legendEl)
 
   const chart = new Chart(ctx, {
     type: 'line',
@@ -37,7 +34,7 @@ function render (id, unit, options = {}, stacked = false) {
     options: Object.assign({
       responsive: true,
       maintainAspectRatio: false,
-      aspectRatio: 4,
+      aspectRatio: 1.3,
       tooltips: {
         mode: 'x',
         intersect: false,
@@ -86,7 +83,6 @@ function render (id, unit, options = {}, stacked = false) {
       }
     }, options)
   })
-  legendEl.classList.add(chart.id + '-legend')
   return chart
 }
 function formatLabel (key) {

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -1,5 +1,5 @@
 import * as helpers from './helpers.js'
-import { Chart, TimeScale, LinearScale, LineController, PointElement, LineElement, Legend, Tooltip, Title } from './lib/chart.js'
+import { Chart, TimeScale, LinearScale, LineController, PointElement, LineElement, Legend, Tooltip, Title, Filler } from './lib/chart.js'
 import './lib/chartjs-adapter-luxon.esm.js'
 Chart.register(TimeScale)
 Chart.register(LinearScale)
@@ -9,6 +9,7 @@ Chart.register(LineElement)
 Chart.register(Legend)
 Chart.register(Tooltip)
 Chart.register(Title)
+Chart.register(Filler)
 
 const chartColors = ['#003f5c', '#ffa600', '#665191', '#a05195', '#d45087', '#f95d6a', '#ff7c43', '#2f4b7c',
   '#EE6868', '#2F6497', '#6C8893']

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -187,12 +187,12 @@ const updateStats = (nodeStats) => {
     }
   }
 }
-const memoryChart = Chart.render('memoryChart', 'MB', { aspectRatio: 2 })
-const ioChart = Chart.render('ioChart', 'ops', { aspectRatio: 2 })
-const cpuChart = Chart.render('cpuChart', '%', { aspectRatio: 2 }, true)
-const connectionChurnChart = Chart.render('connectionChurnChart', '/s', { aspectRatio: 2 })
-const channelChurnChart = Chart.render('channelChurnChart', '/s', { aspectRatio: 2 })
-const queueChurnChart = Chart.render('queueChurnChart', '/s', { aspectRatio: 2 })
+const memoryChart = Chart.render('memoryChart', 'MB')
+const ioChart = Chart.render('ioChart', 'ops')
+const cpuChart = Chart.render('cpuChart', '%', true)
+const connectionChurnChart = Chart.render('connectionChurnChart', '/s')
+const channelChurnChart = Chart.render('channelChurnChart', '/s')
+const queueChurnChart = Chart.render('queueChurnChart', '/s')
 
 const toMegaBytes = (dataPointInBytes) => (dataPointInBytes / 10 ** 6).toFixed(2)
 

--- a/static/main.css
+++ b/static/main.css
@@ -736,49 +736,12 @@ fieldset.inline {
 }
 
 .chart-container {
-  display: grid;
-  grid-template-columns: auto 100px;
+  margin-right: 10px;
   position: relative;
 }
 
 .chart-container .graph {
   grid-column: 1 / span 1;
-}
-
-.chart-container .legend {
-  grid-column: 2 / span 1;
-  grid-row-gap: 5px;
-  overflow-wrap: anywhere;
-}
-
-.chart-container .legend .legend-item {
-  display: grid;
-  grid-template-columns: 15px 20px auto;
-  margin-bottom: 5px;
-  transition: all .2s ease-in-out;
-}
-
-.chart-container .legend .legend-item:hover {
-  transform: scale(1.05);
-  cursor: pointer;
-}
-
-.chart-container .legend .legend-item.checked .toggle:before {
-  content: '✔';
-  position: absolute;
-  top: 5px;
-}
-
-.chart-container .legend .legend-item:not(.checked) {
-  opacity: 0.6;
-}
-
-.chart-container .legend .toggle {
-  position: relative;
-}
-
-.chart-container .legend .color-ref {
-  width: 10px;
 }
 
 #pagination {


### PR DESCRIPTION
Configure chart.js to better handle aspect ratio with new version, as you must use `maintainAspectRatio: false` according to [these](https://www.chartjs.org/docs/latest/configuration/responsive.html#:~:text=Note%20that%20in,%23) docs. 

also remove redundant legend html and css as we currently use the default legend handler in chart.js  