### PR TITLE
Truncate shovel name if too long

### DIFF
--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -258,7 +258,7 @@ document.querySelector('#moveMessages').addEventListener('submit', function (evt
   const password = Auth.getPassword()
   const uri = 'amqp://' + encodeURIComponent(username) + ':' + encodeURIComponent(password) + '@localhost/' + urlEncodedVhost
   const dest = document.querySelector('[name=shovel-destination]').value.trim()
-  const name = ('Move ' + queue + ' to ' + dest).substring(0,240) // max length of shovel name is 255
+  const name = ('Move ' + queue + ' to ' + dest).substring(0, 240) // max length of shovel name is 255
   const url = 'api/parameters/shovel/' + urlEncodedVhost + '/' + encodeURIComponent(name)
   const body = {
     name,

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -258,7 +258,7 @@ document.querySelector('#moveMessages').addEventListener('submit', function (evt
   const password = Auth.getPassword()
   const uri = 'amqp://' + encodeURIComponent(username) + ':' + encodeURIComponent(password) + '@localhost/' + urlEncodedVhost
   const dest = document.querySelector('[name=shovel-destination]').value.trim()
-  const name = 'Move ' + queue + ' to ' + dest
+  const name = ('Move ' + queue + ' to ' + dest).substring(0,240) // max length of shovel name is 255
   const url = 'api/parameters/shovel/' + urlEncodedVhost + '/' + encodeURIComponent(name)
   const body = {
     name,


### PR DESCRIPTION
### WHAT is this pull request doing?
If queue1_name + queue2_name is longer than 255 characters, then moving messages between them will create a shovel with a name longer than 255 characters, which is not allowed. This truncates the shovel name to less then 255 characters. 

### HOW can this pull request be tested?

Manual - create two queues with long names, move messages between them. 
