### PR TITLE
Prevent memory leak of Consumer#deliver_loop fibers

### DIFF
--- a/src/lavinmq/client/channel/consumer.cr
+++ b/src/lavinmq/client/channel/consumer.cr
@@ -76,7 +76,10 @@ module LavinMQ
           ch = @channel
           return if ch.has_capacity?
           @log.debug { "Waiting for global prefetch capacity" }
-          ch.has_capacity.receive
+          select
+          when ch.has_capacity.receive
+          when @close_chan.receive
+          end
           true
         end
 

--- a/src/lavinmq/client/channel/consumer.cr
+++ b/src/lavinmq/client/channel/consumer.cr
@@ -41,7 +41,7 @@ module LavinMQ
 
         def prefetch_count=(prefetch_count : UInt16)
           @prefetch_count = prefetch_count
-          notiy_has_capacity(@prefetch_count > @unacked)
+          notify_hash_capacity(@prefetch_count > @unacked)
         end
 
         private def deliver_loop
@@ -176,7 +176,7 @@ module LavinMQ
 
         getter has_capacity = ::Channel(Bool).new
 
-        private def notiy_has_capacity(value)
+        private def notify_hash_capacity(value)
           while @has_capacity.try_send? value
           end
         end
@@ -184,7 +184,7 @@ module LavinMQ
         def deliver(msg, sp, redelivered = false, recover = false)
           unless @no_ack || recover
             @unacked += 1
-            notiy_has_capacity(false) if @unacked == @prefetch_count
+            notify_hash_capacity(false) if @unacked == @prefetch_count
           end
           persistent = msg.properties.delivery_mode == 2_u8
           # @log.debug { "Getting delivery tag" }
@@ -200,13 +200,13 @@ module LavinMQ
         def ack(sp)
           was_full = @unacked == @prefetch_count
           @unacked -= 1
-          notiy_has_capacity(true) if was_full
+          notify_hash_capacity(true) if was_full
         end
 
         def reject(sp)
           was_full = @unacked == @prefetch_count
           @unacked -= 1
-          notiy_has_capacity(true) if was_full
+          notify_hash_capacity(true) if was_full
         end
 
         def cancel


### PR DESCRIPTION
When listening for external channels, also listen for an internal cancel channel which gets closed on consumer closed, raising a Channel::ClosedError, exiting the fiber.