### PR TITLE
Bugfix: DLX doesn't update timestamp on republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A bug in delay exchanges caused messages to be routed to x-dead-letter-exchange instead of bound queues. It also ruined any dead lettering headers.
 - A bug that prevented headers exchange to match on table in message headers.
 - Purging a queue with a lot of messages blocked LavinMQ from other operations.
+- Message timestamps not being updated when dead lettered breaking TTL.
 
 ## [1.2.4] - 2023-09-26
 

--- a/spec/dlx_spec.cr
+++ b/spec/dlx_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "./../src/lavinmq/queue"
+require "./../src/lavinmq/rough_time"
 
 describe "Dead lettering" do
   q_name = "ttl"
@@ -28,5 +29,33 @@ describe "Dead lettering" do
       x_death[0].as(AMQ::Protocol::Table)["queue"].should eq q_delayed.name
       x_death[1].as(AMQ::Protocol::Table)["queue"].should eq q_delayed_2.name
     end
+  end
+
+  it "should update timestamp" do
+    v = Server.vhosts.create("test")
+    q_args = AMQ::Protocol::Table.new({
+      "x-message-ttl"             => 200,
+      "x-dead-letter-exchange"    => "",
+      "x-dead-letter-routing-key" => "q2",
+    })
+    v.declare_queue("q", true, false, q_args)
+    v.declare_queue("q2", true, false, AMQ::Protocol::Table.new)
+
+    ts = RoughTime.unix_ms
+    msg = LavinMQ::Message.new(ts, "", "q", AMQ::Protocol::Properties.new, 0, IO::Memory.new)
+
+    v.publish msg
+
+    select
+    when v.queues["q2"].empty_change.receive
+    when timeout(1.second)
+      fail "timeout: message not dead lettered?"
+    end
+
+    v.queues["q2"].basic_get(no_ack: true) do |env|
+      msg = env.message
+    end
+
+    msg.timestamp.should be > ts
   end
 end

--- a/spec/dlx_spec.cr
+++ b/spec/dlx_spec.cr
@@ -31,7 +31,7 @@ describe "Dead lettering" do
     end
   end
 
-  it "should update timestamp" do
+  it "should update message timestamp on publish" do
     v = Server.vhosts.create("test")
     q_args = AMQ::Protocol::Table.new({
       "x-message-ttl"             => 200,

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -639,7 +639,7 @@ module LavinMQ
 
     private def dead_letter_msg(msg : BytesMessage, props, dlx, dlrk)
       @log.debug { "Dead lettering ex=#{dlx} rk=#{dlrk} body_size=#{msg.bodysize} props=#{props}" }
-      @vhost.publish Message.new(msg.timestamp, dlx.to_s, dlrk.to_s,
+      @vhost.publish Message.new(RoughTime.unix_ms, dlx.to_s, dlrk.to_s,
         props, msg.bodysize, IO::Memory.new(msg.body))
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

When a message was dead letter the timestamp wasn't updated. This caused TTL to misbehave if a message was dead lettered to another queue with TTL:

1. Declare queue `q1` with `x-message-ttl = 100` and `x-dead-letter-routing-key = q2`
2. Declare queue `q2` with `x-message-ttl = 100` and `x-dead-letter-routing-key = q3`
3. Publish message to `q1`.

After 100ms the message is dead lettered to `q2` (via default exchange). Because the message timestamp isn't updated the message will expire immediately in `q2` and dead lettered to `q3`.

This PR will fix this by setting a new timestamp on the message when it's published by the dead lettering.

### HOW can this pull request be tested?
Run specs
