### PR TITLE
dont clear interval at exception

### DIFF
--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -48,7 +48,7 @@ function updateChannel (all) {
       document.getElementById('ch-mode').textContent = `${item.confirm ? 'C' : ''}`
       document.getElementById('ch-global-prefetch').textContent = item.global_prefetch_count
     }
-  }).catch(HTTP.standardErrorHandler).catch(e => clearInterval(cTimer))
+  }).catch(HTTP.standardErrorHandler)
 }
 updateChannel(true)
-const cTimer = setInterval(updateChannel, 5000)
+setInterval(updateChannel, 5000)

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -43,10 +43,10 @@ function updateConnection (all) {
         infoEl.textContent = cp.information || ''
       }
     }
-  }).catch(HTTP.standardErrorHandler).catch(e => clearInterval(cTimer))
+  }).catch(HTTP.standardErrorHandler)
 }
 updateConnection(true)
-const cTimer = setInterval(updateConnection, 5000)
+setInterval(updateConnection, 5000)
 const channelsUrl = connectionUrl + '/channels'
 const tableOptions = {
   url: channelsUrl,

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -41,10 +41,9 @@ function updateExchange () {
       policyLink.textContent = item.policy
       document.getElementById("e-policy").appendChild(policyLink)
     }
-  }).catch(HTTP.standardErrorHandler).catch(e => clearInterval(eTimer))
+  }).catch(HTTP.standardErrorHandler)
 }
 updateExchange()
-const eTimer = setInterval(updateExchange, 5000)
 
 const tableOptions = { url: exchangeUrl + '/bindings/source', keyColumns: ['properties_key'], interval: 5000 }
 const bindingsTable = Table.renderTable('bindings-table', tableOptions, function (tr, item, all) {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -8,7 +8,6 @@ const vhost = window.sessionStorage.getItem('vhost')
 if (vhost && vhost !== '_all') {
   url += '?vhost=' + encodeURIComponent(vhost)
 }
-let updateTimer = null
 let data = null
 
 if (data === null) {
@@ -35,14 +34,7 @@ function render (data) {
 
 function start (cb) {
   update(cb)
-  updateTimer = setInterval(() => update(cb), 5000)
-}
-
-// Show that we're offline in the UI
-function stop () {
-  if (updateTimer) {
-    clearInterval(updateTimer)
-  }
+  setInterval(() => update(cb), 5000)
 }
 
 function get (key) {

--- a/static/js/overview.js
+++ b/static/js/overview.js
@@ -3,7 +3,6 @@ import * as HTTP from './http.js'
 import * as Helpers from './helpers.js'
 
 const numFormatter = new Intl.NumberFormat()
-let updateTimer = null
 let data = null
 
 const msgChart = Chart.render('msgChart', 'msgs', true)
@@ -101,7 +100,7 @@ function update (cb) {
     if (cb) {
       cb(response)
     }
-  }).catch(HTTP.standardErrorHandler).catch(stop)
+  }).catch(HTTP.standardErrorHandler)
 }
 
 function render (data) {
@@ -116,12 +115,5 @@ function render (data) {
 
 function start (cb) {
   update(cb)
-  updateTimer = setInterval(update, 5000, cb)
-}
-
-// Show that we're offline in the UI
-function stop () {
-  if (updateTimer) {
-    clearInterval(updateTimer)
-  }
+  setInterval(update, 5000, cb)
 }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -38,7 +38,7 @@ const consumersTable = Table.renderTable('table', { keyColumns: ["channel_detail
       .then(() => {
         DOM.toast(`Consumer cancelled`)
         updateQueue(false)
-      }).catch(HTTP.standardErrorHandler).catch(e => clearInterval(qTimer))
+      }).catch(HTTP.standardErrorHandler)
   })
   Table.renderCell(tr, 0, channelLink)
   Table.renderCell(tr, 1, item.consumer_tag)
@@ -124,10 +124,10 @@ function updateQueue (all) {
           qArgs.appendChild(document.createElement("div")).textContent = `${arg}: ${item.arguments[arg]}`
         }
       }
-    }).catch(HTTP.standardErrorHandler).catch(e => clearInterval(qTimer))
+    }).catch(HTTP.standardErrorHandler)
 }
 updateQueue(true)
-const qTimer = setInterval(updateQueue, 5000)
+setInterval(updateQueue, 5000)
 
 const tableOptions = {
   url: queueUrl + '/bindings',

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -15,7 +15,6 @@ function renderTable (id, options = {}, renderRow) {
   const container = table.parentElement
   const keyColumns = options.keyColumns
   const interval = options.interval
-  let timer = null
   let searchTerm = null
   const currentPage = search.get('page') || 1
   let pageSize = search.get('page_size') || 100
@@ -56,7 +55,7 @@ function renderTable (id, options = {}, renderRow) {
     }
     fetchAndUpdate()
     if (interval) {
-      timer = setInterval(fetchAndUpdate, interval)
+      setInterval(fetchAndUpdate, interval)
     }
   }
 
@@ -138,9 +137,6 @@ function renderTable (id, options = {}, renderRow) {
       } else {
         toggleDisplayError(id, "Can't reach server, please try to refresh the page.")
         console.error(e)
-      }
-      if (timer) {
-        clearInterval(timer)
       }
     })
   }


### PR DESCRIPTION
Does not clearInterval when catching an exception on updates, and keeps polling. 
Removes stop() function from both nodes.js and overview.js