### PR TITLE
Use system assigned ports in specs

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -155,9 +155,9 @@ describe LavinMQ::HTTP::Server do
           "component": "shovel",
           "vhost": "/",
           "value": {
-            "src-uri": "#{AMQP_BASE_URL}",
+            "src-uri": "#{SpecHelper.amqp_base_url}",
             "src-queue": "shovel_will_declare_q1",
-            "dest-uri": "#{AMQP_BASE_URL}",
+            "dest-uri": "#{SpecHelper.amqp_base_url}",
             "dest-queue": "shovel_will_declare_q1"
           }
         }

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LavinMQ::HTTP::Server do
   describe "GET /api/overview" do
     it "should refuse access if no basic auth header" do
-      response = ::HTTP::Client.get("#{BASE_URL}/api/overview")
+      response = ::HTTP::Client.get("#{SpecHelper.http_base_url}/api/overview")
       response.status_code.should eq 401
     end
 

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -59,8 +59,8 @@ describe LavinMQ::HTTP::ConsumersController do
 
     it "should perform sanity check on sampled metrics" do
       Server.vhosts.create("pmths")
-      conn1 = AMQP::Client.new.connect
-      conn2 = AMQP::Client.new.connect
+      conn1 = AMQP::Client.new(SpecHelper.amqp_base_url).connect
+      conn2 = AMQP::Client.new(SpecHelper.amqp_base_url).connect
       conn1.close(no_wait: true)
       raw = get("/metrics/detailed?family=connection_churn_metrics").body
       parsed_metrics = parse_prometheus(raw)

--- a/spec/http_static_spec.cr
+++ b/spec/http_static_spec.cr
@@ -2,14 +2,14 @@ require "./spec_helper"
 
 describe LavinMQ::HTTP::StaticController do
   it "GET /robots.txt" do
-    response = ::HTTP::Client.get "#{BASE_URL}/robots.txt"
+    response = ::HTTP::Client.get "#{SpecHelper.http_base_url}/robots.txt"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/plain")
     response.body.should contain("Disallow")
   end
 
   it "GET /img/favicon.png" do
-    response = ::HTTP::Client.get "#{BASE_URL}/img/favicon.png"
+    response = ::HTTP::Client.get "#{SpecHelper.http_base_url}/img/favicon.png"
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("image/png")
   end

--- a/spec/http_views_spec.cr
+++ b/spec/http_views_spec.cr
@@ -2,28 +2,28 @@ require "./spec_helper"
 
 describe LavinMQ::HTTP::MainController do
   it "GET /" do
-    response = ::HTTP::Client.get BASE_URL
+    response = ::HTTP::Client.get SpecHelper.http_base_url
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should contain("LavinMQ")
   end
 
   it "GET / includes head partial" do
-    response = ::HTTP::Client.get BASE_URL
+    response = ::HTTP::Client.get SpecHelper.http_base_url
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should contain("<title>")
   end
 
   it "GET / includes header partial" do
-    response = ::HTTP::Client.get BASE_URL
+    response = ::HTTP::Client.get SpecHelper.http_base_url
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should contain("<header>")
   end
 
   it "GET / includes footer partial" do
-    response = ::HTTP::Client.get BASE_URL
+    response = ::HTTP::Client.get SpecHelper.http_base_url
     response.status_code.should eq 200
     response.headers["Content-Type"].should contain("text/html")
     response.body.should contain("<footer>")

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -464,7 +464,7 @@ describe LavinMQ::Server do
   end
 
   it "splits frames into max frame sizes" do
-    with_channel(port: 5672, frame_max: 4096_u32) do |ch|
+    with_channel(frame_max: 4096_u32) do |ch|
       2.times do
         msg_size = (2**17 + 1)
         pmsg1 = "m" * msg_size

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -18,14 +18,14 @@ describe LavinMQ::Shovel do
     it "should shovel and stop when queue length is met" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "ql_q2",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -47,12 +47,12 @@ describe LavinMQ::Shovel do
     it "should shovel large messages" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "lm_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
-      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(AMQP_BASE_URL), "lm_q2", direct_user: Server.users.direct_user)
+      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(SpecHelper.amqp_base_url), "lm_q2", direct_user: Server.users.direct_user)
       shovel = LavinMQ::Shovel::Runner.new(source, dest, "lm_shovel", vhost)
       with_channel do |ch|
         x, q2 = ShovelSpecHelpers.setup_qs ch, "lm_"
@@ -64,8 +64,8 @@ describe LavinMQ::Shovel do
     end
 
     it "should shovel forever" do
-      source = LavinMQ::Shovel::AMQPSource.new("spec", URI.parse(AMQP_BASE_URL), "sf_q1", direct_user: Server.users.direct_user)
-      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(AMQP_BASE_URL), "sf_q2", direct_user: Server.users.direct_user)
+      source = LavinMQ::Shovel::AMQPSource.new("spec", URI.parse(SpecHelper.amqp_base_url), "sf_q1", direct_user: Server.users.direct_user)
+      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(SpecHelper.amqp_base_url), "sf_q2", direct_user: Server.users.direct_user)
       shovel = LavinMQ::Shovel::Runner.new(source, dest, "sf_shovel", vhost)
       with_channel do |ch|
         x, q2 = ShovelSpecHelpers.setup_qs ch, "sf_"
@@ -89,7 +89,7 @@ describe LavinMQ::Shovel do
       ack_mode = LavinMQ::Shovel::AckMode::OnPublish
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "ap_q1",
         prefetch: 1_u16,
         ack_mode: ack_mode,
@@ -97,7 +97,7 @@ describe LavinMQ::Shovel do
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "ap_q2",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
@@ -118,14 +118,14 @@ describe LavinMQ::Shovel do
       ack_mode = LavinMQ::Shovel::AckMode::NoAck
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "na_q1",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "na_q2",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
@@ -145,7 +145,7 @@ describe LavinMQ::Shovel do
     it "should shovel past prefetch" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "prefetch_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         prefetch: 21_u16,
@@ -153,7 +153,7 @@ describe LavinMQ::Shovel do
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "prefetch_q2",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         prefetch: 21_u16,
@@ -176,13 +176,13 @@ describe LavinMQ::Shovel do
     it "should shovel once qs are declared" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "od_q1",
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "od_q2",
         direct_user: Server.users.direct_user
       )
@@ -204,9 +204,9 @@ describe LavinMQ::Shovel do
         q1.publish_confirm "shovel me 1", props: AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
       end
       config = %({
-        "src-uri": "#{AMQP_BASE_URL}",
+        "src-uri": "#{SpecHelper.amqp_base_url}",
         "src-queue": "rc_q1",
-        "dest-uri": "#{AMQP_BASE_URL}",
+        "dest-uri": "#{SpecHelper.amqp_base_url}",
         "dest-queue": "rc_q2",
         "src-prefetch-count": 2})
       p = LavinMQ::Parameter.new("shovel", "rc_shovel", JSON.parse(config))
@@ -264,14 +264,14 @@ describe LavinMQ::Shovel do
       prefetch = 9_u16
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "prefetch2_q1",
         prefetch: prefetch,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "prefetch2_q2",
         prefetch: prefetch,
         direct_user: Server.users.direct_user
@@ -294,7 +294,7 @@ describe LavinMQ::Shovel do
 
     describe "authentication error" do
       it "should be stopped" do
-        uri = URI.parse(AMQP_BASE_URL)
+        uri = URI.parse(SpecHelper.amqp_base_url)
         uri.user = "foo"
         uri.password = "bar"
         source = LavinMQ::Shovel::AMQPSource.new(
@@ -321,13 +321,13 @@ describe LavinMQ::Shovel do
     it "should count messages shoveled" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "c_q1",
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "c_q2",
         direct_user: Server.users.direct_user
       )
@@ -350,7 +350,7 @@ describe LavinMQ::Shovel do
       consumer_args = {"x-stream-offset" => JSON::Any.new("first")}
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         q1_name,
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user,
@@ -358,7 +358,7 @@ describe LavinMQ::Shovel do
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         q2_name,
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user,
@@ -399,14 +399,14 @@ describe LavinMQ::Shovel do
       long_prefix = "a" * 250
       source = LavinMQ::Shovel::AMQPSource.new(
         "#{long_prefix}q1",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "#{long_prefix}q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "#{long_prefix}q2",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "#{long_prefix}q2",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -447,7 +447,7 @@ describe LavinMQ::Shovel do
       # # Setup shovel source and destination
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -495,7 +495,7 @@ describe LavinMQ::Shovel do
       # # Setup shovel source and destination
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(AMQP_BASE_URL),
+        URI.parse(SpecHelper.amqp_base_url),
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -238,13 +238,13 @@ describe LavinMQ::Shovel do
     it "should shovel over amqps" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse("#{AMQPS_BASE_URL}?verify=none"),
+        URI.parse("#{SpecHelper.amqps_base_url}?verify=none"),
         "ssl_q1",
         direct_user: Server.users.direct_user
       )
       dest = LavinMQ::Shovel::AMQPDestination.new(
         "spec",
-        URI.parse("#{AMQPS_BASE_URL}?verify=none"),
+        URI.parse("#{SpecHelper.amqps_base_url}?verify=none"),
         "ssl_q2",
         direct_user: Server.users.direct_user
       )

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -20,7 +20,7 @@ module UpstreamSpecHelpers
     upstream_vhost = Server.vhosts.create("upstream")
     downstream_vhost = Server.vhosts.create("downstream")
     upstream = LavinMQ::Federation::Upstream.new(downstream_vhost, upstream_name,
-      "#{AMQP_BASE_URL}/upstream", "upstream_ex")
+      "#{SpecHelper.amqp_base_url}/upstream", "upstream_ex")
     downstream_vhost.upstreams.not_nil!.add(upstream)
     {upstream, upstream_vhost, downstream_vhost}
   end
@@ -45,7 +45,7 @@ describe LavinMQ::Federation::Upstream do
   it "should use federated queue's name if @queue is empty" do
     vhost_downstream = Server.vhosts.create("/")
     vhost_upstream = Server.vhosts.create("upstream")
-    upstream = LavinMQ::Federation::Upstream.new(vhost_downstream, "qf test upstream", "#{AMQP_BASE_URL}/upstream", nil, "")
+    upstream = LavinMQ::Federation::Upstream.new(vhost_downstream, "qf test upstream", "#{SpecHelper.amqp_base_url}/upstream", nil, "")
 
     with_channel do |ch|
       ch.queue("federated_q")
@@ -57,7 +57,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate queue" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", SpecHelper.amqp_base_url, nil, "federation_q1")
 
     with_channel do |ch|
       x, q2 = UpstreamSpecHelpers.setup_qs ch
@@ -73,7 +73,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should not federate queue if no downstream consumer" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream wo downstream", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream wo downstream", SpecHelper.amqp_base_url, nil, "federation_q1")
 
     with_channel do |ch|
       x = UpstreamSpecHelpers.setup_qs(ch).first
@@ -87,7 +87,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate queue with ack mode no-ack" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream no-ack", AMQP_BASE_URL, nil, "federation_q1",
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream no-ack", SpecHelper.amqp_base_url, nil, "federation_q1",
       ack_mode: LavinMQ::Federation::AckMode::NoAck)
 
     with_channel do |ch|
@@ -104,7 +104,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate queue with ack mode on-publish" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream on-publish", AMQP_BASE_URL, nil, "federation_q1",
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream on-publish", SpecHelper.amqp_base_url, nil, "federation_q1",
       ack_mode: LavinMQ::Federation::AckMode::OnPublish)
 
     with_channel do |ch|
@@ -121,7 +121,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should resume federation after downstream reconnects" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream reconnect", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream reconnect", SpecHelper.amqp_base_url, nil, "federation_q1")
     msgs = [] of AMQP::Client::DeliverMessage
 
     with_channel do |ch|
@@ -149,7 +149,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should federate exchange" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "ef test upstream", AMQP_BASE_URL, "upstream_ex")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "ef test upstream", SpecHelper.amqp_base_url, "upstream_ex")
 
     with_channel do |ch|
       downstream_ex = ch.exchange("downstream_ex", "topic")
@@ -168,7 +168,7 @@ describe LavinMQ::Federation::Upstream do
 
   it "should keep message properties" do
     vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream props", AMQP_BASE_URL, nil, "federation_q1")
+    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream props", SpecHelper.amqp_base_url, nil, "federation_q1")
 
     with_channel do |ch|
       x, q2 = UpstreamSpecHelpers.setup_qs ch

--- a/spec/websocket_spec.cr
+++ b/spec/websocket_spec.cr
@@ -2,14 +2,14 @@ require "./spec_helper"
 
 describe "Websocket support" do
   it "should connect over websocket" do
-    c = AMQP::Client.new("ws://localhost:#{HTTP_PORT}")
+    c = AMQP::Client.new(SpecHelper.ws_base_url)
     conn = c.connect
     conn.should_not be_nil
     conn.close
   end
 
   it "can publish large messages" do
-    c = AMQP::Client.new("ws://localhost:#{HTTP_PORT}")
+    c = AMQP::Client.new(SpecHelper.ws_base_url)
     conn = c.connect
     ch = conn.channel
     q = ch.queue

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -48,11 +48,13 @@ module LavinMQ
       def bind_tcp(address, port)
         addr = @http.bind_tcp address, port
         Log.info { "Bound to #{addr}" }
+        addr
       end
 
       def bind_tls(address, port, ctx)
         addr = @http.bind_tls address, port, ctx
         Log.info { "Bound on #{addr}" }
+        addr
       end
 
       def bind_unix(path)
@@ -60,6 +62,7 @@ module LavinMQ
         addr = @http.bind_unix(path)
         File.chmod(path, 0o666)
         Log.info { "Bound to #{addr}" }
+        addr
       end
 
       def bind_internal_unix
@@ -67,6 +70,7 @@ module LavinMQ
         addr = @http.bind_unix(INTERNAL_UNIX_SOCKET)
         File.chmod(INTERNAL_UNIX_SOCKET, 0o660)
         Log.info { "Bound to #{addr}" }
+        addr
       end
 
       def listen

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -126,8 +126,7 @@ module LavinMQ
       listen(s)
     end
 
-    def listen_tls(bind, port, context)
-      s = TCPServer.new(bind, port)
+    def listen_tls(s : TCPServer, context)
       @listeners[s] = :amqps
       @log.info { "Listening on #{s.local_address} (TLS)" }
       loop do # do not try to use while
@@ -153,6 +152,10 @@ module LavinMQ
       abort "Unrecoverable error in TLS listener: #{ex.inspect_with_backtrace}"
     ensure
       @listeners.delete(s)
+    end
+
+    def listen_tls(bind, port, context)
+      listen_tls(TCPServer.new(bind, port), context)
     end
 
     def listen_unix(path : String)


### PR DESCRIPTION
### WHAT is this pull request doing?
Refactoring specs to use system assigned ports instead of hard coded ports. 

This makes it possible to run specs without first stopping services running on e.g. port 5672.

### HOW can this pull request be tested?
Run specs
