### PR TITLE
CI: Fix/speed up macOS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
       - name: Install Crystal
         run: brew install crystal
         env:
-          HOMEBREW_NO_AUTO_UPDATE: 0
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
 
       - run: crystal --version
 


### PR DESCRIPTION
Setting `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` avoids triggering updates of other packages after crystal was installed. 

From the manual: 

> If set, do not check for broken linkage of dependents or outdated dependents after installing, upgrading or reinstalling formulae. This will result in fewer dependents (and their dependencies) being upgraded or reinstalled but may result in more breakage from running brew install formula or brew upgrade formula.

Seen at https://github.com/cloudamqp/lavinmq/actions/runs/7180316382/job/19552312371#step:2:81 "Upgrading 18 dependents of upgraded formulae"

Setting `HOMEBREW_NO_AUTO_UPDATE` to 1 makes no difference to having it set to 0, its applied whenever it is set, but 1 makes much more sense so you don't have to think about that. :)