### PR TITLE
fixes #446 keeps queue paused on restart

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -60,6 +60,20 @@ describe LavinMQ::Queue do
       end
     end
 
+    it "should be able to declaue queue as paused" do
+      Server.vhosts.create("/")
+      v = Server.vhosts["/"].not_nil!
+      v.declare_queue("q", true, false)
+      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
+      Server.vhosts["/"].queues["q"].pause!
+      File.exists?(File.join(data_dir, ".paused")).should be_true
+      Server.restart
+      Server.vhosts["/"].queues["q"].state.paused?.should be_true
+      Server.vhosts["/"].queues["q"].resume!
+      File.exists?(File.join(data_dir, ".paused")).should be_false
+    end
+
+
     it "should paused the queue by setting it in flow (consume)" do
       with_channel do |ch|
         x = ch.exchange(x_name, "direct")

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -60,7 +60,7 @@ describe LavinMQ::Queue do
       end
     end
 
-    it "should be able to declaue queue as paused" do
+    it "should be able to declare queue as paused" do
       Server.vhosts.create("/")
       v = Server.vhosts["/"].not_nil!
       v.declare_queue("q", true, false)

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -34,6 +34,19 @@ describe LavinMQ::VHost do
     Server.vhosts["test"].queues["q"].should_not be_nil
   end
 
+  it "should be able to declaue queue as paused" do
+    Server.vhosts.create("/")
+    v = Server.vhosts["/"].not_nil!
+    v.declare_queue("q", true, false)
+    data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
+    Server.vhosts["/"].queues["q"].pause!
+    File.exists?(File.join(data_dir, ".paused")).should be_true
+    Server.restart
+    Server.vhosts["/"].queues["q"].state.paused?.should be_true
+    Server.vhosts["/"].queues["q"].resume!
+    File.exists?(File.join(data_dir, ".paused")).should be_false
+  end
+
   it "should be able to persist bindings" do
     Server.vhosts.create("test")
     v = Server.vhosts["test"].not_nil!

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -34,19 +34,6 @@ describe LavinMQ::VHost do
     Server.vhosts["test"].queues["q"].should_not be_nil
   end
 
-  it "should be able to declaue queue as paused" do
-    Server.vhosts.create("/")
-    v = Server.vhosts["/"].not_nil!
-    v.declare_queue("q", true, false)
-    data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
-    Server.vhosts["/"].queues["q"].pause!
-    File.exists?(File.join(data_dir, ".paused")).should be_true
-    Server.restart
-    Server.vhosts["/"].queues["q"].state.paused?.should be_true
-    Server.vhosts["/"].queues["q"].resume!
-    File.exists?(File.join(data_dir, ".paused")).should be_false
-  end
-
   it "should be able to persist bindings" do
     Server.vhosts.create("test")
     v = Server.vhosts["test"].not_nil!


### PR DESCRIPTION
**Fixes issue 446**

touches a file ".paused" that is checked t restart, setting queue state to paused instead of resuming. 
co-authered with @snichme 

With this you could also manually pause a queue before starting up again, just `touch .paused` in the queues repo and the queue will initialize as paused. 