### PR TITLE
HTTP API docs: improve get message request body documentation

### DIFF
--- a/openapi/schemas/queues.yaml
+++ b/openapi/schemas/queues.yaml
@@ -221,7 +221,7 @@ GetQueueMessagesRequestBody:
     count:
       type: integer
       default: 1
-    ack_mode:
+    ackmode:
       type: string
       default: get
     encoding:

--- a/openapi/schemas/queues.yaml
+++ b/openapi/schemas/queues.yaml
@@ -224,6 +224,9 @@ GetQueueMessagesRequestBody:
     ackmode:
       type: string
       default: get
+      enum:
+      - get
+      - reject_requeue_true
     encoding:
       type: string
       default: auto


### PR DESCRIPTION
* document `ackmode` over `ack_mode`
We have supported "ackmode" since v1.0.0-beta.1 (https://github.com/cloudamqp/lavinmq/pull/347)

* document options for `ackmode`
These seem to be the values supported by LavinMQ: https://github.com/cloudamqp/lavinmq/blob/v1.2.10/src/lavinmq/http/controller/queues.cr#L159-L162