### PR TITLE
No exclusive qs in definitions

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -314,6 +314,17 @@ describe LavinMQ::HTTP::Server do
       body["queues"].as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
     end
 
+    it "does not export exclusive queues" do
+      # Declare exclusive queue with amqp client
+      with_channel do |ch|
+        ch.queue("", exclusive: true)
+        response = get("/api/definitions/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["queues"].as_a.empty?.should be_true
+      end
+    end
+
     it "exports exchanges" do
       Server.vhosts["/"].declare_exchange("export_e2", "topic", false, false)
       response = get("/api/definitions/%2f")

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -277,6 +277,7 @@ module LavinMQ
           json.array do
             vhosts.each_value do |v|
               v.queues.each_value do |q|
+                next if q.exclusive
                 {
                   "name":        q.name,
                   "vhost":       q.vhost.name,


### PR DESCRIPTION
### WHAT is this pull request doing?
Excludes exclusive queues from definitions.

Exclusive queues are exclusive to a connection, makes no sense to include them in definitions. RabbitMQ does not.
Will cause client errors because the queue is declared but without the exclusive flag after import.

### HOW can this pull request be tested?
Specs
