### PR TITLE
Respond with 400 instead of 500 for PreconditionFailed errors

### DIFF
--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -144,6 +144,17 @@ describe LavinMQ::HTTP::QueuesController do
       response.status_code.should eq 400
     end
 
+    it "should respond with 400 for PreconditionFailed errors" do
+      # supplying 'x-dead-letter-routing-key' is only valid if
+      # 'x-dead-letter-exchange' is also in the request
+      # so this request generates a Error::PreconditionFailed
+      body = %({
+        "arguments": {"x-dead-letter-routing-key": "value"}
+      })
+      response = put("/api/queues/%2f/precond-failed", body: body)
+      response.status_code.should eq 400
+    end
+
     it "should require config access to declare" do
       hdrs = HTTP::Headers{"Authorization" => "Basic dGVzdF9wZXJtOnB3"}
       response = put("/api/queues/%2f/test_perm", headers: hdrs, body: %({}))

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -68,9 +68,13 @@ module LavinMQ
             elsif name.starts_with? "amq."
               bad_request(context, "Not allowed to use the amq. prefix")
             else
-              @amqp_server.vhosts[vhost]
-                .declare_queue(name, durable, auto_delete, tbl)
-              context.response.status_code = 201
+              begin
+                @amqp_server.vhosts[vhost]
+                  .declare_queue(name, durable, auto_delete, tbl)
+                context.response.status_code = 201
+              rescue e : LavinMQ::Error::PreconditionFailed
+                bad_request(context, e.message)
+              end
             end
           end
         end


### PR DESCRIPTION
Considering PreconditionFailed is generated by bad input 400 Bad request seems like a good response code
The body is the Exception message