### PR TITLE
by default dont include log in exchange details

### DIFF
--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -84,7 +84,7 @@ module LavinMQ
         policy: @policy.try &.name,
         operator_policy: @operator_policy.try &.name,
         effective_policy_definition: Policy.merge_definitions(@policy, @operator_policy),
-        message_stats: stats_details,
+        message_stats: current_stats_details,
       }
     end
 


### PR DESCRIPTION
Payload can get huge with it.

Same as this: https://github.com/cloudamqp/lavinmq/commit/bf3d0e1a5e730183dcb6ce2cf5e95690cc485c4b