### PR TITLE
CLA workflow: avoid locking PRs after merge

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,10 +31,10 @@ jobs:
           # gives write access to the remote repository
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_GITHUB_TOKEN }}
         with:
+          lock-pullrequest-aftermerge: false
           path-to-signatures: 'signatures/lavinmq/cla.json'
           path-to-document: 'https://github.com/cloudamqp/CLA-signatures/blob/main/cla.md'
-          # branch should not be protected
-          branch: 'main'
           allowlist: 'dependabot[bot]'
+          branch: 'main' # branch should not be protected
           remote-organization-name: 'cloudamqp'
           remote-repository-name: 'CLA-signatures'


### PR DESCRIPTION
I don't think we want the CLA workflow to lock pull requests if they are closed/merged.

See this issue for context https://github.com/contributor-assistant/github-action/issues/77
