### PR TITLE
In specs, let OS pick listen ports by default

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -155,9 +155,9 @@ describe LavinMQ::HTTP::Server do
           "component": "shovel",
           "vhost": "/",
           "value": {
-            "src-uri": "#{AMQP_BASE_URL}",
+            "src-uri": "#{Helper.amqp_base_url}",
             "src-queue": "shovel_will_declare_q1",
-            "dest-uri": "#{AMQP_BASE_URL}",
+            "dest-uri": "#{Helper.amqp_base_url}",
             "dest-queue": "shovel_will_declare_q1"
           }
         }

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LavinMQ::HTTP::Server do
   describe "GET /api/overview" do
     it "should refuse access if no basic auth header" do
-      response = ::HTTP::Client.get("#{BASE_URL}/api/overview")
+      response = HTTP::Client.get "#{Helper.base_url}/api/overview"
       response.status_code.should eq 401
     end
 

--- a/spec/http_static_spec.cr
+++ b/spec/http_static_spec.cr
@@ -2,41 +2,41 @@ require "./spec_helper"
 
 describe LavinMQ::HTTP::StaticController do
   it "GET /" do
-    response = ::HTTP::Client.get BASE_URL
+    response = get "/"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should contain("LavinMQ")
   end
 
   it "GET /robots.txt" do
-    response = ::HTTP::Client.get "#{BASE_URL}/robots.txt"
+    response = get "/robots.txt"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/plain")
     response.body.should contain("Disallow")
   end
 
   it "GET /img/favicon.png" do
-    response = ::HTTP::Client.get "#{BASE_URL}/img/favicon.png"
+    response = get "/img/favicon.png"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("image/png")
   end
 
   it "GET /test/ serves index.html in the directory" do
-    response = ::HTTP::Client.get "#{BASE_URL}/test/"
+    response = get "/test/"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should eq("This is a test\n")
   end
 
   it "GET /test (without trailing /) serves index.html in the directory" do
-    response = ::HTTP::Client.get "#{BASE_URL}/test"
+    response = get "/test"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should eq("This is a test\n")
   end
 
   it "GET /test/index.html" do
-    response = ::HTTP::Client.get "#{BASE_URL}/test/index.html"
+    response = get "/test/index.html"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should eq("This is a test\n")

--- a/spec/http_static_spec.cr
+++ b/spec/http_static_spec.cr
@@ -2,41 +2,41 @@ require "./spec_helper"
 
 describe LavinMQ::HTTP::StaticController do
   it "GET /" do
-    response = get "/"
+    response = HTTP::Client.get "#{Helper.base_url}/"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should contain("LavinMQ")
   end
 
   it "GET /robots.txt" do
-    response = get "/robots.txt"
+    response = HTTP::Client.get "#{Helper.base_url}/robots.txt"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/plain")
     response.body.should contain("Disallow")
   end
 
   it "GET /img/favicon.png" do
-    response = get "/img/favicon.png"
+    response = HTTP::Client.get "#{Helper.base_url}/img/favicon.png"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("image/png")
   end
 
   it "GET /test/ serves index.html in the directory" do
-    response = get "/test/"
+    response = HTTP::Client.get "#{Helper.base_url}/test/"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should eq("This is a test\n")
   end
 
   it "GET /test (without trailing /) serves index.html in the directory" do
-    response = get "/test"
+    response = HTTP::Client.get "#{Helper.base_url}/test"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should eq("This is a test\n")
   end
 
   it "GET /test/index.html" do
-    response = get "/test/index.html"
+    response = HTTP::Client.get "#{Helper.base_url}/test/index.html"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should eq("This is a test\n")

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -435,7 +435,7 @@ describe LavinMQ::Server do
   end
 
   it "splits frames into max frame sizes" do
-    with_channel(port: 5672, frame_max: 4096_u32) do |ch|
+    with_channel(frame_max: 4096_u32) do |ch|
       2.times do
         msg_size = (2**17 + 1)
         pmsg1 = "m" * msg_size

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -18,14 +18,14 @@ describe LavinMQ::Shovel do
     it "should shovel and stop when queue length is met" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "ql_q2",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -47,12 +47,12 @@ describe LavinMQ::Shovel do
     it "should shovel large messages" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "lm_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
-      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(AMQP_BASE_URL), "lm_q2", direct_user: Server.users.direct_user)
+      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(Helper.amqp_base_url), "lm_q2", direct_user: Server.users.direct_user)
       shovel = LavinMQ::Shovel::Runner.new(source, dest, "lm_shovel", vhost)
       with_channel do |ch|
         x, q2 = ShovelSpecHelpers.setup_qs ch, "lm_"
@@ -64,8 +64,8 @@ describe LavinMQ::Shovel do
     end
 
     it "should shovel forever" do
-      source = LavinMQ::Shovel::AMQPSource.new("spec", URI.parse(AMQP_BASE_URL), "sf_q1", direct_user: Server.users.direct_user)
-      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(AMQP_BASE_URL), "sf_q2", direct_user: Server.users.direct_user)
+      source = LavinMQ::Shovel::AMQPSource.new("spec", URI.parse(Helper.amqp_base_url), "sf_q1", direct_user: Server.users.direct_user)
+      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(Helper.amqp_base_url), "sf_q2", direct_user: Server.users.direct_user)
       shovel = LavinMQ::Shovel::Runner.new(source, dest, "sf_shovel", vhost)
       with_channel do |ch|
         x, q2 = ShovelSpecHelpers.setup_qs ch, "sf_"
@@ -89,7 +89,7 @@ describe LavinMQ::Shovel do
       ack_mode = LavinMQ::Shovel::AckMode::OnPublish
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "ap_q1",
         prefetch: 1_u16,
         ack_mode: ack_mode,
@@ -97,7 +97,7 @@ describe LavinMQ::Shovel do
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "ap_q2",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
@@ -118,14 +118,14 @@ describe LavinMQ::Shovel do
       ack_mode = LavinMQ::Shovel::AckMode::NoAck
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "na_q1",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "na_q2",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
@@ -145,7 +145,7 @@ describe LavinMQ::Shovel do
     it "should shovel past prefetch" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "prefetch_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         prefetch: 21_u16,
@@ -153,7 +153,7 @@ describe LavinMQ::Shovel do
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "prefetch_q2",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         prefetch: 21_u16,
@@ -176,13 +176,13 @@ describe LavinMQ::Shovel do
     it "should shovel once qs are declared" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "od_q1",
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "od_q2",
         direct_user: Server.users.direct_user
       )
@@ -204,9 +204,9 @@ describe LavinMQ::Shovel do
         q1.publish_confirm "shovel me 1", props: AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
       end
       config = %({
-        "src-uri": "#{AMQP_BASE_URL}",
+        "src-uri": "#{Helper.amqp_base_url}",
         "src-queue": "rc_q1",
-        "dest-uri": "#{AMQP_BASE_URL}",
+        "dest-uri": "#{Helper.amqp_base_url}",
         "dest-queue": "rc_q2",
         "src-prefetch-count": 2})
       p = LavinMQ::Parameter.new("shovel", "rc_shovel", JSON.parse(config))
@@ -238,13 +238,13 @@ describe LavinMQ::Shovel do
     it "should shovel over amqps" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse("#{AMQPS_BASE_URL}?verify=none"),
+        URI.parse("#{Helper.amqps_base_url}?verify=none"),
         "ssl_q1",
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse("#{AMQPS_BASE_URL}?verify=none"),
+        URI.parse("#{Helper.amqps_base_url}?verify=none"),
         "ssl_q2",
         direct_user: Server.users.direct_user
       )
@@ -264,14 +264,14 @@ describe LavinMQ::Shovel do
       prefetch = 9_u16
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "prefetch2_q1",
         prefetch: prefetch,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "prefetch2_q2",
         prefetch: prefetch,
         direct_user: Server.users.direct_user
@@ -294,7 +294,7 @@ describe LavinMQ::Shovel do
 
     describe "authentication error" do
       it "should be stopped" do
-        uri = URI.parse(AMQP_BASE_URL)
+        uri = URI.parse(Helper.amqp_base_url)
         uri.user = "foo"
         uri.password = "bar"
         source = LavinMQ::Shovel::AMQPSource.new(
@@ -321,13 +321,13 @@ describe LavinMQ::Shovel do
     it "should count messages shoveled" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "c_q1",
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "c_q2",
         direct_user: Server.users.direct_user
       )
@@ -368,7 +368,7 @@ describe LavinMQ::Shovel do
       # # Setup shovel source and destination
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -416,7 +416,7 @@ describe LavinMQ::Shovel do
       # # Setup shovel source and destination
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(Helper.amqp_base_url),
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -111,7 +111,7 @@ def test_headers(headers = nil)
 end
 
 def start_amqp_server
-  amqp_tcp_server = TCPServer.new(port: 0)
+  amqp_tcp_server = TCPServer.new(port: AMQP_PORT)
   s = LavinMQ::Server.new(DATA_DIR)
   # spawn { s.listen(LavinMQ::Config.instance.amqp_bind, LavinMQ::Config.instance.amqp_port) }
   spawn { s.listen(amqp_tcp_server) }
@@ -120,7 +120,7 @@ def start_amqp_server
   ctx = OpenSSL::SSL::Context::Server.new
   ctx.certificate_chain = cert
   ctx.private_key = key
-  amqps_tcp_server = TCPServer.new(port: 0)
+  amqps_tcp_server = TCPServer.new(port: AMQPS_PORT)
   spawn { s.listen_tls(amqps_tcp_server, ctx) }
 
   LavinMQ::Config.instance.tap do |cfg|
@@ -133,7 +133,7 @@ end
 
 def start_http_server
   h = LavinMQ::HTTP::Server.new(Server)
-  addr = h.bind_tcp(LavinMQ::Config.instance.http_bind, LavinMQ::Config.instance.http_port)
+  addr = h.bind_tcp(LavinMQ::Config.instance.http_bind, HTTP_PORT)
   LavinMQ::Config.instance.tap do |cfg|
     cfg.http_port = addr.port
   end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -20,7 +20,7 @@ module UpstreamSpecHelpers
     upstream_vhost = Server.vhosts.create("upstream")
     downstream_vhost = Server.vhosts.create("downstream")
     upstream = LavinMQ::Federation::Upstream.new(downstream_vhost, upstream_name,
-      "#{AMQP_BASE_URL}/upstream", "upstream_ex")
+      "#{Helper.amqp_base_url}/upstream", "upstream_ex")
     downstream_vhost.upstreams.not_nil!.add(upstream)
     {upstream, upstream_vhost, downstream_vhost}
   end
@@ -44,7 +44,7 @@ end
 describe LavinMQ::Federation::Upstream do
   it "should federate queue" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", Helper.amqp_base_url, nil, "federation_q1")
 
     with_channel do |ch|
       x, q2 = UpstreamSpecHelpers.setup_qs ch
@@ -60,7 +60,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should not federate queue if no downstream consumer" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream wo downstream", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream wo downstream", Helper.amqp_base_url, nil, "federation_q1")
 
     with_channel do |ch|
       x = UpstreamSpecHelpers.setup_qs(ch).first
@@ -74,7 +74,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate queue with ack mode no-ack" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream no-ack", AMQP_BASE_URL, nil, "federation_q1",
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream no-ack", Helper.amqp_base_url, nil, "federation_q1",
       ack_mode: LavinMQ::Federation::AckMode::NoAck)
 
     with_channel do |ch|
@@ -91,7 +91,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate queue with ack mode on-publish" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream on-publish", AMQP_BASE_URL, nil, "federation_q1",
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream on-publish", Helper.amqp_base_url, nil, "federation_q1",
       ack_mode: LavinMQ::Federation::AckMode::OnPublish)
 
     with_channel do |ch|
@@ -108,7 +108,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should resume federation after downstream reconnects" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream reconnect", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream reconnect", Helper.amqp_base_url, nil, "federation_q1")
     msgs = [] of AMQP::Client::DeliverMessage
 
     with_channel do |ch|
@@ -136,7 +136,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate exchange" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "ef test upstream", AMQP_BASE_URL, "upstream_ex")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "ef test upstream", Helper.amqp_base_url, "upstream_ex")
 
     with_channel do |ch|
       downstream_ex = ch.exchange("downstream_ex", "topic")
@@ -155,7 +155,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should keep message properties" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream props", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream props", Helper.amqp_base_url, nil, "federation_q1")
 
     with_channel do |ch|
       x, q2 = UpstreamSpecHelpers.setup_qs ch

--- a/spec/websocket_spec.cr
+++ b/spec/websocket_spec.cr
@@ -2,14 +2,14 @@ require "./spec_helper"
 
 describe "Websocket support" do
   it "should connect over websocket" do
-    c = AMQP::Client.new("ws://localhost:#{HTTP_PORT}")
+    c = AMQP::Client.new("ws://localhost:#{Helper.http_port}")
     conn = c.connect
     conn.should_not be_nil
     conn.close
   end
 
   it "can publish large messages" do
-    c = AMQP::Client.new("ws://localhost:#{HTTP_PORT}")
+    c = AMQP::Client.new("ws://localhost:#{Helper.http_port}")
     conn = c.connect
     ch = conn.channel
     q = ch.queue

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -49,21 +49,25 @@ module LavinMQ
       def bind(socket)
         addr = @http.bind(socket)
         @log.info { "Bound to #{addr}" }
+        addr
       end
 
       def bind_tcp(address, port)
         addr = @http.bind_tcp address, port
         @log.info { "Bound to #{addr}" }
+        addr
       end
 
       def bind_tls(address, port, ctx)
         addr = @http.bind_tls address, port, ctx
         @log.info { "Bound on #{addr}" }
+        addr
       end
 
       def bind_unix(path)
         addr = @http.bind_unix path
         @log.info { "Bound to #{addr}" }
+        addr
       end
 
       def bind_internal_unix

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -119,7 +119,10 @@ module LavinMQ
     end
 
     def listen_tls(bind, port, context)
-      s = TCPServer.new(bind, port)
+      listen_tls(TCPServer.new(bind, port), context)
+    end
+
+    def listen_tls(s : TCPServer, context)
       @listeners[s] = :amqps
       @log.info { "Listening on #{s.local_address} (TLS)" }
       loop do # do not try to use while


### PR DESCRIPTION
I always forget to set AMQP_PORT etc when i run specs, and I don't want to stop any running LavinMQ/RabbitMQ, so I made this change to always use a free port.