### PR TITLE
UI changes

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -12,10 +12,6 @@ shards:
     git: https://github.com/cloudamqp/amqp-client.cr.git
     version: 1.0.10
 
-  http-protection:
-    git: https://github.com/84codes/http-protection.git
-    version: 0.2.0+git.commit.893a191d55e301e0df96d6dd0f7d72c527bddeb8
-
   radix:
     git: https://github.com/luislavena/radix.git
     version: 0.4.1

--- a/shard.yml
+++ b/shard.yml
@@ -30,9 +30,6 @@ dependencies:
     github: cloudamqp/amq-protocol.cr
   router:
     github: tbrand/router.cr
-  http-protection:
-    github: 84codes/http-protection
-    branch: master
   systemd:
     github: 84codes/systemd.cr
 

--- a/spec/http_static_spec.cr
+++ b/spec/http_static_spec.cr
@@ -13,25 +13,4 @@ describe LavinMQ::HTTP::StaticController do
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("image/png")
   end
-
-  it "GET /test/ serves index.html in the directory" do
-    response = ::HTTP::Client.get "#{BASE_URL}/test/"
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should eq("This is a test\n")
-  end
-
-  it "GET /test (without trailing /) serves index.html in the directory" do
-    response = ::HTTP::Client.get "#{BASE_URL}/test"
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should eq("This is a test\n")
-  end
-
-  it "GET /test/index.html" do
-    response = ::HTTP::Client.get "#{BASE_URL}/test/index.html"
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should eq("This is a test\n")
-  end
 end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -14,10 +14,6 @@ module LavinMQ
 
       private abstract def register_routes
 
-      private def query_params(context)
-        context.request.query_params
-      end
-
       private def filter_values(params, iterator)
         return iterator unless raw_name = params["name"]?
         term = URI.decode_www_form(raw_name)
@@ -35,7 +31,7 @@ module LavinMQ
       MAX_PAGE_SIZE = 10_000
 
       private def page(context, iterator : Iterator(SortableJSON))
-        params = query_params(context)
+        params = context.request.query_params
         page = params["page"]?.try(&.to_i) || 1
         page_size = params["page_size"]?.try(&.to_i) || 100
         if page_size > MAX_PAGE_SIZE

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -1,12 +1,10 @@
 require "router"
 require "../sortable_json"
-require "./controller/view_helpers"
 
 module LavinMQ
   module HTTP
     abstract class Controller
       include Router
-      include ViewHelpers
       @log : Log
 
       def initialize(@amqp_server : LavinMQ::Server, log : Log)

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -8,9 +8,6 @@ module LavinMQ
       include ConnectionsHelper
 
       private def register_routes
-        static_view "/channels"
-        static_view "/channel"
-
         get "/api/channels" do |context, _params|
           page(context, all_channels(user(context)))
         end

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -17,9 +17,6 @@ module LavinMQ
       include ConnectionsHelper
 
       private def register_routes
-        static_view "/connections"
-        static_view "/connection"
-
         get "/api/connections" do |context, _params|
           page(context, connections(user(context)).each)
         end

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -20,9 +20,6 @@ module LavinMQ
 
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
-        static_view "/exchanges"
-        static_view "/exchange"
-
         get "/api/exchanges" do |context, _params|
           itr = vhosts(user(context)).flat_map &.exchanges.each_value
           page(context, itr)

--- a/src/lavinmq/http/controller/logs.cr
+++ b/src/lavinmq/http/controller/logs.cr
@@ -8,8 +8,6 @@ module LavinMQ
       LogBackend = ::Log::InMemoryBackend.instance
 
       private def register_routes
-        static_view "/logs"
-
         get "/api/livelog" do |context, _params|
           channel = LogBackend.add_channel
           context.response.content_type = "text/event-stream"

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -29,13 +29,6 @@ module LavinMQ
       EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers", "x-federation-upstream", "x-consistent-hash"}
 
       private def register_routes
-        static_view "/", "overview"
-        static_view "/login"
-        static_view "/401"
-        static_view "/404"
-        static_view "/federation"
-        static_view "/shovels"
-
         get "/api/overview" do |context, _params|
           x_vhost = context.request.headers["x-vhost"]?
           channels, connections, exchanges, queues, consumers, ready, unacked = 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -92,8 +92,6 @@ module LavinMQ
       end
 
       private def register_routes
-        static_view "/nodes"
-
         get "/api/nodes" do |context, _params|
           Tuple.new(stats(context)).to_json(context.response)
           context

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -21,9 +21,6 @@ module LavinMQ
 
     class ParametersController < Controller
       private def register_routes # ameba:disable Metrics/CyclomaticComplexity
-        static_view "/policies"
-        static_view "/operator-policies"
-
         get "/api/parameters" do |context, _params|
           user = user(context)
           refuse_unless_policymaker(context, user)

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -19,9 +19,6 @@ module LavinMQ
 
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
-        static_view "/queues"
-        static_view "/queue"
-
         get "/api/queues" do |context, _|
           itr = Iterator(Queue).chain(vhosts(user(context)).map &.queues.each_value)
           page(context, itr)

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -10,7 +10,7 @@ module LavinMQ
       def call(context)
         path = context.request.path
         if context.request.method.in?("GET", "HEAD") && !path.starts_with?("/api/")
-          path = File.join(path, "index.html") if path.ends_with?('/') || !path.includes?('.')
+          path = "/docs/index.html" if path == "/docs/"
           serve(context, path) || call_next(context)
         else
           call_next(context)
@@ -54,7 +54,7 @@ module LavinMQ
               context.response.headers.add("ETag", etag)
               context.response.content_type = mime_type(file.path)
               context.response.content_length = file.size
-              IO.copy(file, context.response) unless context.request.method == "HEAD"
+              IO.copy(file, context.response) if context.request.method == "GET"
             end
             context
           end

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -1,5 +1,4 @@
 require "http/server/handler"
-require "digest/md5"
 
 module LavinMQ
   module HTTP
@@ -24,8 +23,8 @@ module LavinMQ
         }
 
         private def serve(context, file_path)
-          if bytes = Files[file_path]?
-            etag = Digest::MD5.hexdigest(bytes)
+          if bytes_etag = Files[file_path]?
+            bytes, etag = bytes_etag
             if context.request.headers["If-None-Match"]? == etag
               context.response.status_code = 304
             else

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -28,7 +28,7 @@ module LavinMQ
             if context.request.headers["If-None-Match"]? == etag
               context.response.status_code = 304
             else
-              context.response.headers.add("Cache-Control", "public,max-age=300")
+              context.response.headers.add("Cache-Control", "no-cache")
               context.response.headers.add("ETag", etag)
               context.response.content_type = mime_type(file_path)
               context.response.content_length = bytes.size
@@ -50,7 +50,7 @@ module LavinMQ
             if context.request.headers["If-None-Match"]? == etag
               context.response.status_code = 304
             else
-              context.response.headers.add("Cache-Control", "public,max-age=300")
+              context.response.headers.add("Cache-Control", "no-cache")
               context.response.headers.add("ETag", etag)
               context.response.content_type = mime_type(file.path)
               context.response.content_length = file.size

--- a/src/lavinmq/http/controller/static/bake.cr
+++ b/src/lavinmq/http/controller/static/bake.cr
@@ -1,10 +1,14 @@
+require "digest/md5"
+
 def recursive_bake(dir)
   Dir.each_child(dir) do |child|
     path = File.join(dir, child)
     if File.directory? path
       recursive_bake path
     else
-      puts %("#{path.lchop(ARGV[0])}": #{File.read(path).inspect}.to_slice,)
+      bytes = File.read(path)
+      etag = Digest::MD5.hexdigest(bytes)
+      puts %("#{path.lchop(ARGV[0])}": {#{bytes.inspect}.to_slice, #{etag.inspect}},)
     end
   end
 end

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -26,9 +26,6 @@ module LavinMQ
       include UserHelpers
 
       private def register_routes # ameba:disable Metrics/CyclomaticComplexity
-        static_view "/users"
-        static_view "/user"
-
         get "/api/users" do |context, _params|
           refuse_unless_administrator(context, user(context))
           page(context, @amqp_server.users.each_value.reject(&.hidden?)

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -16,9 +16,6 @@ module LavinMQ
 
     class VHostsController < Controller
       private def register_routes
-        static_view "/vhosts"
-        static_view "/vhost"
-
         get "/api/vhosts" do |context, _params|
           vhosts = vhosts(user(context)).map { |v| VHostView.new(v) }
           page(context, vhosts)

--- a/src/lavinmq/http/controller/view_helpers.cr
+++ b/src/lavinmq/http/controller/view_helpers.cr
@@ -1,5 +1,6 @@
 require "html"
 require "../../version"
+require "digest/md5"
 
 module LavinMQ
   module HTTP

--- a/src/lavinmq/http/controller/view_helpers.cr
+++ b/src/lavinmq/http/controller/view_helpers.cr
@@ -35,7 +35,7 @@ module LavinMQ
       macro static_view(path, view = nil, &block)
         {% view = path[1..] if view.nil? %}
         # etag won't change in runtime, so it's enough to calculate it once
-        %etag = Digest::MD5.hexdigest("{{view.id}} #{VERSION}")
+        %etag = Digest::MD5.hexdigest("{{view.id}} #{LavinMQ::VERSION}")
         get {{path}} do |context, params|
           if_non_match = context.request.headers["If-None-Match"]?
           Log.trace { "static_view path={{path.id}} etag=#{%etag} if-non-match=#{if_non_match}" }

--- a/src/lavinmq/http/controller/view_helpers.cr
+++ b/src/lavinmq/http/controller/view_helpers.cr
@@ -45,6 +45,8 @@ module LavinMQ
             context.response.content_type = "text/html;charset=utf-8"
             context.response.headers.add("Cache-Control", "public,max-age=300")
             context.response.headers.add("ETag", %etag)
+            context.response.headers.add("X-Frame-Options", "SAMEORIGIN")
+            context.response.headers.add("Referrer-Policy", "same-origin")
             {{block.body if block}}
             render {{view}}
           end

--- a/src/lavinmq/http/controller/views.cr
+++ b/src/lavinmq/http/controller/views.cr
@@ -1,23 +1,36 @@
-require "html"
+require "router"
 require "../../version"
+require "html"
 require "digest/md5"
 
 module LavinMQ
   module HTTP
-    module ViewHelpers
-      # Render an ecr file from views dir
-      macro render(file)
-        ECR.embed "views/{{file.id}}.ecr", context.response
-      end
+    class ViewsController
+      include Router
 
-      # Use in view to html escape output
-      # `<% escape varaible_name %>` or `<% escape "string" %>`
-      macro escape(value)
-        HTML.escape({{value}}, context.response)
-      end
-
-      macro active_path?(path)
-        context.request.path == "/#{{{path}}}" || (context.request.path == "/" && {{path}} == :".")
+      def initialize
+        static_view "/", "overview"
+        static_view "/login"
+        static_view "/401"
+        static_view "/404"
+        static_view "/federation"
+        static_view "/shovels"
+        static_view "/connections"
+        static_view "/connection"
+        static_view "/channels"
+        static_view "/channel"
+        static_view "/exchanges"
+        static_view "/exchange"
+        static_view "/vhosts"
+        static_view "/vhost"
+        static_view "/queues"
+        static_view "/queue"
+        static_view "/nodes"
+        static_view "/logs"
+        static_view "/users"
+        static_view "/user"
+        static_view "/policies"
+        static_view "/operator-policies"
       end
 
       # Generate a get handler for given path. If no view is specified, path without initial
@@ -43,7 +56,7 @@ module LavinMQ
             context.response.status_code = 304
           else
             context.response.content_type = "text/html;charset=utf-8"
-            context.response.headers.add("Cache-Control", "public,max-age=300")
+            context.response.headers.add("Cache-Control", "no-cache")
             context.response.headers.add("ETag", %etag)
             context.response.headers.add("X-Frame-Options", "SAMEORIGIN")
             context.response.headers.add("Referrer-Policy", "same-origin")
@@ -52,6 +65,15 @@ module LavinMQ
           end
           context
         end
+      end
+
+      # Render an ecr file from views dir
+      macro render(file)
+        ECR.embed "views/{{file.id}}.ecr", context.response
+      end
+
+      macro active_path?(path)
+        context.request.path == "/#{{{path}}}" || (context.request.path == "/" && {{path}} == :".")
       end
     end
   end

--- a/src/lavinmq/http/handler/defaults_handler.cr
+++ b/src/lavinmq/http/handler/defaults_handler.cr
@@ -10,7 +10,6 @@ module LavinMQ
           context.response.content_type = "application/json"
           context.response.headers.add("Cache-Control", "private,max-age=5")
         end
-        context.response.headers.add("Referrer-Policy", "same-origin")
         call_next(context)
       end
     end

--- a/src/lavinmq/http/handler/strict_transport_security.cr
+++ b/src/lavinmq/http/handler/strict_transport_security.cr
@@ -1,0 +1,14 @@
+require "http/server/handler"
+
+module LavinMQ
+  module HTTP
+    class StrictTransportSecurity
+      include ::HTTP::Handler
+
+      def call(context)
+        context.response.headers.add("Strict-Transport-Security", "max-age=31536000")
+        call_next(context)
+      end
+    end
+  end
+end

--- a/src/lavinmq/http/handler/websocket.cr
+++ b/src/lavinmq/http/handler/websocket.cr
@@ -5,8 +5,7 @@ module LavinMQ
     def self.new(amqp_server : Server)
       ::HTTP::WebSocketHandler.new do |ws, ctx|
         req = ctx.request
-        local_address = Socket::IPAddress.new("0.0.0.0", 15672) # guessing local address for older crystal versions
-        local_address = req.local_address.as(Socket::IPAddress) if req.responds_to?(:local_address)
+        local_address = req.local_address.as(Socket::IPAddress)
         remote_address = req.remote_address.as(Socket::IPAddress)
         connection_info = ConnectionInfo.new(remote_address, local_address)
         io = WebSocketIO.new(ws)

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -1,5 +1,4 @@
 require "http/server"
-require "http-protection"
 require "json"
 require "router"
 require "./constants"
@@ -17,12 +16,11 @@ module LavinMQ
       def initialize(@amqp_server : LavinMQ::Server)
         @log = Log.for "http"
         handlers = [
-          ::HTTP::Protection::StrictTransport.new,
-          ::HTTP::Protection::FrameOptions.new,
+          StrictTransportSecurity.new,
+          StaticController.new,
           AMQPWebsocket.new(@amqp_server),
           ApiDefaultsHandler.new,
           ApiErrorHandler.new(@log),
-          StaticController.new,
           BasicAuthHandler.new(@amqp_server, @log),
           MainController.new(@amqp_server, @log).route_handler,
           DefinitionsController.new(@amqp_server, @log).route_handler,

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -17,6 +17,7 @@ module LavinMQ
         @log = Log.for "http"
         handlers = [
           StrictTransportSecurity.new,
+          ViewsController.new.route_handler,
           StaticController.new,
           AMQPWebsocket.new(@amqp_server),
           ApiDefaultsHandler.new,

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -17,9 +17,9 @@ module LavinMQ
         @log = Log.for "http"
         handlers = [
           StrictTransportSecurity.new,
+          AMQPWebsocket.new(@amqp_server),
           ViewsController.new.route_handler,
           StaticController.new,
-          AMQPWebsocket.new(@amqp_server),
           ApiDefaultsHandler.new,
           ApiErrorHandler.new(@log),
           BasicAuthHandler.new(@amqp_server, @log),

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -3,14 +3,13 @@ import * as DOM from './dom.js'
 import * as Table from './table.js'
 import * as Chart from './chart.js'
 
-const urlEncodedConnection = new URLSearchParams(window.location.search).get('name')
-const connection = decodeURIComponent(urlEncodedConnection)
 const chart = Chart.render('chart', 'bytes/s')
 
-document.title = connection + ' | LavinMQ'
+const connection = new URLSearchParams(window.location.hash.substring(1)).get('name')
+document.title = `Connection ${connection} | LavinMQ`
 document.querySelector('#pagename-label').textContent = connection
 
-const connectionUrl = 'api/connections/' + urlEncodedConnection
+const connectionUrl = `api/connections/${connection}`
 function updateConnection (all) {
   HTTP.request('GET', connectionUrl).then(item => {
     const stats = { send_details: item.send_oct_details, receive_details: item.recv_oct_details }
@@ -49,13 +48,18 @@ function updateConnection (all) {
 updateConnection(true)
 const cTimer = setInterval(updateConnection, 5000)
 const channelsUrl = connectionUrl + '/channels'
-const tableOptions = { url: channelsUrl, keyColumns: ['name'], interval: 5000 }
+const tableOptions = {
+  url: channelsUrl,
+  keyColumns: ['name'],
+  interval: 5000,
+  countId: 'table-count'
+}
 Table.renderTable('table', tableOptions, function (tr, item, all) {
   if (all) {
     const channelLink = document.createElement('a')
     const urlEncodedChannel = encodeURIComponent(item.name)
     channelLink.textContent = item.name
-    channelLink.href = 'channel?name=' + urlEncodedChannel
+    channelLink.href = `channel#name=${urlEncodedChannel}`
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.username)

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -4,8 +4,9 @@ import * as DOM from './dom.js'
 import * as Table from './table.js'
 import * as Chart from './chart.js'
 
-const exchange = new URLSearchParams(window.location.search).get('name')
-const vhost = new URLSearchParams(window.location.search).get('vhost')
+const search = new URLSearchParams(window.location.hash.substring(1))
+const exchange = search.get('name')
+const vhost = search.get('vhost')
 const urlEncodedExchange = encodeURIComponent(exchange)
 const urlEncodedVhost = encodeURIComponent(vhost)
 const chart = Chart.render('chart', 'msgs/s')
@@ -37,7 +38,7 @@ function updateExchange () {
     DOM.setChild('#e-arguments', argList)
     if (item.policy) {
       const policyLink = document.createElement('a')
-      policyLink.href = 'policies?name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+      policyLink.href = 'policies#name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
       policyLink.textContent = item.policy
       DOM.setChild('#e-policy', policyLink)
     }
@@ -68,7 +69,7 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
         }).catch(HTTP.standardErrorHandler)
     }
     const d = encodeURIComponent(item.destination)
-    const destinationLink = `<a href="${escapeHTML(item.destination_type)}?vhost=${urlEncodedVhost}&name=${escapeHTML(d)}">${escapeHTML(item.destination)}</a>`
+    const destinationLink = `<a href="${escapeHTML(item.destination_type)}#vhost=${urlEncodedVhost}&name=${escapeHTML(d)}">${escapeHTML(item.destination)}</a>`
     Table.renderCell(tr, 0, item.destination_type)
     Table.renderHtmlCell(tr, 1, destinationLink, 'left')
     Table.renderCell(tr, 2, item.routing_key, 'left')

--- a/static/js/exchanges.js
+++ b/static/js/exchanges.js
@@ -43,7 +43,7 @@ const exchangeTable = Table.renderTable('table', tableOptions, function (tr, ite
     features += item.internal ? ' I' : ''
     features += item.arguments['x-delayed-exchange'] ? ' d' : ''
     const exchangeLink = document.createElement('a')
-    exchangeLink.href = 'exchange?vhost=' + encodeURIComponent(item.vhost) + '&name=' + encodeURIComponent(item.name)
+    exchangeLink.href = `exchange#vhost=${encodeURIComponent(item.vhost)}&name=${encodeURIComponent(item.name)}`
     exchangeLink.textContent = item.name
     Table.renderCell(tr, 0, item.vhost)
     Table.renderCell(tr, 1, exchangeLink)
@@ -53,7 +53,7 @@ const exchangeTable = Table.renderTable('table', tableOptions, function (tr, ite
   let policyLink = ''
   if (item.policy) {
     policyLink = document.createElement('a')
-    policyLink.href = 'policies?name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+    policyLink.href = 'policies#name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
     policyLink.textContent = item.policy
   }
   Table.renderCell(tr, 4, policyLink, 'center')

--- a/static/js/policies.js
+++ b/static/js/policies.js
@@ -84,7 +84,7 @@ function apply(base_url = 'api/policies') {
   function autofill_editpolicy(policies, otherOrigin = true) {
     let policy = null
     if (otherOrigin) {
-      const urlParams = new URLSearchParams(window.location.search);
+      const urlParams = new URLSearchParams(window.location.hash.substring(1));
       const pname = urlParams.get('name')
       const pvhost = urlParams.get('vhost');
       if (!(pname && pvhost)) {

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -5,8 +5,9 @@ import * as Table from './table.js'
 import * as Chart from './chart.js'
 import * as Auth from './auth.js'
 
-const queue = new URLSearchParams(window.location.search).get('name')
-const vhost = new URLSearchParams(window.location.search).get('vhost')
+const search = new URLSearchParams(window.location.hash.substring(1))
+const queue = search.get('name')
+const vhost = search.get('vhost')
 const urlEncodedQueue = encodeURIComponent(queue)
 const urlEncodedVhost = encodeURIComponent(vhost)
 const escapeHTML = DOM.escapeHTML
@@ -17,7 +18,7 @@ document.title = queue + ' | LavinMQ'
 let consumerListLength = 20
 const consumersTable = Table.renderTable('table', { keyColumns: [], countId: "consumer-count" }, function (tr, item) {
   const channelLink = document.createElement('a')
-  channelLink.href = 'channel?name=' + encodeURIComponent(item.channel_details.name)
+  channelLink.href = 'channel#name=' + encodeURIComponent(item.channel_details.name)
   channelLink.textContent = item.channel_details.name
   const ack = item.ack_required ? '●' : '○'
   const exclusive = item.exclusive ? '●' : '○'
@@ -105,13 +106,13 @@ function updateQueue (all) {
         document.querySelector('.queue').textContent = queue
         if (item.policy) {
           const policyLink = document.createElement('a')
-          policyLink.href = 'policies?name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+          policyLink.href = `policies#name=${encodeURIComponent(item.policy)}&vhost=${encodeURIComponent(item.vhost)}`
           policyLink.textContent = item.policy
           document.getElementById("q-policy").appendChild(policyLink)
         }
         if (item.operator_policy) {
           const policyLink = document.createElement('a')
-          policyLink.href = `operator-policies?name=${encodeURIComponent(item.operator_policy)}&vhost=${encodeURIComponent(item.vhost)}`
+          policyLink.href = `operator-policies#name=${encodeURIComponent(item.operator_policy)}&vhost=${encodeURIComponent(item.vhost)}`
           policyLink.textContent = item.operator_policy
           document.getElementById("q-operator-policy").appendChild(policyLink)
         }
@@ -153,10 +154,14 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
         .then(() => { DOM.removeNodes(tr) })
         .catch(HTTP.standardErrorHandler)
     }
-    const exchangeLink = `<a href="exchange?vhost=${urlEncodedVhost}&name=${escapeHTML(e)}">${escapeHTML(item.source)}</a>`
-    Table.renderHtmlCell(tr, 0, exchangeLink)
+    const exchangeLink = document.createElement('a')
+    exchangeLink.href = `exchange#vhost=${urlEncodedVhost}&name=${e}`
+    exchangeLink.textContent = escapeHTML(item.source)
+    Table.renderCell(tr, 0, exchangeLink)
     Table.renderCell(tr, 1, item.routing_key)
-    Table.renderHtmlCell(tr, 2, '<pre>' + JSON.stringify(item.arguments || {}) + '</pre>')
+    const pre = document.createElement("pre")
+    pre.textContent = JSON.stringify(item.arguments || {})
+    Table.renderCell(tr, 2, pre)
     Table.renderCell(tr, 3, btn, 'right')
   }
 })

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -80,7 +80,7 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
     features += item.exclusive ? ' E' : ''
     features += Object.keys(item.arguments).length > 0  ? ' Args ' : ''
     const queueLink = document.createElement('a')
-    queueLink.href = 'queue?vhost=' + encodeURIComponent(item.vhost) + '&name=' + encodeURIComponent(item.name)
+    queueLink.href = 'queue#vhost=' + encodeURIComponent(item.vhost) + '&name=' + encodeURIComponent(item.name)
     queueLink.textContent = item.name
 
     const checkbox = document.createElement('input')
@@ -97,7 +97,7 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
   let policyLink = ''
   if (item.policy) {
     policyLink = document.createElement('a')
-    policyLink.href = 'policies?name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+    policyLink.href = 'policies#name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
     policyLink.textContent = item.policy
   }
   Table.renderCell(tr, 4, policyLink, 'center')

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -1,14 +1,11 @@
 import * as HTTP from './http.js'
 import * as Dom from './dom.js'
 
-function getQueryVariable (variable) {
-  return new URLSearchParams(window.location.search).get(variable)
-}
-
 function renderTable (id, options = {}, renderRow) {
-  let sortKey = getQueryVariable('sort')
-  let reverseOrder = strToBool(getQueryVariable('reverseOrder'))
-  const view = window.location.pathname.split('/').pop()
+  const search = new URLSearchParams(window.location.hash.substring(1))
+  let sortKey = search.get('sort')
+  let reverseOrder = strToBool(search.get('reverseOrder'))
+  const view = window.location.pathname.split('/', 2)[0]
   if (!sortKey || reverseOrder === null) {
     sortKey = window.sessionStorage.getItem(view + '-sortkey')
     reverseOrder = strToBool(window.sessionStorage.getItem(view + '-reverseorder'))
@@ -21,15 +18,15 @@ function renderTable (id, options = {}, renderRow) {
   const interval = options.interval
   let timer = null
   let searchTerm = null
-  const currentPage = getQueryVariable('page') || 1
-  let pageSize = getQueryVariable('page_size') || 100
+  const currentPage = search.get('page') || 1
+  let pageSize = search.get('page_size') || 100
 
   if (options.columnSelector) {
     renderColumnSelector(table)
   }
 
   if (options.search) {
-    searchTerm = getQueryVariable('name')
+    searchTerm = search.get('name')
     renderSearch(table)
   }
 
@@ -120,11 +117,11 @@ function renderTable (id, options = {}, renderRow) {
   }
 
   function getData () {
-    return JSON.parse(window.sessionStorage.getItem(`${url}?${buildQuery(currentPage)}`)).items
+    return JSON.parse(window.sessionStorage.getItem(`${url}#${buildQuery(currentPage)}`)).items
   }
 
   function fetchAndUpdate () {
-    const fullUrl = `${url}?${buildQuery(currentPage)}`
+    const fullUrl = `${url}#${buildQuery(currentPage)}`
     return HTTP.request('GET', fullUrl).then(function (response) {
       toggleDisplayError(id, false)
       try {
@@ -243,18 +240,18 @@ function renderTable (id, options = {}, renderRow) {
     }
 
     if (page > 1) {
-      str += `<div class="page-item previous"><a href="?${buildQuery(page - 1)}">Previous</a></div>`
+      str += `<div class="page-item previous"><a href="#${buildQuery(page - 1)}">Previous</a></div>`
     }
     if (pages < 6) {
       for (let p = 1; p <= pages; p++) {
         active = page === p ? 'active' : ''
-        str += `<div class="page-item ${active}"><a href="?${buildQuery(p)}">${p}</a></div>`
+        str += `<div class="page-item ${active}"><a href="#${buildQuery(p)}">${p}</a></div>`
       }
     } else {
       if (page > 2) {
-        str += `<div class="page-item"><a href="?${buildQuery(1)}">1</a></div>`
+        str += `<div class="page-item"><a href="#${buildQuery(1)}">1</a></div>`
         if (page > 3) {
-          str += `<div class="page-item out-of-range"><a href="?${buildQuery(page - 2)}">...</a></div>`
+          str += `<div class="page-item out-of-range"><a href="#${buildQuery(page - 2)}">...</a></div>`
         }
       }
       if (page === 1) {
@@ -275,17 +272,17 @@ function renderTable (id, options = {}, renderRow) {
           continue
         }
         active = page === p ? 'active' : ''
-        str += `<div class="page-item ${active}"><a href="?${buildQuery(p)}">${p}</a></div>`
+        str += `<div class="page-item ${active}"><a href="#${buildQuery(p)}">${p}</a></div>`
       }
       if (page < pages - 1) {
         if (page < pages - 2) {
-          str += `<div class="page-item out-of-range"><a href="?${buildQuery(page + 2)}">...</a></div>`
+          str += `<div class="page-item out-of-range"><a href="#${buildQuery(page + 2)}">...</a></div>`
         }
-        str += `<div class="page-item"><a href="?${buildQuery(pages)}">${pages}</a></div>`
+        str += `<div class="page-item"><a href="#${buildQuery(pages)}">${pages}</a></div>`
       }
     }
     if (page < pages) {
-      str += `<div class="page-item next"><a href="?${buildQuery(page + 1)}">Next</a></div>`
+      str += `<div class="page-item next"><a href="#${buildQuery(page + 1)}">Next</a></div>`
     }
     document.getElementById('pagination').innerHTML = str
     return str
@@ -429,11 +426,11 @@ function debounce (func, wait, immediate) {
 }
 
 function updateQueryState (params) {
-  const searchParams = new URLSearchParams(window.location.search)
+  const searchParams = new URLSearchParams(window.location.hash.substring(1))
   Object.keys(params).forEach(k => {
     searchParams.set(k, params[k])
   })
-  const newurl = window.location.pathname + '?' + searchParams.toString()
+  const newurl = `${window.location.pathname}#${searchParams.toString()}`
   window.history.replaceState(null, '', newurl)
 }
 

--- a/static/js/user.js
+++ b/static/js/user.js
@@ -5,7 +5,7 @@ import * as DOM from './dom.js'
 import * as Vhosts from './vhosts.js'
 import * as Form from './form.js'
 
-const user = new URLSearchParams(window.location.search).get('name')
+const user = new URLSearchParams(window.location.hash.substring(1)).get('name')
 const urlEncodedUsername = encodeURIComponent(user)
 
 function updateUser () {

--- a/static/js/vhost.js
+++ b/static/js/vhost.js
@@ -3,7 +3,7 @@ import * as Table from './table.js'
 import * as Users from './users.js'
 import * as DOM from './dom.js'
 
-const vhost = new URLSearchParams(window.location.search).get('name')
+const vhost = new URLSearchParams(window.location.hash.substring(1)).get('name')
 const urlEncodedVhost = encodeURIComponent(vhost)
 document.title = vhost + ' | LavinMQ'
 document.querySelector('#pagename-label').textContent = vhost
@@ -45,7 +45,7 @@ const permissionsTable = Table.renderTable('permissions', tableOptions, (tr, ite
         .catch(HTTP.standardErrorHandler)
     }
     const userLink = document.createElement('a')
-    userLink.href = 'user?name=' + encodeURIComponent(item.user)
+    userLink.href = `user#name=${encodeURIComponent(item.user)}`
     userLink.textContent = item.user
     Table.renderCell(tr, 0, userLink)
     Table.renderCell(tr, 4, btn, 'right')
@@ -108,7 +108,7 @@ document.querySelector('#resetVhost').addEventListener('submit', function (evt) 
   const url = 'api/vhosts/' + urlEncodedVhost + '/purge_and_close_consumers'
   if (window.confirm('This will purge all queues and close the consumers on this vhost\nAre you sure?')) {
     HTTP.request('POST', url)
-      .then(() => { window.location = 'vhost?name=' + urlEncodedVhost })
+      .then(() => { window.location = 'vhost#name=' + urlEncodedVhost })
       .catch(HTTP.standardErrorHandler)
   }
 })

--- a/static/test/index.html
+++ b/static/test/index.html
@@ -1,1 +1,0 @@
-This is a test

--- a/views/channel.ecr
+++ b/views/channel.ecr
@@ -78,7 +78,7 @@
       import * as DOM from './js/dom.js'
       import * as Chart from './js/chart.js'
 
-      const channel = new URLSearchParams(window.location.search).get('name')
+      const channel = new URLSearchParams(window.location.hash.substring(1)).get('name')
       const urlEncodedChannel = encodeURIComponent(channel)
       const chart = Chart.render('chart', 'msgs/s')
       let vhost = null
@@ -92,7 +92,7 @@
         if (!all) return
         Table.renderCell(tr, 0, item.consumer_tag)
         const queueLink = document.createElement('a')
-        queueLink.href = 'queue?vhost=' + encodeURIComponent(vhost) + '&name=' + encodeURIComponent(item.queue.name)
+        queueLink.href = `queue#vhost=${encodeURIComponent(vhost)}&name=${encodeURIComponent(item.queue.name)}`
         queueLink.textContent = item.queue.name
         const ack = item.ack_required ? '●' : '○'
         const exclusive = item.exclusive ? '●' : '○'
@@ -117,7 +117,7 @@
             document.querySelector('#pagename-label').textContent = channel + ' in virtual host ' + item.vhost
             document.getElementById('ch-username').textContent = item.user
             const connectionLink = document.createElement('a')
-            connectionLink.href = 'connection?name=' + encodeURIComponent(item.connection_details.name)
+            connectionLink.href = `connection#name=${encodeURIComponent(item.connection_details.name)}`
             connectionLink.textContent = item.connection_details.name
             DOM.setChild('#ch-connection', connectionLink)
             document.getElementById('ch-prefetch').textContent = item.prefetch_count

--- a/views/channels.ecr
+++ b/views/channels.ecr
@@ -50,7 +50,7 @@
           const channelLink = document.createElement('a')
           const urlEncodedChannel = encodeURIComponent(item.name)
           channelLink.textContent = item.name
-          channelLink.href = 'channel?name=' + urlEncodedChannel
+          channelLink.href = `channel#name=${urlEncodedChannel}`
           Table.renderCell(tr, 0, channelLink)
           Table.renderCell(tr, 1, item.vhost)
           Table.renderCell(tr, 2, item.user)

--- a/views/connections.ecr
+++ b/views/connections.ecr
@@ -63,7 +63,7 @@
           }
           const clientVersion = item.client_properties.version || ''
           const connectionLink = document.createElement('a')
-          connectionLink.href = `connection?name=${encodeURIComponent(item.name)}`
+          connectionLink.href = `connection#name=${encodeURIComponent(item.name)}`
           if (item.client_properties.connection_name) {
             connectionLink.innerHTML = `<span>${item.name}</span>
               <br><small>${escapeHTML(item.client_properties.connection_name)}</small>`

--- a/views/head.ecr
+++ b/views/head.ecr
@@ -3,7 +3,7 @@
     window.location.assign("login")
 </script>
 <script type="module" src="js/layout.js"></script>
-<title><% escape pagename %> | LavinMQ</title>
+<title><%=pagename%> | LavinMQ</title>
 <link href="main.css" rel="stylesheet">
 <link rel="icon" type="image/png" href="img/favicon.png"/>
 <link rel="apple-touch-icon" href="img/apple-touch-icon.png" />

--- a/views/header.ecr
+++ b/views/header.ecr
@@ -1,5 +1,5 @@
 <header>
-  <h2><% escape pagename %><small id="pagename-label"></small>
+  <h2><%=pagename%><small id="pagename-label"></small>
   </h2>
   <nav id="user-menu">
     <ul>

--- a/views/users.ecr
+++ b/views/users.ecr
@@ -67,7 +67,7 @@
         usersTable = Table.renderTable('users', tableOptions, (tr, item, all) => {
           if (all) {
             const userLink = document.createElement('a')
-            userLink.href = 'user?name=' + encodeURIComponent(item.name)
+            userLink.href = 'user#name=' + encodeURIComponent(item.name)
             userLink.textContent = item.name
             Table.renderCell(tr, 0, userLink)
           }

--- a/views/vhosts.ecr
+++ b/views/vhosts.ecr
@@ -63,7 +63,7 @@
         permissionsPromise.then(permissions => {
           if (all) {
             const vhostLink = document.createElement('a')
-            vhostLink.href = 'vhost?name=' + urlEncodedVhost
+            vhostLink.href = `vhost#name=${urlEncodedVhost}`
             vhostLink.textContent = item.name
             Table.renderCell(tr, 0, vhostLink)
           }
@@ -88,5 +88,4 @@
       })
     </script>
   </body>
-
 </html>


### PR DESCRIPTION
* Drop http-protection dependency, and reimplement the only one that was used (HSTS)
* Calculate etags for static resources on compile time
* Fix etag for views (was using the wrong `VERSION` constant)
* Move all ECR rendering to own controller
* no-cache for views and static resources, the browser will still cache them, but query the browser if there are newer versions
* Use the hash part of the URL as arguments to `/queue` and other views, so that the browser reuse the same cache HTML.