### PR TITLE
Ameba rule updates

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -27,7 +27,7 @@ Lint/NotNil:
   Enabled: true
   Severity: Warning
 
-Lint/DocumentationAdmonition:
+Documentation/DocumentationAdmonition:
   Enabled: false
 
 # Problems found: 2

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -32,6 +32,8 @@ Documentation/DocumentationAdmonition:
 
 Naming/BlockParameterName:
   AllowedNames: [_, e, i, j, k, v, x, y, ex, io, ws, op, tx, id, ip, k1, k2, v1, v2, ch, q]
+  Excluded:
+  - spec
 
 # Problems found: 2
 # Run `ameba --only Metrics/CyclomaticComplexity` for details

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -30,6 +30,9 @@ Lint/NotNil:
 Documentation/DocumentationAdmonition:
   Enabled: false
 
+Naming/BlockParameterName:
+  AllowedNames: [_, e, i, j, k, v, x, y, ex, io, ws, op, tx, id, ip, k1, k2, v1, v2, ch, q]
+
 # Problems found: 2
 # Run `ameba --only Metrics/CyclomaticComplexity` for details
 Metrics/CyclomaticComplexity:


### PR DESCRIPTION
Update our ameba exceptions to match latest ameba:

- `DocumentationAdmonition` had moved from `Lint` to `Documentation`
- `Naming/BlockParameterName` has been introduced. Added `ch` and `q` as allowed parameter names as I think that makes sense in lavinmq.