### PR TITLE
move addVhostOptions for vhost dropdown menu to layout

### DIFF
--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -164,19 +164,6 @@ function addVhostOptions (formId, options) {
   })
 }
 
-addVhostOptions('user-vhost', {addAll: true}).then(() => {
-  const vhost = window.sessionStorage.getItem('vhost')
-  if (vhost) {
-    const opt = document.querySelector('#userMenuVhost option[value="' + vhost + '"]')
-    if (opt) {
-      document.querySelector('#userMenuVhost').value = vhost
-      window.sessionStorage.setItem('vhost', vhost)
-    }
-  } else {
-    window.sessionStorage.setItem('vhost', '_all')
-  }
-})
-
 export {
   addVhostOptions,
   formatNumber,

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -70,7 +70,7 @@ function argumentHelperJSON (formID, name, e) {
   const form = document.getElementById(formID)
   try {
     let currentValue = form.elements[name].value.trim()
-    if (currentValue.length == 0) {
+    if (currentValue.length === 0) {
       currentValue = '{}'
     }
     currentValue = JSON.parse(currentValue)
@@ -82,39 +82,39 @@ function argumentHelperJSON (formID, name, e) {
   }
 }
 
-function formatJSONargument(obj) {
+function formatJSONargument (obj) {
   const values = Object.keys(obj).map(key => `"${key}": ${JSON.stringify(obj[key])}`).join(',\n')
   return `{ ${values} }`
 }
 
-function formatTimestamp(timestamp) {
-  const date = new Date(timestamp).toISOString().split("T");
+function formatTimestamp (timestamp) {
+  const date = new Date(timestamp).toISOString().split('T')
 
-  return `${date[0]} ${date[1].split(".")[0]}`;
+  return `${date[0]} ${date[1].split('.')[0]}`
 }
 
 /**
  * @param datalistID id of the datalist element linked to input
  * @param type input content, accepts: queues, exchanges, vhosts, users
  */
-function autoCompleteDatalist(datalistID, type, vhost) {
-  HTTP.request('GET',`api/${type}/${vhost}?columns=name`).then(res => {
-    const datalist = document.getElementById(datalistID);
+function autoCompleteDatalist (datalistID, type, vhost) {
+  HTTP.request('GET', `api/${type}/${vhost}?columns=name`).then(res => {
+    const datalist = document.getElementById(datalistID)
     while (datalist.firstChild) {
-      datalist.removeChild(datalist.lastChild);
+      datalist.removeChild(datalist.lastChild)
     }
     const values = res.map(val => val.name).sort()
     values.forEach(val => {
-      const option = document.createElement("option")
+      const option = document.createElement('option')
       option.value = val
       datalist.appendChild(option)
-    });
+    })
   })
 }
 
 let loadedVhosts
 
-function fetch() {
+function fetch () {
   const vhost = window.sessionStorage.getItem('vhost')
   const url = 'api/vhosts?columns=name'
   if (!loadedVhosts) {
@@ -133,7 +133,7 @@ function fetch() {
 
 function addVhostOptions (formId, options) {
   options = options ?? {}
-  const addAllOpt = options["addAll"] ?? false
+  const addAllOpt = options.addAll ?? false
   return fetch().then(vhosts => {
     const select = document.forms[formId].elements.vhost
     while (select.options.length) {
@@ -147,7 +147,7 @@ function addVhostOptions (formId, options) {
       const err = document.createElement('span')
       err.id = 'error-msg'
       err.textContent = 'Error fetching data: Please try to refresh the page!'
-      select.parentElement.insertAdjacentElement('beforebegin',err)
+      select.parentElement.insertAdjacentElement('beforebegin', err)
       return
     }
 

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -1,4 +1,5 @@
 import * as Auth from './auth.js'
+import * as Helpers from './helpers.js'
 
 document.getElementById('username').textContent = Auth.getUsername()
 
@@ -9,6 +10,19 @@ menuButton.onclick = (e) => {
   menuButton.classList.toggle('open-menu')
   menuContent.classList.toggle('show-menu')
 }
+
+Helpers.addVhostOptions('user-vhost', { addAll: true }).then(() => {
+  const vhost = window.sessionStorage.getItem('vhost')
+  if (vhost) {
+    const opt = document.querySelector('#userMenuVhost option[value="' + vhost + '"]')
+    if (opt) {
+      document.querySelector('#userMenuVhost').value = vhost
+      window.sessionStorage.setItem('vhost', vhost)
+    }
+  } else {
+    window.sessionStorage.setItem('vhost', '_all')
+  }
+})
 
 document.getElementById('userMenuVhost').onchange = (e) => {
   window.sessionStorage.setItem('vhost', e.target.value)


### PR DESCRIPTION
Vhost menu was broken for some views because they did not import helpers, and the menu was structured/"created" by helpers. I moved the addVhostOptions call to layout.js and imported helpers.js there, so that it is done for all views. 