### PR TITLE
Import definitions bug

### DIFF
--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -205,10 +205,7 @@ module LavinMQ
               name = u["name"].as_s
               pass_hash = u["password_hash"].as_s
               hash_algo = u["hashing_algorithm"]?.try(&.as_s)
-              pp u["tags"]
               tags = u["tags"].to_s.tr("[]\"", "").split(",").compact_map { |t| Tag.parse?(t) }
-              pp tags
-              pp "-----------------"
               @amqp_server.users.add(name, pass_hash, hash_algo, tags, save: false)
             end
             @amqp_server.users.save!

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -205,7 +205,10 @@ module LavinMQ
               name = u["name"].as_s
               pass_hash = u["password_hash"].as_s
               hash_algo = u["hashing_algorithm"]?.try(&.as_s)
-              tags = u["tags"]?.try(&.as_s).to_s.split(",").compact_map { |t| Tag.parse?(t) }
+              pp u["tags"]
+              tags = u["tags"].to_s.tr("[]\"", "").split(",").compact_map { |t| Tag.parse?(t) }
+              pp tags
+              pp "-----------------"
               @amqp_server.users.add(name, pass_hash, hash_algo, tags, save: false)
             end
             @amqp_server.users.save!

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -205,7 +205,8 @@ module LavinMQ
               name = u["name"].as_s
               pass_hash = u["password_hash"].as_s
               hash_algo = u["hashing_algorithm"]?.try(&.as_s)
-              tags = u["tags"]?.to_s.tr("[]\"", "").split(",").compact_map { |t| Tag.parse?(t) }
+              tags = u["tags"]?.to_s.gsub(/[\[\]"\s]/, "").split(",").compact_map { |t| Tag.parse?(t) }
+              pp tags
               @amqp_server.users.add(name, pass_hash, hash_algo, tags, save: false)
             end
             @amqp_server.users.save!

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -205,7 +205,7 @@ module LavinMQ
               name = u["name"].as_s
               pass_hash = u["password_hash"].as_s
               hash_algo = u["hashing_algorithm"]?.try(&.as_s)
-              tags = u["tags"].to_s.tr("[]\"", "").split(",").compact_map { |t| Tag.parse?(t) }
+              tags = u["tags"]?.to_s.tr("[]\"", "").split(",").compact_map { |t| Tag.parse?(t) }
               @amqp_server.users.add(name, pass_hash, hash_algo, tags, save: false)
             end
             @amqp_server.users.save!


### PR DESCRIPTION
### WHAT is this pull request doing?
Avoids raising an error for tag inputs that are not of type String, which allows users to input tags as an array. Instead it only does the string conversion and truncates abundant json characters. This allows some leeway for how users input the tags value. 

### HOW can this pull request be tested?
Try and upload a definitions file with this input 

````
{
  "users": [
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u1",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": "administrator,testing"
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u2",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": "administrator,monitoring"
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u3",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": ["administrator,testing"]
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u4",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": ["administrator,monitoring"]
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u5",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": "[administrator,testing]"
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u6",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": "[administrator,monitoring]"
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u7",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": ["administrator", "testing"]
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u8",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": ["administrator", "monitoring"]
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u9",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": ["[administrator,testing]"]
    },
    {
      "hashing_algorithm": "rabbit_password_hashing_sha256",
      "limits": {},
      "name": "u10",
      "password_hash": "AxrffQakJjL/8iKHmIBrFoceAKj9R6sRrKDq+LmCa/0GN+mH",
      "tags": ["[administrator,monitoring]"]
    }
  ]

}
````
produces this outcome
<img width="363" alt="image" src="https://github.com/cloudamqp/lavinmq/assets/85930202/49cd13d8-e980-473f-908a-63adf79f654d">
