### PR TITLE
Add Random Exchange Type (x-random)

### DIFF
--- a/openapi/schemas/exchanges.yaml
+++ b/openapi/schemas/exchanges.yaml
@@ -76,6 +76,7 @@ type-field:
       - x-delayed-message
       - x-federation-upstream
       - x-consistent-hash
+      - x-random
 
 PutExchangeRequestBody:
   allOf:

--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -28,6 +28,25 @@ describe LavinMQ::DirectExchange do
   end
 end
 
+describe LavinMQ::RandomExchange do
+  it "matches one in any rk" do
+    vhost = Server.vhosts.create("x")
+    q1 = LavinMQ::Queue.new(vhost, "q1")
+    q2 = LavinMQ::Queue.new(vhost, "q2")
+    x = LavinMQ::RandomExchange.new(vhost, "")
+    x.bind(q1, "q1", Hash(String, LavinMQ::AMQP::Field).new)
+    x.bind(q2, "")
+    matches = x.matches("q1")
+    (matches == Set{q1} || matches == Set{q2}).should be_true
+  end
+
+  it "matches no rk" do
+    vhost = Server.vhosts.create("x")
+    x = LavinMQ::RandomExchange.new(vhost, "")
+    x.matches("q1").should be_empty
+  end
+end
+
 describe LavinMQ::FanoutExchange do
   it "matches any rk" do
     vhost = Server.vhosts.create("x")

--- a/src/lavinmq/exchange/random.cr
+++ b/src/lavinmq/exchange/random.cr
@@ -1,0 +1,50 @@
+require "./exchange"
+
+module LavinMQ
+  class RandomExchange < Exchange
+    def type : String
+      "x-random"
+    end
+
+    def bind(destination : Queue, routing_key, headers = nil)
+      @queue_bindings[{routing_key, nil}] << destination
+      after_bind(destination, routing_key, headers)
+    end
+
+    def bind(destination : Exchange, routing_key, headers = nil)
+      @exchange_bindings[{routing_key, nil}] << destination
+      after_bind(destination, routing_key, headers)
+    end
+
+    def unbind(destination : Queue, routing_key, headers = nil)
+      @queue_bindings[{routing_key, nil}].delete destination
+      after_unbind(destination, routing_key, headers)
+    end
+
+    def unbind(destination : Exchange, routing_key, headers = nil)
+      @exchange_bindings[{routing_key, nil}].delete destination
+      after_unbind(destination, routing_key, headers)
+    end
+
+    def do_queue_matches(routing_key, headers = nil, & : Queue -> _)
+      queues = @queue_bindings.values.map { |s| s.to_a }.flatten
+      without_internal = queues.select { |q| !q.internal? }
+
+      if without_internal.empty?
+        return
+      end
+
+      yield without_internal.sample
+    end
+
+    def do_exchange_matches(routing_key, headers = nil, & : Exchange -> _)
+      exchanges = @exchange_bindings.values.map { |s| s.to_a }.flatten
+
+      if exchanges.empty?
+        return
+      end
+
+      yield exchanges.sample
+    end
+  end
+end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -25,7 +25,7 @@ module LavinMQ
     class MainController < Controller
       include StatsHelpers
       OVERVIEW_STATS = {"ack", "deliver", "get", "publish", "confirm", "redeliver", "reject"}
-      EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers", "x-federation-upstream", "x-consistent-hash"}
+      EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers", "x-federation-upstream", "x-consistent-hash", "x-random"}
 
       private def register_routes
         get "/api/overview" do |context, _params|

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -992,6 +992,8 @@ module LavinMQ
         FederationExchange.new(vhost, name, arguments)
       when "x-consistent-hash"
         ConsistentHashExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+      when "x-random"
+        RandomExchange.new(vhost, name, durable, auto_delete, internal, arguments)
       else raise Error::ExchangeTypeError.new("invalid exchange type '#{type}'")
       end
     end


### PR DESCRIPTION
### Additional Context
In rabbit this previously used routing keys.
> It's basically a direct exchange, with the exception that, instead of each consumer bound to that exchange with the same routing key getting a copy of the message, the exchange type randomly selects a queue to route to.

The behavior was changed to not use routing keys in this commit: [Ignore [binding] routing keys](https://github.com/rabbitmq/rabbitmq-server/commit/10115654c8e0ddd970558e89b8390f65e1c3e7ef).