### PR TITLE
Drop overflow in loop for stream_queue to make sure max-age is respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't update user's password hash if given password is the same as current [#586](https://github.com/cloudamqp/lavinmq/pull/586)
+- Remove old segments in the background for stream queues [#608](https://github.com/cloudamqp/lavinmq/pull/608)
 
 ## [1.2.5] - 2023-11-06
 

--- a/src/lavinmq/queue/stream_queue.cr
+++ b/src/lavinmq/queue/stream_queue.cr
@@ -161,9 +161,9 @@ module LavinMQ
         end
       end
       @msg_store_lock.synchronize do
+        stream_queue_msg_store.drop_overflow
         stream_queue_msg_store.unmap_segments(except: used_segments)
       end
-      stream_queue_msg_store.drop_overflow
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?

Replaces `unmap_unused_segments_loop` with `unmap_and_remove_segments_loop`. The new function also removes segments from stream queues where all messages are past max-age. 

### HOW can this pull request be tested?

Create a stream queue with max-age (ex. 60s). 
Publish more messages than fits in one segment file. 
Wait the max-age to pass and for the loop to run.
Check that the older segment file has been deleted.
