### PR TITLE
Refactor and move a MessageStore spec

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -330,6 +330,18 @@ describe LavinMQ::Queue do
   end
 
   describe "MessageStore" do
+    # Delete unused segments bug
+    # https://github.com/cloudamqp/lavinmq/pull/565
+    it "should remove unused segments after being consumed" do
+      store = LavinMQ::Queue::MessageStore.new(
+        LavinMQ::Config.instance.data_dir, nil)
+      body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
+      msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
+      sps = Array(LavinMQ::SegmentPosition).new(10) { store.push msg }
+      sps.each { |sp| store.delete sp }
+      store.@segments.size.should be <= 2
+    end
+
     it "should yield fiber while purging" do
       tmpdir = File.tempname "lavin", ".spec"
       Dir.mkdir_p tmpdir

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -94,21 +94,6 @@ describe LavinMQ::DurableQueue do
     queue = Server.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
     queue.message_count.should eq 2
   end
-
-  # Delete unused segments bug
-  # https://github.com/cloudamqp/lavinmq/pull/565
-  it "should remove unused segments after being consumed" do
-    with_channel do |ch|
-      q_name = "segment_delete_test"
-      q = ch.queue(q_name, durable: true)
-      10.times do # Publish and consume large messages that ensures new segments are created
-        q.publish_confirm Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size)
-        q.subscribe(no_ack: false, &.ack)
-      end
-      queue = Server.vhosts["/"].queues[q_name].as(LavinMQ::DurableQueue)
-      queue.@msg_store.@segments.size.should be <= 2
-    end
-  end
 end
 
 describe LavinMQ::VHost do


### PR DESCRIPTION
### WHAT is this pull request doing?
Writing a `MessageStore` spec i found this spec and realized it could be simplified and more isolated to only involve `MessageStore`. I also moved it to the `MessageStore` describe block in `queue_spec`, but that entire block should probably be moved to it's own file at some point.

### HOW can this pull request be tested?
Run specs
