### PR TITLE
do Fiber.yield in deliver_loop

### DIFF
--- a/src/lavinmq/client/channel/consumer.cr
+++ b/src/lavinmq/client/channel/consumer.cr
@@ -62,6 +62,7 @@ module LavinMQ
             queue.consume_get(no_ack) do |env|
               deliver(env.message, env.segment_position, env.redelivered)
             end
+            Fiber.yield
           end
         rescue ex : ClosedError | Queue::ClosedError | Client::Channel::ClosedError | ::Channel::ClosedError
           @log.debug { "deliver loop exiting: #{ex.inspect}" }


### PR DESCRIPTION
Do Fiber.yield in deliver_loop to allow lavinmq to do other stuff while consuming

https://trello.com/c/DXlvpqpn/273-ui-doesnt-load-when-only-consuming-with-lavinmqperf