### PR TITLE
Compact definitions during runtime

### DIFF
--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -68,19 +68,15 @@ describe LavinMQ::VHost do
   end
 
   it "should compact definitions during runtime" do
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    (LavinMQ::VHost::DEFINITIONS_DIRT_COMPACT_THREASHOLD - 1).times do
+    v = Server.vhosts.create("test")
+    (LavinMQ::Config.instance.max_deleted_definitions - 1).times do
       v.declare_queue("q", true, false)
       v.delete_queue("q")
     end
-    v.@definitions_dirt_counter.should eq(LavinMQ::VHost::DEFINITIONS_DIRT_COMPACT_THREASHOLD - 1)
-    definitions_file_pos_before = v.@definitions_file.pos
+    file_size = v.@definitions_file.size
     v.declare_queue("q", true, false)
     v.delete_queue("q")
-    wait_for(timeout: 1.second) { v.@definitions_dirt_counter.zero? }
-    v.@definitions_file.pos.should be < definitions_file_pos_before
-    v.@definitions_dirt_counter.should eq 0
+    v.@definitions_file.size.should be < file_size
   end
 
   describe "auto add permissions" do

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -47,6 +47,7 @@ module LavinMQ
     property replication_follow : URI? = nil
     property replication_bind : String? = nil
     property replication_port = 5679
+    property max_deleted_definitions = 8192 # number of deleted queues, unbinds etc that compacts the definitions file
     @@instance : Config = self.new
 
     def self.instance : LavinMQ::Config
@@ -80,27 +81,28 @@ module LavinMQ
     private def parse_main(settings)
       settings.each do |config, v|
         case config
-        when "data_dir"             then @data_dir = v
-        when "data_dir_lock"        then @data_dir_lock = true?(v)
-        when "log_level"            then @log_level = Log::Severity.parse(v)
-        when "log_file"             then @log_file = v
-        when "stats_interval"       then @stats_interval = v.to_i32
-        when "stats_log_size"       then @stats_log_size = v.to_i32
-        when "segment_size"         then @segment_size = v.to_i32
-        when "set_timestamp"        then @set_timestamp = true?(v)
-        when "socket_buffer_size"   then @socket_buffer_size = v.to_i32
-        when "tcp_nodelay"          then @tcp_nodelay = true?(v)
-        when "tcp_keepalive"        then @tcp_keepalive = tcp_keepalive?(v)
-        when "tcp_recv_buffer_size" then @tcp_recv_buffer_size = v.to_i32?
-        when "tcp_send_buffer_size" then @tcp_send_buffer_size = v.to_i32?
-        when "tls_cert"             then @tls_cert_path = v
-        when "tls_key"              then @tls_key_path = v
-        when "tls_ciphers"          then @tls_ciphers = v
-        when "tls_min_version"      then @tls_min_version = v
-        when "guest_only_loopback"  then @guest_only_loopback = true?(v)
-        when "log_exchange"         then @log_exchange = true?(v)
-        when "free_disk_min"        then @free_disk_min = v.to_i64
-        when "free_disk_warn"       then @free_disk_warn = v.to_i64
+        when "data_dir"                then @data_dir = v
+        when "data_dir_lock"           then @data_dir_lock = true?(v)
+        when "log_level"               then @log_level = Log::Severity.parse(v)
+        when "log_file"                then @log_file = v
+        when "stats_interval"          then @stats_interval = v.to_i32
+        when "stats_log_size"          then @stats_log_size = v.to_i32
+        when "segment_size"            then @segment_size = v.to_i32
+        when "set_timestamp"           then @set_timestamp = true?(v)
+        when "socket_buffer_size"      then @socket_buffer_size = v.to_i32
+        when "tcp_nodelay"             then @tcp_nodelay = true?(v)
+        when "tcp_keepalive"           then @tcp_keepalive = tcp_keepalive?(v)
+        when "tcp_recv_buffer_size"    then @tcp_recv_buffer_size = v.to_i32?
+        when "tcp_send_buffer_size"    then @tcp_send_buffer_size = v.to_i32?
+        when "tls_cert"                then @tls_cert_path = v
+        when "tls_key"                 then @tls_key_path = v
+        when "tls_ciphers"             then @tls_ciphers = v
+        when "tls_min_version"         then @tls_min_version = v
+        when "guest_only_loopback"     then @guest_only_loopback = true?(v)
+        when "log_exchange"            then @log_exchange = true?(v)
+        when "free_disk_min"           then @free_disk_min = v.to_i64
+        when "free_disk_warn"          then @free_disk_warn = v.to_i64
+        when "max_deleted_definitions" then @max_deleted_definitions = v.to_i
         else
           STDERR.puts "WARNING: Unrecognized configuration 'main/#{config}'"
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
With high churns (e.g. tons of short-lived queues) the definitions file can grow indefinitely. This will add compaction every 10000th "delete" frame. (10k was chosen completely arbitrary.)

### HOW can this pull request be tested?
Run specs, or launch lavinmq and create and delete a queue more than 10k times.
