### PR TITLE
Dont use shovel name as consumer tag

### DIFF
--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -422,7 +422,6 @@ describe LavinMQ::Shovel do
         Server.vhosts["/"].shovels.empty?.should be_true
       end
     end
-
   end
 
   describe "HTTP" do

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -398,20 +398,19 @@ describe LavinMQ::Shovel do
     it "should move messages between queues with long names" do
       long_prefix = "a" * 250
       source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
+        "#{long_prefix}q1",
         URI.parse(AMQP_BASE_URL),
         "#{long_prefix}q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
+        "#{long_prefix}q2",
         URI.parse(AMQP_BASE_URL),
         "#{long_prefix}q2",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
-      shovel_name = "Move #{long_prefix}q1 to #{long_prefix}q2"
       shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
       with_channel do |ch|
         q1, q2 = ShovelSpecHelpers.setup_qs ch, long_prefix

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -394,6 +394,36 @@ describe LavinMQ::Shovel do
         Server.vhosts["/"].shovels.empty?.should be_true
       end
     end
+
+    it "should move messages between queues with long names" do
+      long_prefix = "a" * 250
+      source = LavinMQ::Shovel::AMQPSource.new(
+        "spec",
+        URI.parse(AMQP_BASE_URL),
+        "#{long_prefix}q1",
+        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+        direct_user: Server.users.direct_user
+      )
+      dest = LavinMQ::Shovel::AMQPDestination.new(
+        "spec",
+        URI.parse(AMQP_BASE_URL),
+        "#{long_prefix}q2",
+        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+        direct_user: Server.users.direct_user
+      )
+      shovel_name = "Move #{long_prefix}q1 to #{long_prefix}q2"
+      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
+      with_channel do |ch|
+        q1, q2 = ShovelSpecHelpers.setup_qs ch, long_prefix
+        q1.publish_confirm "shovel me 1", "#{long_prefix}q1"
+        q1.publish_confirm "shovel me 2", "#{long_prefix}q1"
+        shovel.run
+        q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
+        q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
+        Server.vhosts["/"].shovels.empty?.should be_true
+      end
+    end
+
   end
 
   describe "HTTP" do

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -44,7 +44,7 @@ module LavinMQ
                      @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
                      @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
-        @tag = "Shovel-#{Random::Secure.urlsafe_base64(24)}"
+        @tag = "Shovel"
         cfg = Config.instance
         @uri.host ||= "#{cfg.amqp_bind}:#{cfg.amqp_port}"
         unless @uri.user

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -44,7 +44,7 @@ module LavinMQ
                      @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
                      @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
-        @tag = "Shovel[#{@name}]"
+        @tag = "Shovel-#{Random::Secure.urlsafe_base64(24)}"
         cfg = Config.instance
         @uri.host ||= "#{cfg.amqp_bind}:#{cfg.amqp_port}"
         unless @uri.user

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -258,7 +258,7 @@ document.querySelector('#moveMessages').addEventListener('submit', function (evt
   const password = Auth.getPassword()
   const uri = 'amqp://' + encodeURIComponent(username) + ':' + encodeURIComponent(password) + '@localhost/' + urlEncodedVhost
   const dest = document.querySelector('[name=shovel-destination]').value.trim()
-  const name = ('Move ' + queue + ' to ' + dest).substring(0, 240) // max length of shovel name is 255
+  const name = 'Move ' + queue + ' to ' + dest
   const url = 'api/parameters/shovel/' + urlEncodedVhost + '/' + encodeURIComponent(name)
   const body = {
     name,


### PR DESCRIPTION
### WHAT is this pull request doing?
Sets consumer tag for shovels to just `shovel` instead of using the shovel name, since that could be longer than 255 characters. 

Based on discussion in [#627](https://github.com/cloudamqp/lavinmq/pull/627)

### HOW can this pull request be tested?

Run spec
