### PR TITLE
Dont update password hash if given current password

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -27,6 +27,9 @@ Lint/NotNil:
   Enabled: true
   Severity: Warning
 
+Lint/DocumentationAdmonition:
+  Enabled: false
+
 # Problems found: 2
 # Run `ameba --only Metrics/CyclomaticComplexity` for details
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't update user's password hash if given password is the same as current [#586](https://github.com/cloudamqp/lavinmq/pull/586)
+
 ## [1.2.5] - 2023-11-06
 
 ### Added

--- a/spec/users_spec.cr
+++ b/spec/users_spec.cr
@@ -1,5 +1,23 @@
 require "./spec_helper"
 
+describe LavinMQ::User do
+  describe "#update_password" do
+    it "should not update password hash when given same password as current" do
+      u = LavinMQ::User.create("username", "password", "sha256", [] of LavinMQ::Tag)
+      password_hash_before = u.password
+      u.update_password("password")
+      u.password.should eq password_hash_before
+    end
+
+    it "should update password hash when given other password than current" do
+      u = LavinMQ::User.create("username", "password", "sha256", [] of LavinMQ::Tag)
+      password_hash_before = u.password
+      u.update_password("other")
+      u.password.should_not eq password_hash_before
+    end
+  end
+end
+
 describe LavinMQ::Server do
   it "rejects invalid password" do
     expect_raises(AMQP::Client::Connection::ClosedException) do

--- a/src/lavinmq/user.cr
+++ b/src/lavinmq/user.cr
@@ -109,6 +109,7 @@ module LavinMQ
     end
 
     def update_password(password, hash_algorithm = "sha256")
+      return if @password.try &.verify(password)
       @password = User.hash_password(password, hash_algorithm)
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
If a user was updated with the same password as it currently has, the password hash was updated resulting in the definitions to change. This prevents efficient backup and caching of definitions, since they look changed even though they really aren't. 

### HOW can this pull request be tested?
Run specs.
