### PR TITLE
add exponential backoff for shovel-error connection retries

### DIFF
--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -275,12 +275,14 @@ module LavinMQ
       @state = State::Stopped
       @error : String?
       @message_count : UInt64 = 0
+      @retries : Int64 = 0
 
       getter name, vhost
 
       def initialize(@source : AMQPSource, @destination : Destination,
                      @name : String, @vhost : VHost, @reconnect_delay = DEFAULT_RECONNECT_DELAY)
         @log = @vhost.log.for "shovel=#{@name}"
+        @delay = @reconnect_delay
       end
 
       def state
@@ -301,6 +303,8 @@ module LavinMQ
           break if terminated?
           @log.info { "started" }
           @state = State::Running
+          @retries = 0
+          @delay = @reconnect_delay
           @source.each do |msg|
             @message_count += 1
             @destination.push(msg, @source)
@@ -316,16 +320,26 @@ module LavinMQ
           end
           @log.error(exception: ex) { ex.message }
           @error = ex.message
-          sleep @reconnect_delay.seconds
+          exponential_reconnect_delay
         rescue ex
           break if terminated?
           @state = State::Error
           @log.error(exception: ex) { ex.message }
           @error = ex.message
-          sleep @reconnect_delay.seconds
+          exponential_reconnect_delay
         end
       ensure
         terminate
+      end
+
+      def exponential_reconnect_delay
+        @retries += 1
+        if @retries > 5
+          sleep @delay.seconds
+          @delay = [@delay * 2, 300].min unless @delay > 300
+        else
+          sleep @delay.seconds
+        end
       end
 
       def details_tuple

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -334,11 +334,9 @@ module LavinMQ
 
       def exponential_reconnect_delay
         @retries += 1
+        sleep @delay.seconds
         if @retries > 5
-          sleep @delay.seconds
-          @delay = [@delay * 2, 300].min unless @delay > 300
-        else
-          sleep @delay.seconds
+          @delay = [@delay * 2, 300].min
         end
       end
 

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -276,6 +276,8 @@ module LavinMQ
       @error : String?
       @message_count : UInt64 = 0
       @retries : Int64 = 0
+      @retry_threshold : Int64 = 10
+      @max_delay : Int64 = 300
 
       getter name, vhost
 
@@ -335,8 +337,8 @@ module LavinMQ
       def exponential_reconnect_delay
         @retries += 1
         sleep @delay.seconds
-        if @retries > 5
-          @delay = [@delay * 2, 300].min
+        if @retries > @retry_threshold
+          @delay = [@delay * 2, @max_delay].min
         end
       end
 


### PR DESCRIPTION
Adds an exponential backoff function for the reconnection delay on a shovel's runner. 

If you have an persistent error, the error will loop on reconnection_delay which by default is 5 seconds, and that can be a bit annoying. With this PR, the reconnection_delay will after 5 retries exponentially increase up to 5 minutes. 
If you have manually set the reconnection_delay to > 300(5 minutes), it will retry on that delay and not increase. 