### PR TITLE
reformat type and arguments when redeclaring exchange via HTTP api

### DIFF
--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -116,6 +116,23 @@ describe LavinMQ::HTTP::ExchangesController do
       response.status_code.should eq 400
     end
 
+    it "should redeclare identical delayed_message_exchange" do
+      body = %({
+        "type": "x-delayed-message",
+        "durable": true,
+        "internal": false,
+        "auto_delete": false,
+        "arguments": {
+          "x-delayed-type": "fanout",
+          "test": "hello"
+        }
+      })
+      response = put("/api/exchanges/%2f/spechange", body: body)
+      response.status_code.should eq 201
+      response = put("/api/exchanges/%2f/spechange", body: body)
+      response.status_code.should eq 204
+    end
+
     it "should require config access to declare" do
       body = %({
         "type": "topic"

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -73,4 +73,14 @@ describe LavinMQ::Exchange do
       end
     end
   end
+
+  describe "delayed message exchange declaration" do
+    it "should redeclare same delayed message exchange" do
+      with_channel do |ch|
+        xdm_args = AMQP::Client::Arguments.new({"x-delayed-type" => "topic", "test" => "hello"})
+        x = ch.exchange("test", "x-delayed-message", args: xdm_args)
+        x = ch.exchange("test", "x-delayed-message", args: xdm_args)
+      end
+    end
+  end
 end

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -89,19 +89,17 @@ module LavinMQ
     end
 
     def match?(frame : AMQP::Frame)
-      type == frame.exchange_type &&
-        @durable == frame.durable &&
-        @auto_delete == frame.auto_delete &&
-        @internal == frame.internal &&
-        @arguments == frame.arguments.to_h
+      match?(frame.exchange_type, frame.durable, frame.auto_delete, frame.internal, frame.arguments)
     end
 
     def match?(type, durable, auto_delete, internal, arguments)
-      self.type == type &&
+      delayed = type == "x-delayed-message"
+      frame_args = arguments.to_h.dup.reject("x-delayed-type").merge({"x-delayed-exchange" => true})
+      self.type == (delayed ? arguments["x-delayed-type"] : type) &&
         @durable == durable &&
         @auto_delete == auto_delete &&
         @internal == internal &&
-        @arguments == arguments.to_h
+        @arguments == (delayed ? frame_args : arguments.to_h)
     end
 
     def in_use?


### PR DESCRIPTION
 related to #445 
When you declare a delayed message exchange, it is created as an exchange of the specified type. When one then wants to redeclare a delayed message exchange, the match check done to see if it is already declared fails since the reformatting is done AFTER the match method. 
This PR adds specs for redeclaring a delayed message exchange, as well as changes the match() method to compare on the correct values(type and arguments). 
