### PR TITLE
Add docker-compose.yml, environment variables and a script to generate TLS files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ WORKDIR /var/lib/lavinmq
 ENV GC_UNMAP_THRESHOLD=1
 HEALTHCHECK CMD ["/usr/bin/lavinmqctl", "status"]
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["-b", "0.0.0.0", "--guest-only-loopback", "false"]
+CMD ["-b", "0.0.0.0", "--guest-only-loopback=false"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,11 @@ RUN apt-get update && \
     apt-get install -y libssl3 libevent-2.1-7 libevent-pthreads-2.1-7 ca-certificates && \
     rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/*
 COPY --from=builder /tmp/bin/* /usr/bin/
-EXPOSE 5672 15672
+COPY entrypoint.sh /usr/bin/
+EXPOSE 5672 15672 5671 15671
 VOLUME /var/lib/lavinmq
 WORKDIR /var/lib/lavinmq
 ENV GC_UNMAP_THRESHOLD=1
 HEALTHCHECK CMD ["/usr/bin/lavinmqctl", "status"]
-ENTRYPOINT ["/usr/bin/lavinmq", "-b", "0.0.0.0", "--guest-only-loopback=false"]
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["-b", "0.0.0.0", "--guest-only-loopback", "false"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+  lavinmq:
+    build: .
+    environment:
+      # LAVINMQ_CONF: /etc/lavinmq/config.ini
+      # LAVINMQ_DATADIR: /var/lib/lavinmq/
+      LAVINMQ_BIND: 0.0.0.0
+      # LAVINMQ_PORT: 5672
+      # LAVINMQ_AMQPS_PORT: 5671
+      # LAVINMQ_AMQP_BIND: 0.0.0.0
+      # LAVINMQ_HTTP_PORT: 15672
+      # LAVINMQ_HTTPS_PORT: 15671
+      # LAVINMQ_HTTP_BIND: 0.0.0.0
+      # LAVINMQ_AMQP_UNIX_PATH: /tmp/lavinmq.sock
+      # LAVINMQ_HTTP_UNIX_PATH: /tmp/lavinmq-http.sock
+      # LAVINMQ_CERT: /etc/lavinmq/cert.pem
+      # LAVINMQ_KEY: /etc/lavinmq/key.pem
+      # LAVINMQ_CIPHERS:
+      # LAVINMQ_TLS_MIN_VERSION: 1.2
+      # LAVINMQ_LOG_LEVEL: info
+      # LAVINMQ_RAISE_GC_WARN: true
+      # LAVINMQ_NO_DATA_DIR_LOCK: true
+      # LAVINMQ_DEBUG: false
+      LAVINMQ_GUEST_ONLY_LOOPBACK: false
+    volumes:
+      - ./lavinmq/data/:/var/lib/lavinmq/
+      # - ./extras/config.ini:/etc/lavinmq/config.ini
+      - ./lavinmq/logs/:/var/log/
+      - ./lavinmq/tls/cert.pem:/etc/lavinmq/cert.pem
+      - ./lavinmq/tls/key.pem:/etc/lavinmq/key.pem
+    ports:
+      - 5672:5672
+      - 15672:15672
+      - 5671:5671
+      - 15671:15671

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,15 +46,15 @@ if [ -n "${LAVINMQ_HTTP_UNIX_PATH}" ]; then
 fi
 
 if [ -n "${LAVINMQ_CERT}" ]; then
-  ENV_ARGS="$ENV_ARGS --cert $LAVINMQ_CERT"
+  ENV_ARGS="$ENV_ARGS --cert=$LAVINMQ_CERT"
 fi
 
 if [ -n "${LAVINMQ_KEY}" ]; then
-  ENV_ARGS="$ENV_ARGS --key $LAVINMQ_KEY"
+  ENV_ARGS="$ENV_ARGS --key=$LAVINMQ_KEY"
 fi
 
 if [ -n "${LAVINMQ_CIPHERS}" ]; then
-  ENV_ARGS="$ENV_ARGS --ciphers $LAVINMQ_CIPHERS"
+  ENV_ARGS="$ENV_ARGS --ciphers=$LAVINMQ_CIPHERS"
 fi
 
 if [ -n "${LAVINMQ_TLS_MIN_VERSION}" ]; then
@@ -87,4 +87,5 @@ if [ -n "${LAVINMQ_GUEST_ONLY_LOOPBACK}" ]; then
     ENV_ARGS="$ENV_ARGS --guest-only-loopback=$LAVINMQ_GUEST_ONLY_LOOPBACK"
 fi
 
-exec lavinmq "$@ $ENV_ARGS"
+ARGS="$@ $ENV_ARGS"
+exec lavinmq $ARGS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+ENV_ARGS=""
+
+if [ -n "${LAVINMQ_CONF}" ]; then
+  ENV_ARGS="--config=$LAVINMQ_CONF"
+fi
+
+if [ -n "${LAVINMQ_DATADIR}" ]; then
+  ENV_ARGS="$ENV_ARGS --data-dir=$LAVINMQ_DATADIR"
+fi
+
+if [ -n "${LAVINMQ_BIND}" ]; then
+  ENV_ARGS="$ENV_ARGS --bind=$LAVINMQ_BIND"
+fi
+
+if [ -n "${LAVINMQ_PORT}" ]; then
+  ENV_ARGS="$ENV_ARGS --amqp-port=$LAVINMQ_PORT"
+fi
+
+if [ -n "${LAVINMQ_AMQPS_PORT}" ]; then
+  ENV_ARGS="$ENV_ARGS --amqps-port=$LAVINMQ_AMQPS_PORT"
+fi
+
+if [ -n "${LAVINMQ_AMQP_BIND}" ]; then
+  ENV_ARGS="$ENV_ARGS --amqp-bind=$LAVINMQ_AMQP_BIND"
+fi
+
+if [ -n "${LAVINMQ_HTTP_PORT}" ]; then
+  ENV_ARGS="$ENV_ARGS --http-port=$LAVINMQ_HTTP_PORT"
+fi
+
+if [ -n "${LAVINMQ_HTTPS_PORT}" ]; then
+  ENV_ARGS="$ENV_ARGS --https-port=$LAVINMQ_HTTPS_PORT"
+fi
+
+if [ -n "${LAVINMQ_HTTP_BIND}" ]; then
+  ENV_ARGS="$ENV_ARGS --http-bind=$LAVINMQ_HTTP_BIND"
+fi
+
+if [ -n "${LAVINMQ_AMQP_UNIX_PATH}" ]; then
+  ENV_ARGS="$ENV_ARGS --amqp-unix-path=$LAVINMQ_AMQP_UNIX_PATH"
+fi
+
+if [ -n "${LAVINMQ_HTTP_UNIX_PATH}" ]; then
+  ENV_ARGS="$ENV_ARGS --http-unix-path=$LAVINMQ_HTTP_UNIX_PATH"
+fi
+
+if [ -n "${LAVINMQ_CERT}" ]; then
+  ENV_ARGS="$ENV_ARGS --cert $LAVINMQ_CERT"
+fi
+
+if [ -n "${LAVINMQ_KEY}" ]; then
+  ENV_ARGS="$ENV_ARGS --key $LAVINMQ_KEY"
+fi
+
+if [ -n "${LAVINMQ_CIPHERS}" ]; then
+  ENV_ARGS="$ENV_ARGS --ciphers $LAVINMQ_CIPHERS"
+fi
+
+if [ -n "${LAVINMQ_TLS_MIN_VERSION}" ]; then
+  ENV_ARGS="$ENV_ARGS --tls-min-version=$LAVINMQ_TLS_MIN_VERSION"
+fi
+
+if [ -n "${LAVINMQ_LOG_LEVEL}" ]; then
+  ENV_ARGS="$ENV_ARGS --log-level=$LAVINMQ_LOG_LEVEL"
+fi
+
+if [ -n "${LAVINMQ_RAISE_GC_WARN}" ]; then
+  if [ "$LAVINMQ_RAISE_GC_WARN" = "true" ]; then
+    ENV_ARGS="$ENV_ARGS --raise-gc-warn"
+  fi
+fi
+
+if [ -n "${LAVINMQ_NO_DATA_DIR_LOCK}" ]; then
+  if [ "$LAVINMQ_NO_DATA_DIR_LOCK" = "true" ]; then
+    ENV_ARGS="$ENV_ARGS --no-data-dir-lock"
+  fi
+fi
+
+if [ -n "${LAVINMQ_DEBUG}" ]; then
+  if [ "$LAVINMQ_DEBUG" = "true" ]; then
+    ENV_ARGS="$ENV_ARGS --debug"
+  fi
+fi
+
+if [ -n "${LAVINMQ_GUEST_ONLY_LOOPBACK}" ]; then
+    ENV_ARGS="$ENV_ARGS --guest-only-loopback=$LAVINMQ_GUEST_ONLY_LOOPBACK"
+fi
+
+exec lavinmq "$@ $ENV_ARGS"

--- a/extras/generate-tls-files.sh
+++ b/extras/generate-tls-files.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd $(dirname $0)
+OUTPUT_DIR=../lavinmq/tls
+mkdir -p $OUTPUT_DIR
+
+openssl genrsa -out $OUTPUT_DIR/key.pem 2048
+openssl req -new -key $OUTPUT_DIR/key.pem -out $OUTPUT_DIR/csr.pem
+openssl x509 -req -in $OUTPUT_DIR/csr.pem -signkey $OUTPUT_DIR/key.pem -out $OUTPUT_DIR/cert.pem


### PR DESCRIPTION
- [`Dockerfile`] Define TLS ports using `EXPOSE` instruction
- [`Dockerfile`] Shift the default `lavinmq` arguments to the `CMD` instruction
- [`Dockerfile`] Specify `entrypoint.sh` in the `ENTRYPOINT` instruction
- [`entrypoint.sh`] Implement environment variables for all `lavinmq` argument options
- [`entrypoint.sh`] Give preference to environment variables over `CMD` / Docker command
- [`extras/generate-tls-files.sh`] Include a script for generating the key and certificate required for TLS configuration