### PR TITLE
Federation links should use downstream queue name

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -277,4 +277,22 @@ describe LavinMQ::Federation::Upstream do
       upstream_q.bindings.size.should eq 0
     end
   end
+
+  describe "@queue nil" do
+    describe "#link(Queue)" do
+      it "should create link that consumes upstream queue with same name as downstream queue" do
+        vhost = Server.vhosts["/"]
+
+        vhost.declare_queue("q1", true, false)
+        vhost.declare_queue("q2", true, false)
+
+        upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", nil, nil)
+        link1 = upstream.link(vhost.queues["q1"])
+        link2 = upstream.link(vhost.queues["q2"])
+
+        link1.@upstream_q.should eq "q1"
+        link2.@upstream_q.should eq "q2"
+      end
+    end
+  end
 end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -278,7 +278,7 @@ describe LavinMQ::Federation::Upstream do
     end
   end
 
-  describe "@queue nil" do
+  describe "when @queue is nil" do
     describe "#link(Queue)" do
       it "should create link that consumes upstream queue with same name as downstream queue" do
         vhost = Server.vhosts["/"]

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -80,7 +80,7 @@ module LavinMQ
         end
         upstream_q = @queue
         if upstream_q.nil? || upstream_q.empty?
-          upstream_q = @queue = federated_q.name
+          upstream_q = federated_q.name
         end
         link = QueueLink.new(self, federated_q, upstream_q)
         @q_links[federated_q.name] = link


### PR DESCRIPTION
### WHAT is this pull request doing?
#562 introduced a bug, making all links to use the same upstream queue name.
This PR fixes that.

### HOW can this pull request be tested?
Run specs
