### PR TITLE
Specify memory usage details

### DIFF
--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -24,7 +24,7 @@
             <td id="tr-vcpu"></td>
           </tr>
           <tr>
-            <th>Memory usage</th>
+            <th>LavinMQ memory usage</th>
             <td id="tr-memory"></td>
           </tr>
           <tr>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85930202/224939734-4bd6c468-b65b-4bc0-8602-56a44b672d3a.png)

Currently we display the amount of memory used as if it is regardin the entire system memory, when in fact it only represents the amount of memory that the lavinmq process is utilizing. 
This is a draft to come closer to a more clear presentation. 