### PR TITLE
Small queues api payload

### DIFF
--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -34,9 +34,9 @@ module LavinMQ
         get "/api/queues/:vhost/:name" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            consumer_count = context.request.query_params["consumer_list_length"]?.try &.to_i || -1
-            JSON.build(context.response) do |builder|
-              queue(context, params, vhost).to_json(builder, consumer_count)
+            consumer_limit = context.request.query_params["consumer_list_length"]?.try &.to_i || -1
+            JSON.build(context.response) do |json|
+              queue(context, params, vhost).to_json(json, consumer_limit)
             end
           end
         end
@@ -97,9 +97,8 @@ module LavinMQ
         get "/api/queues/:vhost/:name/size-details" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            consumer_count = context.request.query_params["consumer_list_length"]?.try &.to_i || -1
-            JSON.build(context.response) do |builder|
-              queue(context, params, vhost).size_details_to_json(builder, consumer_count)
+            JSON.build(context.response) do |json|
+              queue(context, params, vhost).size_details_to_json(json)
             end
           end
         end

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -384,7 +384,7 @@ module LavinMQ
         exclusive_consumer_tag:      @exclusive ? @consumers_lock.synchronize { @consumers.first?.try(&.tag) } : nil,
         state:                       @state.to_s,
         effective_policy_definition: Policy.merge_definitions(@policy, @operator_policy),
-        message_stats:               stats_details,
+        message_stats:               current_stats_details,
       }
     end
 

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -875,18 +875,18 @@ module LavinMQ
     def fsync_ack
     end
 
-    def to_json(builder : JSON::Builder, limit : Int32 = -1)
-      builder.object do
-        details_tuple.each do |k, v|
-          builder.field(k, v) unless v.nil?
+    def to_json(json : JSON::Builder, consumer_limit : Int32 = -1)
+      json.object do
+        details_tuple.merge(message_stats: stats_details).each do |k, v|
+          json.field(k, v) unless v.nil?
         end
-        builder.field("consumer_details") do
-          builder.array do
+        json.field("consumer_details") do
+          json.array do
             @consumers_lock.synchronize do
               @consumers.each do |c|
-                c.to_json(builder)
-                limit -= 1
-                break if limit.zero?
+                c.to_json(json)
+                consumer_limit -= 1
+                break if consumer_limit.zero?
               end
             end
           end
@@ -894,10 +894,10 @@ module LavinMQ
       end
     end
 
-    def size_details_to_json(builder : JSON::Builder, limit : Int32 = -1)
-      builder.object do
+    def size_details_to_json(json : JSON::Builder)
+      json.object do
         size_details_tuple.each do |k, v|
-          builder.field(k, v) unless v.nil?
+          json.field(k, v) unless v.nil?
         end
       end
     end

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -27,6 +27,18 @@ module LavinMQ
         }
       end
 
+      # Like stats_details but without log
+      def current_stats_details
+        {
+          {% for name in stats_keys %}
+            {{name.id}}: @{{name.id}}_count,
+              {{name.id}}_details: {
+              rate: @{{name.id}}_rate,
+            },
+          {% end %}
+        }
+      end
+
       def update_rates : Nil
         interval = Config.instance.stats_interval // 1000
         log_size = Config.instance.stats_log_size

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -128,7 +128,7 @@ document.querySelector('#deleteExchange').addEventListener('submit', function (e
 
 function updateAutocomplete(e) {
   const type = e === 'q' ? 'queues' : 'exchanges'
-  Helpers.autoCompleteDatalist("exchange-dest-list", type)
+  Helpers.autoCompleteDatalist("exchange-dest-list", type, urlEncodedVhost)
 }
 updateAutocomplete('q')
 

--- a/static/js/federation.js
+++ b/static/js/federation.js
@@ -93,5 +93,3 @@ document.querySelector('#createUpstream').addEventListener('submit', function (e
       DOM.toast(`Upstream ${name} saved`)
     }).catch(HTTP.standardErrorHandler)
 })
-Helpers.autoCompleteDatalist('queue-datalist', 'queues')
-Helpers.autoCompleteDatalist('exchange-datalist', 'exchanges')

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -95,15 +95,14 @@ function formatTimestamp(timestamp) {
  * @param datalistID id of the datalist element linked to input
  * @param type input content, accepts: queues, exchanges, vhosts, users
  */
-function autoCompleteDatalist(datalistID, type) {
-  HTTP.request('GET',`api/${type}`).then(res => {
+function autoCompleteDatalist(datalistID, type, vhost) {
+  HTTP.request('GET',`api/${type}/${vhost}?columns=name`).then(res => {
     const datalist = document.getElementById(datalistID);
     while (datalist.firstChild) {
       datalist.removeChild(datalist.lastChild);
     }
-    const values = res.map(val => val.name)
-    const uniqValues = [...new Set(values)];
-    uniqValues.sort().forEach(val => {
+    const values = res.map(val => val.name).sort()
+    values.forEach(val => {
       const option = document.createElement("option")
       option.value = val
       datalist.appendChild(option)

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -371,8 +371,8 @@ messageSnapshotForm.addEventListener('submit', function (evt) {
   }
 })
 
-Helpers.autoCompleteDatalist('exchange-list', 'exchanges')
-Helpers.autoCompleteDatalist('queue-list', 'queues')
+Helpers.autoCompleteDatalist('exchange-list', 'exchanges', urlEncodedVhost)
+Helpers.autoCompleteDatalist('queue-list', 'queues', urlEncodedVhost)
 
 document.querySelector('#dataTags').onclick = e => {
   Helpers.argumentHelperJSON('publishMessage', 'properties', e)

--- a/static/js/shovels.js
+++ b/static/js/shovels.js
@@ -168,5 +168,5 @@ function updateAutocomplete(e, id) {
   const type = e === 'queue' ? 'queues' : 'exchanges'
   Helpers.autoCompleteDatalist(id, type)
 }
-updateAutocomplete('queue',"shovel-src-list")
-updateAutocomplete('queue',"shovel-dest-list")
+//updateAutocomplete("queue", "shovel-src-list")
+//updateAutocomplete("queue", "shovel-dest-list")


### PR DESCRIPTION
Don't include `log` when listing queues, the data is never used and can be come large when many queues are listed. Only include it when inspecting an indiviual queue. 