### PR TITLE
reroutes to /login when cookie expires

### DIFF
--- a/static/js/datasource.js
+++ b/static/js/datasource.js
@@ -49,7 +49,8 @@ class DataSource {
     sort_reverse: false,
     name: ''
   }
-  constructor(opts) {
+
+  constructor (opts) {
     this._opts = Object.assign(
       {
         autoReloadTimeout: 5000,
@@ -70,14 +71,14 @@ class DataSource {
         try {
           cachedState = JSON.parse(cachedState)
           this._setState(cachedState)
-        } catch(e) {
+        } catch (e) {
           console.error(`Failed to load cached query state: ${e}`, cachedState)
         }
       }
       this._setStateFromHash()
       window.addEventListener('hashchange', evt => {
         this._setStateFromHash()
-        this.reload({updateState: false})
+        this.reload({ updateState: false })
       })
     }
   }
@@ -131,7 +132,7 @@ class DataSource {
     throw "Not implemented"
   }
 
-  reload(args) {
+  reload (args) {
     clearTimeout(this._reloadTimer)
     return this._reload(args).then(resp => {
       this._enqueueReload()
@@ -139,6 +140,7 @@ class DataSource {
       return resp
     }).catch(err => {
       this._enqueueReload()
+      if (err.status === 401) { return }
       if (err.message) {
         this.emit('error', err.message)
       } else {

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -18,7 +18,7 @@ function request (method, path, options = {}) {
         var error = { status: response.status, reason: response.statusText }
         return response.json()
           .then(json => { error.reason = json.reason })
-          .finally(() => { throw new HTTPError(error.status, error.reason) })
+          .finally(() => { standardErrorHandler(error) })
       } else { return response.json().catch(() => null) }
     })
 }


### PR DESCRIPTION
We currently have two error handlers, one "general", in http.js (standardErrorHandler), and one in datasource.js, for table errors. 
I have added some conditions to make it look smooth, so the datasource error will not trigger if it is a 401.. but im wondering if there is a better way? 
let me know what you think 