### PR TITLE
StreamQueue: only unmap unused segments

### DIFF
--- a/src/lavinmq/client/channel.cr
+++ b/src/lavinmq/client/channel.cr
@@ -104,7 +104,7 @@ module LavinMQ
         end
         raise Error::UnexpectedFrame.new(frame) if @next_publish_exchange_name
         if ex = @client.vhost.exchanges[frame.exchange]?
-          if !ex.internal
+          if !ex.internal?
             @next_publish_exchange_name = frame.exchange
             @next_publish_routing_key = frame.routing_key
             @next_publish_mandatory = frame.mandatory

--- a/src/lavinmq/client/client.cr
+++ b/src/lavinmq/client/client.cr
@@ -592,7 +592,7 @@ module LavinMQ
       else
         size = q.message_count
         @vhost.apply(frame)
-        @exclusive_queues.delete(q) if q.exclusive
+        @exclusive_queues.delete(q) if q.exclusive?
         send AMQP::Frame::Queue::DeleteOk.new(frame.channel, size) unless frame.no_wait
       end
     end
@@ -603,7 +603,7 @@ module LavinMQ
     end
 
     def queue_exclusive_to_other_client?(q)
-      q.exclusive && !@exclusive_queues.includes?(q)
+      q.exclusive? && !@exclusive_queues.includes?(q)
     end
 
     private def declare_queue(frame)
@@ -643,7 +643,7 @@ module LavinMQ
             q.message_count, q.consumer_count)
         end
         @last_queue_name = frame.queue_name
-      elsif frame.exclusive && !q.exclusive
+      elsif frame.exclusive && !q.exclusive?
         send_resource_locked(frame, "Not an exclusive queue")
       else
         send_precondition_failed(frame, "Existing queue '#{q.name}' declared with other arguments")
@@ -651,7 +651,7 @@ module LavinMQ
     end
 
     private def invalid_exclusive_redclare?(frame, q)
-      q.exclusive && !frame.passive && !frame.exclusive
+      q.exclusive? && !frame.passive && !frame.exclusive
     end
 
     @last_queue_name : String?

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -15,7 +15,8 @@ module LavinMQ
     include SortableJSON
     include Observable
 
-    getter name, durable, auto_delete, internal, arguments, queue_bindings, exchange_bindings, vhost, type, alternate_exchange
+    getter name, arguments, queue_bindings, exchange_bindings, vhost, type, alternate_exchange
+    getter? durable, internal, auto_delete
     getter policy : Policy?
     getter operator_policy : OperatorPolicy?
     getter? delayed = false
@@ -126,7 +127,7 @@ module LavinMQ
         "x-dead-letter-exchange" => @name,
         "auto-delete"            => @auto_delete,
       }
-      @delayed_queue = if durable
+      @delayed_queue = if durable?
                          DurableDelayedExchangeQueue.new(@vhost, q_name, false, false, arguments)
                        else
                          DelayedExchangeQueue.new(@vhost, q_name, false, false, arguments)

--- a/src/lavinmq/http/controller/bindings.cr
+++ b/src/lavinmq/http/controller/bindings.cr
@@ -133,7 +133,7 @@ module LavinMQ
               access_refused(context, "User doesn't have write permissions to exchange '#{destination.name}'")
             elsif source.name.empty? || destination.name.empty?
               access_refused(context, "Not allowed to bind to the default exchange")
-            elsif destination.internal
+            elsif destination.internal?
               bad_request(context, "Not allowed to bind to an internal exchange")
             end
             body = parse_body(context)
@@ -173,7 +173,7 @@ module LavinMQ
               access_refused(context, "User doesn't have write permissions to queue '#{destination.name}'")
             elsif source.name.empty? || destination.name.empty?
               access_refused(context, "Not allowed to unbind from the default exchange")
-            elsif destination.internal
+            elsif destination.internal?
               bad_request(context, "Not allowed to unbind from an internal exchange")
             end
             props = URI.decode_www_form(params["props"])

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -277,12 +277,12 @@ module LavinMQ
           json.array do
             vhosts.each_value do |v|
               v.queues.each_value do |q|
-                next if q.exclusive
+                next if q.exclusive?
                 {
                   "name":        q.name,
                   "vhost":       q.vhost.name,
-                  "durable":     q.durable,
-                  "auto_delete": q.auto_delete,
+                  "durable":     q.durable?,
+                  "auto_delete": q.auto_delete?,
                   "arguments":   q.arguments,
                 }.to_json(json)
               end
@@ -293,14 +293,14 @@ module LavinMQ
         private def export_exchanges(json)
           json.array do
             vhosts.each_value do |v|
-              v.exchanges.each_value.reject(&.internal).each do |e|
+              v.exchanges.each_value.reject(&.internal?).each do |e|
                 {
                   "name":        e.name,
                   "vhost":       e.vhost.name,
                   "type":        e.type,
-                  "durable":     e.durable,
-                  "auto_delete": e.auto_delete,
-                  "internal":    e.internal,
+                  "durable":     e.durable?,
+                  "auto_delete": e.auto_delete?,
+                  "internal":    e.internal?,
                   "arguments":   e.arguments,
                 }.to_json(json)
               end

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -65,7 +65,7 @@ module LavinMQ
               unless e.match?(type, durable, auto_delete, internal, tbl)
                 bad_request(context, "Existing exchange declared with other arguments arg")
               end
-              if e.internal
+              if e.internal?
                 bad_request(context, "Not allowed to publish to internal exchange")
               end
               context.response.status_code = 204
@@ -92,7 +92,7 @@ module LavinMQ
             if context.request.query_params["if-unused"]? == "true"
               bad_request(context, "Exchange #{e.name} in vhost #{e.vhost.name} in use") if e.in_use?
             end
-            if e.internal
+            if e.internal?
               bad_request(context, "Not allowed to delete internal queue")
             end
             @amqp_server.vhosts[vhost].delete_exchange(e.name)
@@ -125,7 +125,7 @@ module LavinMQ
             unless user.can_write?(e.vhost.name, e.name)
               access_refused(context, "User doesn't have permissions to write exchange '#{e.name}'")
             end
-            if e.internal
+            if e.internal?
               bad_request(context, "Not allowed to publish to internal exchange")
             end
             body = parse_body(context)

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -68,6 +68,7 @@ module LavinMQ
       {% else %}
         private def serve(context, file_path)
           File.open(File.join(PUBLIC_DIR, file_path)) do |file|
+            file.read_buffering = false
             etag = %(W/"#{Digest::MD5.hexdigest(file)}")
             if context.request.headers["If-None-Match"]? == etag
               context.response.status_code = 304

--- a/src/lavinmq/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/queue/delayed_exchange_queue.cr
@@ -6,7 +6,7 @@ module LavinMQ
     @internal = true
 
     private def init_msg_store(data_dir)
-      replicator = @durable ? @vhost.@replicator : nil
+      replicator = durable? ? @vhost.@replicator : nil
       DelayedMessageStore.new(data_dir, replicator)
     end
 
@@ -96,6 +96,8 @@ module LavinMQ
   end
 
   class DurableDelayedExchangeQueue < DelayedExchangeQueue
-    @durable = true
+    def durable?
+      true
+    end
   end
 end

--- a/src/lavinmq/queue/durable_queue.cr
+++ b/src/lavinmq/queue/durable_queue.cr
@@ -2,6 +2,8 @@ require "./queue"
 
 module LavinMQ
   class DurableQueue < Queue
-    @durable = true
+    def durable?
+      true
+    end
   end
 end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -187,9 +187,9 @@ module LavinMQ
 
       def delete
         close
+        @segments.each_value { |f| @replicator.try &.delete_file(f.path); f.delete }
+        @acks.each_value { |f| @replicator.try &.delete_file(f.path); f.delete }
         FileUtils.rm_rf @data_dir
-        @segments.each_value { |f| @replicator.try &.delete_file(f.path) }
-        @acks.each_value { |f| @replicator.try &.delete_file(f.path) }
       end
 
       def empty?

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -208,6 +208,14 @@ module LavinMQ
         (@bytesize / @size).to_u32
       end
 
+      def unmap_segments(except : Enumerable(UInt32) = StaticArray(UInt32, 0).new(0u32))
+        @segments.each do |seg_id, mfile|
+          next if mfile == @wfile
+          next if except.includes? seg_id
+          mfile.unmap
+        end
+      end
+
       private def select_next_read_segment : MFile?
         # Expect @segments to be ordered
         if id = @segments.each_key.find { |sid| sid > @rfile_id }

--- a/src/lavinmq/queue/priority_queue.cr
+++ b/src/lavinmq/queue/priority_queue.cr
@@ -3,7 +3,7 @@ require "./durable_queue"
 module LavinMQ
   class PriorityQueue < Queue
     private def init_msg_store(data_dir)
-      replicator = @durable ? @vhost.@replicator : nil
+      replicator = durable? ? @vhost.@replicator : nil
       PriorityMessageStore.new(data_dir, replicator)
     end
 
@@ -51,6 +51,8 @@ module LavinMQ
   end
 
   class DurablePriorityQueue < PriorityQueue
-    @durable = true
+    def durable?
+      true
+    end
   end
 end

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -831,8 +831,14 @@ module LavinMQ
         end
       end
       if @consumers.empty?
-        notify_consumers_empty(true)
-        delete if @auto_delete
+        if @auto_delete
+          delete
+        else
+          notify_consumers_empty(true)
+          @msg_store_lock.synchronize do
+            @msg_store.unmap_segments
+          end
+        end
       end
     end
 

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -137,7 +137,7 @@ module LavinMQ
       @last_get_time = RoughTime.monotonic
       @log = Log.for "queue[vhost=#{@vhost.name} name=#{@name}]"
       @data_dir = make_data_dir
-      File.write(File.join(@data_dir, ".queue"), @name)
+      File.open(File.join(@data_dir, ".queue"), "w") { |f| f.sync = true; f.print @name }
       @state = QueueState::Paused if File.exists?(File.join(@data_dir, ".paused"))
       @msg_store = init_msg_store(@data_dir)
       @empty_change = @msg_store.empty_change

--- a/src/lavinmq/queue/stream_queue.cr
+++ b/src/lavinmq/queue/stream_queue.cr
@@ -3,9 +3,7 @@ require "../client/channel/stream_consumer"
 require "./stream_queue_message_store"
 
 module LavinMQ
-  class StreamQueue < Queue
-    @durable = true
-
+  class StreamQueue < DurableQueue
     def initialize(@vhost : VHost, @name : String,
                    @exclusive = false, @auto_delete = false,
                    @arguments = Hash(String, AMQP::Field).new)

--- a/src/lavinmq/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/queue/stream_queue_message_store.cr
@@ -16,14 +16,6 @@ module LavinMQ
         drop_overflow
       end
 
-      def unmap_segments(except : Enumerable(UInt32))
-        @segments.each do |seg_id, mfile|
-          next if mfile == @wfile
-          next if except.includes? seg_id
-          mfile.unmap
-        end
-      end
-
       private def get_last_offset : Int64
         return 0i64 if @size.zero?
         bytesize = 0_u32

--- a/src/lavinmq/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/queue/stream_queue_message_store.cr
@@ -1,7 +1,7 @@
 require "./stream_queue"
 
 module LavinMQ
-  class StreamQueue < Queue
+  class StreamQueue < DurableQueue
     class StreamQueueMessageStore < MessageStore
       getter new_messages = Channel(Bool).new
       property max_length : Int64?

--- a/src/lavinmq/reporter.cr
+++ b/src/lavinmq/reporter.cr
@@ -16,7 +16,7 @@ module LavinMQ
         puts_size_capacity vh.@exchanges, 4
         puts_size_capacity vh.@queues, 4
         vh.queues.each do |_, q|
-          puts "    #{q.name} #{q.durable ? "durable" : ""} args=#{q.arguments}"
+          puts "    #{q.name} #{q.durable? ? "durable" : ""} args=#{q.arguments}"
           puts_size_capacity q.@consumers, 6
           puts_size_capacity q.@deliveries, 6
           puts_size_capacity q.@msg_store.@segments, 6


### PR DESCRIPTION
Previous behavior could unmap segments that other consumers were still delivering from, causing segfaults.