### PR TITLE
Keep the same vhost selected when creating queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Truncate long shovel names [#627](https://github.com/cloudamqp/lavinmq/pull/627)
+- Keep the same vhost selected when creating queues [#629](https://github.com/cloudamqp/lavinmq/pull/629)
 
 ## [1.2.9] - 2024-02-05
 

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -129,6 +129,7 @@ document.querySelector('#declare').addEventListener('submit', function (evt) {
       if (response?.is_error) { return }
       queuesTable.reload()
       evt.target.reset()
+      evt.target.querySelector('select[name="vhost"]').value = decodeURIComponent(vhost) // Keep selected vhost selected
       Dom.toast('Queue ' + queue + ' created')
     })
 })


### PR DESCRIPTION
### WHAT is this pull request doing?
Keeps the vhost field the same after creating a queue instead of defaulting to /
Makes it a little easier to create multiple queues. 

https://trello.com/c/UmpNY4F5/462-vhost-selection-on-create-queue-resets-when-creating-a-queue

### HOW can this pull request be tested?
Manual
