### PR TITLE
Prevent verifying schema version of a file to mmap it

### DIFF
--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -254,4 +254,12 @@ class MFile < IO
     @size = new_size.to_i64
     @pos = new_size.to_i64 if @pos > new_size
   end
+
+  # Read from a specific position in the file
+  # but without mapping the whole file, it uses `pread`
+  def read_at(pos, bytes)
+    cnt = LibC.pread(@fd, bytes, bytes.bytesize, pos)
+    raise IO::Error.from_errno("pread") if cnt == -1
+    cnt
+  end
 end

--- a/src/lavinmq/schema.cr
+++ b/src/lavinmq/schema.cr
@@ -278,8 +278,18 @@ module LavinMQ
       index:      4,
     }
 
-    def self.verify(file, type) : Int32
+    def self.verify(file : File, type) : Int32
       version = file.read_bytes Int32
+      if version != VERSIONS[type]
+        raise OutdatedSchemaVersion.new version, file.path
+      end
+      version
+    end
+
+    def self.verify(file : MFile, type) : Int32
+      buf = uninitialized UInt8[4]
+      file.read_at(0, buf.to_slice)
+      version = IO::ByteFormat::SystemEndian.decode(Int32, buf.to_slice)
       if version != VERSIONS[type]
         raise OutdatedSchemaVersion.new version, file.path
       end


### PR DESCRIPTION
Before the whole file was mmap:ed for just reading the first four bytes, causing high memory usage.