### PR TITLE
Handle empty arguments hash on bindings for definitions import/export

### DIFF
--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -316,7 +316,7 @@ module LavinMQ
         destination:      @destination.name,
         destination_type: @destination.is_a?(Queue) ? "queue" : "exchange",
         routing_key:      routing_key,
-        arguments:        arguments.nil? ? Hash(String, AMQP::Field).new : arguments,
+        arguments:        arguments || NamedTuple.new,
         properties_key:   BindingDetails.hash_key(@key),
       }
     end

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -316,7 +316,7 @@ module LavinMQ
         destination:      @destination.name,
         destination_type: @destination.is_a?(Queue) ? "queue" : "exchange",
         routing_key:      routing_key,
-        arguments:        arguments,
+        arguments:        arguments.nil? ? Hash(String, AMQP::Field).new : arguments,
         properties_key:   BindingDetails.hash_key(@key),
       }
     end

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -210,7 +210,7 @@ module LavinMQ
           destination = b["destination"].as_s
           destination_type = b["destination_type"].as_s
           routing_key = b["routing_key"].as_s
-          arguments = AMQP::Table.new(b["arguments"].as_h)
+          arguments = AMQP::Table.new(b["arguments"].as_h?)
           next unless v = fetch_vhost?(vhosts, vhost)
           case destination_type
           when "queue"


### PR DESCRIPTION
Export definitions exports empty hash instead of null if there are no arguments for binding.
Import definitions allows import even if arguments on binding is null.

Fixes https://github.com/cloudamqp/lavinmq/issues/455