### PR TITLE
add consumer rates to connection churn metrics

### DIFF
--- a/src/lavinmq/event_type.cr
+++ b/src/lavinmq/event_type.cr
@@ -13,5 +13,7 @@ module LavinMQ
     ClientPublishConfirm
     ClientRedeliver
     ClientReject
+    ConsumerAdded
+    ConsumerRemoved
   end
 end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -262,7 +262,7 @@ module LavinMQ
       end
 
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,
-                        :queue_declared, :queue_deleted}
+                        :queue_declared, :queue_deleted, :consumer_added, :consumer_removed}
 
       private def vhost_stats(vhosts)
         {% for sm in SERVER_METRICS %}
@@ -308,6 +308,14 @@ module LavinMQ
                       value: stats[:queue_deleted],
                       type:  "counter",
                       help:  "Total number of queues deleted"})
+        writer.write({name:  "detailed_consumers_added_total",
+                      value: stats[:consumer_added],
+                      type:  "counter",
+                      help:  "Total number of consumers added"})
+        writer.write({name:  "detailed_consumers_removed_total",
+                      value: stats[:consumer_removed],
+                      type:  "counter",
+                      help:  "Total number of consumers removed"})
       end
 
       private def detailed_queue_coarse_metrics(vhosts, writer)

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -817,6 +817,7 @@ module LavinMQ
       @exclusive_consumer = true if consumer.exclusive
       @has_priority_consumers = true unless consumer.priority.zero?
       @log.debug { "Adding consumer (now #{@consumers.size})" }
+      @vhost.event_tick(EventType::ConsumerAdded)
       notify_observers(:add_consumer, consumer)
     end
 
@@ -839,6 +840,7 @@ module LavinMQ
               end
             end
           end
+          @vhost.event_tick(EventType::ConsumerRemoved)
           notify_observers(:rm_consumer, consumer)
         end
       end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -20,7 +20,8 @@ module LavinMQ
     include Stats
 
     rate_stats({"channel_closed", "channel_created", "connection_closed", "connection_created",
-                "queue_declared", "queue_deleted", "ack", "deliver", "get", "publish", "confirm", "redeliver", "reject"})
+                "queue_declared", "queue_deleted", "ack", "deliver", "get", "publish", "confirm",
+                "redeliver", "reject", "consumer_added", "consumer_removed"})
 
     getter name, exchanges, queues, data_dir, operator_policies, policies, parameters, shovels,
       direct_reply_consumers, connections, dir, gc_runs, gc_timing, log, users
@@ -729,6 +730,8 @@ module LavinMQ
       in EventType::ClientPublishConfirm then @confirm_count += 1
       in EventType::ClientRedeliver      then @redeliver_count += 1
       in EventType::ClientReject         then @reject_count += 1
+      in EventType::ConsumerAdded        then @consumer_added_count += 1
+      in EventType::ConsumerRemoved      then @consumer_removed_count += 1
       end
     end
   end


### PR DESCRIPTION
Adds consumer metrics `consumer_added` and `consumer_removed` to the prometheus `detailed_connection_churn_metrics`