### PR TITLE
Bugfix: delayed exchanges using and ruing dead lettering headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A bug in delay exchange made it expire messages to the exchange in x-dead-letter-exchange if present. It also ruined any dead-lettering headers in the message.
+- A bug in delay exchanges caused messages to be routed to x-dead-letter-exchange instead of bound queues. It also ruined any dead lettering headers.
 
 ## [1.2.4] - 2023-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A bug in delay exchange made it expire messages to the exchange in x-dead-letter-exchange if present. It also ruined any dead-lettering headers in the message.
+
 ## [1.2.4] - 2023-09-26
 
 ### Fixed

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -96,7 +96,7 @@ describe "Delayed Message Exchange" do
       })
       x.publish "delay", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
 
-      msgs = Channel(DeliverMessage).new
+      msgs = Channel(AMQP::Client::DeliverMessage).new
       q.subscribe { |msg| msgs.send msg }
       msg = msgs.receive
       headers = msg.properties.headers.should_not be_nil

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -96,8 +96,9 @@ describe "Delayed Message Exchange" do
       })
       x.publish "delay", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
 
-      wait_for { q.message_count >= 1 }
-      msg = q.get(no_ack: true).should_not be_nil
+      msgs = Channel(DeliverMessage).new
+      q.subscribe { |msg| msgs.send msg }
+      msg = msgs.receive
       headers = msg.properties.headers.should_not be_nil
       header_keys = headers.to_h.keys
       header_keys.should_not contain "x-first-death-reason"

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -574,7 +574,7 @@ module LavinMQ
 
     private def handle_dlx_header(msg, reason) : AMQP::Properties
       h = msg.properties.headers || AMQP::Table.new
-      h.reject! { |k, _| k.in?("x-delay", "x-dead-letter-exchange", "x-dead-letter-routing-key") }
+      h.reject! { |k, _| k.in?("x-dead-letter-exchange", "x-dead-letter-routing-key") }
 
       # there's a performance advantage to do `has_key?` over `||=`
       h["x-first-death-reason"] = reason.to_s unless h.has_key? "x-first-death-reason"


### PR DESCRIPTION
### WHAT is this pull request doing?

Delayed exchanges are using internal queues and message ttl when delaying messages. When the message expires it's dead-lettered back to the same exchange without the `x-delay` header making it routed to the bound queues instead of being delayed again.

When queues' expires a message it will check dead-lettering headers and update the message header accordingly, but this was also done for delayed messages making delay exchanges' republish the message to `x-dead-letter-exchange` instead of to itself. It also set `x-first-death-*` headers and removes `x-dead-letter-'` headers, making the intentional dead-lettering for the message to be ruined.

This change will override the behavior of expiring messages in the internal queues used by delay exchanges.

### HOW can this pull request be tested?

Run specs
