### PR TITLE
Export replication lag in prometheus metrics

### DIFF
--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -252,6 +252,17 @@ module LavinMQ
                       value: @amqp_server.stats_system_collection_duration_seconds.to_f,
                       type:  "gauge",
                       help:  "Time it takes to collect system metrics"})
+        writer.write({name:  "total_connected_followers",
+                      value: @amqp_server.@replicator.followers.size,
+                      type:  "gauge",
+                      help:  "Amount of follower nodes connected"})
+        @amqp_server.@replicator.followers.each_with_index do |f, i|
+        writer.write({name:  "follower_#{i}_lag",
+                      value: f.lag,
+                      type:  "gauge",
+                      help:  "Lag for follower #{i}"})
+  end
+
       end
 
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -257,7 +257,7 @@ module LavinMQ
                       type:  "gauge",
                       help:  "Amount of follower nodes connected"})
         @amqp_server.@replicator.followers.each_with_index do |f, i|
-          writer.write({name:  "replication_lag_follower_#{i}",
+          writer.write({name:  "follower_lag_#{i}",
                         value: f.lag,
                         type:  "gauge",
                         help:  "Lag for follower on address: #{f.@socket.remote_address}"})

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -256,8 +256,8 @@ module LavinMQ
                       value: @amqp_server.@replicator.followers.size,
                       type:  "gauge",
                       help:  "Amount of follower nodes connected"})
-        @amqp_server.@replicator.followers.each do |f|
-          writer.write({name:  "follower_lag_#{f.@socket.remote_address}",
+        @amqp_server.@replicator.followers.each_with_index do |f, i|
+          writer.write({name:  "replication_lag_follower_#{i}",
                         value: f.lag,
                         type:  "gauge",
                         help:  "Lag for follower on address: #{f.@socket.remote_address}"})

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -257,12 +257,11 @@ module LavinMQ
                       type:  "gauge",
                       help:  "Amount of follower nodes connected"})
         @amqp_server.@replicator.followers.each_with_index do |f, i|
-        writer.write({name:  "follower_#{i}_lag",
-                      value: f.lag,
-                      type:  "gauge",
-                      help:  "Lag for follower #{i}"})
-  end
-
+          writer.write({name:  "follower_#{i}_lag",
+                        value: f.lag,
+                        type:  "gauge",
+                        help:  "Lag for follower #{i}"})
+        end
       end
 
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -256,11 +256,11 @@ module LavinMQ
                       value: @amqp_server.@replicator.followers.size,
                       type:  "gauge",
                       help:  "Amount of follower nodes connected"})
-        @amqp_server.@replicator.followers.each_with_index do |f, i|
-          writer.write({name:  "follower_#{i}_lag",
+        @amqp_server.@replicator.followers.each do |f|
+          writer.write({name:  "follower_lag_#{f.@socket.remote_address}",
                         value: f.lag,
                         type:  "gauge",
-                        help:  "Lag for follower #{i}"})
+                        help:  "Lag for follower on address: #{f.@socket.remote_address}"})
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
exports the amount of followers and the lag for each follower in prometheus metrics

### HOW can this pull request be tested?
start lavinmq with a couple of followers and run `laivnmqperf throughput` and check `http://localhost:15672/metrics`
