### PR TITLE
Add playwright for frontend specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y make libevent-2.1-7
+          apt-get update
+          apt-get install -y make libevent-2.1-7
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,8 @@ jobs:
     steps:
       - name: Install LavinMQ dependencies
         run: |
-          apt-get update
-          apt-get install -y make libevent-2.1-7 openssl
+          sudo apt-get update
+          sudo apt-get install -y make libevent-2.1-7 openssl
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,13 +143,10 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.34.0-jammy
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Install playwright/test
-        run: npm install -g '@playwright/test'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make libevent-2.1-7
 
       - uses: actions/download-artifact@v3
         with:
@@ -160,6 +157,11 @@ jobs:
         run: |
           chmod +x bin/*
           bin/lavinmq --data-dir=/tmp/amqp --bind=:: &
+
+      - uses: actions/checkout@v3
+
+      - name: Install playwright/test
+        run: npm install -g '@playwright/test'
 
       - name: Run your tests
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Install LavinMQ dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y make libevent-2.1-7 openssl
+          sudo apt-get install -y make libevent-2.1-7
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,8 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install dependencies
-        run: npm ci
+            #      - name: Install dependencies
+            #        run: npm ci
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
       - name: Install browsers
         run: npx playwright install --with-deps
 
+      - name: Install @playwright/test
+        run: npm install @playwright/test
+
       - name: Run your tests
         run: npx playwright test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ on:
       - 'build/build_docs_in_ci'
       - 'openapi/**'
   push:
-    #    branches:
-    #      - main
-    #    paths:
-    #      - Makefile
-    #      - 'src/**'
-    #      - 'spec/**'
-    #      - 'playwright.config.js'
-    #      - 'shard.*'
-    #      - 'static/**'
-    #      - 'views/**'
-    #      - '.github/workflows/ci.yml'
-    #      - 'build/build_docs_in_ci'
-    #      - 'openapi/**'
+    branches:
+      - main
+    paths:
+      - Makefile
+      - 'src/**'
+      - 'spec/**'
+      - 'playwright.config.js'
+      - 'shard.*'
+      - 'static/**'
+      - 'views/**'
+      - '.github/workflows/ci.yml'
+      - 'build/build_docs_in_ci'
+      - 'openapi/**'
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,10 +135,29 @@ jobs:
           name: bin
           path: bin/
 
+  path_filter:
+    name: Filters for fronted specs
+    runs-on: ubuntu-latest
+    outputs:
+      views: ${{ steps.changes.outputs.views }}
+      js: ${{ steps.changes.outputs.js }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            views:
+              - '**/*.ecr'
+            js:
+              - '**/*.js'
+
   spec_frontend:
     name: Fronted specs
     runs-on: ubuntu-latest
-    needs: compile
+    needs: [compile, path_filter]
+    if: ${{ needs.path_filter.outputs.views == 'true' || needs.path_filter.outputs.js == 'true' }}
     steps:
       - name: Install LavinMQ dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,34 @@ jobs:
           name: bin
           path: bin/
 
+  spec_frontend:
+    name: Fronted specs
+    runs-on: ubuntu-latest
+    needs: compile
+    continue-on-error: true
+    container:
+      image: mcr.microsoft.com/playwright:v1.34.0-jammy
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: bin
+          path: bin
+
+      - name: Run LavinMQ in background
+        run: |
+          chmod +x bin/*
+          bin/lavinmq --data-dir=/tmp/amqp --bind=:: &
+
+      - name: Run your tests
+        run: npx playwright test
+
   java-client-test:
     name: RabbitMQ java client test
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run your tests
-        run: npx playwright test
+        run: npx playwright test --reporter=list
 
   java-client-test:
     name: RabbitMQ java client test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,8 @@ jobs:
         with:
           node-version: 18
 
-            #      - name: Install dependencies
-            #        run: npm ci
+      - name: Install playwright/test
+        run: npm install -g '@playwright/test'
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,14 +139,14 @@ jobs:
     name: Fronted specs
     runs-on: ubuntu-latest
     needs: compile
-    continue-on-error: true
     steps:
       - name: Install LavinMQ dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y make libevent-2.1-7
 
-      - uses: actions/download-artifact@v3
+      - name: Download lavinmq
+        uses: actions/download-artifact@v3
         with:
           name: bin
           path: bin
@@ -167,7 +167,7 @@ jobs:
       - name: Install browsers
         run: npx playwright install --with-deps
 
-      - name: Run your tests
+      - name: Run tests
         run: npx playwright test --reporter=list
 
   java-client-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 on:
   # Temporary while adding playwright
-  push
+  push:
+    branches: add-playwright-for-frontend-spec
   pull_request:
     paths:
       - Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
-  # Temporary while adding playwright
   push:
-    branches: add-playwright-for-frontend-spec
+    branches:
+      - add-playwright-for-frontend-spec
   pull_request:
     paths:
       - Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,11 @@ jobs:
 
   spec_frontend:
     name: Fronted specs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: compile
     continue-on-error: true
-    container:
-      image: mcr.microsoft.com/playwright:next-focal
     steps:
-      - name: Install dependencies
+      - name: Install LavinMQ dependencies
         run: |
           apt-get update
           apt-get install -y make libevent-2.1-7 openssl
@@ -159,9 +157,12 @@ jobs:
           bin/lavinmq --data-dir=/tmp/amqp --bind=:: &
 
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
 
-      - name: Install playwright/test
-        run: npm install @playwright/test
+      - name: Install browsers
+        run: npx playwright install --with-deps
 
       - name: Run your tests
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 on:
-  push:
-    branches:
-      - add-playwright-for-frontend-spec
   pull_request:
     paths:
       - Makefile
@@ -17,10 +14,12 @@ on:
   push:
     branches:
       - main
+      - add-playwright-for-frontend-spec
     paths:
       - Makefile
       - 'src/**'
       - 'spec/**'
+      - 'playwright.config.js'
       - 'shard.*'
       - 'static/**'
       - 'views/**'
@@ -149,6 +148,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y make libevent-2.1-7
+          apt-get install -y make libevent-2.1-7 openssl
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  # Temporary while adding playwright
+  push
   pull_request:
     paths:
       - Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,19 @@ on:
       - 'build/build_docs_in_ci'
       - 'openapi/**'
   push:
-    branches:
-      - main
-      - add-playwright-for-frontend-spec
-        #    paths:
-        #      - Makefile
-        #      - 'src/**'
-        #      - 'spec/**'
-        #      - 'playwright.config.js'
-        #      - 'shard.*'
-        #      - 'static/**'
-        #      - 'views/**'
-        #      - '.github/workflows/ci.yml'
-        #      - 'build/build_docs_in_ci'
-        #      - 'openapi/**'
+    #    branches:
+    #      - main
+    #    paths:
+    #      - Makefile
+    #      - 'src/**'
+    #      - 'spec/**'
+    #      - 'playwright.config.js'
+    #      - 'shard.*'
+    #      - 'static/**'
+    #      - 'views/**'
+    #      - '.github/workflows/ci.yml'
+    #      - 'build/build_docs_in_ci'
+    #      - 'openapi/**'
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,11 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install browsers
-        run: npx playwright install --with-deps
-
       - name: Install @playwright/test
         run: npm install @playwright/test
+
+      - name: Install browsers
+        run: npx playwright install --with-deps
 
       - name: Run your tests
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,11 @@ jobs:
 
   spec_frontend:
     name: Fronted specs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: compile
     continue-on-error: true
     container:
-      image: mcr.microsoft.com/playwright:v1.34.0-jammy
+      image: mcr.microsoft.com/playwright:next-focal
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ on:
     branches:
       - main
       - add-playwright-for-frontend-spec
-    paths:
-      - Makefile
-      - 'src/**'
-      - 'spec/**'
-      - 'playwright.config.js'
-      - 'shard.*'
-      - 'static/**'
-      - 'views/**'
-      - '.github/workflows/ci.yml'
-      - 'build/build_docs_in_ci'
-      - 'openapi/**'
+        #    paths:
+        #      - Makefile
+        #      - 'src/**'
+        #      - 'spec/**'
+        #      - 'playwright.config.js'
+        #      - 'shard.*'
+        #      - 'static/**'
+        #      - 'views/**'
+        #      - '.github/workflows/ci.yml'
+        #      - 'build/build_docs_in_ci'
+        #      - 'openapi/**'
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install playwright/test
-        run: npm install -g '@playwright/test'
+        run: npm install @playwright/test
 
       - name: Run your tests
         run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ config.ini
 *.pem
 perf.data*
 massif.*
+node_modules
+package.json
+package-lock.json
+/playwright/

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,106 @@
+// @ts-check
+import { defineConfig, devices, expect } from '@playwright/test';
+
+expect.extend(
+  {
+    async toBeRequested(received, params) {
+      return received.then(req => {
+        return {
+          message: _ => 'requested',
+          pass: true
+        }
+      }).catch(e => {
+        return {
+          message: _ => e.message,
+          pass: false
+        }
+      })
+    },
+
+    async toHaveQueryParams(received, query) {
+      try {
+        const request = await received
+        const requestedUrl = new URL(request.url())
+        const expectedParams = new URLSearchParams(query)
+        const actualParams = requestedUrl.searchParams
+        for (let [name, value] of expectedParams.entries()) {
+          const actualValue = actualParams.get(name)
+          if (actualValue !== value) {
+            return {
+              message: _ => `expected query param '${name}' to be '${value}', got '${actualValue}'`,
+              pass: false
+            }
+          }
+        }
+        return {
+          message: _ => "yes",
+          pass: true
+        }
+      } catch(e) {
+        return {
+          message: _ => e.toString(),
+          pass: false
+        }
+      }
+    }
+  })
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig(
+  {
+    testDir: './spec/frontend',
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: 'html',
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+      /* Base URL to use in actions like `await page.goto('/')`. */
+      baseURL: process.env.BASE_URL ?? 'http://127.0.0.1:15672',
+
+      /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+      trace: 'on-first-retry',
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+      {
+        name: 'setup',
+        testMatch: /.*\.setup\.js/
+      },
+      {
+        name: 'chromium',
+        use: { 
+          ...devices['Desktop Chrome'],
+          storageState: 'playwright/.auth/user.json',
+        },
+        dependencies: ['setup'],
+      },
+      {
+        name: 'firefox',
+        use: {
+          ...devices['Desktop Firefox'],
+          storageState: 'playwright/.auth/user.json',
+        },
+        dependencies: ['setup'],
+      },
+
+      {
+        name: 'webkit',
+        use: {
+          ...devices['Desktop Safari'],
+          storageState: 'playwright/.auth/user.json'
+        },
+        dependencies: ['setup'],
+      },
+    ],
+  })
+

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,49 +1,6 @@
 // @ts-check
-import { defineConfig, devices, expect } from '@playwright/test';
-
-expect.extend(
-  {
-    async toBeRequested(received, params) {
-      return received.then(req => {
-        return {
-          message: _ => 'requested',
-          pass: true
-        }
-      }).catch(e => {
-        return {
-          message: _ => e.message,
-          pass: false
-        }
-      })
-    },
-
-    async toHaveQueryParams(received, query) {
-      try {
-        const request = await received
-        const requestedUrl = new URL(request.url())
-        const expectedParams = new URLSearchParams(query)
-        const actualParams = requestedUrl.searchParams
-        for (let [name, value] of expectedParams.entries()) {
-          const actualValue = actualParams.get(name)
-          if (actualValue !== value) {
-            return {
-              message: _ => `expected query param '${name}' to be '${value}', got '${actualValue}'`,
-              pass: false
-            }
-          }
-        }
-        return {
-          message: _ => "yes",
-          pass: true
-        }
-      } catch(e) {
-        return {
-          message: _ => e.toString(),
-          pass: false
-        }
-      }
-    }
-  })
+import { defineConfig, devices, expect } from '@playwright/test'
+import './spec/frontend/expect_extensions.js'
 
 /**
  * @see https://playwright.dev/docs/test-configuration

--- a/spec/frontend/README.md
+++ b/spec/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend specs
+
+These specs are some frontend.

--- a/spec/frontend/auth.setup.js
+++ b/spec/frontend/auth.setup.js
@@ -1,0 +1,14 @@
+import { test, test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Username').fill('guest');
+  await page.getByLabel('Password').fill('guest');
+  await page.getByRole('button').click();
+  await page.waitForURL('/');
+  await page.context().storageState({ path: authFile });
+});
+

--- a/spec/frontend/auth.spec.js
+++ b/spec/frontend/auth.spec.js
@@ -1,0 +1,11 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.describe('when unauthenticated', _ =>  {
+  test.use({ storageState: {} })
+  test('redirects to login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login$/);
+  })
+})
+

--- a/spec/frontend/channel.spec.js
+++ b/spec/frontend/channel.spec.js
@@ -1,0 +1,11 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("channel", _ => {
+  test('is loaded', async ({ page, baseURL }) => {
+    const channelName = "127.0.0.1:63221[1]"
+    const apiChannelRequest = helpers.waitForPathRequest(page, `/api/channels/${channelName}`, {})
+    await page.goto(`/channel#name=${channelName}`)
+    await expect(apiChannelRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/channels.spec.js
+++ b/spec/frontend/channels.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("channels", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiChannelsRequest = helpers.waitForPathRequest(page, '/api/channels', {})
+    await page.goto('/channels')
+    await expect(apiChannelsRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/connection.spec.js
+++ b/spec/frontend/connection.spec.js
@@ -1,0 +1,17 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("connection", _ => {
+  test('info is loaded', async ({ page, baseURL }) => {
+    const connectionName = "127.0.0.1:63610 -> 127.0.0.1:12345"
+    const apiConnectionRequest = helpers.waitForPathRequest(page, `/api/connections/${connectionName}`, {})
+    await page.goto(`/connection#name=${connectionName}`)
+    await expect(apiConnectionRequest).toBeRequested()
+  })
+  test('channels are loaded', async ({ page, baseURL }) => {
+    const connectionName = "127.0.0.1:63610 -> 127.0.0.1:12345"
+    const apiChannelsRequest = helpers.waitForPathRequest(page, `/api/connections/${connectionName}/channels`, {})
+    await page.goto(`/connection#name=${connectionName}`)
+    await expect(apiChannelsRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/connections.spec.js
+++ b/spec/frontend/connections.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("connections", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiConnectionsRequest = helpers.waitForPathRequest(page, '/api/connections')
+    await page.goto('/connections')
+    await expect(apiConnectionsRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/exchanges.spec.js
+++ b/spec/frontend/exchanges.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("exchanges", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiExchangesRequest = helpers.waitForPathRequest(page, '/api/exchanges', {})
+    await page.goto('/exchanges')
+    await expect(apiExchangesRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/expect_extensions.js
+++ b/spec/frontend/expect_extensions.js
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 expect.extend(
   {
     async toBeRequested(received, params) {
-      return received.then(req => {
+      return received.then(reqs => {
         return {
           message: _ => 'requested',
           pass: true

--- a/spec/frontend/expect_extensions.js
+++ b/spec/frontend/expect_extensions.js
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test';
+
+expect.extend(
+  {
+    async toBeRequested(received, params) {
+      return received.then(req => {
+        return {
+          message: _ => 'requested',
+          pass: true
+        }
+      }).catch(e => {
+        return {
+          message: _ => e.message,
+          pass: false
+        }
+      })
+    },
+
+    async toHaveQueryParams(received, query) {
+      try {
+        const request = await received
+        const requestedUrl = new URL(request.url())
+        const expectedParams = new URLSearchParams(query)
+        const actualParams = requestedUrl.searchParams
+        for (let [name, value] of expectedParams.entries()) {
+          const actualValue = actualParams.get(name)
+          if (actualValue !== value) {
+            return {
+              message: _ => `expected query param '${name}' to be '${value}', got '${actualValue}'`,
+              pass: false
+            }
+          }
+        }
+        return {
+          message: _ => "yes",
+          pass: true
+        }
+      } catch(e) {
+        return {
+          message: _ => e.toString(),
+          pass: false
+        }
+      }
+    }
+  })
+
+

--- a/spec/frontend/federation.spec.js
+++ b/spec/frontend/federation.spec.js
@@ -1,0 +1,12 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("federation", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiFederationUpstreamsRequest = helpers.waitForPathRequest(page, '/api/parameters/federation-upstream', {})
+    const apiFederationLinksRequest = helpers.waitForPathRequest(page, '/api/federation-links', {})
+    await page.goto('/federation')
+    await expect(apiFederationUpstreamsRequest).toBeRequested()
+    await expect(apiFederationLinksRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/fixtures.js
+++ b/spec/frontend/fixtures.js
@@ -1,0 +1,14 @@
+import { test as base, expect } from "@playwright/test";
+
+const vhosts = ['foo', 'bar']
+const test = base.extend(
+  {
+    vhosts,
+    page: async ({ baseURL, page }, use) => {
+      const vhostResponse = vhosts.map(x => { return {name: x} })
+      await page.route(/\/api\/vhosts(\?|$)/, async route => await route.fulfill({ json: vhostResponse }))
+      use(page)
+    }
+  })
+
+export { test, expect }

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -1,0 +1,30 @@
+function waitForPathRequest(page, path, response_data = {}) {
+  return new Promise((resolve, reject) => {
+    page.route('**/*', (route, request) => {
+      const requestedUrl = new URL(request.url())
+      if (requestedUrl.pathname !== path) {
+        return route.fallback()
+      }
+      page.unroute('**/*')
+      route.fulfill({ json: response_data })
+      resolve(request)
+    })
+  })
+  return page.waitForRequest(req => {
+    const reqUrl = new URL(req.url())
+    return reqUrl.pathname == path
+  }, { timeout: 1000 })
+}
+
+function setupVhostResponse(test) {
+  const vhosts = ['foo', 'bar']
+
+  test.beforeEach(async ({ page }) => {
+    const vhostResponse = vhosts.map(x => { return {name: x} })
+    await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
+  })
+}
+
+
+
+export { waitForPathRequest, setupVhostResponse }

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -1,15 +1,16 @@
 function waitForPathRequest(page, path, response_data = {}) {
   const matchUrl = new URL(path, 'http://example.com')
   return new Promise((resolve, reject) => {
-    page.route('**/*', (route, request) => {
+    const handler = (route, request) => {
       const requestedUrl = new URL(request.url())
       if (requestedUrl.pathname !== matchUrl.pathname) {
         return route.fallback()
       }
-      page.unroute('**/*')
+      page.unroute('**/*', handler)
       route.fulfill({ json: response_data })
       resolve(request)
-    })
+    }
+    page.route('**/*', handler)
   })
   return page.waitForRequest(req => {
     const reqUrl = new URL(req.url())

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -1,8 +1,9 @@
 function waitForPathRequest(page, path, response_data = {}) {
+  const matchUrl = new URL(path, 'http://example.com')
   return new Promise((resolve, reject) => {
     page.route('**/*', (route, request) => {
       const requestedUrl = new URL(request.url())
-      if (requestedUrl.pathname !== path) {
+      if (requestedUrl.pathname !== matchUrl.pathname) {
         return route.fallback()
       }
       page.unroute('**/*')
@@ -18,13 +19,10 @@ function waitForPathRequest(page, path, response_data = {}) {
 
 function setupVhostResponse(test) {
   const vhosts = ['foo', 'bar']
-
   test.beforeEach(async ({ page }) => {
     const vhostResponse = vhosts.map(x => { return {name: x} })
     await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
   })
 }
-
-
 
 export { waitForPathRequest, setupVhostResponse }

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -18,12 +18,5 @@ function waitForPathRequest(page, path, response_data = {}) {
   }, { timeout: 1000 })
 }
 
-function setupVhostResponse(test) {
-  const vhosts = ['foo', 'bar']
-  test.beforeEach(async ({ page }) => {
-    const vhostResponse = vhosts.map(x => { return {name: x} })
-    await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
-  })
-}
 
-export { waitForPathRequest, setupVhostResponse }
+export { waitForPathRequest }

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -3,7 +3,7 @@ function waitForPathRequest(page, path, response_data = {}) {
   return new Promise((resolve, reject) => {
     const handler = (route, request) => {
       const requestedUrl = new URL(request.url())
-      if (requestedUrl.pathname !== matchUrl.pathname) {
+      if (decodeURIComponent(requestedUrl.pathname) !== decodeURIComponent(matchUrl.pathname)) {
         return route.continue()
       }
       page.unroute('**/*', handler)

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -4,7 +4,7 @@ function waitForPathRequest(page, path, response_data = {}) {
     const handler = (route, request) => {
       const requestedUrl = new URL(request.url())
       if (requestedUrl.pathname !== matchUrl.pathname) {
-        return route.fallback()
+        return route.continue()
       }
       page.unroute('**/*', handler)
       route.fulfill({ json: response_data })

--- a/spec/frontend/layout.spec.js
+++ b/spec/frontend/layout.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe("vhosts", _ => {
+  const vhosts = ['foo', 'bar']
+
+  test.beforeEach(async ({ page }) => {
+    const vhostResponse = vhosts.map(x => { return {name: x} })
+    await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
+    await page.goto('/')
+  })
+
+  test('are loaded', async ({ page }) => {
+    const vhostOptions = await page.locator('#userMenuVhost option').allTextContents()
+    vhosts.forEach(vhost => {
+      expect(vhostOptions).toContain(vhost)
+    })
+  })
+
+  test('remember selection', async ({ page }) => {
+    await page.locator('#userMenuVhost').selectOption('foo')
+    await expect(page.locator('#userMenuVhost option:checked')).toHaveText(['foo'])
+  })
+})

--- a/spec/frontend/layout.spec.js
+++ b/spec/frontend/layout.spec.js
@@ -1,15 +1,8 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js'
 
 test.describe("vhosts", _ => {
-  const vhosts = ['foo', 'bar']
-
-  test.beforeEach(async ({ page }) => {
-    const vhostResponse = vhosts.map(x => { return {name: x} })
-    await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
+  test('are loaded', async ({ page, baseURL, vhosts }) => {
     await page.goto('/')
-  })
-
-  test('are loaded', async ({ page }) => {
     const vhostOptions = await page.locator('#userMenuVhost option').allTextContents()
     vhosts.forEach(vhost => {
       expect(vhostOptions).toContain(vhost)
@@ -17,6 +10,7 @@ test.describe("vhosts", _ => {
   })
 
   test('remember selection', async ({ page }) => {
+    await page.goto('/')
     await page.locator('#userMenuVhost').selectOption('foo')
     await expect(page.locator('#userMenuVhost option:checked')).toHaveText(['foo'])
   })

--- a/spec/frontend/layout.spec.js
+++ b/spec/frontend/layout.spec.js
@@ -11,7 +11,7 @@ test.describe("vhosts", _ => {
 
   test('remember selection', async ({ page }) => {
     await page.goto('/')
-    await page.locator('#userMenuVhost').selectOption('foo')
+    await page.locator('#userMenuVhost').selectOption('foo') // selectOption trigger page load
     await expect(page.locator('#userMenuVhost option:checked')).toHaveText(['foo'])
   })
 })

--- a/spec/frontend/logs.spec.js
+++ b/spec/frontend/logs.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("logs", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiLogsRequest = page.waitForRequest(/\/api\/livelog$/, { timeout: 1000 })
+    await page.goto('/logs')
+    await expect(apiLogsRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/nodes.spec.js
+++ b/spec/frontend/nodes.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("nodes", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiNodesRequest = helpers.waitForPathRequest(page, '/api/nodes', {})
+    await page.goto('/nodes')
+    await expect(apiNodesRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/operator-policies.spec.js
+++ b/spec/frontend/operator-policies.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("operator-policies", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiPoliciesRequest = helpers.waitForPathRequest(page, '/api/operator-policies', {})
+    await page.goto('/operator-policies')
+    await expect(apiPoliciesRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/overview.spec.js
+++ b/spec/frontend/overview.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("overview", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiOverviewRequest = helpers.waitForPathRequest(page, '/api/overview')
+    await page.goto('/')
+    await expect(apiOverviewRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/policies.spec.js
+++ b/spec/frontend/policies.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("policies", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiPoliciesRequest = helpers.waitForPathRequest(page, '/api/policies', {})
+    await page.goto('/policies')
+    await expect(apiPoliciesRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/queue.spec.js
+++ b/spec/frontend/queue.spec.js
@@ -1,0 +1,19 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("queue", _ => {
+  test('info is loaded', async ({ page, baseURL }) => {
+    const vhost = "/"
+    const queueName = "foo"
+    const apiQueueRequest = helpers.waitForPathRequest(page, `/api/queues/${encodeURIComponent(vhost)}/${queueName}`, {})
+    await page.goto(`/queue#vhost=${encodeURIComponent(vhost)}&name=${queueName}`)
+    await expect(apiQueueRequest).toBeRequested()
+  })
+  test('bindings are loaded', async ({ page, baseURL }) => {
+    const vhost = "/"
+    const queueName = "foo"
+    const apiBindingsRequest = helpers.waitForPathRequest(page, `/api/queues/${encodeURIComponent(vhost)}/${queueName}/bindings`, {})
+    await page.goto(`/queue#vhost=${encodeURIComponent(vhost)}&name=${queueName}`)
+    await expect(apiBindingsRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -55,11 +55,15 @@ test.describe("queues", _ => {
       const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.goto('/queues')
       await apiQueuesRequest
+      const apiQueuesRequest2 = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.locator('#table thead').getByText('Name').click()
       await expect(page).toHaveURL(/sort=name/)
+      await apiQueuesRequest2
       const sort_reverse = (new URL(page.url())).searchParams.get('sort_reverse') == 'true'
+      const apiQueuesRequest3 = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.locator('#table thead').getByText('Name').click()
       await expect(page).toHaveURL(new RegExp(`sort_reverse=${!sort_reverse}`))
+      await expect(apiQueuesRequest3).toHaveQueryParams(`sort_reverse=${!sort_reverse}`)
     })
   })
 
@@ -78,8 +82,10 @@ test.describe("queues", _ => {
       const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.goto('/queues')
       await apiQueuesRequest
+      const apiQueuesRequest2 = helpers.waitForPathRequest(page, '/api/queues')
       await page.locator('#table .pagination .page-item').getByText('Next').click()
       await expect(page).toHaveURL(/page=2/)
+      await expect(apiQueuesRequest2).toHaveQueryParams('page=2')
     })
   })
 
@@ -88,8 +94,10 @@ test.describe("queues", _ => {
       await page.goto('/queues')
       const searchField = page.locator('.filter-table')
       await searchField.fill('my filter')
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await searchField.press('Enter')
       await expect(page).toHaveURL(/name=my(\+|%20)filter/)
+      await expect(apiQueuesRequest).toHaveQueryParams('name=my filter&use_regex=true')
     })
   })
 })

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -1,10 +1,8 @@
 import * as helpers from './helpers.js'
 import * as qHelpers from './queues_helpers.js'
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js';
 
 test.describe("queues", _ => {
-  helpers.setupVhostResponse(test)
-
   // Test that different combination of hash params are sent in the request
   test.describe('are loaded with params when hash params', _ => {
     test('are empty', async ({ page, baseURL }) => {

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -1,3 +1,4 @@
+import * as qHelpers from './queues_helpers.js'
 import { test, expect } from '@playwright/test';
 
 test.describe("queues", _ => {
@@ -8,14 +9,15 @@ test.describe("queues", _ => {
     await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
   })
 
-  function waitForPathRequest(page, path) {
+  function waitForPathRequest(page, path, response_data = {}) {
     return new Promise((resolve, reject) => {
       page.route('**/*', (route, request) => {
         const requestedUrl = new URL(request.url())
         if (requestedUrl.pathname !== path) {
           return route.fallback()
         }
-        route.fulfill({ json: {} })
+        page.unroute('**/*')
+        route.fulfill({ json: response_data })
         resolve(request)
       })
     })
@@ -58,4 +60,26 @@ test.describe("queues", _ => {
       await expect(apiQueuesRequest).toHaveQueryParams(q)
     })
   })
+
+  //
+  test.describe('pagination', _ => {
+    const queues = Array.from(Array(10), (_, i) => qHelpers.queue(`queue-${i}`))
+    const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })
+
+    test('is visible for page_count=10', async ({ page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      await page.goto('/queues')
+      await apiQueuesRequest
+      await expect(page.locator('#table .pagination .page-item')).toContainText(['Previous', 'Next'], { timeout: 10 })
+    })
+
+    test('updates url when Next is clicked', async ({page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      await page.goto('/queues')
+      await apiQueuesRequest
+      await page.locator('#table .pagination .page-item').getByText('Next').click()
+      await expect(page).toHaveURL(/page=2/)
+    })
+  })
+
 })

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test.describe("queues", _ => {
+  const vhosts = ['foo', 'bar']
+
+  test.beforeEach(async ({ page }) => {
+    const vhostResponse = vhosts.map(x => { return {name: x} })
+    await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
+  })
+
+  function waitForPathRequest(page, path) {
+    return new Promise((resolve, reject) => {
+      page.route('**/*', (route, request) => {
+        const requestedUrl = new URL(request.url())
+        if (requestedUrl.pathname !== path) {
+          return route.fallback()
+        }
+        route.fulfill({ json: {} })
+        resolve(request)
+      })
+    })
+    return page.waitForRequest(req => {
+      const reqUrl = new URL(req.url())
+      return reqUrl.pathname == path
+    }, { timeout: 1000 })
+  }
+
+  // Test that different combination of hash params are sent in the request
+  test.describe('are loaded with params when hash params', _ => {
+    test('are empty', async ({ page, baseURL }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      await page.goto('/queues')
+      await expect(apiQueuesRequest).toBeRequested()
+    })
+
+    test('are page_size=10, page=2', async ({ page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      await page.goto('/queues#page_size=10&page=2')
+      await expect(apiQueuesRequest).toHaveQueryParams('page_size=10&page=2')
+    })
+
+    test('are name=queue-a, use_regex=true', async ({ page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      await page.goto('/queues#name=queue-a&use_regex=true')
+      await expect(apiQueuesRequest).toHaveQueryParams('name=queue-a&use_regex=true')
+    })
+
+    test('are sort=name, sort_reverse=false', async ({ page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      await page.goto('/queues#sort=name&sort_reverse=false')
+      await expect(apiQueuesRequest).toHaveQueryParams('sort=name&sort_reverse=false')
+    })
+
+    test('are page_size=10, page=3, name=qname, use_regex=true, sort=name, sort_reverse=true', async ({ page }) => {
+      const q = 'page_size=10&page=3&name=qname&use_regex=true&sort=name&sort_reverse=true'
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      await page.goto(`/queues#${q}`)
+      await expect(apiQueuesRequest).toHaveQueryParams(q)
+    })
+  })
+})

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -1,61 +1,39 @@
+import * as helpers from './helpers.js'
 import * as qHelpers from './queues_helpers.js'
 import { test, expect } from '@playwright/test';
 
 test.describe("queues", _ => {
-  const vhosts = ['foo', 'bar']
-
-  test.beforeEach(async ({ page }) => {
-    const vhostResponse = vhosts.map(x => { return {name: x} })
-    await page.route(/\/api\/vhosts/, route => route.fulfill({ json: vhostResponse }))
-  })
-
-  function waitForPathRequest(page, path, response_data = {}) {
-    return new Promise((resolve, reject) => {
-      page.route('**/*', (route, request) => {
-        const requestedUrl = new URL(request.url())
-        if (requestedUrl.pathname !== path) {
-          return route.fallback()
-        }
-        page.unroute('**/*')
-        route.fulfill({ json: response_data })
-        resolve(request)
-      })
-    })
-    return page.waitForRequest(req => {
-      const reqUrl = new URL(req.url())
-      return reqUrl.pathname == path
-    }, { timeout: 1000 })
-  }
+  helpers.setupVhostResponse(test)
 
   // Test that different combination of hash params are sent in the request
   test.describe('are loaded with params when hash params', _ => {
     test('are empty', async ({ page, baseURL }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await page.goto('/queues')
       await expect(apiQueuesRequest).toBeRequested()
     })
 
     test('are page_size=10, page=2', async ({ page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await page.goto('/queues#page_size=10&page=2')
       await expect(apiQueuesRequest).toHaveQueryParams('page_size=10&page=2')
     })
 
     test('are name=queue-a, use_regex=true', async ({ page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await page.goto('/queues#name=queue-a&use_regex=true')
       await expect(apiQueuesRequest).toHaveQueryParams('name=queue-a&use_regex=true')
     })
 
     test('are sort=name, sort_reverse=false', async ({ page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await page.goto('/queues#sort=name&sort_reverse=false')
       await expect(apiQueuesRequest).toHaveQueryParams('sort=name&sort_reverse=false')
     })
 
     test('are page_size=10, page=3, name=qname, use_regex=true, sort=name, sort_reverse=true', async ({ page }) => {
       const q = 'page_size=10&page=3&name=qname&use_regex=true&sort=name&sort_reverse=true'
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues')
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await page.goto(`/queues#${q}`)
       await expect(apiQueuesRequest).toHaveQueryParams(q)
     })
@@ -66,7 +44,7 @@ test.describe("queues", _ => {
     const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })
 
     test('updates url when a table header is clicked', async ({ page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.goto('/queues')
       await apiQueuesRequest
       await page.locator('#table thead').getByText('Name').click()
@@ -74,7 +52,7 @@ test.describe("queues", _ => {
     })
 
     test('is reversed when click on the same header', async ({ page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.goto('/queues')
       await apiQueuesRequest
       await page.locator('#table thead').getByText('Name').click()
@@ -90,14 +68,14 @@ test.describe("queues", _ => {
     const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })
 
     test('is visible for page_count=10', async ({ page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.goto('/queues')
       await apiQueuesRequest
       await expect(page.locator('#table .pagination .page-item')).toContainText(['Previous', 'Next'], { timeout: 10 })
     })
 
     test('updates url when Next is clicked', async ({page }) => {
-      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues', queues_response)
       await page.goto('/queues')
       await apiQueuesRequest
       await page.locator('#table .pagination .page-item').getByText('Next').click()

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -61,7 +61,30 @@ test.describe("queues", _ => {
     })
   })
 
-  //
+  test.describe('sorting', _ => {
+    const queues = Array.from(Array(10), (_, i) => qHelpers.queue(`queue-${i}`))
+    const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })
+
+    test('updates url when a table header is clicked', async ({ page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      await page.goto('/queues')
+      await apiQueuesRequest
+      await page.locator('#table thead').getByText('Name').click()
+      await expect(page).toHaveURL(/sort=name/)
+    })
+
+    test('is reversed when click on the same header', async ({ page }) => {
+      const apiQueuesRequest = waitForPathRequest(page, '/api/queues', queues_response)
+      await page.goto('/queues')
+      await apiQueuesRequest
+      await page.locator('#table thead').getByText('Name').click()
+      await expect(page).toHaveURL(/sort=name/)
+      const sort_reverse = (new URL(page.url())).searchParams.get('sort_reverse') == 'true'
+      await page.locator('#table thead').getByText('Name').click()
+      await expect(page).toHaveURL(new RegExp(`sort_reverse=${!sort_reverse}`))
+    })
+  })
+
   test.describe('pagination', _ => {
     const queues = Array.from(Array(10), (_, i) => qHelpers.queue(`queue-${i}`))
     const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -82,4 +82,13 @@ test.describe("queues", _ => {
     })
   })
 
+  test.describe('search', _ => {
+    test('updates url when value is entered and Enter is hit', async ({ page })=> {
+      await page.goto('/queues')
+      const searchField = page.locator('.filter-table')
+      await searchField.fill('my filter')
+      await searchField.press('Enter')
+      await expect(page).toHaveURL(/name=my(\+|%20)filter/)
+    })
+  })
 })

--- a/spec/frontend/queues_helpers.js
+++ b/spec/frontend/queues_helpers.js
@@ -1,0 +1,38 @@
+function queue(name, opts = {}) {
+  const defaults = {
+    name: name,
+    vhost: '/',
+    durable: true,
+    auto_delete: false,
+    exclusive: false,
+    arguments: [],
+    policy: '',
+    consumers: 0,
+    state: 'running',
+    ready: 0,
+    unacked: 0,
+    mesages: 0,
+    message_stats: {
+      publish_details: { rate: 0 },
+      deliver_details: { rate: 0 },
+      redeliver_details: { rate: 0 },
+      ack_details: { rate: 0 },
+    }
+  }
+  return Object.assign({}, defaults, opts)
+}
+
+function response(queues = [], opts = {}) {
+  const defaults = {
+    page: 1,
+    page_size: queues.length,
+    page_count: queues.size > 0 ? 1 : 0,
+    filtered_count: queues.length,
+    total_count: queues.length,
+    item_count: queues.length,
+    items: queues
+  }
+  return Object.assign({}, defaults, opts)
+}
+
+export { queue, response }

--- a/spec/frontend/shovels.spec.js
+++ b/spec/frontend/shovels.spec.js
@@ -1,0 +1,12 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("shovels", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiShovelsRequest = helpers.waitForPathRequest(page, '/api/shovels', {})
+    const apiParametersRequest = helpers.waitForPathRequest(page, '/api/parameters/shovel', {})
+    await page.goto('/shovels')
+    await expect(apiShovelsRequest).toBeRequested()
+    await expect(apiParametersRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/users.spec.js
+++ b/spec/frontend/users.spec.js
@@ -1,0 +1,10 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("users", _ => {
+  test('are loaded', async ({ page, baseURL }) => {
+    const apiUsersRequest = helpers.waitForPathRequest(page, '/api/users', {})
+    await page.goto('/users')
+    await expect(apiUsersRequest).toBeRequested()
+  })
+})

--- a/spec/frontend/vhosts.spec.js
+++ b/spec/frontend/vhosts.spec.js
@@ -1,0 +1,11 @@
+import * as helpers from './helpers.js'
+import { test, expect } from './fixtures.js';
+
+test.describe("vhosts", _ => {
+  test('are loaded', async ({ page, baseURL, vhosts }) => {
+    // vhosts are the vhosts returned in fixtures
+    const apiPermissionsRequests = vhosts.map(v => page.waitForRequest(`${baseURL}/api/vhosts/${v}/permissions`))
+    await page.goto('/vhosts')
+    await expect(Promise.all(apiPermissionsRequests)).toBeRequested()
+  })
+})

--- a/static/js/test-trigger.js
+++ b/static/js/test-trigger.js
@@ -1,0 +1,2 @@
+/* test again */
+const a = 3;

--- a/static/js/test-trigger.js
+++ b/static/js/test-trigger.js
@@ -1,2 +1,0 @@
-/* test again */
-const a = 3;


### PR DESCRIPTION
This will add [playwright](https://playwright.dev/) tests for some of the frontend code. The goal is to verify that all requests are done as expected and that data is handled correct (e.g. rendered). 

### HOW can this pull request be tested?
Start lavinmq and run

```
# npm install @playwright/test
# npx playwright install --with-deps
# BASE_URL=http://locahost:15672 npx playwright test --reporter=list
```
