### PR TITLE
server settings for replication

### DIFF
--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -22,3 +22,5 @@ tcp_proxy_protocol = false
 tls_port = 5671
 unix_path = /tmp/lavinmq.sock
 unix_proxy_protocol = true
+min_followers = 1
+max_lag = 10000000000

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -23,4 +23,4 @@ tls_port = 5671
 unix_path = /tmp/lavinmq.sock
 unix_proxy_protocol = true
 min_followers = 1
-max_lag = 10000000000
+max_lag = 100

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -22,5 +22,3 @@ tcp_proxy_protocol = false
 tls_port = 5671
 unix_path = /tmp/lavinmq.sock
 unix_proxy_protocol = true
-min_followers = 1
-max_lag = 100

--- a/spec/replication_spec.cr
+++ b/spec/replication_spec.cr
@@ -125,7 +125,7 @@ describe LavinMQ::Replication::Server do
       when done.receive
         fail "Should not receive message"
       when timeout(0.1.seconds)
-        #ugly hack to release replicator from waiting for lag
+        # ugly hack to release replicator from waiting for lag
         repli = LavinMQ::Replication::Client.new(data_dir)
         done = Channel(Nil).new
         spawn do

--- a/spec/replication_spec.cr
+++ b/spec/replication_spec.cr
@@ -65,3 +65,83 @@ describe LavinMQ::Replication::Client do
     end
   end
 end
+
+describe LavinMQ::Replication::Server do
+  data_dir = "/tmp/lavinmq-follower"
+
+  before_each do
+    FileUtils.rm_rf data_dir
+    Dir.mkdir_p data_dir
+    File.write File.join(data_dir, ".replication_secret"), Server.@replicator.@password, 0o400
+    Server.vhosts["/"].declare_queue("repli", true, false)
+    LavinMQ::Config.instance.min_followers = 1
+  end
+
+  after_each do
+    FileUtils.rm_rf data_dir
+    LavinMQ::Config.instance.min_followers = 0
+  end
+
+
+  it "should shut down gracefully" do
+    repli = LavinMQ::Replication::Client.new(data_dir)
+    3.times do
+      spawn do
+        repli.follow("127.0.0.1", LavinMQ::Config.instance.replication_port)
+      end
+    end
+
+    # repli.closing
+
+  end
+
+  it "should publish when min_followers is fulfilled" do
+    q = Server.vhosts["/"].queues["repli"].as(LavinMQ::Queue)
+    repli = LavinMQ::Replication::Client.new(data_dir)
+    spawn do
+      repli.follow("127.0.0.1", LavinMQ::Config.instance.replication_port)
+    end
+    with_channel do |ch|
+      ch.basic_publish "hello world", "", "repli"
+    end
+    q.basic_get(true) { }.should be_true
+    repli.close
+  end
+
+  it "should not publish when min_followers is not fulfilled" do
+    done = Channel(Nil).new
+    client : AMQP::Client::Connection? = nil
+    spawn do
+      with_channel do |ch, conn|
+        client = conn
+        q = ch.queue("repli")
+        q.publish_confirm "hello world"
+        done.send nil
+      end
+    end
+    select
+    when done.receive
+      fail "Should not receive message"
+    when timeout(0.1.seconds)
+      client.try &.close(no_wait: true)
+      Server.close
+    end
+  end
+
+  # it "should publish when max_lag is not reached" do
+  #   LavinMQ::Config.instance.max_lag = 10000
+  #   q = Server.vhosts["/"].queues["repli"].as(LavinMQ::Queue)
+  #   repli = LavinMQ::Replication::Client.new(data_dir)
+  #   spawn do
+  #     repli.follow("127.0.0.1", LavinMQ::Config.instance.replication_port)
+  #   end
+  #   with_channel do |ch|
+  #     ch.basic_publish "hello world", "", "repli"
+  #   end
+  #   q.basic_get(true) { }.should be_true
+  #   repli.close
+  # end
+
+  # it "should not publish when max_lag is reached" do
+  # end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -160,8 +160,14 @@ start_http_server
 Spec.after_each do
   Server.stop
   FileUtils.rm_rf("/tmp/lavinmq-spec")
+end
+
+Spec.before_each do
+  Server.stop
+  FileUtils.rm_rf("/tmp/lavinmq-spec")
   Server.restart
 end
+
 
 class Invalid < Exception
   def initialize

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -168,7 +168,6 @@ Spec.before_each do
   Server.restart
 end
 
-
 class Invalid < Exception
   def initialize
     super("invalid input")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -43,7 +43,7 @@ def with_channel(file = __FILE__, line = __LINE__, **args, &)
   args = {port: LavinMQ::Config.instance.amqp_port, name: name}.merge(args)
   conn = AMQP::Client.new(**args).connect
   ch = conn.channel
-  yield ch
+  yield ch, conn
 ensure
   conn.try &.close(no_wait: false)
 end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -6,7 +6,7 @@ module LavinMQ
     DEFAULT_LOG_LEVEL = Log::Severity::Info
 
     property data_dir : String = ENV.fetch("STATE_DIRECTORY", "/var/lib/lavinmq")
-    property config_file = File.exists?(File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini")) ? File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini") : ""
+    property config_file = File.exists?(File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini")) ? File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini") : "/Users/christinadahlen/84codes/lavinmq/extras/lavinmq.ini"
     property log_file : String? = nil
     property log_level : Log::Severity = DEFAULT_LOG_LEVEL
     property amqp_bind = "127.0.0.1"
@@ -50,6 +50,8 @@ module LavinMQ
     property max_deleted_definitions = 8192 # number of deleted queues, unbinds etc that compacts the definitions file
     property consumer_timeout : UInt64? = nil
     property consumer_timeout_loop_interval = 60 # seconds
+    property min_followers : Int64 = 0
+    property max_lag : Int64? = nil
     @@instance : Config = self.new
 
     def self.instance : LavinMQ::Config
@@ -141,6 +143,8 @@ module LavinMQ
         when "systemd_socket_name" then @amqp_systemd_socket_name = v
         when "unix_proxy_protocol" then @unix_proxy_protocol = true?(v) ? 1u8 : v.to_u8? || 0u8
         when "tcp_proxy_protocol"  then @tcp_proxy_protocol = true?(v) ? 1u8 : v.to_u8? || 0u8
+        when "min_followers"       then @min_followers = v.to_i64
+        when "max_lag"             then @max_lag = v.to_i64
         else
           STDERR.puts "WARNING: Unrecognized configuration 'amqp/#{config}'"
         end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -6,7 +6,7 @@ module LavinMQ
     DEFAULT_LOG_LEVEL = Log::Severity::Info
 
     property data_dir : String = ENV.fetch("STATE_DIRECTORY", "/var/lib/lavinmq")
-    property config_file = File.exists?(File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini")) ? File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini") : "/Users/christinadahlen/84codes/lavinmq/extras/lavinmq.ini"
+    property config_file = File.exists?(File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini")) ? File.join(ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini") : ""
     property log_file : String? = nil
     property log_level : Log::Severity = DEFAULT_LOG_LEVEL
     property amqp_bind = "127.0.0.1"

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -77,7 +77,6 @@ module LavinMQ
           run_queue:          0,
           sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
           followers:          @amqp_server.followers,
-          min_followers:      LavinMQ::Config.instance.min_followers,
           max_lag:            LavinMQ::Config.instance.max_lag,
         }
       end

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -77,6 +77,8 @@ module LavinMQ
           run_queue:          0,
           sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
           followers:          @amqp_server.followers,
+          min_followers:      LavinMQ::Config.instance.min_followers,
+          max_lag:            LavinMQ::Config.instance.max_lag,
         }
       end
 

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -10,13 +10,13 @@ module LavinMQ
       @data_dir_lock : DataDirLock?
       @closed = false
 
-      def initialize(@data_dir : String)
+      def initialize(@data_dir : String, pwd : String? = nil)
         System.maximize_fd_limit
         @socket = TCPSocket.new
         @socket.sync = true
         @socket.read_buffering = false
         @lz4 = Compress::LZ4::Reader.new(@socket)
-        @password = password
+        @password = pwd || password
         @files = Hash(String, File).new do |h, k|
           path = File.join(@data_dir, k)
           Dir.mkdir_p File.dirname(path)

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -71,12 +71,11 @@ module LavinMQ
 
       private def action_loop(socket = @lz4)
         while action = @actions.receive?
-          sent_bytes = action.send(socket)
+          action.send(socket)
           while action2 = @actions.try_receive?
-            sent_bytes += action2.send(socket)
+            action2.send(socket)
           end
           socket.flush
-          @sent_bytes += sent_bytes
         end
       rescue IO::Error
       ensure

--- a/src/lavinmq/replication/server.cr
+++ b/src/lavinmq/replication/server.cr
@@ -124,7 +124,7 @@ module LavinMQ
       end
 
       def wait_for_max_lag
-        return unless max_lag = Config.instance.max_lag
+        return unless Config.instance.max_lag
         each_follower do |f|
           f.wait_for_max_lag
         end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -171,10 +171,12 @@ module LavinMQ
 
     def close
       @closed = true
+      @replicator.closing
       @log.debug { "Closing listeners" }
       @listeners.each_key &.close
       @log.debug { "Closing vhosts" }
       @vhosts.close
+      @log.debug { "Closing replicator" }
       @replicator.close
     end
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -53,6 +53,7 @@ module LavinMQ
     def restart
       stop
       Dir.mkdir_p @data_dir
+      # @replicator = Replication::Server.new
       Schema.migrate(@data_dir, @replicator)
       @users = UserStore.new(@data_dir, @replicator)
       @vhosts = VHostStore.new(@data_dir, @users, @replicator)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -125,6 +125,7 @@ module LavinMQ
       headers = msg.properties.headers
       find_all_queues(ex, msg.routing_key, headers, visited, found_queues)
       headers.delete("BCC") if headers
+
       if found_queues.empty?
         ex.unroutable_count += 1
         return false
@@ -456,8 +457,11 @@ module LavinMQ
         sleep 0.1
       end
       # then force close the remaining (close tcp socket)
+      @log.debug { "force closing connection" } unless connections.empty?
+
       @connections.each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
+      @log.debug { "Closing queues" }
       @queues.each_value &.close
       Fiber.yield
       compact!

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -30,6 +30,7 @@ function render (data) {
   document.querySelector('#version').textContent = data[0].applications[0].version
   for (const node of data) {
     updateDetails(node)
+    updateFollowerSettings(node)
     updateStats(node)
   }
 }
@@ -70,6 +71,11 @@ const updateDetails = (nodeStats) => {
     diskUsage = 'N/A'
   }
   document.getElementById('tr-disk').textContent = diskUsage
+}
+
+const updateFollowerSettings = (nodeStats) => {
+  document.getElementById('tr-max-lag').textContent = nodeStats.max_lag || 'No max_lag value specified'
+  document.getElementById('tr-min-followers').textContent = nodeStats.min_followers
 }
 
 const stats = [

--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -74,7 +74,7 @@
         <h3>Queue churn</h3>
         <div class="chart-container" id="queueChurnChart"></div>
       </section>
-      <section class="card">
+      <section class="card cols-10">
         <h3>
           Followers
           <small id="followers-count"></small>
@@ -94,6 +94,18 @@
           </table>
         </div>
       </section>
+      <section class="card cols-2">
+        <h3>Follower Settings</h3>
+        <table class="details-table">
+          <tr>
+            <th>Minimum amount of followers</th>
+            <td id="tr-min-followers"></td>
+          </tr>
+          <tr>
+            <th>Maximum amount of lag</th>
+            <td id="tr-max-lag"></td>
+          </tr>
+        </table>
     </main>
     <% render "footer" %>
   </body>


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds properties `min_followers` and `max_lag` to the Config class and the values are parsed from `lavinmq.ini`
The values are then conditioned in `vhost.cr` via the replication servers new `wait_for_max_lag`.  You cannot publish to a queue if you have less followers connected than `min_followers` or if min_followers amount of followers have more lag than `max_lag`.  

Fixes #674

### HOW can this pull request be tested?
Start LavinMQ and configure the values in your config file, connect too few followers and try to publish.   

