### PR TITLE
dont truncate mfiles on startup

### DIFF
--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -308,7 +308,7 @@ module LavinMQ
               @size += 1
             end
           rescue ex : IO::EOFError
-            if  mfile.pos < mfile.size
+            if mfile.pos < mfile.size
               Log.warn { "Truncating #{mfile.path} from #{mfile.size} to #{mfile.pos}" }
               mfile.truncate(mfile.pos)
             end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -305,10 +305,6 @@ module LavinMQ
               @size += 1
             end
           rescue ex : IO::EOFError
-            if mfile.pos < mfile.size
-              Log.warn { "Truncating #{mfile.path} from #{mfile.size} to #{mfile.pos}" }
-              mfile.truncate(mfile.pos)
-            end
             break
           rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
             raise Error.new(mfile, cause: ex)

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -296,10 +296,7 @@ module LavinMQ
             pos = mfile.pos
             raise IO::EOFError.new if pos + BytesMessage::MIN_BYTESIZE >= mfile.size # EOF or a message can't fit, truncate
             ts = IO::ByteFormat::SystemEndian.decode(Int64, mfile.to_slice + pos)
-            if ts.zero? # This means that the rest of the file is zero, so resize it
-              mfile.resize(mfile.pos)
-              break
-            end
+            break mfile.resize(pos) if ts.zero? # This means that the rest of the file is zero, so resize it
 
             bytesize = BytesMessage.skip(mfile)
             count += 1

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -308,8 +308,10 @@ module LavinMQ
               @size += 1
             end
           rescue ex : IO::EOFError
-            Log.warn { "Truncating #{mfile.path} from #{mfile.size} to #{mfile.pos}" }
-            mfile.truncate(mfile.pos)
+            if  mfile.pos < mfile.size
+              Log.warn { "Truncating #{mfile.path} from #{mfile.size} to #{mfile.pos}" }
+              mfile.truncate(mfile.pos)
+            end
             break
           rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
             raise Error.new(mfile, cause: ex)


### PR DESCRIPTION
Disable truncating mfiles on startup

https://trello.com/c/k8uAEipk/310-starting-lavinmq-with-many-empty-queues-after-crash-is-slow