### PR TITLE
Fix publish properties shortcut

### DIFF
--- a/static/exchange.html
+++ b/static/exchange.html
@@ -150,6 +150,13 @@
           <span>Payload</span>
           <textarea name="payload"></textarea>
         </label>
+        <label>
+          <span>Payload encoding</span>
+          <select name="payload_encoding">
+            <option value="string">String</option>
+            <option value="base64">Base64</option>
+          </select>
+        </label>
         <button type="submit" class="btn-primary">Publish message</button>
       </form>
       <section class="card cols-4">

--- a/static/exchange.html
+++ b/static/exchange.html
@@ -111,10 +111,10 @@
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
           <div id="dataTags" class="label">
             <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
-              <span class="tooltiptext">Content type of the payload used by connected application. Default set to 'application/json'</span>
+              <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
             </a> |
             <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
-              <span class="tooltiptext">Content encoding of the payload used by connected application.</span>
+              <span class="tooltiptext">Encoding of the content used by application.</span>
             </a> |
             <a class="arg-tooltip" data-tag="expiration">Message TTL
               <span class="tooltiptext">How long a message published to a queue can live before it is discarded
@@ -124,19 +124,25 @@
               <span class="tooltiptext">Priority of the message in the queue.</span>
             </a> |
             <a class="arg-tooltip" data-tag="message_id">Message ID
-              <span class="tooltiptext">Message identifier of the message used by connected application.</span>
+              <span class="tooltiptext">Message identifier of the message used by application.</span>
             </a> |
             <a class="arg-tooltip" data-tag="timestamp">Timestamp
               <span class="tooltiptext">Timestamp of the message used by application.</span>
             </a> |
             <a class="arg-tooltip" data-tag="type">Type
-              <span class="tooltiptext">Type of the message used by connected application.</span>
+              <span class="tooltiptext">Type of the message used by application.</span>
             </a> |
             <a class="arg-tooltip" data-tag="user_id">User ID
               <span class="tooltiptext">User identifier when impersonate another user.</span>
             </a> |
             <a class="arg-tooltip" data-tag="app_id">App ID
-              <span class="tooltiptext">Publisher application identifier.</span>
+              <span class="tooltiptext">Application identifier.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
+              <span class="tooltiptext">Correlation identifier for RPC</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="reply_to">Reply To
+              <span class="tooltiptext">Reply to queue for RPC</span>
             </a>
           </div>
         </label>

--- a/static/exchange.html
+++ b/static/exchange.html
@@ -133,7 +133,7 @@
               <span class="tooltiptext">Type of the message used by application.</span>
             </a> |
             <a id="property-tag" class="arg-tooltip" data-tag="user_id">User ID
-              <span class="tooltiptext">User identifier when impersonate another user.</span>
+              <span class="tooltiptext">User identifier when impersonating another user.</span>
             </a> |
             <a id="property-tag" class="arg-tooltip" data-tag="app_id">App ID
               <span class="tooltiptext">Application identifier.</span>

--- a/static/exchange.html
+++ b/static/exchange.html
@@ -110,38 +110,38 @@
           <span>Properties</span>
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
+            <a id="property-tag" class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
               <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
             </a> |
-            <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
+            <a id="property-tag" class="arg-tooltip" data-tag="content_encoding">Content Encoding
               <span class="tooltiptext">Encoding of the content used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="expiration">Message TTL
+            <a id="property-tag" class="arg-tooltip" data-tag="expiration">Message TTL
               <span class="tooltiptext">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="priority">Priority
+            <a id="property-tag" class="arg-tooltip" data-tag="priority">Priority
               <span class="tooltiptext">Priority of the message in the queue.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="message_id">Message ID
+            <a id="property-tag" class="arg-tooltip" data-tag="message_id">Message ID
               <span class="tooltiptext">Message identifier of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="timestamp">Timestamp
+            <a id="property-tag" class="arg-tooltip" data-tag="timestamp">Timestamp
               <span class="tooltiptext">Timestamp of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="type">Type
+            <a id="property-tag" class="arg-tooltip" data-tag="type">Type
               <span class="tooltiptext">Type of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="user_id">User ID
+            <a id="property-tag" class="arg-tooltip" data-tag="user_id">User ID
               <span class="tooltiptext">User identifier when impersonate another user.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="app_id">App ID
+            <a id="property-tag" class="arg-tooltip" data-tag="app_id">App ID
               <span class="tooltiptext">Application identifier.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
+            <a id="property-tag" class="arg-tooltip" data-tag="correlation_id">Correlation ID
               <span class="tooltiptext">Correlation identifier for RPC</span>
             </a> |
-            <a class="arg-tooltip" data-tag="reply_to">Reply To
+            <a id="property-tag" class="arg-tooltip" data-tag="reply_to">Reply To
               <span class="tooltiptext">Reply to queue for RPC</span>
             </a>
           </div>

--- a/static/exchange.html
+++ b/static/exchange.html
@@ -111,11 +111,32 @@
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
           <div id="dataTags" class="label">
             <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
-              <span class="tooltiptext">Content type of the payload used by application. Default set to 'application/json'</span>
+              <span class="tooltiptext">Content type of the payload used by connected application. Default set to 'application/json'</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
+              <span class="tooltiptext">Content encoding of the payload used by connected application.</span>
             </a> |
             <a class="arg-tooltip" data-tag="expiration">Message TTL
               <span class="tooltiptext">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="priority">Priority
+              <span class="tooltiptext">Priority of the message in the queue.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="message_id">Message ID
+              <span class="tooltiptext">Message identifier of the message used by connected application.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="timestamp">Timestamp
+              <span class="tooltiptext">Timestamp of the message used by application.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="type">Type
+              <span class="tooltiptext">Type of the message used by connected application.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="user_id">User ID
+              <span class="tooltiptext">User identifier when impersonate another user.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="app_id">App ID
+              <span class="tooltiptext">Publisher application identifier.</span>
             </a>
           </div>
         </label>

--- a/static/exchange.html
+++ b/static/exchange.html
@@ -109,7 +109,15 @@
         <label>
           <span>Properties</span>
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
-          <a onclick="addProperty('content_type', 'application/json')">JSON</a>
+          <div id="dataTags" class="label">
+            <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
+              <span class="tooltiptext">Content type of the payload used by application. Default set to 'application/json'</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="expiration">Message TTL
+              <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+                (milliseconds).</span>
+            </a>
+          </div>
         </label>
         <label>
           <span>Payload</span>

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -115,14 +115,6 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
     .catch(HTTP.alertErrorHandler)
 })
 
-window.addProperty = addProperty
-function addProperty (key, value) { // eslint-disable-line no-unused-vars
-  const el = document.querySelector('#publishMessage textarea[name=properties]')
-  const properties = DOM.parseJSON(el.value || '{}')
-  properties[key] = value
-  el.value = JSON.stringify(properties)
-}
-
 document.querySelector('#deleteExchange').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const url = '/api/exchanges/' + urlEncodedVhost + '/' + urlEncodedExchange

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -138,3 +138,7 @@ function updateAutocomplete(e) {
   Helpers.autoCompleteDatalist("exchange-dest-list", type)
 }
 updateAutocomplete('q')
+
+document.querySelector('#dataTags').onclick = e => {
+  Helpers.argumentHelperJSON("properties", e)
+}

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -104,7 +104,7 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
   properties.headers = DOM.parseJSON(data.get('headers'))
   const body = {
     payload: data.get('payload'),
-    payload_encoding: 'string',
+    payload_encoding: data.get('payload_encoding'),
     routing_key: data.get('routing_key').trim(),
     properties
   }

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -115,6 +115,7 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
     .catch(HTTP.alertErrorHandler)
 })
 
+window.addProperty = addProperty
 function addProperty (key, value) { // eslint-disable-line no-unused-vars
   const el = document.querySelector('#publishMessage textarea[name=properties]')
   const properties = DOM.parseJSON(el.value || '{}')

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -69,7 +69,9 @@ function argumentHelperJSON (className, e) {
     value = 'value'
   }
   const currentVal = document.querySelector(`[name=${className}]`).value
-  if (currentVal === "" && val) {
+  if (currentVal.includes(val)) {
+    return
+  } else if (currentVal === "" && val) {
     document.querySelector(`[name=${className}]`).value = `{"${val}": ${value}}`
   } else if (currentVal[currentVal.length - 1] === "}" && val) {
     document.querySelector(`[name=${className}]`).value = currentVal.substr(0, currentVal.length - 1) + `,\n"${val}": ${value}}`

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -64,11 +64,15 @@ function argumentHelper (className, e) {
 
 function argumentHelperJSON (className, e) {
   const val = e.target.getAttribute('data-tag')
+  let value = e.target.getAttribute('value')
+  if (value === null) {
+    value = 'value'
+  }
   const currentVal = document.querySelector(`[name=${className}]`).value
   if (currentVal === "" && val) {
-    document.querySelector(`[name=${className}]`).value = "{\"" + val + "\": value}"
+    document.querySelector(`[name=${className}]`).value = `{"${val}": ${value}}`
   } else if (currentVal[currentVal.length - 1] === "}" && val) {
-    document.querySelector(`[name=${className}]`).value = currentVal.substr(0, currentVal.length - 1) + ",\n\"" + val + "\": value}"
+    document.querySelector(`[name=${className}]`).value = currentVal.substr(0, currentVal.length - 1) + `,\n"${val}": ${value}}`
   }
 }
 

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -191,7 +191,7 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
   properties.headers = DOM.parseJSON(data.get('headers'))
   const body = {
     payload: data.get('payload'),
-    payload_encoding: 'string',
+    payload_encoding: data.get('payload_encoding'),
     routing_key: queue,
     properties
   }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -174,14 +174,6 @@ document.querySelector('#addBinding').addEventListener('submit', function (evt) 
     }).catch(HTTP.alertErrorHandler)
 })
 
-window.addProperty = addProperty
-function addProperty (key, value) { // eslint-disable-line no-unused-vars
-  const el = document.querySelector('#publishMessage textarea[name=properties]')
-  const properties = DOM.parseJSON(el.value || '{}')
-  properties[key] = value
-  el.value = JSON.stringify(properties)
-}
-
 document.querySelector('#publishMessage').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -371,3 +371,7 @@ messageSnapshotForm.addEventListener('submit', function (evt) {
 
 Helpers.autoCompleteDatalist('exchange-list', 'exchanges')
 Helpers.autoCompleteDatalist('queue-list', 'queues')
+
+document.querySelector('#dataTags').onclick = e => {
+  Helpers.argumentHelperJSON("properties", e)
+}

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -174,6 +174,7 @@ document.querySelector('#addBinding').addEventListener('submit', function (evt) 
     }).catch(HTTP.alertErrorHandler)
 })
 
+window.addProperty = addProperty
 function addProperty (key, value) { // eslint-disable-line no-unused-vars
   const el = document.querySelector('#publishMessage textarea[name=properties]')
   const properties = DOM.parseJSON(el.value || '{}')

--- a/static/main.css
+++ b/static/main.css
@@ -30,6 +30,7 @@ textarea {
 
 a:hover {
   cursor: pointer;
+  color:#6a5855;
 }
 
 header,
@@ -925,9 +926,15 @@ pre.arguments > div {
   padding-left: 1em;
   text-indent: -1em;
 }
+
 #dataTags {
   margin-left :150px;
   padding: 7px;
+  max-width: 400px;
+}
+
+#property{
+  margin: 2px;
 }
 
 .popup-card {

--- a/static/queue.html
+++ b/static/queue.html
@@ -171,10 +171,10 @@
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
           <div id="dataTags" class="label">
             <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
-              <span class="tooltiptext">Content type of the payload used by application. Default set to 'application/json'</span>
+              <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
             </a> |
             <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
-              <span class="tooltiptext">Content encoding of the payload used by application.</span>
+              <span class="tooltiptext">Encoding of the content used by application.</span>
             </a> |
             <a class="arg-tooltip" data-tag="expiration">Message TTL
               <span class="tooltiptext">How long a message published to a queue can live before it is discarded
@@ -197,6 +197,12 @@
             </a> |
             <a class="arg-tooltip" data-tag="app_id">App ID
               <span class="tooltiptext">Application identifier.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
+              <span class="tooltiptext">Correlation identifier for RPC</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="reply_to">Reply To
+              <span class="tooltiptext">Reply to queue for RPC</span>
             </a>
           </div>
         </label>

--- a/static/queue.html
+++ b/static/queue.html
@@ -170,38 +170,38 @@
           <span>Properties</span>
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
+            <a id="property-tag" class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
               <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
             </a> |
-            <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
+            <a id="property-tag" class="arg-tooltip" data-tag="content_encoding">Content Encoding
               <span class="tooltiptext">Encoding of the content used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="expiration">Message TTL
+            <a id="property-tag" class="arg-tooltip" data-tag="expiration">Message TTL
               <span class="tooltiptext">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="priority">Priority
+            <a id="property-tag" class="arg-tooltip" data-tag="priority">Priority
               <span class="tooltiptext">Priority of the message in the queue.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="message_id">Message ID
+            <a id="property-tag" class="arg-tooltip" data-tag="message_id">Message ID
               <span class="tooltiptext">Message identifier of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="timestamp">Timestamp
+            <a id="property-tag" class="arg-tooltip" data-tag="timestamp">Timestamp
               <span class="tooltiptext">Timestamp of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="type">Type
+            <a id="property-tag" class="arg-tooltip" data-tag="type">Type
               <span class="tooltiptext">Type of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="user_id">User ID
+            <a id="property-tag" class="arg-tooltip" data-tag="user_id">User ID
               <span class="tooltiptext">User identifier when impersonate another user.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="app_id">App ID
+            <a id="property-tag" class="arg-tooltip" data-tag="app_id">App ID
               <span class="tooltiptext">Application identifier.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
+            <a id="property-tag" class="arg-tooltip" data-tag="correlation_id">Correlation ID
               <span class="tooltiptext">Correlation identifier for RPC</span>
             </a> |
-            <a class="arg-tooltip" data-tag="reply_to">Reply To
+            <a id="property-tag" class="arg-tooltip" data-tag="reply_to">Reply To
               <span class="tooltiptext">Reply to queue for RPC</span>
             </a>
           </div>

--- a/static/queue.html
+++ b/static/queue.html
@@ -169,7 +169,15 @@
         <label>
           <span>Properties</span>
           <textarea name="properties" placeholder='{ "key": value }' style="height: 65px;"></textarea>
-          <a onclick="addProperty('content_type', 'application/json')">JSON</a>
+          <div id="dataTags" class="label">
+            <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
+              <span class="tooltiptext">Content type of the payload used by application. Default set to 'application/json'</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="expiration">Message TTL
+              <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+                (milliseconds).</span>
+            </a>
+          </div>
         </label>
         <label>
           <span>Payload</span>

--- a/static/queue.html
+++ b/static/queue.html
@@ -173,9 +173,30 @@
             <a class="arg-tooltip" data-tag="content_type" value='"application/json"'>Content Type
               <span class="tooltiptext">Content type of the payload used by application. Default set to 'application/json'</span>
             </a> |
+            <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
+              <span class="tooltiptext">Content encoding of the payload used by application.</span>
+            </a> |
             <a class="arg-tooltip" data-tag="expiration">Message TTL
               <span class="tooltiptext">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="priority">Priority
+              <span class="tooltiptext">Priority of the message in the queue.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="message_id">Message ID
+              <span class="tooltiptext">Message identifier of the message used by application.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="timestamp">Timestamp
+              <span class="tooltiptext">Timestamp of the message used by application.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="type">Type
+              <span class="tooltiptext">Type of the message used by application.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="user_id">User ID
+              <span class="tooltiptext">User identifier when impersonate another user.</span>
+            </a> |
+            <a class="arg-tooltip" data-tag="app_id">App ID
+              <span class="tooltiptext">Application identifier.</span>
             </a>
           </div>
         </label>

--- a/static/queue.html
+++ b/static/queue.html
@@ -210,6 +210,13 @@
           <span>Payload</span>
           <textarea name="payload"></textarea>
         </label>
+        <label>
+          <span>Payload encoding</span>
+          <select name="payload_encoding">
+            <option value="string">String</option>
+            <option value="base64">Base64</option>
+          </select>
+        </label>
         <button type="submit" class="btn-primary">Publish message</button>
       </form>
       <section class="card cols-6">


### PR DESCRIPTION
- More property tags are added to shortcut 
- Avoids adding a single tag multiple times 
- Adds payload encoding selector, you can now choose Base64 as well as String

(img: hovering over "Priority" tag)
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/85930202/208415111-a1df0c2e-46f1-4c5e-bbf6-81a360fb642f.png">
