### PR TITLE
only log if the permission is changed

### DIFF
--- a/src/lavinmq/user_store.cr
+++ b/src/lavinmq/user_store.cr
@@ -45,9 +45,11 @@ module LavinMQ
 
     def add_permission(user, vhost, config, read, write)
       perm = {config: config, read: read, write: write}
+      unless perm == @users[user].permissions[vhost]
+        Log.info { "Updated permissions for user=#{user} on vhost=#{vhost}" }
+      end
       @users[user].permissions[vhost] = perm
       @users[user].invalidate_acl_caches
-      Log.info { "Updated permissions for user=#{user} on vhost=#{vhost}" }
       save!
       perm
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
Don't log thet the permission is updated if the permission is the same that we already have. 
I tried opting for an early return.. but it looks like we do this on launch, and if we don't have a default user we can't create one. 

Oskar also gave his two cents, and makes the case that we could change these permissions updates in ssh-monitor.. and hat we should log because we do the update. 

### HOW can this pull request be tested?
try to update permissions without changing them