### PR TITLE
quick fix for displaying toasts correctly

### DIFF
--- a/static/js/http.js
+++ b/static/js/http.js
@@ -15,9 +15,9 @@ function request (method, path, options = {}) {
   return window.fetch(path, opts)
     .then(response => {
       if (!response.ok) {
-        const error = { status: response.status, reason: response.statusText }
+        const error = { status: response.status, reason: response.statusText, is_error: true }
         return response.json()
-          .then(json => { error.reason = json.reason })
+          .then(json => { error.reason = json.reason; return error })
           .finally(() => { standardErrorHandler(error) })
       } else { return response.json().catch(() => null) }
     })

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -125,10 +125,12 @@ document.querySelector('#declare').addEventListener('submit', function (evt) {
     arguments: Dom.parseJSON(data.get('arguments'))
   }
   HTTP.request('PUT', url, { body })
-    .then(() => {
+    .then((response) => {
       queuesTable.reload()
       evt.target.reset()
-      Dom.toast('Queue ' + queue + ' created')
+      if (!(typeof response === 'undefined')) {
+        Dom.toast('Queue ' + queue + ' created')
+      }
     })
 })
 queuesTable.on('updated', _ => {

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -126,11 +126,10 @@ document.querySelector('#declare').addEventListener('submit', function (evt) {
   }
   HTTP.request('PUT', url, { body })
     .then((response) => {
+      if (response?.is_error) { return }
       queuesTable.reload()
       evt.target.reset()
-      if ((typeof response !== 'undefined')) {
-        Dom.toast('Queue ' + queue + ' created')
-      }
+      Dom.toast('Queue ' + queue + ' created')
     })
 })
 queuesTable.on('updated', _ => {

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -128,7 +128,7 @@ document.querySelector('#declare').addEventListener('submit', function (evt) {
     .then((response) => {
       queuesTable.reload()
       evt.target.reset()
-      if (!(typeof response === 'undefined')) {
+      if ((typeof response !== 'undefined')) {
         Dom.toast('Queue ' + queue + ' created')
       }
     })


### PR DESCRIPTION
### WHAT is this pull request doing?
This is a quick-fix for not rendering toasts for failed requests when declaring queues. 
However Im going to look closer at http.js and try and get the json parse stuff to work. currently we just always return null for ok requests which feels wierd


