### PR TITLE
use zstd to compress replication data

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -24,3 +24,7 @@ shards:
     git: https://github.com/84codes/systemd.cr.git
     version: 2.0.0
 
+  zstd:
+    git: https://github.com/didactic-drunk/zstd.cr.git
+    version: 1.2.0
+

--- a/shard.yml
+++ b/shard.yml
@@ -32,6 +32,8 @@ dependencies:
     github: tbrand/router.cr
   systemd:
     github: 84codes/systemd.cr
+  zstd:
+    github: didactic-drunk/zstd.cr
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
Doesn't work as `zstd.cr` currently has no way of flushing data