### PR TITLE
Allow lavinmq to be used as a dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lavinmq
-version: 1.0.0-beta.10
+version: 1.0.0-beta10
 
 authors:
   - Carl Hörberg <carl@cloudamqp.com>

--- a/shard.yml
+++ b/shard.yml
@@ -28,7 +28,6 @@ dependencies:
     github: tbrand/router.cr
   amqp-client:
     github: cloudamqp/amqp-client.cr
-    branch: main
   http-protection:
     github: 84codes/http-protection
     branch: master


### PR DESCRIPTION
Shards didn't accept the version format and pinning against a branch, even if it's the default, results in version conflicts for the same dependency is used in the project dependent on lavinmq.

This enables lavinmq to be used as a dependency.