### PR TITLE
Bugfix: federation queue link, dont transfer messages unless consumer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Follower lag is now based on bytes written to action queue instead of socket [#652](https://github.com/cloudamqp/lavinmq/pull/652)
 
+### Fixed
+- Federated queues now only transfers messages if there is a consumer on the downstream queue [#637](https://github.com/cloudamqp/lavinmq/pull/637)
+
 ## [1.2.11] - 2024-04-26
 
 ### Fixed

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -32,12 +32,10 @@ module UpstreamSpecHelpers
   end
 
   def self.cleanup_vhost(vhost_name)
-    begin
-      v = Server.vhosts[vhost_name]
-      Server.vhosts.delete(vhost_name)
-      wait_for { !(Dir.exists?(v.data_dir)) }
-    rescue KeyError
-    end
+    v = Server.vhosts[vhost_name]
+    Server.vhosts.delete(vhost_name)
+    wait_for { !(Dir.exists?(v.data_dir)) }
+  rescue KeyError
   end
 
   def self.cleanup_vhosts

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -284,7 +284,7 @@ describe LavinMQ::Federation::Upstream do
 
       sleep 1.seconds
       # resume consuming on downstream, both upstream and downstream should be empty
-      with_channel(vhost:"downstream") do |downstream_ch2|
+      with_channel(vhost: "downstream") do |downstream_ch2|
         msgs = Channel(String).new
         downstream_q2 = downstream_ch2.queue("downstream_q")
         downstream_q2.subscribe do |msg|

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -16,28 +16,29 @@ module UpstreamSpecHelpers
     wait_for { links.all?(&.state.terminated?) }
   end
 
-  def self.setup_ex_federation(upstream_name)
+  def self.setup_federation(upstream_name, exchange = nil, queue = nil)
     upstream_vhost = Server.vhosts.create("upstream")
     downstream_vhost = Server.vhosts.create("downstream")
     upstream = LavinMQ::Federation::Upstream.new(downstream_vhost, upstream_name,
-      "#{SpecHelper.amqp_base_url}/upstream", "upstream_ex")
+      "#{SpecHelper.amqp_base_url}/upstream", exchange, queue)
     downstream_vhost.upstreams.not_nil!.add(upstream)
     {upstream, upstream_vhost, downstream_vhost}
   end
 
-  def self.start_link(upstream)
+  def self.start_link(upstream, pattern = "downstream_ex", applies_to = "exchanges")
     definitions = {"federation-upstream" => JSON::Any.new(upstream.name)} of String => JSON::Any
-    upstream.vhost.add_policy("FE", "downstream_ex", "exchanges",
-      definitions, 12_i8)
+    upstream.vhost.add_policy("FE", pattern, applies_to, definitions, 12_i8)
+  end
+
+  def self.cleanup_vhost(vhost_name)
+    v = Server.vhosts[vhost_name]
+    Server.vhosts.delete(vhost_name)
+    wait_for { !(Dir.exists?(v.data_dir)) }
   end
 
   def self.cleanup_ex_federation
-    v1 = Server.vhosts["downstream"]
-    v2 = Server.vhosts["upstream"]
-    Server.vhosts.delete("downstream")
-    Server.vhosts.delete("upstream")
-
-    wait_for { !(Dir.exists?(v1.data_dir) || Dir.exists?(v2.data_dir)) }
+    cleanup_vhost("upstream")
+    cleanup_vhost("downstream")
   end
 end
 
@@ -143,7 +144,7 @@ describe LavinMQ::Federation::Upstream do
       end
       wait_for { msgs.size == 2 }
       msgs.size.should eq 2
-      vhost.queues["federation_q1"].message_count.should eq 0
+      wait_for { vhost.queues["federation_q1"].message_count == 0 }
     end
   end
 
@@ -182,7 +183,7 @@ describe LavinMQ::Federation::Upstream do
   end
 
   it "should federate exchange even with no downstream consumer" do
-    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_ex_federation("ef test upstream wo downstream")
+    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation("ef test upstream wo downstream", "upstream_ex")
     UpstreamSpecHelpers.start_link(upstream)
     Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
     Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
@@ -208,7 +209,7 @@ describe LavinMQ::Federation::Upstream do
   end
 
   it "should continue after upstream restart" do
-    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_ex_federation("ef test upstream restart")
+    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation("ef test upstream restart", "upstream_ex")
     UpstreamSpecHelpers.start_link(upstream)
     Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
     Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
@@ -243,10 +244,60 @@ describe LavinMQ::Federation::Upstream do
       end
     end
     upstream_vhost.queues.each_value.all?(&.empty?).should be_true
+    UpstreamSpecHelpers.cleanup_ex_federation
+  end
+
+  it "should not transfer messages unless downstream has consumer" do
+    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation("ef test upstream restart", nil, "upstream_q")
+    UpstreamSpecHelpers.start_link(upstream, "downstream_q", "queues")
+    Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
+    Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
+
+    with_channel(vhost: "upstream") do |upstream_ch|
+      upstream_q = upstream_ch.queue("upstream_q")
+      with_channel(vhost: "downstream") do |downstream_ch|
+        msgs = Channel(String).new
+        downstream_ch.exchange("downstream_ex", "topic")
+        downstream_q = downstream_ch.queue("downstream_q")
+        wait_for { downstream_vhost.queues["downstream_q"].policy.try(&.name) == "FE" }
+
+        # Assert setup is correct
+        wait_for { upstream.links.first?.try &.state.running? }
+
+        # publish a msg to upstream_q
+        upstream_q.publish "msg1"
+        downstream_q.subscribe do |msg|
+          msgs.send msg.body_io.to_s
+        end
+        msgs.receive.should eq "msg1"
+
+        sleep 1.seconds
+        downstream_ch.close
+
+        sleep 1.seconds
+        upstream_q.publish "msg2"
+
+        sleep 1.seconds
+        upstream_vhost.queues.each_value.all?(&.empty?).should be_false
+        downstream_vhost.queues.each_value.all?(&.empty?).should be_true
+      end
+
+      sleep 1.seconds
+      # resume consuming on downstream, both upstream and downstream should be empty
+      with_channel(vhost:"downstream") do |downstream_ch2|
+        msgs = Channel(String).new
+        downstream_q2 = downstream_ch2.queue("downstream_q")
+        downstream_q2.subscribe do |msg|
+          msgs.send msg.body_io.to_s
+        end
+        msgs.receive.should eq "msg2"
+      end
+    end
+    UpstreamSpecHelpers.cleanup_ex_federation
   end
 
   it "should reflect all bindings to upstream q" do
-    upstream, upstream_vhost, _ = UpstreamSpecHelpers.setup_ex_federation("ef test bindings")
+    upstream, upstream_vhost, _ = UpstreamSpecHelpers.setup_federation("ef test bindings", "upstream_ex")
     Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
     Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
 

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -339,7 +339,7 @@ describe LavinMQ::Federation::Upstream do
       end
       wait_for { messages_consumed == 1 }
       wait_for { Server.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
-      wait_for { Server.vhosts[us_vhost.name].queues[us_queue_name].message_count == message_count}
+      wait_for { Server.vhosts[us_vhost.name].queues[us_queue_name].message_count == message_count }
     end
 
     # make sure consumer is disconnected

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -332,7 +332,7 @@ describe LavinMQ::Federation::Upstream do
       wait_for { upstream.links.first?.try &.state.running? }
 
       messages_consumed = 0
-      downstream_q.subscribe(tag: "c") do |msg|
+      downstream_q.subscribe(tag: "c") do |_msg|
         messages_consumed += 1
         message_count -= 1
         downstream_q.unsubscribe("c")
@@ -349,7 +349,7 @@ describe LavinMQ::Federation::Upstream do
     with_channel(vhost: ds_vhost.name) do |downstream_ch|
       downstream_q = downstream_ch.queue(ds_queue_name)
       messages_consumed = 0
-      downstream_q.subscribe(tag: "c2") do |msg|
+      downstream_q.subscribe(tag: "c2") do |_msg|
         messages_consumed += 1
       end
       wait_for { Server.vhosts[us_vhost.name].queues[us_queue_name].message_count == 0 }

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -104,7 +104,7 @@ module LavinMQ
           status
         end
 
-        private def ack(delivery_tag, upstream_ch, close = false)
+        private def ack(delivery_tag, upstream_ch)
           return unless delivery_tag
           if ch = upstream_ch
             raise "Channel closed when acking" if ch.closed?
@@ -112,7 +112,7 @@ module LavinMQ
           end
         end
 
-        private def reject(delivery_tag, upstream_ch, close = false)
+        private def reject(delivery_tag, upstream_ch)
           return unless delivery_tag
           if ch = upstream_ch
             raise "Channel closed when rejecting" if ch.closed?

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -242,7 +242,6 @@ module LavinMQ
               headers["x-received-from"] = received_from
               msg.properties.headers = headers
 
-              # investigate use of consumers_empty_change?
               unless federate(msg, upstream_channel.not_nil!, EXCHANGE, @federated_q.name, true)
                 raise NoDownstreamConsumerError.new("Federate failed, no downstream consumer available")
               end

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -89,11 +89,14 @@ module LavinMQ
         end
 
         private def federate(msg, upstream_ch, exchange, routing_key, immediate = false)
+          @log.debug { "Federating routing_key=#{routing_key}" }
           status = @upstream.vhost.publish(
             Message.new(
               RoughTime.unix_ms, exchange, routing_key, msg.properties,
               msg.body_io.bytesize.to_u64, msg.body_io,
-            ), immediate)
+            ),
+            immediate
+          )
 
           if status
             ack(msg.delivery_tag, upstream_ch) if @upstream.ack_mode != AckMode::NoAck


### PR DESCRIPTION
### WHAT is this pull request doing?

Stops federation queue links from transferring messages unless there is an active consumer on the downstream. 
`federate` now publishes directly to vhost instead of using a client. This allows us to use the immediate flag to make sure we don't federate messages unless there is a consumer on the downstream queue. 


### HOW can this pull request be tested?
Run the specs