### PR TITLE
Use DirectDispatcher for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Build binaries and container images using Crystal 1.11.0
 - Don't allow clients open an already open channel
+- Use DirectDispatcher for logging and add more logging to startup procedure [#619](https://github.com/cloudamqp/lavinmq/pull/619)
 
 ### Added
 

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -84,7 +84,7 @@ module LavinMQ
       backend = if ENV.has_key?("JOURNAL_STREAM")
                   ::Log::IOBackend.new(io: log_file, formatter: JournalLogFormat, dispatcher: ::Log::DirectDispatcher)
                 else
-                  ::Log::IOBackend.new(io: log_file, formatter: StdoutLogFormat)
+                  ::Log::IOBackend.new(io: log_file, formatter: StdoutLogFormat, dispatcher: ::Log::DirectDispatcher)
                 end
 
       broadcast_backend.append(backend, @config.log_level)

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -82,7 +82,7 @@ module LavinMQ
       log_file = (path = @config.log_file) ? File.open(path, "a") : STDOUT
       broadcast_backend = ::Log::BroadcastBackend.new
       backend = if ENV.has_key?("JOURNAL_STREAM")
-                  ::Log::IOBackend.new(io: log_file, formatter: JournalLogFormat)
+                  ::Log::IOBackend.new(io: log_file, formatter: JournalLogFormat, dispatcher: ::Log::DirectDispatcher)
                 else
                   ::Log::IOBackend.new(io: log_file, formatter: StdoutLogFormat)
                 end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -284,7 +284,7 @@ module LavinMQ
             end
             @replicator.try &.register_file(file)
           end
-          log_progress_and_yield("Loading acks (#{count}/#{ack_files})") if (count += 1) % 100 == 0
+          log_progress_and_yield("Loading acks (#{count}/#{ack_files})") if (count += 1) % 128 == 0
           @deleted[seg] = acked.sort! unless acked.empty?
         end
       end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -289,7 +289,6 @@ module LavinMQ
       end
 
       private def load_segments_from_disk : Nil
-        log_progress_and_yield("Loading msg files")
         ids = Array(UInt32).new
         Dir.each_child(@data_dir) do |f|
           if f.starts_with? "msgs."

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -266,7 +266,7 @@ module LavinMQ
 
       private def load_deleted_from_disk
         count = 0
-        ack_files = Dir.entries(@data_dir).reject { |f| f.starts_with?("msgs")}.size
+        ack_files = Dir.entries(@data_dir).reject { |f| f.starts_with?("msgs") }.size
         Dir.each_child(@data_dir) do |child|
           next unless child.starts_with? "acks."
           seg = child[5, 10].to_u32

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -266,7 +266,7 @@ module LavinMQ
 
       private def load_deleted_from_disk
         count = 0
-        ack_files = Dir.entries(@data_dir).reject { |f| f.starts_with?("msgs") }.size
+        ack_files = Dir.each(@data_dir).count { |f| f.starts_with?("acks.") }
         Dir.each_child(@data_dir) do |child|
           next unless child.starts_with? "acks."
           seg = child[5, 10].to_u32

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -366,7 +366,6 @@ module LavinMQ
             end
             mfile.delete.close
             @replicator.try &.delete_file(mfile.path)
-
             true
           end
         end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -266,6 +266,7 @@ module LavinMQ
 
       private def load_deleted_from_disk
         count = 0
+        ack_files = Dir.entries(@data_dir).reject { |f| f.starts_with?("msgs")}.size
         Dir.each_child(@data_dir) do |child|
           next unless child.starts_with? "acks."
           seg = child[5, 10].to_u32
@@ -283,7 +284,7 @@ module LavinMQ
             end
             @replicator.try &.register_file(file)
           end
-          log_progress_and_yield("Loading acks...") if (count += 1) % 100 == 0
+          log_progress_and_yield("Loading acks (#{count}/#{ack_files})") if (count += 1) % 100 == 0
           @deleted[seg] = acked.sort! unless acked.empty?
         end
       end
@@ -340,7 +341,7 @@ module LavinMQ
           end
           mfile.pos = 4
           mfile.unmap # will be mmap on demand
-          log_progress_and_yield("Loading stats...") if (counter += 1) % 100 == 0
+          log_progress_and_yield("Loading stats (#{counter}/#{@segments.size})") if (counter += 1) % 100 == 0
           @segment_msg_count[seg] = count
         end
       end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -348,6 +348,7 @@ module LavinMQ
 
       private def delete_unused_segments : Nil
         current_seg = @segments.last_key
+        count = 0
         @segments.reject! do |seg, mfile|
           next if seg == current_seg # don't the delete the segment still being written to
 
@@ -361,6 +362,9 @@ module LavinMQ
             end
             mfile.delete.close
             @replicator.try &.delete_file(mfile.path)
+
+            count += 1
+            Fiber.yield if (count % 5).zero?
             true
           end
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
Sets up DirectDispatcher for logging so we always log directly, without manually having to yield Fibers. 

Also adds more logging to the startup procedure, making it more verbose.

Relates to the bug that was fixed in https://github.com/cloudamqp/lavinmq/pull/565

https://trello.com/c/FUxNAzYu/402-no-logs-during-startup

### HOW can this pull request be tested?

Manual for now