### PR TITLE
log warn instead of preconditioned failed when redeclaring exchange

### DIFF
--- a/src/lavinmq/client/client.cr
+++ b/src/lavinmq/client/client.cr
@@ -533,7 +533,7 @@ module LavinMQ
           send AMQP::Frame::Exchange::DeclareOk.new(frame.channel)
         end
       else
-        send_precondition_failed(frame, "Existing exchange '#{frame.exchange_name}' declared with other arguments")
+        @log.warn { "Existing exchange '#{frame.exchange_name}' declared with other arguments" }
       end
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Logs warning instead of raising preconditioned failure when trying to redeclare exchange with differing arguments, we only raise a preconditioned failed exception when it is an alternate exchange

### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
