### PR TITLE
Bugfix: crash during startup because of missing 'x-delayed-type'

### DIFF
--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -644,6 +644,7 @@ module LavinMQ
       when "headers"
         HeadersExchange.new(vhost, name, durable, auto_delete, internal, arguments)
       when "x-delayed-message"
+        arguments = arguments.clone
         type = arguments.delete("x-delayed-type")
         raise Error::ExchangeTypeError.new("Missing required argument 'x-delayed-type'") unless type
         arguments["x-delayed-exchange"] = true


### PR DESCRIPTION
### WHAT is this pull request doing?

If a delayed exchange was declared with `type=x-delayed-message` and `arguments={x-delayed-type: '…'}` and LavinMQ crashed before definitions has been compacted, it couldn't start again because of:
`Unhandled exception: Missing required argument 'x-delayed-type' (LavinMQ::Error::ExchangeTypeError)`

In LavinMQ any exchange can be delayed by specifiy `x-delayed-exchange: true` in exchange arguments, and declare frames with `type=x-delayed-message` was converted to `type=<value of x-delayed-type>` with `arguments={x-delayed-exchange: true}`. However, the original frame was stored to the definition file, but with modified arguments causing the crash on startup, i.e. the frame had `type=x-delayed-message` but no `x-delayed-type` in the arguments table.

This change will make sure to clone the arguments table before modifying it.

### HOW can this pull request be tested?
Specs, or run lavinmq and declare a delayed exchange with `type=x-delayed-message` then kill -9 lavinmq and try start it.
