### PR TITLE
Make sure name of Queues, Exchanges and Vhosts is not longer than 255 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't use shovel name as consumer tag [#634](https://github.com/cloudamqp/lavinmq/pull/634)
 - Keep the same vhost selected when creating queues [#629](https://github.com/cloudamqp/lavinmq/pull/629)
+- Make sure name of Queues, Exchanges & Vhosts is not longer than 255 characters [#631](https://github.com/cloudamqp/lavinmq/pull/631)
 
 ## [1.2.9] - 2024-02-05
 

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -71,7 +71,7 @@ module LavinMQ
               context.response.status_code = 204
             elsif name.starts_with? "amq."
               bad_request(context, "Not allowed to use the amq. prefix")
-            elsif name.size > 255
+            elsif name.bytesize > UInt8::MAX
               bad_request(context, "Exchange name too long, can't exceed 255 characters")
             else
               @amqp_server.vhosts[vhost]

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -71,6 +71,8 @@ module LavinMQ
               context.response.status_code = 204
             elsif name.starts_with? "amq."
               bad_request(context, "Not allowed to use the amq. prefix")
+            elsif name.size > 255
+              bad_request(context, "Exchange name too long, can't exceed 255 characters")
             else
               @amqp_server.vhosts[vhost]
                 .declare_exchange(name, type.not_nil!, durable, auto_delete, internal, tbl)

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -73,6 +73,9 @@ module LavinMQ
             unless value
               bad_request(context, "Field 'value' is required")
             end
+            if name.size > 255
+              bad_request(context, "#{component} name too long, can't exceed 255 characters")
+            end
             p = Parameter.new(component, name, value)
             is_update = @amqp_server.vhosts[vhost].parameters[{component, name}]?
             @amqp_server.vhosts[vhost].add_parameter(p)

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -73,9 +73,6 @@ module LavinMQ
             unless value
               bad_request(context, "Field 'value' is required")
             end
-            if name.size > 255
-              bad_request(context, "#{component} name too long, can't exceed 255 characters")
-            end
             p = Parameter.new(component, name, value)
             is_update = @amqp_server.vhosts[vhost].parameters[{component, name}]?
             @amqp_server.vhosts[vhost].add_parameter(p)

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -64,7 +64,7 @@ module LavinMQ
               context.response.status_code = 204
             elsif name.starts_with? "amq."
               bad_request(context, "Not allowed to use the amq. prefix")
-            elsif name.size > 255
+            elsif name.bytesize > UInt8::MAX
               bad_request(context, "Queue name too long, can't exceed 255 characters")
             else
               begin

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -64,6 +64,8 @@ module LavinMQ
               context.response.status_code = 204
             elsif name.starts_with? "amq."
               bad_request(context, "Not allowed to use the amq. prefix")
+            elsif name.size > 255
+              bad_request(context, "Queue name too long, can't exceed 255 characters")
             else
               begin
                 @amqp_server.vhosts[vhost]

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -34,7 +34,7 @@ module LavinMQ
           refuse_unless_administrator(context, u)
           name = URI.decode_www_form(params["name"])
           is_update = @amqp_server.vhosts[name]?
-          if name.size > 255
+          if name.bytesize > UInt8::MAX
             bad_request(context, "Vhost name too long, can't exceed 255 characters")
           end
           @amqp_server.vhosts.create(name, u)

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -34,6 +34,9 @@ module LavinMQ
           refuse_unless_administrator(context, u)
           name = URI.decode_www_form(params["name"])
           is_update = @amqp_server.vhosts[name]?
+          if name.size > 255
+            bad_request(context, "Vhost name too long, can't exceed 255 characters")
+          end
           @amqp_server.vhosts.create(name, u)
           context.response.status_code = is_update ? 204 : 201
           context


### PR DESCRIPTION
### WHAT is this pull request doing?
Stops users from creating queues, vhosts and exchanges with names longer than 255 characters (short string)

### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
