### PR TITLE
Fix broken FreeBSD ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 freebsd_task:
   skip: "!changesInclude('.cirrus.yml', 'shard.lock', 'src/**', 'spec/**')"
   freebsd_instance:
-    image_family: freebsd-14-0-snap
+    image_family: freebsd-13-2
     memory: 4G
   pkg_cache:
     folder: /var/cache/pkg

--- a/spec/replication_spec.cr
+++ b/spec/replication_spec.cr
@@ -45,7 +45,11 @@ describe LavinMQ::Replication::Client do
       q = ch.queue("repli")
       q.publish_confirm "hello world"
     end
-    sleep 0.1
+    {% if flag?(:freebsd) %}
+      sleep 1
+    {% else %}
+      sleep 0.1
+    {% end %}
     repli.close
     done.receive
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Compiling LavinMQ doesn't work with the `freebsd-14-0-snap` image, causing our CI to be red.
See https://reviews.freebsd.org/D41746

This will change to use `freebsd-13-2` instead. Also had to increase a sleep in one spec when running in freebsd. This should probable be fixed

### HOW can this pull request be tested?
Just check CI log.
