### PR TITLE
Consumer arg support for shovels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Consumer arguments support for shovels [#578](https://github.com/cloudamqp/lavinmq/pull/578)
+
 ### Fixed
 
 - A bug in delay exchanges caused messages to be routed to x-dead-letter-exchange instead of bound queues. It also ruined any dead lettering headers.

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -21,7 +21,6 @@ module LavinMQ
 
         post "/api/definitions/upload" do |context, _params|
           refuse_unless_administrator(context, user(context))
-
           ::HTTP::FormData.parse(context.request) do |part|
             if part.name == "file"
               body = JSON.parse(part.body)

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -21,15 +21,11 @@ module LavinMQ
 
         post "/api/definitions/upload" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          if context.request.headers["Content-Type"] == "application/json"
-            body = parse_body(context)
-            GlobalDefinitions.new(@amqp_server).import(body)
-          else
-            ::HTTP::FormData.parse(context.request) do |part|
-              if part.name == "file"
-                body = JSON.parse(part.body)
-                GlobalDefinitions.new(@amqp_server).import(body)
-              end
+
+          ::HTTP::FormData.parse(context.request) do |part|
+            if part.name == "file"
+              body = JSON.parse(part.body)
+              GlobalDefinitions.new(@amqp_server).import(body)
             end
           end
           redirect_back(context) if context.request.headers["Referer"]?

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -21,10 +21,15 @@ module LavinMQ
 
         post "/api/definitions/upload" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          ::HTTP::FormData.parse(context.request) do |part|
-            if part.name == "file"
-              body = JSON.parse(part.body)
-              GlobalDefinitions.new(@amqp_server).import(body)
+          if context.request.headers["Content-Type"] == "application/json"
+            body = parse_body(context)
+            GlobalDefinitions.new(@amqp_server).import(body)
+          else
+            ::HTTP::FormData.parse(context.request) do |part|
+              if part.name == "file"
+                body = JSON.parse(part.body)
+                GlobalDefinitions.new(@amqp_server).import(body)
+              end
             end
           end
           redirect_back(context) if context.request.headers["Referer"]?

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -122,10 +122,11 @@ module LavinMQ
         raise "Not started" unless started?
         q = @q.not_nil!
         ch = @ch.not_nil!
+        exclusive = !@args["x-stream-offset"]? # consumers for streams can not be exclusive
         return if @delete_after.queue_length? && q[:message_count].zero?
         ch.basic_consume(q[:queue_name],
           no_ack: @ack_mode.no_ack?,
-          exclusive: true,
+          exclusive: exclusive,
           block: true,
           args: @args,
           tag: @tag) do |msg|

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -42,7 +42,7 @@ module LavinMQ
       def initialize(@name : String, @uri : URI, @queue : String?, @exchange : String? = nil,
                      @exchange_key : String? = nil,
                      @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
-                     @ack_mode = DEFAULT_ACK_MODE, @consumer_args = {} of String => JSON::Any || nil,
+                     @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
         @tag = "Shovel[#{@name}]"
         cfg = Config.instance
@@ -62,8 +62,8 @@ module LavinMQ
           raise ArgumentError.new("Shovel source requires a queue or an exchange")
         end
         @args = AMQ::Protocol::Table.new
-        @consumer_args.try &.each do |k, v|
-          @args[k] = v
+        consumer_args.try &.each do |k, v|
+          @args[k] = v.as_s?
         end
       end
 
@@ -161,7 +161,7 @@ module LavinMQ
       def initialize(@name : String, @uri : URI, @queue : String?, @exchange : String? = nil,
                      @exchange_key : String? = nil,
                      @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
-                     @ack_mode = DEFAULT_ACK_MODE, @consumer_args = {} of String => String,
+                     @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
         cfg = Config.instance
         @uri.host ||= "#{cfg.amqp_bind}:#{cfg.amqp_port}"
@@ -184,8 +184,8 @@ module LavinMQ
           raise ArgumentError.new("Shovel destination requires an exchange")
         end
         @args = AMQ::Protocol::Table.new
-        @consumer_args.try &.each do |k, v|
-          @args[k] = v
+        consumer_args.try &.each do |k, v|
+          @args[k] = v.as_s?
         end
       end
 

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -61,7 +61,7 @@ module LavinMQ
         if @queue.nil? && @exchange.nil?
           raise ArgumentError.new("Shovel source requires a queue or an exchange")
         end
-        @args = AMQ::Protocol::Table.new()
+        @args = AMQ::Protocol::Table.new
         @consumer_args.try &.each do |k, v|
           @args[k] = v
         end
@@ -183,7 +183,7 @@ module LavinMQ
         if @exchange.nil?
           raise ArgumentError.new("Shovel destination requires an exchange")
         end
-        @args = AMQ::Protocol::Table.new()
+        @args = AMQ::Protocol::Table.new
         @consumer_args.try &.each do |k, v|
           @args[k] = v
         end

--- a/src/lavinmq/shovel/shovel_store.cr
+++ b/src/lavinmq/shovel/shovel_store.cr
@@ -23,6 +23,7 @@ module LavinMQ
         delete_after,
         prefetch,
         ack_mode,
+        config["src-consumer-args"]?.try &.as_h?,
         direct_user: @vhost.users.direct_user)
       dest = destination(name, config, ack_mode, delete_after, prefetch)
       shovel = Shovel::Runner.new(src, dest, name, @vhost, reconnect_delay)


### PR DESCRIPTION
### WHAT is this pull request doing?
Shovels handle `src-consumer-args` to enable them to handle stream queues. 

### HOW can this pull request be tested?
Create a shovel for a stream queue via API with x-stream-offset 
