### PR TITLE
Adds consumer view

### DIFF
--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -24,7 +24,7 @@ module LavinMQ
         end
       end
 
-      private def match_value(value)
+      protected def match_value(value)
         value[:name]? || value["name"]?
       end
 

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -7,6 +7,10 @@ module LavinMQ
     class ConsumersController < Controller
       include ConnectionsHelper
 
+      protected def match_value(value)
+        value[:consumer_tag]? || value["consumer_tag"]?
+      end
+
       private def register_routes
         get "/api/consumers" do |context, _params|
           page(context, all_consumers(user(context)))

--- a/src/lavinmq/http/controller/views.cr
+++ b/src/lavinmq/http/controller/views.cr
@@ -14,6 +14,7 @@ module LavinMQ
         static_view "/federation"
         static_view "/shovels"
         static_view "/connections"
+        static_view "/consumers"
         static_view "/connection"
         static_view "/channels"
         static_view "/channel"

--- a/static/js/consumers.js
+++ b/static/js/consumers.js
@@ -17,7 +17,8 @@ const tableOptions = {
   search: true
 }
 
-Table.renderTable('table', tableOptions, function (tr, item, all) {
+Table.renderTable('table', tableOptions, function (tr, item, firstRender) {
+  if (!firstRender) return
   const channelLink = document.createElement('a')
   channelLink.href = 'channel#name=' + encodeURIComponent(item.channel_details.name)
   channelLink.textContent = item.channel_details.name

--- a/static/js/consumers.js
+++ b/static/js/consumers.js
@@ -1,0 +1,57 @@
+import * as Table from './table.js'
+import * as HTTP from './http.js'
+import * as DOM from './dom.js'
+
+const vhost = window.sessionStorage.getItem('vhost')
+let url = 'api/consumers'
+if (vhost && vhost !== '_all') {
+  url = `api/consumers/${encodeURIComponent(vhost)}`
+}
+
+const tableOptions = {
+  url,
+  keyColumns: ['channel_details', 'consumer_tag'],
+  interval: 5000,
+  pagination: true,
+  columnSelector: true,
+  search: true
+}
+
+Table.renderTable('table', tableOptions, function (tr, item, all) {
+  console.log(item)
+  const channelLink = document.createElement('a')
+  channelLink.href = 'channel#name=' + encodeURIComponent(item.channel_details.name)
+  channelLink.textContent = item.channel_details.name
+  const ack = item.ack_required ? '●' : '○'
+  const exclusive = item.exclusive ? '●' : '○'
+  const cancelForm = document.createElement('form')
+  const btn = document.createElement('button')
+  btn.classList.add('btn-primary')
+  btn.type = 'submit'
+  btn.textContent = 'Cancel'
+
+  cancelForm.appendChild(btn)
+  const urlEncodedVhost = encodeURIComponent(item.queue.vhost)
+  console.log(urlEncodedVhost)
+  const urlEncodedConsumerTag = encodeURIComponent(item.consumer_tag)
+  const conn = encodeURIComponent(item.channel_details.connection_name)
+  const ch = encodeURIComponent(item.channel_details.number)
+  const actionPath = `api/consumers/${urlEncodedVhost}/${conn}/${ch}/${urlEncodedConsumerTag}`
+  cancelForm.addEventListener('submit', function (evt) {
+    evt.preventDefault()
+    if (!confirm('Are you sure?')) return false
+    HTTP.request('DELETE', actionPath)
+      .then(() => {
+        DOM.toast('Consumer cancelled')
+      }).catch(HTTP.standardErrorHandler)
+  })
+
+  Table.renderCell(tr, 0, item.queue.vhost)
+  Table.renderCell(tr, 1, item.queue.name)
+  Table.renderCell(tr, 2, channelLink)
+  Table.renderCell(tr, 3, item.consumer_tag)
+  Table.renderCell(tr, 4, ack, 'center')
+  Table.renderCell(tr, 5, exclusive, 'center')
+  Table.renderCell(tr, 6, item.prefetch_count, 'right')
+  Table.renderCell(tr, 7, cancelForm, 'center')
+})

--- a/static/js/consumers.js
+++ b/static/js/consumers.js
@@ -31,7 +31,6 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
 
   cancelForm.appendChild(btn)
   const urlEncodedVhost = encodeURIComponent(item.queue.vhost)
-  console.log(urlEncodedVhost)
   const urlEncodedConsumerTag = encodeURIComponent(item.consumer_tag)
   const conn = encodeURIComponent(item.channel_details.connection_name)
   const ch = encodeURIComponent(item.channel_details.number)

--- a/static/js/consumers.js
+++ b/static/js/consumers.js
@@ -18,7 +18,6 @@ const tableOptions = {
 }
 
 Table.renderTable('table', tableOptions, function (tr, item, all) {
-  console.log(item)
   const channelLink = document.createElement('a')
   channelLink.href = 'channel#name=' + encodeURIComponent(item.channel_details.name)
   channelLink.textContent = item.channel_details.name

--- a/views/consumers.ecr
+++ b/views/consumers.ecr
@@ -14,13 +14,13 @@
           <table id="table" class="table">
             <thead>
               <tr>
-                <th>Virtual host</th>
-                <th>Queue</th>
-                <th>Channel</th>
-                <th class="left">Consumer tag</th>
+                <th data-sort-key="vhost">Virtual host</th>
+                <th data-sort-key="queue">Queue</th>
+                <th data-sort-key="channel">Channel</th>
+                <th data-sort-key="consumer-tag" class="left">Consumer tag</th>
                 <th>Ack required</th>
                 <th>Exclusive</th>
-                <th class="right">Prefetch count</th>
+                <th data-sort-key="prefetch" class="right">Prefetch count</th>
                 <th></th>
               </tr>
             </thead>

--- a/views/consumers.ecr
+++ b/views/consumers.ecr
@@ -1,0 +1,34 @@
+<%- pagename = "Consumers" -%>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <% render "head" %>
+    <script type="module" src="js/consumers.js"></script>
+  </head>
+  <body>
+    <% render "header" %>
+    <main>
+      <section class="card">
+        <div class="table-wrapper">
+          <div id="table-error"></div>
+          <table id="table" class="table">
+            <thead>
+              <tr>
+                <th>Virtual host</th>
+                <th>Queue</th>
+                <th>Channel</th>
+                <th class="left">Consumer tag</th>
+                <th>Ack required</th>
+                <th>Exclusive</th>
+                <th class="right">Prefetch count</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+    <% render "footer" %>
+  </body>
+</html>

--- a/views/header.ecr
+++ b/views/header.ecr
@@ -30,6 +30,7 @@
     <% {
       ".":            "Overview",
       "connections":  "Connections",
+      "consumers":    "Consumers",
       "channels":     "Channels",
       "exchanges":    "Exchanges",
       "queues":       "Queues",

--- a/views/overview.ecr
+++ b/views/overview.ecr
@@ -19,7 +19,7 @@
         </div>
         <div>
           <div class="counter" id="consumers">0</div>
-          <div class="counter-header">Consumers</div>
+          <div class="counter-header"><a href="consumers">Consumers</div>
         </div>
         <div>
           <div class="counter" id="exchanges">0</div>


### PR DESCRIPTION
Adds a consumer view, with same values as the one found in queue. 

The value with having a separate consumers page is that you can list all consumers across LavinMQ, and not see them one queue at a time. 

Should we remove the consumer form from queues, i don't think so because its nice to have all metrics gathered together. But its worth mentioning that they are more or less the same forms.  