### PR TITLE
Github Action for Benchmarking

### DIFF
--- a/.github/workflows/lavinmqperf.yml
+++ b/.github/workflows/lavinmqperf.yml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   spec:
-    name: Spec
+    name: benchmark
     runs-on: ubuntu-latest
     container: 84codes/crystal:latest-ubuntu-20.04
     steps:

--- a/.github/workflows/lavinmqperf.yml
+++ b/.github/workflows/lavinmqperf.yml
@@ -1,8 +1,5 @@
 name: lavinmqperf benchmark
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/lavinmqperf.yml
+++ b/.github/workflows/lavinmqperf.yml
@@ -1,0 +1,67 @@
+name: lavinmqperf benchmark
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  spec:
+    name: Spec
+    runs-on: ubuntu-latest
+    container: 84codes/crystal:latest-ubuntu-20.04
+    steps:
+      - name: Print Crystal version
+        run: crystal -v
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: 'pr'
+
+      - name: Build lavinmq
+        run: cd pr && make -j bin/lavinmq bin/lavinmqperf DOCS= CRYSTAL_FLAGS=-Dbake_static
+
+      - name: Perf
+        run: cd pr && chmod u+x extras/action_benchmark.sh && ./extras/action_benchmark.sh /tmp/pr.log
+
+      - name: Checkout main
+        uses: actions/checkout@v3
+        with:
+          path: 'main'
+          ref: 'main'
+
+      - name: Build lavinmq
+        run: cd main && make -j bin/lavinmq bin/lavinmqperf DOCS= CRYSTAL_FLAGS=-Dbake_static
+
+      - name: Perf
+        run: cp pr/extras/action_benchmark.sh main/extras/action_benchmark.sh && cd main && ./extras/action_benchmark.sh /tmp/main.log
+
+      - name: Compare
+        run: |
+          PR_LOG_CONTENTS=$(cat /tmp/pr.log)
+          MAIN_LOG_CONTENTS=$(cat /tmp/main.log)
+          PR_PUBLISH=$(tail -n 2 /tmp/pr.log | head -n 1)
+          PR_CONSUME=$(tail -n 1 /tmp/pr.log)
+          MAIN_PUBLISH=$(tail -n 2 /tmp/main.log | head -n 1)
+          MAIN_CONSUME=$(tail -n 1 /tmp/main.log)
+          echo "PR_PUBLISH='$PR_PUBLISH'" >> $GITHUB_ENV
+          echo "PR_CONSUME='$PR_CONSUME'" >> $GITHUB_ENV
+          echo "MAIN_PUBLISH='$MAIN_PUBLISH'" >> $GITHUB_ENV
+          echo "MAIN_CONSUME='$MAIN_CONSUME'" >> $GITHUB_ENV
+
+      - name: comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            **Main benchmark**
+            ${{ env.MAIN_PUBLISH }}
+            ${{ env.MAIN_CONSUME }}
+
+            **PR benchmark**
+            ${{ env.PR_PUBLISH }}
+            ${{ env.PR_CONSUME }}
+
+            _Keep in mind, these numbers are not representative of LavinMQ's peak performance.
+            It is rather an indication of how the changes of this pull request affects the performance of the main branch._

--- a/extras/action_benchmark.sh
+++ b/extras/action_benchmark.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+set -eux
+
+bin/lavinmq -D /tmp/amqp --amqp-unix-path /tmp/lavinmq_amqp.sock &
+LAVINPID=$!
+
+while ! test -S /tmp/lavinmq_amqp.sock ; do sleep 1; done
+sleep 1
+
+bin/lavinmqperf throughput -z 60 > $1
+
+kill -INT $LAVINPID
+wait $LAVINPID


### PR DESCRIPTION
The goal is to continuously benchmark lavinmq/main in order to discover regressions in performance. 
Since both the main and pr branches are built and run on the same GHA runner they should have the same conditions and it is appropriate to compare them as they are presented in the comment made by github-actions bot. However, performance is expected to vary from runner to runner, so it is not appropriate to compare the benchmarking results form one commit to the results of another. 
**co-authered by @spuun** 