### PR TITLE
send connection_information to amqp-client

### DIFF
--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -209,6 +209,11 @@ module LavinMQ
           @downstream_connection.try &.close
           upstream_uri = named_uri(@upstream.uri)
           local_uri = named_uri(@local_uri)
+          params = upstream_uri.query_params
+          pp "creating 3"
+          params["product"] = "LavinMQ"
+          params["product_version"] = LavinMQ::VERSION.to_s
+          upstream_uri.query = params.to_s
           ::AMQP::Client.start(upstream_uri) do |c|
             @upstream_connection = c
             ::AMQP::Client.start(local_uri) do |p|
@@ -301,7 +306,10 @@ module LavinMQ
         private def cleanup
           upstream_uri = @upstream.uri.dup
           params = upstream_uri.query_params
+          pp "creating 1"
           params["name"] ||= "Federation link cleanup: #{@upstream.name}/#{name}"
+          params["product"] = "LavinMQ"
+          params["product_version"] = LavinMQ::VERSION.to_s
           upstream_uri.query = params.to_s
           ::AMQP::Client.start(upstream_uri) do |c|
             ch = c.channel
@@ -353,6 +361,11 @@ module LavinMQ
           @downstream_connection.try &.close
           upstream_uri = named_uri(@upstream.uri)
           local_uri = named_uri(@local_uri)
+          params = upstream_uri.query_params
+          pp "creating 2"
+          params["product"] = "LavinMQ"
+          params["product_version"] = LavinMQ::VERSION.to_s
+          upstream_uri.query = params.to_s
           ::AMQP::Client.start(upstream_uri) do |c|
             @upstream_connection = c
             ::AMQP::Client.start(local_uri) do |p|

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -139,7 +139,7 @@ module LavinMQ
         private abstract def start_link
         private abstract def unregister_observer
 
-        protected def start_link_common
+        private def start_link_common(&)
           return if @state.terminated?
           @upstream_connection.try &.close
           @downstream_connection.try &.close

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -210,7 +210,6 @@ module LavinMQ
           upstream_uri = named_uri(@upstream.uri)
           local_uri = named_uri(@local_uri)
           params = upstream_uri.query_params
-          pp "creating 3"
           params["product"] = "LavinMQ"
           params["product_version"] = LavinMQ::VERSION.to_s
           upstream_uri.query = params.to_s
@@ -306,7 +305,6 @@ module LavinMQ
         private def cleanup
           upstream_uri = @upstream.uri.dup
           params = upstream_uri.query_params
-          pp "creating 1"
           params["name"] ||= "Federation link cleanup: #{@upstream.name}/#{name}"
           params["product"] = "LavinMQ"
           params["product_version"] = LavinMQ::VERSION.to_s
@@ -362,7 +360,6 @@ module LavinMQ
           upstream_uri = named_uri(@upstream.uri)
           local_uri = named_uri(@local_uri)
           params = upstream_uri.query_params
-          pp "creating 2"
           params["product"] = "LavinMQ"
           params["product_version"] = LavinMQ::VERSION.to_s
           upstream_uri.query = params.to_s

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -139,6 +139,26 @@ module LavinMQ
         private abstract def start_link
         private abstract def unregister_observer
 
+
+        protected def start_link_common
+          return if @state.terminated?
+          @upstream_connection.try &.close
+          @downstream_connection.try &.close
+          upstream_uri = named_uri(@upstream.uri)
+          local_uri = named_uri(@local_uri)
+          params = upstream_uri.query_params
+          params["product"] = "LavinMQ"
+          params["product_version"] = LavinMQ::VERSION.to_s
+          upstream_uri.query = params.to_s
+          ::AMQP::Client.start(upstream_uri) do |c|
+            @upstream_connection = c
+            ::AMQP::Client.start(local_uri) do |p|
+              @downstream_connection = p
+              yield c, p
+            end
+          end
+        end
+
         enum State
           Starting
           Running
@@ -204,42 +224,29 @@ module LavinMQ
         end
 
         private def start_link
-          return if @state.terminated?
-          @upstream_connection.try &.close
-          @downstream_connection.try &.close
-          upstream_uri = named_uri(@upstream.uri)
-          local_uri = named_uri(@local_uri)
-          params = upstream_uri.query_params
-          params["product"] = "LavinMQ"
-          params["product_version"] = LavinMQ::VERSION.to_s
-          upstream_uri.query = params.to_s
-          ::AMQP::Client.start(upstream_uri) do |c|
-            @upstream_connection = c
-            ::AMQP::Client.start(local_uri) do |p|
-              @downstream_connection = p
-              cch, q = setup_queue(c)
-              cch.prefetch(count: @upstream.prefetch)
-              pch = p.channel
-              pch.confirm_select if @upstream.ack_mode.on_confirm?
-              no_ack = @upstream.ack_mode.no_ack?
-              state(State::Running)
-              unless @federated_q.immediate_delivery?
-                @log.debug { "Waiting for consumers" }
-                @consumer_available.receive?
-              end
-              q_name = q[:queue_name]
-              cch.basic_consume(q_name, no_ack: no_ack, tag: @upstream.consumer_tag, block: true) do |msg|
-                @last_changed = RoughTime.unix_ms
-                headers, received_from = received_from_header(msg)
-                received_from << ::AMQP::Client::Arguments.new({
-                  "uri"         => @scrubbed_uri,
-                  "queue"       => q_name,
-                  "redelivered" => msg.redelivered,
-                })
-                headers["x-received-from"] = received_from
-                msg.properties.headers = headers
-                federate(msg, pch, cch.not_nil!, EXCHANGE, @federated_q.name)
-              end
+          start_link_common do |c, p|
+            cch, q = setup_queue(c)
+            cch.prefetch(count: @upstream.prefetch)
+            pch = p.channel
+            pch.confirm_select if @upstream.ack_mode.on_confirm?
+            no_ack = @upstream.ack_mode.no_ack?
+            state(State::Running)
+            unless @federated_q.immediate_delivery?
+              @log.debug { "Waiting for consumers" }
+              @consumer_available.receive?
+            end
+            q_name = q[:queue_name]
+            cch.basic_consume(q_name, no_ack: no_ack, tag: @upstream.consumer_tag, block: true) do |msg|
+              @last_changed = RoughTime.unix_ms
+              headers, received_from = received_from_header(msg)
+              received_from << ::AMQP::Client::Arguments.new({
+                "uri"         => @scrubbed_uri,
+                "queue"       => q_name,
+                "redelivered" => msg.redelivered,
+              })
+              headers["x-received-from"] = received_from
+              msg.properties.headers = headers
+              federate(msg, pch, cch.not_nil!, EXCHANGE, @federated_q.name)
             end
           end
         end
@@ -354,41 +361,27 @@ module LavinMQ
         end
 
         private def start_link
-          return if @state.terminated?
-          @upstream_connection.try &.close
-          @downstream_connection.try &.close
-          upstream_uri = named_uri(@upstream.uri)
-          local_uri = named_uri(@local_uri)
-          params = upstream_uri.query_params
-          params["product"] = "LavinMQ"
-          params["product_version"] = LavinMQ::VERSION.to_s
-          upstream_uri.query = params.to_s
-          ::AMQP::Client.start(upstream_uri) do |c|
-            @upstream_connection = c
-            ::AMQP::Client.start(local_uri) do |p|
-              @downstream_connection = p
-              cch, @consumer_q = setup(c)
-              cch.prefetch(count: @upstream.prefetch)
-              pch = p.channel
-              pch.confirm_select if @upstream.ack_mode.on_confirm?
-              no_ack = @upstream.ack_mode.no_ack?
-              state(State::Running)
-
-              cch.basic_consume(@upstream_q, no_ack: no_ack, tag: @upstream.consumer_tag, block: true) do |msg|
-                @last_changed = RoughTime.unix_ms
-                headers, received_from = received_from_header(msg)
-                received_from << ::AMQP::Client::Arguments.new({
-                  "uri"         => @scrubbed_uri,
-                  "exchange"    => @upstream_exchange,
-                  "redelivered" => msg.redelivered,
-                })
-                headers["x-received-from"] = received_from
-                msg.properties.headers = headers
-                federate(msg, pch, cch.not_nil!, @federated_ex.name, msg.routing_key)
-              end
-            ensure
-              @consumer_q = nil
+          start_link_common do |c, p|
+            cch, @consumer_q = setup(c)
+            cch.prefetch(count: @upstream.prefetch)
+            pch = p.channel
+            pch.confirm_select if @upstream.ack_mode.on_confirm?
+            no_ack = @upstream.ack_mode.no_ack?
+            state(State::Running)
+            cch.basic_consume(@upstream_q, no_ack: no_ack, tag: @upstream.consumer_tag, block: true) do |msg|
+              @last_changed = RoughTime.unix_ms
+              headers, received_from = received_from_header(msg)
+              received_from << ::AMQP::Client::Arguments.new({
+                "uri"         => @scrubbed_uri,
+                "exchange"    => @upstream_exchange,
+                "redelivered" => msg.redelivered,
+              })
+              headers["x-received-from"] = received_from
+              msg.properties.headers = headers
+              federate(msg, pch, cch.not_nil!, @federated_ex.name, msg.routing_key)
             end
+          ensure
+            @consumer_q = nil
           end
         end
       end

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -139,7 +139,6 @@ module LavinMQ
         private abstract def start_link
         private abstract def unregister_observer
 
-
         protected def start_link_common
           return if @state.terminated?
           @upstream_connection.try &.close

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -144,14 +144,13 @@ module LavinMQ
           @upstream_connection.try &.close
           @downstream_connection.try &.close
           upstream_uri = named_uri(@upstream.uri)
-          local_uri = named_uri(@local_uri)
           params = upstream_uri.query_params
           params["product"] = "LavinMQ"
           params["product_version"] = LavinMQ::VERSION.to_s
           upstream_uri.query = params.to_s
           ::AMQP::Client.start(upstream_uri) do |c|
             @upstream_connection = c
-            ::AMQP::Client.start(local_uri) do |p|
+            ::AMQP::Client.start(named_uri(@local_uri)) do |p|
               @downstream_connection = p
               yield c, p
             end

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -31,9 +31,20 @@ function updateConnection (all) {
       const cp = item.client_properties
       document.getElementById('cp-name').textContent = cp.connection_name
       document.getElementById('cp-capabilities').textContent = DOM.jsonToText(cp.capabilities)
-      document.getElementById('cp-product').textContent = cp.product
-      document.getElementById('cp-platform').textContent = cp.platform
-      document.getElementById('cp-version').textContent = cp.version
+      if (cp.product_version) {
+        document.getElementById('cp-product').appendChild(document.createElement('span')).textContent = cp.product
+        document.getElementById('cp-product').appendChild(document.createElement('br'))
+        document.getElementById('cp-product').appendChild(document.createElement('small')).textContent = 'Verison: ' + cp.product_version
+      } else {
+        document.getElementById('cp-product').textContent = cp.product
+      }
+      if (cp.platform_version) {
+        document.getElementById('cp-platform').appendChild(document.createElement('span')).textContent = cp.platform
+        document.getElementById('cp-platform').appendChild(document.createElement('br'))
+        document.getElementById('cp-platform').appendChild(document.createElement('small')).textContent = 'Verison: ' + cp.platform_version
+      } else {
+        document.getElementById('cp-platform').textContent = cp.platform
+      }
       const infoEl = document.getElementById('cp-information')
       if (cp.information && cp.information.startsWith('http')) {
         const infoLink = document.createElement('a')

--- a/views/connection.ecr
+++ b/views/connection.ecr
@@ -61,10 +61,6 @@
             <td id="cp-platform"></td>
           </tr>
           <tr>
-            <th>Version</th>
-            <td id="cp-version"></td>
-          </tr>
-          <tr>
             <th>Information</th>
             <td id="cp-information"></td>
           </tr>


### PR DESCRIPTION
### WHAT is this pull request doing?
Cannot be merged until [#39](https://github.com/cloudamqp/amqp-client.cr/pull/39) is released. 

With this PR we send in connection information 
` product: "LavinMQ", platform: "Crystal", product_version: LavinMQ::VERSION, platform_version: Crystal::VERSION `

to amqp-client, in order for us to be able to have more accurate connection information displayed for federation connections.  

Also: does a little refactor on `start_link`, to dry out some of the code repeated in both `QueueLink` and `ExchangeLink`

### HOW can this pull request be tested?
pull down the amqp-client PR and create an override shards file, then start a federation to another broker and look at the connection information in the UI. 
