### PR TITLE
Don't fsync on confirm but syncfs on transaction

### DIFF
--- a/src/lavinmq/client/channel.cr
+++ b/src/lavinmq/client/channel.cr
@@ -732,6 +732,7 @@ module LavinMQ
         return @client.send_precondition_failed(frame, "Not in transaction mode") unless @tx
         process_tx_acks
         process_tx_publishes
+        @client.vhost.sync
         send AMQP::Frame::Tx::CommitOk.new(frame.channel)
       end
 

--- a/src/lavinmq/client/channel.cr
+++ b/src/lavinmq/client/channel.cr
@@ -711,8 +711,7 @@ module LavinMQ
       private def next_msg_body_file
         @next_msg_body_file ||=
           begin
-            tmp_path = File.join(@client.vhost.data_dir, "tmp", Random::Secure.urlsafe_base64)
-            File.open(tmp_path, "w+").tap do |f|
+            File.tempfile("channel.", nil, dir: @client.vhost.data_dir).tap do |f|
               f.sync = true
               f.read_buffering = false
               f.delete

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -117,8 +117,13 @@ class MFile < IO
     msync(buffer, @size, LibC::MS_ASYNC)
   end
 
-  def fsync
+  def msync
     msync(buffer, @size, LibC::MS_SYNC)
+  end
+
+  def fsync : Nil
+    ret = LibC.fsync(@fd)
+    raise IO::Error.from_errno("Error syncing file") if ret != 0
   end
 
   # unload the memory mapping, will be remapped on demand

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -893,12 +893,6 @@ module LavinMQ
       !(empty? && @consumers.empty?)
     end
 
-    def fsync_enq
-    end
-
-    def fsync_ack
-    end
-
     def to_json(json : JSON::Builder, consumer_limit : Int32 = -1)
       json.object do
         details_tuple.merge(message_stats: stats_details).each do |k, v|

--- a/src/lavinmq/reporter.cr
+++ b/src/lavinmq/reporter.cr
@@ -5,7 +5,6 @@ module LavinMQ
       puts_size_capacity s.@vhosts
       s.vhosts.each do |_, vh|
         puts "VHost #{vh.name}"
-        puts_size_capacity vh.@awaiting_confirm, 4
         puts_size_capacity vh.@exchanges, 4
         puts_size_capacity vh.@queues, 4
         vh.queues.each do |_, q|

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -46,8 +46,8 @@ module LavinMQ
       @log = Log.for "vhost[name=#{@name}]"
       @dir = Digest::SHA1.hexdigest(@name)
       @data_dir = File.join(@server_data_dir, @dir)
+      Dir.mkdir_p File.join(@data_dir)
       @data_dir_fd = LibC.dirfd(Dir.new(@data_dir).@dir)
-      Dir.mkdir_p File.join(@data_dir, "tmp")
       File.write(File.join(@data_dir, ".vhost"), @name)
       load_limits
       @operator_policies = ParameterStore(OperatorPolicy).new(@data_dir, "operator_policies.json", @log)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -611,8 +611,7 @@ module LavinMQ
     end
 
     private def save!
-      File.open(File.join(@data_dir, "definitions.amqp"), "W") do |f|
-        f.seek(0, IO::Seek::End)
+      File.open(File.join(@data_dir, "definitions.amqp"), "a") do |f|
         while frame = @save.receive?
           @log.debug { "Storing definition: #{frame.inspect}" }
           f.write_bytes frame

--- a/src/stdlib/libc.cr
+++ b/src/stdlib/libc.cr
@@ -2,8 +2,10 @@
 lib LibC
   {% if flag?(:linux) %}
     fun get_phys_pages : Int32
+    fun syncfs(fd : Int) : Int
   {% end %}
 
+  fun sync : Void
   fun getpagesize : Int32
 
   {% if flag?(:darwin) %}


### PR DESCRIPTION
Rabbit is removing fsync on confirm and transactions. Was no-op already. `syncfs` synchronizes all files on the filesystem, which is convinent instead of having to track all possible files that would need to be synced when acking/publishing in a transaction.