### PR TITLE
Bugfix: Use federated queue's name if upstream queue name is empty

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -42,6 +42,19 @@ module UpstreamSpecHelpers
 end
 
 describe LavinMQ::Federation::Upstream do
+  it "should use federated queue's name if @queue is empty" do
+    vhost_downstream = Server.vhosts.create("/")
+    vhost_upstream = Server.vhosts.create("upstream")
+    upstream = LavinMQ::Federation::Upstream.new(vhost_downstream, "qf test upstream", "#{AMQP_BASE_URL}/upstream", nil, "")
+
+    with_channel do |ch|
+      ch.queue("federated_q")
+      link = upstream.link(vhost_downstream.queues["federated_q"])
+      wait_for { link.state.running? }
+      vhost_upstream.queues.has_key?("federated_q").should be_true
+    end
+  end
+
   it "should federate queue" do
     vhost = Server.vhosts["/"]
     upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", AMQP_BASE_URL, nil, "federation_q1")

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -78,7 +78,10 @@ module LavinMQ
         if link = @q_links[federated_q.name]?
           return link
         end
-        upstream_q = @queue ||= federated_q.name
+        upstream_q = @queue
+        if upstream_q.nil? || upstream_q.empty?
+          upstream_q = @queue = federated_q.name
+        end
         link = QueueLink.new(self, federated_q, upstream_q)
         @q_links[federated_q.name] = link
         link.run


### PR DESCRIPTION
### WHAT is this pull request doing?
When an federation upstream is created without queue name the queue name on the upstream server was auto generated (amq.gen-*) because empty string was passed in the declare call.

This will extend the nil check of queue name to also check for empty string.

### HOW can this pull request be tested?
1. Create an federation upstream without any exchange or queue parameters
2. Create a queue on downstream
3. Apply federation to the queue
4. Verify that a queue has been declared on upstream with the same name as the federated queue
