### PR TITLE
dont let clients create policies with wrongly typed definitions

### DIFF
--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -271,6 +271,17 @@ describe LavinMQ::HTTP::ParametersController do
       body = JSON.parse(response.body)
       body["reason"].as_s.should eq("Malformed JSON.")
     end
+
+    it "should handle invalid definition types" do
+      body = %({
+        "apply-to": "queues",
+        "priority": 0,
+        "definition": { "max-length": "String" },
+        "pattern": ".*"
+      })
+      response = put("/api/policies/%2f/name", body: body)
+      response.status_code.should eq 400
+    end
   end
 
   describe "DELETE /api/policies/vhost/name" do

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -162,6 +162,14 @@ module LavinMQ
             unless pattern && definition
               bad_request(context, "Fields 'pattern' and 'definition' are required")
             end
+            definition.keys.all? do |k|
+              case k
+              when "max-length", "max-length-bytes", "message-ttl", "expires", "delivery-limit"
+                bad_request(context, "Policy definition '#{k}' should be of type Int") unless definition[k].as_i64?
+              else
+                bad_request(context, "Policy definition '#{k}' should be of type String") unless definition[k].as_s?
+              end
+            end
             is_update = @amqp_server.vhosts[vhost].policies[name]?
             @amqp_server.vhosts[vhost]
               .add_policy(name, pattern, apply_to, definition, priority.to_i8)


### PR DESCRIPTION
Raise 400 (bad request) if client tries to declare a policy with wrongly typed definitions. 