### PR TITLE
Allow json upload to be a json body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Purging a queue with a lot of messages blocked LavinMQ from other operations.
 - Message timestamps not being updated when dead lettered breaking TTL.
 
+### Changed
+
+- Definitions uploads can now be JSON body [#580](https://github.com/cloudamqp/lavinmq/pull/580)
+
 ## [1.2.4] - 2023-09-26
 
 ### Fixed

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -540,6 +540,15 @@ describe LavinMQ::HTTP::Server do
       Server.vhosts["uploaded_vhost"]?.should_not be_nil
       Server.vhosts["uploaded_vhost"].should be_a(LavinMQ::VHost)
     end
+
+    it "imports definitions from json body" do
+      body = {vhosts: [{name: "uploaded_vhost"}]}.to_json
+      headers = {"Content-Type" => "application/json"}
+      response = post("/api/definitions/upload", headers: headers, body: body)
+      response.status_code.should eq 200
+      Server.vhosts["uploaded_vhost"]?.should_not be_nil
+      Server.vhosts["uploaded_vhost"].should be_a(LavinMQ::VHost)
+    end
   end
 
   it "should update existing user on import" do

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -21,10 +21,15 @@ module LavinMQ
 
         post "/api/definitions/upload" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          ::HTTP::FormData.parse(context.request) do |part|
-            if part.name == "file"
-              body = JSON.parse(part.body)
-              GlobalDefinitions.new(@amqp_server).import(body)
+          if context.request.headers["Content-Type"] == "application/json"
+            body = parse_body(context)
+            GlobalDefinitions.new(@amqp_server).import(body)
+          else
+            ::HTTP::FormData.parse(context.request) do |part|
+              if part.name == "file"
+                body = JSON.parse(part.body)
+                GlobalDefinitions.new(@amqp_server).import(body)
+              end
             end
           end
           redirect_back(context) if context.request.headers["Referer"]?


### PR DESCRIPTION
### WHAT is this pull request doing?
Enables LavinMQ to handle definitions upload to be json body in the request as well. 

### HOW can this pull request be tested?
Do an API request with definitions in body
