### PR TITLE
Nilguard delayed arguments

### DIFF
--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -77,7 +77,7 @@ describe LavinMQ::Exchange do
   describe "delayed message exchange declaration" do
     dmx_args = AMQP::Client::Arguments.new({"x-delayed-type" => "topic", "test" => "hello"})
     dmx_args2 = AMQP::Client::Arguments.new({"x-delayed-type" => "topic", "test" => "hello2"})
-    illegal_dmx_args = AMQP::Client::Arguments.new({ "test" => "hello" })
+    illegal_dmx_args = AMQP::Client::Arguments.new({"test" => "hello"})
 
     it "should declare delayed message exchange" do
       with_channel do |ch|

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -76,7 +76,6 @@ describe LavinMQ::Exchange do
 
   describe "delayed message exchange declaration" do
     dmx_args = AMQP::Client::Arguments.new({"x-delayed-type" => "topic", "test" => "hello"})
-    dmx_args2 = AMQP::Client::Arguments.new({"x-delayed-type" => "topic", "test" => "hello2"})
     illegal_dmx_args = AMQP::Client::Arguments.new({"test" => "hello"})
 
     it "should declare delayed message exchange" do
@@ -87,7 +86,7 @@ describe LavinMQ::Exchange do
 
     it "should raise and not declare delayed message exchange if missing x-delayed-type argument" do
       with_channel do |ch|
-        expect_raises(AMQP::Client::Channel::ClosedException) do
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
           ch.exchange("test2", "x-delayed-message", args: illegal_dmx_args)
         end
         Server.vhosts["/"].exchanges["test2"]?.should be_nil
@@ -104,8 +103,8 @@ describe LavinMQ::Exchange do
     it "should raise exception when redeclaring exchange with mismatched arguments" do
       with_channel do |ch|
         ch.exchange("test4", "x-delayed-message", args: dmx_args)
-        expect_raises(AMQP::Client::Channel::ClosedException) do
-          ch.exchange("test4", "x-delayed-message", args: dmx_args2)
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          ch.exchange("test4", "x-delayed-message", args: illegal_dmx_args)
         end
       end
     end

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -96,7 +96,7 @@ module LavinMQ
         frame_args = frame_args.clone.merge!({"x-delayed-exchange": true})
         frame_args.delete("x-delayed-type")
       end
-      self.type == (delayed ? arguments["x-delayed-type"] : type) &&
+      self.type == (delayed ? arguments["x-delayed-type"]? : type) &&
         @durable == durable &&
         @auto_delete == auto_delete &&
         @internal == internal &&


### PR DESCRIPTION
### WHAT is this pull request doing?
If you try and redeclare a delayed exchange with no `x-delayed-type` argument, it will crash in `exchanges.cr`: `match?(frame)`

This pull request adds a nilguard for the argument check, and as a result, the `match` method will return false if there is no `x-delayed-type` argument and send a`Preconditioned Failed: Existing exchange 'my_delayed_exchange' declared with other arguments` instead of crashing. 

### HOW can this pull request be tested?
Declare a delayed exchange "my-delayed-exchange", with argument `{ "x-delayed-type" => "direct" }`, then try and declare the exchange again, but with no `x-delayed-type` argument.  
