### PR TITLE
add nilguard for matching x-delayed-type argument

### DIFF
--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -96,7 +96,7 @@ module LavinMQ
         frame_args = frame_args.clone.merge!({"x-delayed-exchange": true})
         frame_args.delete("x-delayed-type")
       end
-      self.type == (delayed ? arguments["x-delayed-type"] : type) &&
+      self.type == (delayed ? arguments["x-delayed-type"]? : type) &&
         @durable == durable &&
         @auto_delete == auto_delete &&
         @internal == internal &&


### PR DESCRIPTION
### WHAT is this pull request doing?
If you try and redeclare a delayed exchange with no `x-delayed-type` argument, it will crash in `exchanges.cr`: `match?(frame)`

This pull request adds a nilguard for the argument check, and as a result, the `match` method will return false if there is no `x-delayed-type` argument and send a`Preconditioned Failed: Existing exchange 'my_delayed_exchange' declared with other arguments` instead of crashing. 

### HOW can this pull request be tested?
Declare a delayed exchange "my-delayed-exchange", with argument `{ "x-delayed-type" => "direct" }`, then try and declare the exchange again, but with no `x-delayed-type` argument.  
