### PR TITLE
Replication lag improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Follower lag is now based on bytes written to action queue instead of socket [#652](https://github.com/cloudamqp/lavinmq/pull/652)
+
 ## [1.2.11] - 2024-04-26
 
 ### Fixed

--- a/spec/replication/actions_spec.cr
+++ b/spec/replication/actions_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
-def with_datadir_tempfile(&)
-  relative_path = Path.new "data.spec"
+def with_datadir_tempfile(filename = "data.spec", &)
+  relative_path = Path.new filename
   absolute_path = Path.new(LavinMQ::Config.instance.data_dir).join relative_path
   yield relative_path.to_s, absolute_path.to_s
 ensure
@@ -55,6 +55,16 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
+
+      describe "#bytesize" do
+        it "should count filename and filesize" do
+          with_datadir_tempfile("data") do |_relative, absolute|
+            File.write absolute, "foo"
+            action = LavinMQ::Replication::AddAction.new absolute
+            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
+          end
+        end
+      end
     end
 
     describe "with @mfile" do
@@ -69,6 +79,15 @@ describe LavinMQ::Replication::Action do
 
             read_and_verify_filename(io, relative)
             read_and_verify_data(io, "foo")
+          end
+        end
+      end
+      describe "#bytesize" do
+        it "should count filename and filesize" do
+          with_datadir_tempfile("data") do |_relative, absolute|
+            File.write absolute, "foo"
+            action = LavinMQ::Replication::AddAction.new absolute
+            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
           end
         end
       end
@@ -90,9 +109,17 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
+      describe "#bytesize" do
+        it "should count filename and size of Int32" do
+          with_datadir_tempfile("data") do |_relative, absolute|
+            action = LavinMQ::Replication::AppendAction.new absolute, 123i32
+            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + sizeof(Int32))
+          end
+        end
+      end
     end
 
-    describe "with Int32" do
+    describe "with UInt32" do
       describe "#send" do
         it "writes filename and data to IO" do
           with_datadir_tempfile do |relative, absolute|
@@ -103,6 +130,14 @@ describe LavinMQ::Replication::Action do
 
             read_and_verify_filename(io, relative)
             read_and_verify_data(io, 123u32)
+          end
+        end
+      end
+      describe "#bytesize" do
+        it "should count filename and size of UInt32" do
+          with_datadir_tempfile("data") do |_relative, absolute|
+            action = LavinMQ::Replication::AppendAction.new absolute, 123u32
+            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + sizeof(UInt32))
           end
         end
       end
@@ -122,6 +157,14 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
+      describe "#bytesize" do
+        it "should count filename and size of Bytes" do
+          with_datadir_tempfile("data") do |_relative, absolute|
+            action = LavinMQ::Replication::AppendAction.new absolute, "foo".to_slice
+            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".to_slice.bytesize)
+          end
+        end
+      end
     end
 
     describe "with FileRange" do
@@ -138,6 +181,16 @@ describe LavinMQ::Replication::Action do
 
             read_and_verify_filename(io, relative)
             read_and_verify_data(io, "foo".to_slice)
+          end
+        end
+      end
+      describe "#bytesize" do
+        it "should count filename and size of FileRange" do
+          with_datadir_tempfile("data") do |_relative, absolute|
+            File.write absolute, "foo bar baz"
+            range = LavinMQ::Replication::FileRange.new(MFile.new(absolute), 4, 3)
+            action = LavinMQ::Replication::AppendAction.new absolute, range
+            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + range.len)
           end
         end
       end

--- a/spec/replication/actions_spec.cr
+++ b/spec/replication/actions_spec.cr
@@ -56,12 +56,12 @@ describe LavinMQ::Replication::Action do
         end
       end
 
-      describe "#bytesize" do
+      describe "#lag_size" do
         it "should count filename and filesize" do
           with_datadir_tempfile("data") do |_relative, absolute|
             File.write absolute, "foo"
             action = LavinMQ::Replication::AddAction.new absolute
-            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
+            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
           end
         end
       end
@@ -82,12 +82,12 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
-      describe "#bytesize" do
+      describe "#lag_size" do
         it "should count filename and filesize" do
           with_datadir_tempfile("data") do |_relative, absolute|
             File.write absolute, "foo"
             action = LavinMQ::Replication::AddAction.new absolute
-            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
+            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
           end
         end
       end
@@ -109,11 +109,11 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
-      describe "#bytesize" do
+      describe "#lag_size" do
         it "should count filename and size of Int32" do
           with_datadir_tempfile("data") do |_relative, absolute|
             action = LavinMQ::Replication::AppendAction.new absolute, 123i32
-            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + sizeof(Int32))
+            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + sizeof(Int32))
           end
         end
       end
@@ -133,11 +133,11 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
-      describe "#bytesize" do
+      describe "#lag_size" do
         it "should count filename and size of UInt32" do
           with_datadir_tempfile("data") do |_relative, absolute|
             action = LavinMQ::Replication::AppendAction.new absolute, 123u32
-            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + sizeof(UInt32))
+            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + sizeof(UInt32))
           end
         end
       end
@@ -157,11 +157,11 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
-      describe "#bytesize" do
+      describe "#lag_size" do
         it "should count filename and size of Bytes" do
           with_datadir_tempfile("data") do |_relative, absolute|
             action = LavinMQ::Replication::AppendAction.new absolute, "foo".to_slice
-            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".to_slice.bytesize)
+            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".to_slice.bytesize)
           end
         end
       end
@@ -184,13 +184,13 @@ describe LavinMQ::Replication::Action do
           end
         end
       end
-      describe "#bytesize" do
+      describe "#lag_size" do
         it "should count filename and size of FileRange" do
           with_datadir_tempfile("data") do |_relative, absolute|
             File.write absolute, "foo bar baz"
             range = LavinMQ::Replication::FileRange.new(MFile.new(absolute), 4, 3)
             action = LavinMQ::Replication::AppendAction.new absolute, range
-            action.bytesize.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + range.len)
+            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + range.len)
           end
         end
       end

--- a/src/lavinmq/replication/actions.cr
+++ b/src/lavinmq/replication/actions.cr
@@ -12,7 +12,7 @@ module LavinMQ
       def initialize(@path : String)
       end
 
-      abstract def bytesize : Int32
+      abstract def bytesize : Int64
       abstract def send(socket : IO) : Int64
 
       protected def filename_bytesize : Int32
@@ -33,12 +33,12 @@ module LavinMQ
       def initialize(@path : String, @mfile : MFile? = nil)
       end
 
-      def bytesize : Int32
+      def bytesize : Int64
         if mfile = @mfile
-          sizeof(Int32) + filename.bytesize +
+          0i64 + sizeof(Int32) + filename.bytesize +
             sizeof(Int64) + mfile.size.to_i64
         else
-          sizeof(Int32) + filename.bytesize +
+          0i64 + sizeof(Int32) + filename.bytesize +
             sizeof(Int64) + File.size(@path).to_i64
         end
       end
@@ -66,7 +66,7 @@ module LavinMQ
       def initialize(@path : String, @obj : Bytes | FileRange | UInt32 | Int32)
       end
 
-      def bytesize : Int32
+      def bytesize : Int64
         datasize = case obj = @obj
                    in Bytes
                      obj.bytesize.to_i64
@@ -75,7 +75,7 @@ module LavinMQ
                    in UInt32, Int32
                      4i64
                    end
-        sizeof(Int32) + filename.bytesize +
+        0i64 + sizeof(Int32) + filename.bytesize +
           sizeof(Int64) + datasize
       end
 
@@ -102,11 +102,11 @@ module LavinMQ
     end
 
     struct DeleteAction < Action
-      def bytesize : Int32
+      def bytesize : Int64
         # Maybe it would be ok to not include delete action in lag, because
         # the follower should have all info necessary to GC the file during
         # startup?
-        sizeof(Int32) + filename.bytesize + sizeof(Int64)
+        (sizeof(Int32) + filename.bytesize + sizeof(Int64)).to_i64
       end
 
       def send(socket) : Int64

--- a/src/lavinmq/replication/actions.cr
+++ b/src/lavinmq/replication/actions.cr
@@ -12,7 +12,7 @@ module LavinMQ
       def initialize(@path : String)
       end
 
-      abstract def bytesize : Int64
+      abstract def lag_size : Int64
       abstract def send(socket : IO) : Int64
 
       protected def filename_bytesize : Int32
@@ -33,7 +33,7 @@ module LavinMQ
       def initialize(@path : String, @mfile : MFile? = nil)
       end
 
-      def bytesize : Int64
+      def lag_size : Int64
         if mfile = @mfile
           0i64 + sizeof(Int32) + filename.bytesize +
             sizeof(Int64) + mfile.size.to_i64
@@ -66,7 +66,7 @@ module LavinMQ
       def initialize(@path : String, @obj : Bytes | FileRange | UInt32 | Int32)
       end
 
-      def bytesize : Int64
+      def lag_size : Int64
         datasize = case obj = @obj
                    in Bytes
                      obj.bytesize.to_i64
@@ -102,7 +102,7 @@ module LavinMQ
     end
 
     struct DeleteAction < Action
-      def bytesize : Int64
+      def lag_size : Int64
         # Maybe it would be ok to not include delete action in lag, because
         # the follower should have all info necessary to GC the file during
         # startup?

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -195,7 +195,7 @@ module LavinMQ
             f.truncate
             IO.copy(socket, f, len) == len || raise IO::EOFError.new
           end
-          ack_value : Int64 = sizeof(Int32) + filename_len + sizeof(Int64) + len.abs
+          ack_value : Int64 = len.abs + sizeof(Int64) + filename_len + sizeof(Int32)
           @socket.write_bytes ack_value, IO::ByteFormat::LittleEndian # ack
           @socket.flush
         end

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -195,7 +195,7 @@ module LavinMQ
             f.truncate
             IO.copy(socket, f, len) == len || raise IO::EOFError.new
           end
-          ack_value = sizeof(Int32) + filename_len + sizeof(Int64) + len.abs
+          ack_value : Int64 = sizeof(Int32) + filename_len + sizeof(Int64) + len.abs
           @socket.write_bytes ack_value, IO::ByteFormat::LittleEndian # ack
           @socket.flush
         end

--- a/src/lavinmq/replication/client.cr
+++ b/src/lavinmq/replication/client.cr
@@ -195,7 +195,8 @@ module LavinMQ
             f.truncate
             IO.copy(socket, f, len) == len || raise IO::EOFError.new
           end
-          @socket.write_bytes len.abs, IO::ByteFormat::LittleEndian # ack
+          ack_value = sizeof(Int32) + filename_len + sizeof(Int64) + len.abs
+          @socket.write_bytes ack_value, IO::ByteFormat::LittleEndian # ack
           @socket.flush
         end
       end

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -133,19 +133,19 @@ module LavinMQ
         end
       end
 
-      def add(path, mfile : MFile? = nil) : Int32
+      def add(path, mfile : MFile? = nil) : Int64
         send_action AddAction.new(path, mfile)
       end
 
-      def append(path, obj) : Int32
+      def append(path, obj) : Int64
         send_action AppendAction.new(path, obj)
       end
 
-      def delete(path) : Int32
+      def delete(path) : Int64
         send_action DeleteAction.new(path)
       end
 
-      private def send_action(action : Action) : Int32
+      private def send_action(action : Action) : Int64
         action_size = action.bytesize
         @sent_bytes += action_size
         @actions.send action

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -46,10 +46,14 @@ module LavinMQ
       def read_acks(socket = @socket) : Nil
         spawn action_loop, name: "Follower#action_loop"
         loop do
-          len = socket.read_bytes(Int64, IO::ByteFormat::LittleEndian)
-          @acked_bytes += len
+          read_ack(socket)
         end
       rescue IO::Error
+      end
+
+      def read_ack(socket = @socket) : Nil
+        len = socket.read_bytes(Int64, IO::ByteFormat::LittleEndian)
+        @acked_bytes += len
       end
 
       private def action_loop(socket = @lz4)

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -1,4 +1,3 @@
-require "../replication"
 require "./actions"
 require "./file_index"
 

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -145,10 +145,10 @@ module LavinMQ
       end
 
       private def send_action(action : Action) : Int64
-        action_size = action.bytesize
-        @sent_bytes += action_size
+        lag_size = action.lag_size
+        @sent_bytes += lag_size
         @actions.send action
-        action_size
+        lag_size
       end
 
       def close(synced_close : Channel({Follower, Bool})? = nil)

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -130,19 +130,18 @@ module LavinMQ
       end
 
       def add(path, mfile : MFile? = nil)
-        action = AddAction.new(path, mfile)
-        @sent_bytes += action.bytesize
-        @actions.send action
+        send_action AddAction.new(path, mfile)
       end
 
       def append(path, obj)
-        action = AppendAction.new(path, obj)
-        @sent_bytes += action.bytesize
-        @actions.send action
+        send_action AppendAction.new(path, obj)
       end
 
       def delete(path)
-        action = DeleteAction.new(path)
+        send_action DeleteAction.new(path)
+      end
+
+      private def send_action(action : Action) : Nil
         @sent_bytes += action.bytesize
         @actions.send action
       end

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -133,21 +133,23 @@ module LavinMQ
         end
       end
 
-      def add(path, mfile : MFile? = nil)
+      def add(path, mfile : MFile? = nil) : Int32
         send_action AddAction.new(path, mfile)
       end
 
-      def append(path, obj)
+      def append(path, obj) : Int32
         send_action AppendAction.new(path, obj)
       end
 
-      def delete(path)
+      def delete(path) : Int32
         send_action DeleteAction.new(path)
       end
 
-      private def send_action(action : Action) : Nil
-        @sent_bytes += action.bytesize
+      private def send_action(action : Action) : Int32
+        action_size = action.bytesize
+        @sent_bytes += action_size
         @actions.send action
+        action_size
       end
 
       def close(synced_close : Channel({Follower, Bool})? = nil)

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -57,9 +57,9 @@ module LavinMQ
 
       private def action_loop(socket = @lz4)
         while action = @actions.receive?
-          @sent_bytes += action.send(socket)
+          action.send(socket)
           while action2 = @actions.try_receive?
-            @sent_bytes += action2.send(socket)
+            action2.send(socket)
           end
           socket.flush
         end

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -130,15 +130,21 @@ module LavinMQ
       end
 
       def add(path, mfile : MFile? = nil)
-        @actions.send AddAction.new(path, mfile)
+        action = AddAction.new(path, mfile)
+        @sent_bytes += action.bytesize
+        @actions.send action
       end
 
       def append(path, obj)
-        @actions.send AppendAction.new(path, obj)
+        action = AppendAction.new(path, obj)
+        @sent_bytes += action.bytesize
+        @actions.send action
       end
 
       def delete(path)
-        @actions.send DeleteAction.new(path)
+        action = DeleteAction.new(path)
+        @sent_bytes += action.bytesize
+        @actions.send action
       end
 
       def close(synced_close : Channel({Follower, Bool})? = nil)


### PR DESCRIPTION
### WHAT is this pull request doing?

Before this we only counted data written to the follower socket as lag, we didn't count the data in the "action queue" of the follower.

This will change so we count data written to the action queue.

### HOW can this pull request be tested?

Run follower specs
