### PR TITLE
Live log view in manager UI with SSE

### DIFF
--- a/src/lavinmq/http/controller/logs.cr
+++ b/src/lavinmq/http/controller/logs.cr
@@ -1,0 +1,55 @@
+require "../controller"
+require "../../config"
+require "../../in_memory_backend"
+
+module LavinMQ
+  module HTTP
+    class LogsController < Controller
+      LogBackend = ::Log::InMemoryBackend.instance
+
+      private def register_routes
+        get "/api/livelog" do |context, _params|
+          channel = LogBackend.add_channel
+          context.response.content_type = "text/event-stream"
+          context.response.upgrade do |io|
+            if last_event_id = context.request.headers["Last-Event-Id"]?
+              last_ts = last_event_id.to_i64
+              LogBackend.entries.each do |entry|
+                next if entry.timestamp.to_unix_ms <= last_ts 
+                print_entry(entry, io)
+              end
+            else
+              LogBackend.entries.each do |entry|
+                print_entry(entry, io)
+              end
+            end
+            io.flush
+            while entry = channel.receive
+              print_entry(entry, io)
+              io.flush
+            end
+          ensure
+            LogBackend.remove_channel(channel)
+          end
+          context
+        end
+
+        get "/api/logs" do |context, _params|
+          context.response.content_type = "text/plain"
+          context.response.headers["Content-Disposition"] = "attachment; filename=logs.txt"
+          LogBackend.entries.each do |e|
+            context.response.puts "#{e.timestamp} [#{e.severity.to_s.upcase}] #{e.source} - #{e.message}"
+          end
+          context
+        end
+      end
+
+      private def print_entry(entry, io)
+        io.print("id: #{entry.timestamp.to_unix_ms}\n")
+        io.print("data: ")
+        {entry.severity, entry.source, entry.message}.to_json(io)
+        io.print("\n\n")
+      end
+    end
+  end
+end

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -40,6 +40,7 @@ module LavinMQ
           ParametersController.new(@amqp_server, @log).route_handler,
           NodesController.new(@amqp_server, @log).route_handler,
           PrometheusController.new(@amqp_server, @log).route_handler,
+          LogsController.new(@amqp_server, @log).route_handler,
         ] of ::HTTP::Handler
         handlers.unshift(::HTTP::LogHandler.new(@log)) if @log.level == Log::Severity::Debug
         @http = ::HTTP::Server.new(handlers)

--- a/src/lavinmq/in_memory_backend.cr
+++ b/src/lavinmq/in_memory_backend.cr
@@ -1,0 +1,53 @@
+require "log"
+require "../stdlib/channel"
+
+# A `Log::Backend` for holding last x nr of messages in memory.
+class Log::InMemoryBackend < Log::Backend
+  @entries = Deque(Log::Entry).new
+  @lock = Mutex.new
+  getter channels = Array(Channel(Log::Entry)).new
+  property size = 1024
+
+  @@instance : self = self.new
+
+  def entries
+    @lock.synchronize do
+      @entries.dup
+    end
+  end
+
+  def self.instance
+    @@instance
+  end
+
+  private def initialize
+    super(:direct)
+  end
+
+  def write(entry : Log::Entry) : Nil
+    @lock.synchronize do 
+      if @entries.size >= @size
+        @entries.shift(@entries.size - @size + 1)
+      end
+      @entries << entry
+
+      @channels.each do |ch|
+        ch.try_send(entry)
+      end
+    end
+  end
+
+  def add_channel
+    ch = Channel(Log::Entry).new(128)
+    @lock.synchronize do
+      @channels << ch
+    end
+    ch
+  end
+
+  def remove_channel(channel)
+    @lock.synchronize do
+      @channels.delete(channel)
+    end
+  end
+end

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -15,6 +15,7 @@ const menuLinks = `
         <li><a id="menu-item" href="vhosts">Virtual hosts</a></li>
         <li><a id="menu-item" href="users">Users</a></li>
         <li><a id="menu-item" href="nodes">Nodes</a></li>
+        <li><a id="menu-item" href="logs">Log</a></li>
         <li><a id="menu-item" href="docs" target="_blank">HTTP API</a></li>
     `
 

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -1,0 +1,51 @@
+import * as Auth from './auth.js'
+
+const url = new URL("/api/livelog", window.location.origin)
+url.username = Auth.getUsername()
+url.password = Auth.getPassword()
+
+let shouldAutoScroll = true
+const evtSource = new EventSource(url)
+const livelog = document.getElementById('livelog')
+const tbody = document.getElementById("livelog-body")
+
+evtSource.onmessage = (event) => {
+  const timestamp = new Date(parseInt(event.lastEventId))
+  const [ severity, source, message ] = JSON.parse(event.data)
+
+  const tdTs = document.createElement("td")
+  tdTs.textContent = timestamp.toLocaleString()
+  const tdSev = document.createElement("td")
+  tdSev.textContent = severity
+  const tdSrc = document.createElement("td")
+  tdSrc.textContent = source
+  const preMsg = document.createElement("pre")
+  preMsg.textContent = message
+  const tdMsg = document.createElement("td")
+  tdMsg.appendChild(preMsg)
+
+  const tr = document.createElement("tr")
+  tr.append(tdTs, tdSev, tdSrc, tdMsg)
+  const row = tbody.appendChild(tr)
+
+  if (shouldAutoScroll) row.scrollIntoView()
+}
+
+evtSource.onerror = (err) => {
+  console.error("EventSource error", err)
+  //document.getElementById("table-error").textContent = `Lost connection to server`
+  //document.getElementById("table-error").style.display = "block"
+  //document.getElementById("table-error").style.position = "fixed"
+}
+
+let lastScrollTop = livelog.pageYOffset || livelog.scrollTop
+livelog.addEventListener('scroll', event => {
+  const {scrollHeight, scrollTop, clientHeight} = event.target
+  const st = livelog.pageYOffset || livelog.scrollTop
+  if (st > lastScrollTop && shouldAutoScroll === false) {
+    shouldAutoScroll = (Math.abs(scrollHeight - clientHeight - scrollTop) < 3)
+  } else if (st < lastScrollTop) {
+    shouldAutoScroll = false
+  }
+  lastScrollTop = st <= 0 ? 0 : st
+})

--- a/static/logs.html
+++ b/static/logs.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Log | LavinMQ</title>
+    <link href="/main.css" rel="stylesheet">
+    <meta name="google" content="notranslate">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" type="image/png" href="/img/favicon.png"/>
+    <link rel="apple-touch-icon" href="/img/apple-touch-icon-iphone.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="/img/apple-touch-icon-ipad.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="/img/apple-touch-icon-iphone4.png" />
+    <script type="module" src="/js/layout.js"></script>
+    <script type="module" src="/js/logs.js"></script>
+  </head>
+  <body>
+    <header>
+      <nav id="small-menu"></nav>
+      <h2>
+        Log
+        <small id="table-count"></small>
+      </h2>
+      <nav id="user-menu"/>
+    </header>
+    <nav id="menu"></nav>
+    <main>
+      <section id="livelog" class="card livelog">
+        <button id="download-logs" class="btn-primary"><a href="/api/logs">Download logs</a></button>
+        <div id="table-error"></div>
+        <table id="table" class="table">
+          <thead>
+            <tr>
+              <th class="livelog-timestamp">Timestamp</th>
+              <th class="livelog-severity">Severity</th>
+              <th class="livelog-source">Source</th>
+              <th class="livelog-message">Message</th>
+            </tr>
+          </thead>
+          <tbody id="livelog-body"></tbody>
+        </table>
+      </section>
+    </main>
+    <footer>LavinMQ is open source and developed by <a href="https://www.84codes.com" target="_blank"><img class="logo" src="/img/logo-84codes.svg"></a></footer>
+  </body>
+</html>

--- a/static/main.css
+++ b/static/main.css
@@ -1023,3 +1023,44 @@ pre.arguments > div {
   text-decoration: none;
   color: #000;
 }
+
+#livelog {
+  max-height: 85vh;
+  overflow-y: scroll;
+}
+
+#livelog td {
+  white-space: normal;
+}
+
+.btn-primary a, .btn-primary a:visited {
+  color: #fff;
+}
+
+#download-logs {
+  margin: 5px 0 5px 0;
+}
+
+#livelog table td, #livelog table th {
+  padding:0;
+}
+
+#livelog table thead .livelog-timestamp {
+  width:185px;
+}
+
+#livelog table thead .livelog-severity {
+  width:75px;
+}
+
+#livelog table thead .livelog-source {
+  width:150px;
+}
+
+#livelog table thead .livelog-message {
+  width:auto;
+}
+
+#livelog table th {
+  text-align: left;
+}


### PR DESCRIPTION
Adds a log view in the manager UI that updates live with SSE, and an /api/livelog endpoint. 
Adds `in_memory_backend` that sends new log entries to any connected clients via channels. 
The in_memory_backend also keeps the latest 128 messages in memory and sends them to newly connected clients. 