### PR TITLE
Mmap on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Precompress static assets (inflate on-demand if client don't accept deflate)
 - Don't include historic message stats when listing queues via the API
 - New favicon (that works both in dark and light mode)
-- Autocomplete queues/vhosts is now correct in the UI (selecting only from the vhost in question)
 - Return 403 rather than 401 for access refused in /api (401 only if unauthenticated)
 - Cleaning up JS in UI
-- Error message in UI when lacking access to Logs
+
+### Fixed
+
+- Error message in UI when lacking access to Logs/Vhosts/Users/shovels/federation
+- Autocomplete queues/vhosts is now correct in the UI (selecting only from the vhost in question)
 
 ## [1.0.1] - 2023-04-06
 

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -26,7 +26,7 @@ class MFile < IO
   getter capacity : Int64 = 0i64
   getter path : String
   getter fd : Int32
-  @buffer : Pointer(UInt8)
+  @buffer = Pointer(UInt8).null
 
   # Map a file, if no capacity is given the file must exists and
   # the file will be mapped as readonly
@@ -40,7 +40,6 @@ class MFile < IO
       code = LibC.ftruncate(@fd, @capacity)
       raise File::Error.from_errno("Error truncating file", file: @path) if code < 0
     end
-    @buffer = mmap
   end
 
   # Opens an existing file in readonly mode


### PR DESCRIPTION
Queuing 110M msgs uses the same amount of memory as 0 msgs, 25MiB, compared to 4GiB before.