### PR TITLE
Add more logging when loading definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep the same vhost selected when creating queues [#629](https://github.com/cloudamqp/lavinmq/pull/629)
 - Make sure name of Queues, Exchanges & Vhosts is not longer than 255 characters [#631](https://github.com/cloudamqp/lavinmq/pull/631)
 
+### Added
+
+- Improved logging during definitions loading [#621](https://github.com/cloudamqp/lavinmq/pull/621)
+
 ## [1.2.9] - 2024-02-05
 
 ### Fixed

--- a/src/lavinmq/error.cr
+++ b/src/lavinmq/error.cr
@@ -15,5 +15,8 @@ module LavinMQ
 
     class ExchangeTypeError < Error
     end
+
+    class InvalidDefinitions < Error
+    end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
If something failed during definitions loading it was hard to debug because the lack of logs. This will add more logging.

E.g. the bug that #620 fixes would have been much easier to find with this logging.

### HOW can this pull request be tested?
Create a bunch of queues, exchanges and bindings and restart LavibMQ. Use log level `trace` to see all logs.
