### PR TITLE
Use persisted sorting/query information when loading table

### DIFF
--- a/static/js/datasource.js
+++ b/static/js/datasource.js
@@ -75,9 +75,8 @@ class DataSource {
         } catch (e) {
           console.error(`Failed to load cached query state: ${e}`, cachedState)
         }
-      } else {
-        this._setStateFromHash()
       }
+      this._setStateFromHash()
       window.addEventListener('hashchange', evt => {
         this._setStateFromHash()
         this.reload({ updateState: false })
@@ -86,8 +85,10 @@ class DataSource {
   }
 
   _setStateFromHash () {
-    const urlParams = Object.fromEntries(new URLSearchParams(window.location.hash.substring(1)).entries())
-    this._setState(urlParams)
+    if (window.location.hash.length > 0) {
+      const urlParams = Object.fromEntries(new URLSearchParams(window.location.hash.substring(1)).entries())
+      this._setState(urlParams)
+    }
   }
 
   _setState (properties = {}) {

--- a/static/js/datasource.js
+++ b/static/js/datasource.js
@@ -75,8 +75,9 @@ class DataSource {
         } catch (e) {
           console.error(`Failed to load cached query state: ${e}`, cachedState)
         }
+      } else {
+        this._setStateFromHash()
       }
-      this._setStateFromHash()
       window.addEventListener('hashchange', evt => {
         this._setStateFromHash()
         this.reload({ updateState: false })

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -112,8 +112,8 @@ function renderTable (id, options = {}, renderRow) {
     container.addEventListener('keyup', e => {
       if (!e.target.classList.contains('filter-table')) return true
       if (e.key === 'Enter') {
-        dataSource.reset()
         dataSource.searchTerm = e.target.value
+        dataSource.page = 1
         reload()
       }
     })


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes #599

### HOW can this pull request be tested?

Open a table view, eg queues, sort on eg. ready msgs, click on the Queue menu item again, the sorting should be the same. 
