### PR TITLE
check if disk is full before creating queues and users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A bug in amq-protocol caused lost headers when dead-lettering [amq-protocol/#12](https://github.com/cloudamqp/amq-protocol.cr/pull/12)
+- Block creation of queues and users when disk is close to full to prevent disk from becoming full [#567](https://github.com/cloudamqp/lavinmq/pull/567)
 
 ## [1.2.2] - 2023-08-22
 

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -167,6 +167,8 @@ describe LavinMQ::HTTP::UsersController do
       response.status_code.should eq 412
       body = JSON.parse(response.body)
       body["reason"].as_s.should eq("Server low on disk space, can not create new user")
+    ensure
+      Server.flow(true)
     end
   end
 

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -157,6 +157,17 @@ describe LavinMQ::HTTP::UsersController do
       body = JSON.parse(response.body)
       body["reason"].as_s.should eq("Malformed JSON.")
     end
+
+    it "should not create user if disk is full" do
+      Server.flow(false)
+      body = %({
+        "password": "test"
+      })
+      response = put("/api/users/alan", body: body)
+      response.status_code.should eq 412
+      body = JSON.parse(response.body)
+      body["reason"].as_s.should eq("Server low on disk space, can not create new user")
+    end
   end
 
   describe "GET /api/users/user/permissions" do

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -36,7 +36,6 @@ describe "Flow" do
   end
 
   it "should stop flow when disk is almost full" do
-    wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
     Server.is_disk_full?.should be_true
   ensure
@@ -45,7 +44,6 @@ describe "Flow" do
   end
 
   it "should resume flow when disk is no longer full" do
-    wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
     Server.is_disk_full?.should be_true
 

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -40,6 +40,9 @@ describe "Flow" do
     wait_for { Server.disk_free > 0 }
     LavinMQ::Config.instance.free_disk_min = Server.disk_free + 1_000_000_000
     should_eventually(be_false) { Server.flow? }
+  ensure
+    LavinMQ::Config.instance.free_disk_min = 0
+    Server.flow(true)
   end
 
   it "should resume flow when disk is no longer full" do
@@ -49,5 +52,8 @@ describe "Flow" do
     should_eventually(be_false) { Server.flow? }
     LavinMQ::Config.instance.free_disk_min = 0
     should_eventually(be_true) { Server.flow? }
+  ensure
+    LavinMQ::Config.instance.free_disk_min = 0
+    Server.flow(true)
   end
 end

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -37,8 +37,8 @@ describe "Flow" do
 
   it "should stop flow when disk is almost full" do
     LavinMQ::Config.instance.stats_interval = 100
-    wait_for { Server.disk_free > 0 }
-    LavinMQ::Config.instance.free_disk_min = Server.disk_free + 1_000_000_000
+    wait_for { Server.disk_total > 0 }
+    LavinMQ::Config.instance.free_disk_min = Server.disk_total
     should_eventually(be_false) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
@@ -47,13 +47,12 @@ describe "Flow" do
 
   it "should resume flow when disk is no longer full" do
     LavinMQ::Config.instance.stats_interval = 100
-    wait_for { Server.disk_free > 0 }
-    LavinMQ::Config.instance.free_disk_min = Server.disk_free + 1_000_000_000
+    wait_for { Server.disk_total > 0 }
+    LavinMQ::Config.instance.free_disk_min = Server.disk_total
     should_eventually(be_false) { Server.flow? }
     LavinMQ::Config.instance.free_disk_min = 0
     should_eventually(be_true) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
-    Server.flow(true)
   end
 end

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -38,7 +38,7 @@ describe "Flow" do
   it "should stop flow when disk is almost full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
+    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)
@@ -47,9 +47,9 @@ describe "Flow" do
   it "should resume flow when disk is no longer full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
+    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
     LavinMQ::Config.instance.free_disk_min = 0
-    should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
+    should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -39,7 +39,7 @@ describe "Flow" do
     stats_interval = LavinMQ::Config.instance.stats_interval
     LavinMQ::Config.instance.stats_interval = 100
     wait_for { Server.disk_total > 0 }
-    LavinMQ::Config.instance.free_disk_min = Server.disk_total
+    LavinMQ::Config.instance.free_disk_min = Int64::MAX
     should_eventually(be_false) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
@@ -51,7 +51,7 @@ describe "Flow" do
     stats_interval = LavinMQ::Config.instance.stats_interval
     LavinMQ::Config.instance.stats_interval = 100
     wait_for { Server.disk_total > 0 }
-    LavinMQ::Config.instance.free_disk_min = Server.disk_total
+    LavinMQ::Config.instance.free_disk_min = Int64::MAX
     should_eventually(be_false) { Server.flow? }
     LavinMQ::Config.instance.free_disk_min = 0
     should_eventually(be_true) { Server.flow? }

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -38,7 +38,7 @@ describe "Flow" do
   it "should stop flow when disk is almost full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    should_eventually(be_false, timeout=(LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
+    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)
@@ -47,9 +47,9 @@ describe "Flow" do
   it "should resume flow when disk is no longer full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    should_eventually(be_false, timeout=(LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
+    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
     LavinMQ::Config.instance.free_disk_min = 0
-    should_eventually(be_true, timeout=(LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
+    should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -38,9 +38,7 @@ describe "Flow" do
   it "should stop flow when disk is almost full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    puts "Server disk total: #{Server.disk_total}"
-    puts "Server disk free: #{Server.disk_free}"
-    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 4).milliseconds) { Server.flow? }
+    Server.is_disk_full?.should be_true
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)
@@ -49,13 +47,10 @@ describe "Flow" do
   it "should resume flow when disk is no longer full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    puts "Server disk total: #{Server.disk_total}"
-    puts "Server disk free: #{Server.disk_free}"
-    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 4).milliseconds) { Server.flow? }
-    puts "Server disk total: #{Server.disk_total}"
-    puts "Server disk free: #{Server.disk_free}"
+    Server.is_disk_full?.should be_true
+
     LavinMQ::Config.instance.free_disk_min = 0
-    should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval * 4).milliseconds) { Server.flow? }
+    Server.is_disk_full?.should be_false
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -38,7 +38,7 @@ describe "Flow" do
   it "should stop flow when disk is almost full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
     sleep 0.1
-    Server.is_disk_full?.should be_true
+    Server.disk_full?.should be_true
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)
@@ -47,11 +47,11 @@ describe "Flow" do
   it "should resume flow when disk is no longer full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
     sleep 0.1
-    Server.is_disk_full?.should be_true
+    Server.disk_full?.should be_true
 
     LavinMQ::Config.instance.free_disk_min = 0
     sleep 0.1
-    Server.is_disk_full?.should be_false
+    Server.disk_full?.should be_false
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -37,6 +37,7 @@ describe "Flow" do
 
   it "should stop flow when disk is almost full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
+    sleep 0.1
     Server.is_disk_full?.should be_true
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
@@ -45,9 +46,11 @@ describe "Flow" do
 
   it "should resume flow when disk is no longer full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
+    sleep 0.1
     Server.is_disk_full?.should be_true
 
     LavinMQ::Config.instance.free_disk_min = 0
+    sleep 0.1
     Server.is_disk_full?.should be_false
   ensure
     LavinMQ::Config.instance.free_disk_min = 0

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -40,7 +40,7 @@ describe "Flow" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
     puts "Server disk total: #{Server.disk_total}"
     puts "Server disk free: #{Server.disk_free}"
-    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
+    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 4).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)
@@ -51,11 +51,11 @@ describe "Flow" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
     puts "Server disk total: #{Server.disk_total}"
     puts "Server disk free: #{Server.disk_free}"
-    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
+    should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 4).milliseconds) { Server.flow? }
     puts "Server disk total: #{Server.disk_total}"
     puts "Server disk free: #{Server.disk_free}"
     LavinMQ::Config.instance.free_disk_min = 0
-    should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
+    should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval * 4).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
     Server.flow(true)

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -36,27 +36,22 @@ describe "Flow" do
   end
 
   it "should stop flow when disk is almost full" do
-    stats_interval = LavinMQ::Config.instance.stats_interval
-    LavinMQ::Config.instance.stats_interval = 100
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    should_eventually(be_false) { Server.flow? }
+    should_eventually(be_false, timeout=(LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
-    LavinMQ::Config.instance.stats_interval = stats_interval if stats_interval
     Server.flow(true)
   end
 
   it "should resume flow when disk is no longer full" do
-    stats_interval = LavinMQ::Config.instance.stats_interval
-    LavinMQ::Config.instance.stats_interval = 100
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    should_eventually(be_false) { Server.flow? }
+    should_eventually(be_false, timeout=(LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
     LavinMQ::Config.instance.free_disk_min = 0
-    should_eventually(be_true) { Server.flow? }
+    should_eventually(be_true, timeout=(LavinMQ::Config.instance.stats_interval + 1000).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
-    LavinMQ::Config.instance.stats_interval = stats_interval if stats_interval
+    Server.flow(true)
   end
 end

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -34,4 +34,20 @@ describe "Flow" do
   ensure
     Server.flow(true)
   end
+
+  it "should stop flow when disk is almost full" do
+    LavinMQ::Config.instance.stats_interval = 100
+    wait_for { Server.disk_free > 0 }
+    LavinMQ::Config.instance.free_disk_min = Server.disk_free + 1_000_000_000
+    should_eventually(be_false) { Server.flow? }
+  end
+
+  it "should resume flow when disk is no longer full" do
+    LavinMQ::Config.instance.stats_interval = 100
+    wait_for { Server.disk_free > 0 }
+    LavinMQ::Config.instance.free_disk_min = Server.disk_free + 1_000_000_000
+    should_eventually(be_false) { Server.flow? }
+    LavinMQ::Config.instance.free_disk_min = 0
+    should_eventually(be_true) { Server.flow? }
+  end
 end

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -38,6 +38,8 @@ describe "Flow" do
   it "should stop flow when disk is almost full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
+    puts "Server disk total: #{Server.disk_total}"
+    puts "Server disk free: #{Server.disk_free}"
     should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
@@ -47,7 +49,11 @@ describe "Flow" do
   it "should resume flow when disk is no longer full" do
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
+    puts "Server disk total: #{Server.disk_total}"
+    puts "Server disk free: #{Server.disk_free}"
     should_eventually(be_false, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
+    puts "Server disk total: #{Server.disk_total}"
+    puts "Server disk free: #{Server.disk_free}"
     LavinMQ::Config.instance.free_disk_min = 0
     should_eventually(be_true, timeout = (LavinMQ::Config.instance.stats_interval * 2).milliseconds) { Server.flow? }
   ensure

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -36,16 +36,19 @@ describe "Flow" do
   end
 
   it "should stop flow when disk is almost full" do
+    stats_interval = LavinMQ::Config.instance.stats_interval
     LavinMQ::Config.instance.stats_interval = 100
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Server.disk_total
     should_eventually(be_false) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
+    LavinMQ::Config.instance.stats_interval = stats_interval if stats_interval
     Server.flow(true)
   end
 
   it "should resume flow when disk is no longer full" do
+    stats_interval = LavinMQ::Config.instance.stats_interval
     LavinMQ::Config.instance.stats_interval = 100
     wait_for { Server.disk_total > 0 }
     LavinMQ::Config.instance.free_disk_min = Server.disk_total
@@ -54,5 +57,6 @@ describe "Flow" do
     should_eventually(be_true) { Server.flow? }
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
+    LavinMQ::Config.instance.stats_interval = stats_interval if stats_interval
   end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -324,6 +324,8 @@ describe LavinMQ::Queue do
           q = ch.queue("test_queue_flow", durable: true)
         end
       end
+    ensure
+      Server.flow(true)
     end
   end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -315,4 +315,15 @@ describe LavinMQ::Queue do
       Dir.exists?(data_dir).should be_false
     end
   end
+
+  describe "Flow" do
+    it "should stop queues from being declared when disk is full" do
+      Server.flow(false)
+      with_channel do |ch|
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          q = ch.queue("test_queue_flow", durable: true)
+        end
+      end
+    end
+  end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -321,7 +321,7 @@ describe LavinMQ::Queue do
       Server.flow(false)
       with_channel do |ch|
         expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-          q = ch.queue("test_queue_flow", durable: true)
+          ch.queue("test_queue_flow", durable: true)
         end
       end
     ensure

--- a/src/lavinmq/client/client.cr
+++ b/src/lavinmq/client/client.cr
@@ -657,6 +657,9 @@ module LavinMQ
     @last_queue_name : String?
 
     private def declare_new_queue(frame)
+      unless @vhost.flow?
+        send_precondition_failed(frame, "Server low on disk space, can not create queue")
+      end
       if frame.queue_name.empty?
         frame.queue_name = Queue.generate_name
       end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -164,6 +164,10 @@ module LavinMQ
         halt(context, 403, {error: "forbidden", reason: message})
       end
 
+      private def precondition_failed(context, message = "Precondition failed")
+        halt(context, 412, {error: "Precondition failed", reason: message})
+      end
+
       private def halt(context, status_code, body = nil)
         context.response.status_code = status_code
         body.try &.to_json(context.response)

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -73,7 +73,7 @@ module LavinMQ
           tags = Tag.parse_list(body["tags"]?.try(&.as_s).to_s).uniq
           hashing_algorithm = body["hashing_algorithm"]?.try &.as_s? || "SHA256"
           unless @amqp_server.flow?
-            precondition_failed(context, "Disk space almost full, can not create new user")
+            precondition_failed(context, "Server low on disk space, can not create new user")
           end
           if u = @amqp_server.users[name]?
             if password_hash

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -72,6 +72,9 @@ module LavinMQ
           password = body["password"]?.try &.as_s?
           tags = Tag.parse_list(body["tags"]?.try(&.as_s).to_s).uniq
           hashing_algorithm = body["hashing_algorithm"]?.try &.as_s? || "SHA256"
+          unless @amqp_server.flow?
+            precondition_failed(context, "Disk space almost full, can not create new user")
+          end
           if u = @amqp_server.users[name]?
             if password_hash
               u.update_password_hash(password_hash, hashing_algorithm)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -385,7 +385,7 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
 
     private def control_flow!
-      if is_disk_full?
+      if disk_full?
         if flow?
           @log.info { "Low disk space: #{@disk_free.humanize}B, stopping flow" }
           flow(false)
@@ -393,16 +393,16 @@ module LavinMQ
       elsif !flow?
         @log.info { "Not low on disk space, starting flow" }
         flow(true)
-      elsif is_disk_usage_over_warning_level?
+      elsif disk_usage_over_warning_level?
         @log.info { "Low on disk space: #{@disk_free.humanize}B" }
       end
     end
 
-    def is_disk_full?
+    def disk_full?
       @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
     end
 
-    def is_disk_usage_over_warning_level?
+    def disk_usage_over_warning_level?
       @disk_free < 6_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_warn
     end
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -385,9 +385,7 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
 
     private def control_flow!
-      puts "control_flow: disk_free: #{@disk_free}"
-      puts "control_flow: disk_total: #{@disk_total}"
-      if @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
+      if is_disk_full?
         if flow?
           @log.info { "Low disk space: #{@disk_free.humanize}B, stopping flow" }
           flow(false)
@@ -395,9 +393,17 @@ module LavinMQ
       elsif !flow?
         @log.info { "Not low on disk space, starting flow" }
         flow(true)
-      elsif @disk_free < 6_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_warn
+      elsif is_disk_usage_over_warning_level?
         @log.info { "Low on disk space: #{@disk_free.humanize}B" }
       end
+    end
+
+    def is_disk_full?
+      @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
+    end
+
+    def is_disk_usage_over_warning_level?
+      @disk_free < 6_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_warn
     end
 
     def flow(active : Bool)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -385,7 +385,7 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
 
     private def control_flow!
-      if @disk_free < 2_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
+      if @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
         if flow?
           @log.info { "Low disk space: #{@disk_free.humanize}B, stopping flow" }
           flow(false)
@@ -393,7 +393,7 @@ module LavinMQ
       elsif !flow?
         @log.info { "Not low on disk space, starting flow" }
         flow(true)
-      elsif @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_warn
+      elsif @disk_free < 6_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_warn
         @log.info { "Low on disk space: #{@disk_free.humanize}B" }
       end
     end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -385,6 +385,8 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
 
     private def control_flow!
+      puts "control_flow: disk_free: #{@disk_free}"
+      puts "control_flow: disk_total: #{@disk_total}"
       if @disk_free < 3_i64 * Config.instance.segment_size || @disk_free < Config.instance.free_disk_min
         if flow?
           @log.info { "Low disk space: #{@disk_free.humanize}B, stopping flow" }


### PR DESCRIPTION
Check if disk is full before creating queues and users, and send `PreconditionFailed` if disk is full (if flow is stopped). 

Also slightly raises the default free disk value to `3 * segment_size` to give Lavin more time to stop flow. 

https://trello.com/c/2iP4j8ca/316-catch-disk-full-errors-instead-of-crashing

### WHAT is this pull request doing?
Makes sure LavinMQ doesn't fill up disk and crash when creating queues and/or users. 

### HOW can this pull request be tested?
Fill up disk, try creating queue/user. 
