### PR TITLE
Bugfix: one msg going to multiple queues fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Messages larger than frame_max, routed to multiple queues, were only written to the first queue, and corrupted the others
 - Message segments are agressivly unmapped to decrease memory usage
-
 
 ## [1.1.5] - 2023-06-23
 

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -1007,4 +1007,52 @@ describe LavinMQ::Server do
       end
     end
   end
+
+  it "can publish large messages to multiple queues" do
+    with_channel do |ch|
+      q1 = ch.queue
+      q2 = ch.queue
+      q1.bind("amq.fanout", "")
+      q2.bind("amq.fanout", "")
+      2.times do |i|
+        ch.basic_publish_confirm(i.to_s * 200_000, "amq.fanout", "")
+      end
+      2.times do |i|
+        if msg = q1.get
+          msg.body_io.to_s.should eq i.to_s * 200_000
+        else
+          msg.should_not be_nil
+        end
+        if msg = q2.get
+          msg.body_io.to_s.should eq i.to_s * 200_000
+        else
+          msg.should_not be_nil
+        end
+      end
+    end
+  end
+
+  it "can publish small messages to multiple queues" do
+    with_channel do |ch|
+      q1 = ch.queue
+      q2 = ch.queue
+      q1.bind("amq.fanout", "")
+      q2.bind("amq.fanout", "")
+      2.times do |i|
+        ch.basic_publish_confirm(i.to_s * 200, "amq.fanout", "")
+      end
+      2.times do |i|
+        if msg = q1.get
+          msg.body_io.to_s.should eq i.to_s * 200
+        else
+          msg.should_not be_nil
+        end
+        if msg = q2.get
+          msg.body_io.to_s.should eq i.to_s * 200
+        else
+          msg.should_not be_nil
+        end
+      end
+    end
+  end
 end

--- a/src/lavinmq/message.cr
+++ b/src/lavinmq/message.cr
@@ -113,6 +113,7 @@ module LavinMQ
       io.write_bytes @bodysize, format
       if io_mem = @body_io.as?(IO::Memory)
         io.write(io_mem.to_slice)
+        io_mem.pos = @bodysize # necessary for rewinding in Vhost#publish
       else
         copied = IO.copy(@body_io, io, @bodysize)
         if copied != @bodysize

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -105,6 +105,8 @@ module LavinMQ
     # True if it also succesfully wrote to one or more queues
     # False if no queue was able to receive the message because they're
     # closed
+    # The position of the msg.body_io should be at the start of the body
+    # When this method finishes, the position will be the same, start of the body
     def publish(msg : Message, immediate = false,
                 visited = Set(Exchange).new, found_queues = Set(Queue).new) : Bool
       ex = @exchanges[msg.exchange_name]? || return false
@@ -124,6 +126,7 @@ module LavinMQ
         if q.publish(msg)
           ex.publish_out_count += 1
           ok += 1
+          msg.body_io.seek(-msg.bodysize.to_i64, IO::Seek::Current) # rewind
         end
       end
       ok > 0


### PR DESCRIPTION
Before, if a message was larger than frame_max, the message body would only be written to the first queue. If the message was less than frame_max a IO::Memory would be used and we would copy the whole underlaying `Slice`, without the need for rewinding.