### PR TITLE
add toolstips for memory usage and disk usage

### DIFF
--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -24,16 +24,24 @@
             <td id="tr-vcpu"></td>
           </tr>
           <tr>
-            <th>Memory usage</th>
+            <th>
+              <a class="prop-tooltip" data-tag="alternate-exchange">Memory usage
+              <span class="prop-tooltiptext">The amount of memory LavinMQ uses relative to the available system space</span>
+              </a>
+            </th>
             <td id="tr-memory"></td>
           </tr>
           <tr>
-            <th>Average CPU usage</th>
-            <td id="tr-cpu"></td>
+            <th>
+              <a class="prop-tooltip" data-tag="alternate-exchange">Disk usage
+              <span class="prop-tooltiptext">The amount of disk memory the system uses relative to the available system space</span>
+              </a>
+            </th>
+            <td id="tr-disk"></td>
           </tr>
           <tr>
-            <th>Disk usage</th>
-            <td id="tr-disk"></td>
+            <th>CPU Usage</th>
+            <td id="tr-cpu"></td>
           </tr>
         </table>
       </section>


### PR DESCRIPTION
Specify what the memory metrics actually mean, so that it is less confusing and especially so that you don't mistake memory usage to be the number for the total system usage. 