### PR TITLE
deletes unused segments when opening a new segment. Also checks if nr…

### DIFF
--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -106,7 +106,7 @@ describe LavinMQ::DurableQueue do
         q.subscribe(no_ack: false, &.ack)
       end
       queue = Server.vhosts["/"].queues[q_name].as(LavinMQ::DurableQueue)
-      queue.@msg_store.@segments.size.should be <= 2 
+      queue.@msg_store.@segments.size.should be <= 2
     end
   end
 end

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -94,6 +94,21 @@ describe LavinMQ::DurableQueue do
     queue = Server.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
     queue.message_count.should eq 2
   end
+
+  # Delete unused segments bug
+  # https://github.com/cloudamqp/lavinmq/pull/565
+  it "should remove unused segments after being consumed" do
+    with_channel do |ch|
+      q_name = "segment_delete_test"
+      q = ch.queue(q_name, durable: true)
+      10.times do # Publish and consume large messages that ensures new segments are created
+        q.publish_confirm Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size)
+        q.subscribe(no_ack: false, &.ack)
+      end
+      queue = Server.vhosts["/"].queues[q_name].as(LavinMQ::DurableQueue)
+      queue.@msg_store.@segments.size.should be <= 2 
+    end
+  end
 end
 
 describe LavinMQ::VHost do

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -341,7 +341,7 @@ module LavinMQ
         @segments.reject! do |seg, mfile|
           next if seg == current_seg # don't the delete the segment still being written to
 
-          if @segment_msg_count[seg] == @deleted[seg]?.try(&.size) || @segment_msg_count[seg] == @acks[seg].size // sizeof(UInt32)
+          if @segment_msg_count[seg] == @acks[seg].size // sizeof(UInt32)
             Log.info { "Deleting unused segment #{seg}" }
             @segment_msg_count.delete seg
             @deleted.delete seg


### PR DESCRIPTION
… of acks equals nr of messages in segment

### WHAT is this pull request doing?
Deletes unused segments when creating a new segment. 

With a low pub/sub rate the file we read from will "always" be the file we write to (even if the next message written won't fit in the segment), so we can't delete it. This means the message store will grow indefinitely. 

### HOW can this pull request be tested?
Run lavinmqperf with a low rate and make check that the message dir isn't growing
`bin/lavinmqperf throughput --uri=<uri> -x 1 -y 1 -r 1 -s 4000000`
