### PR TITLE
filter out unsupported policies

### DIFF
--- a/src/lavinmq/policy.cr
+++ b/src/lavinmq/policy.cr
@@ -10,10 +10,10 @@ module LavinMQ
   end
 
   class Policy
-    SUPPORTED_POLICIES = ["max-length", "max-length-bytes", "message-ttl", "expires", "overflow",
+    SUPPORTED_POLICIES = {"max-length", "max-length-bytes", "message-ttl", "expires", "overflow",
                           "dead-letter-exchange", "dead-letter-routing-key", "federation-upstream",
                           "federation-upstream-set", "delivery-limit", "max-age",
-                          "alternate-exchange", "delayed-message"]
+                          "alternate-exchange", "delayed-message"}
     enum Target
       All
       Queues

--- a/src/lavinmq/policy.cr
+++ b/src/lavinmq/policy.cr
@@ -10,6 +10,10 @@ module LavinMQ
   end
 
   class Policy
+    SUPPORTED_POLICIES = ["max-length", "max-length-bytes", "message-ttl", "expires", "overflow",
+                          "dead-letter-exchange", "dead-letter-routing-key", "federation-upstream",
+                          "federation-upstream-set", "delivery-limit", "max-age",
+                          "alternate-exchange", "delayed-message"]
     enum Target
       All
       Queues
@@ -67,15 +71,15 @@ module LavinMQ
           merged[k] = v
         end
       end
-      merged
+      merged.select { |key, _| SUPPORTED_POLICIES.includes?(key) }
     end
 
     def self.merge_definitions(p1 : Nil, p2 : Policy) : Hash(String, JSON::Any)
-      p2.definition
+      p2.definition.select { |key, _| SUPPORTED_POLICIES.includes?(key) }
     end
 
     def self.merge_definitions(p1 : Policy, p2 : Nil) : Hash(String, JSON::Any)
-      p1.definition
+      p1.definition.select { |key, _| SUPPORTED_POLICIES.includes?(key) }
     end
 
     def self.merge_definitions(p1 : Nil, p2 : Nil) : Hash(String, JSON::Any)


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds an array `SUPPORTED_POLICIES` and filters on it `Policy`'s `merge_definitions`

### HOW can this pull request be tested?
try and add an unsupported policy, eg. HA policy, and view the effective policy definition on the queue 