### PR TITLE
Bugfix: Dont include permissions on users array when exporting definitions

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -214,7 +214,9 @@ describe LavinMQ::HTTP::Server do
       body = JSON.parse(response.body)
       body["users"].as_a.empty?.should be_false
       keys = ["name", "password_hash", "hashing_algorithm"]
+      bad_keys = ["permissions"]
       body["users"].as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      body["users"].as_a.each { |v| bad_keys.each { |k| v.as_h.keys.should_not contain(k) } }
     end
 
     it "exports vhosts" do

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -334,6 +334,19 @@ module LavinMQ
             end
           end
         end
+
+        private def export_users(json)
+          json.array do
+            @amqp_server.users.each_value.reject(&.hidden?).each do |u|
+              {
+                "hashing_algorithm": u.user_details["hashing_algorithm"],
+                "name":              u.name,
+                "password_hash":     u.user_details["password_hash"],
+                "tags":              u.tags,
+              }.to_json(json)
+            end
+          end
+        end
       end
 
       class VHostDefinitions < Definitions
@@ -387,7 +400,7 @@ module LavinMQ
           JSON.build(response) do |json|
             json.object do
               json.field("lavinmq_version", LavinMQ::VERSION)
-              json.field("users", @amqp_server.users.values.reject(&.hidden?))
+              json.field("users") { export_users(json) }
               json.field("vhosts", @amqp_server.vhosts)
               json.field("permissions") { export_permissions(json) }
               json.field("queues") { export_queues(json) }


### PR DESCRIPTION
### WHAT is this pull request doing?

RabbitMQ will not import LavinMQ definitions that include permissions in the users array. 

### HOW can this pull request be tested?

- Run spec
- Export LavinMQ definitions, import to RabbitMQ

