### PR TITLE
Use CLA Assistant GitHub action instead of app

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,8 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          # gives write access to the remote repository
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/lavinmq/cla.json'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           path-to-document: 'https://github.com/cloudamqp/CLA-signatures/blob/main/cla.md'
           # branch should not be protected
           branch: 'main'
-          allowlist: user1,bot*
+          allowlist: 'dependabot[bot]'
 
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: 'cloudamqp'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,11 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+# https://github.com/contributor-assistant/github-action needs permissions to
+# - re-run workflows
+# - comment in pull requests
+# - update commit statuses 
 permissions:
   actions: write
   pull-requests: write

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://gist.github.com/kickster97/5557237e130fa18f87a32ffc6158bc9d'
+          # branch should not be protected
+          branch: 'main'
+          allowlist: user1,bot*
+
+         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
           # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/lavinmq/cla.json'
           path-to-document: 'https://github.com/cloudamqp/CLA-signatures/blob/main/cla.md'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,5 @@ jobs:
           # branch should not be protected
           branch: 'main'
           allowlist: 'dependabot[bot]'
-
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: 'cloudamqp'
           remote-repository-name: 'CLA-signatures'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,10 +32,3 @@ jobs:
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: 'cloudamqp'
           remote-repository-name: 'CLA-signatures'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.author_association != 'MEMBER' && github.event.pull_request.author_association != 'OWNER' }}
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,15 +25,15 @@ jobs:
           # This token is required only if you have configured to store the signatures in a remote repository/organization
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://gist.github.com/kickster97/5557237e130fa18f87a32ffc6158bc9d'
+          path-to-signatures: 'signatures/lavinmq/cla.json'
+          path-to-document: 'https://github.com/cloudamqp/CLA-signatures/blob/main/cla.md'
           # branch should not be protected
           branch: 'main'
           allowlist: user1,bot*
 
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-organization-name: 'cloudamqp'
+          remote-repository-name: 'CLA-signatures'
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
           #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,6 @@ on:
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: write
-  contents: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
### WHAT is this pull request doing?

[adds CLA github action](https://github.com/contributor-assistant/github-action), allowing us to store json of signatures instead of using centralized storage of signatures with cla assistant app, as well as allows us to use other formats than gist for the CLA document


### HOW can this pull request be tested?
test by opening, synchronize, closing PR

