### PR TITLE
add configurable values for min and warn for free_disk

### DIFF
--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -41,6 +41,8 @@ module LavinMQ
     property? guest_only_loopback : Bool = true
     property max_message_size = 128 * 1024**2
     property? log_exchange : Bool = false
+    property free_disk_min : Int64 = 0  # bytes
+    property free_disk_warn : Int64 = 0 # bytes
     @@instance : Config = self.new
 
     def self.instance : LavinMQ::Config
@@ -95,6 +97,8 @@ module LavinMQ
         when "tls_min_version"      then @tls_min_version = v
         when "guest_only_loopback"  then @guest_only_loopback = true?(v)
         when "log_exchange"         then @log_exchange = true?(v)
+        when "free_disk_min"        then @free_disk_min = v.to_i64
+        when "free_disk_warn"       then @free_disk_warn = v.to_i64
         else
           STDERR.puts "WARNING: Unrecognized configuration 'main/#{config}'"
         end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -372,7 +372,7 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
 
     private def control_flow!
-      if @disk_free < 2_i64 * Config.instance.segment_size
+      if @disk_free < 2_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
         if flow?
           @log.info { "Low disk space: #{@disk_free.humanize}B, stopping flow" }
           flow(false)
@@ -380,7 +380,7 @@ module LavinMQ
       elsif !flow?
         @log.info { "Not low on disk space, starting flow" }
         flow(true)
-      elsif @disk_free < 3_i64 * Config.instance.segment_size
+      elsif @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_warn
         @log.info { "Low on disk space: #{@disk_free.humanize}B" }
       end
     end


### PR DESCRIPTION
Adds option to set `free_disk_min` and `free_disk_warn` in config to help stop lavinmq from filling up the disk