### PR TITLE
JSON.stringify table key data

### DIFF
--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -24,7 +24,7 @@ class ConsumersDataSource extends DataSource {
 }
 const consumersDataSource = new ConsumersDataSource()
 const consumersTableOpts = {
-  keyColumns: ["channel_details"],
+  keyColumns: ["consumer_tag", "channel_details"],
   countId: 'consumer-count',
   dataSource: consumersDataSource
 }

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -97,13 +97,11 @@ function renderTable (id, options = {}, renderRow) {
   }
 
   function findRow (rows, item) {
-    return rows.find(row => keyColumns.every(key => row.dataset[key] === item[key]))
+    return rows.find(row => keyColumns.every(key => row.dataset[key] === JSON.stringify(item[key])))
   }
 
   function setKeyAttributes (tr, item) {
-    keyColumns.forEach(function (key) {
-      tr.dataset[key] = item[key]
-    })
+    keyColumns.forEach(key => tr.dataset[key] = JSON.stringify(item[key]))
   }
 
   function renderSearch (conatiner, dataSource) {


### PR DESCRIPTION
Dataset always returns DOMStrings, so if the key column value was a number or an object it wasn't correct before.