### PR TITLE
SystemD.notify_ready when starting as follower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- LavinMQ now calls Systemd.notify_ready when started as follower [#626](https://github.com/cloudamqp/lavinmq/pull/626)
+
 ## [1.2.8] - 2024-01-10
 
 ### Fixed

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -69,6 +69,7 @@ module LavinMQ
         set_socket_opts
         sync_files(notify_in_sync)
         Log.info { "Synchronised" }
+        SystemD.notify_ready
       end
 
       private def set_socket_opts(socket = @socket)

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -44,6 +44,7 @@ module LavinMQ
       end
 
       def follow(host, port)
+        SystemD.notify_ready
         loop do
           sync(host, port, notify_in_sync: true)
           Log.info { "Streaming changes" }
@@ -62,7 +63,6 @@ module LavinMQ
       end
 
       def sync(host, port, notify_in_sync = false)
-        SystemD.notify_ready
         @socket.connect(host, port)
         Log.info { "Connected" }
         authenticate

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -62,6 +62,7 @@ module LavinMQ
       end
 
       def sync(host, port, notify_in_sync = false)
+        SystemD.notify_ready
         @socket.connect(host, port)
         Log.info { "Connected" }
         authenticate
@@ -69,7 +70,6 @@ module LavinMQ
         set_socket_opts
         sync_files(notify_in_sync)
         Log.info { "Synchronised" }
-        SystemD.notify_ready
       end
 
       private def set_socket_opts(socket = @socket)


### PR DESCRIPTION
### WHAT is this pull request doing?
Sends SystemD.notify_ready when starting LavinMQ as follower, so systemd knows the service has finished activating. 

### HOW can this pull request be tested?
Start LavinMQ as a service as a follower
