### PR TITLE
Bugfix: dont create empty ack files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Empty ack files created for all segments [#658](https://github.com/cloudamqp/lavinmq/pull/658)
+
 ## [1.2.10] - 2024-03-25
 
 ### Fixed

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -344,9 +344,9 @@ describe LavinMQ::Queue do
     end
 
     it "should not create ack files when cleaning up segments" do
+      # This spec verifies a bugfix where one ack file per segment was created
       data_dir = File.join(LavinMQ::Config.instance.data_dir, "msgstore")
       Dir.mkdir_p data_dir
-      # This spec verifies a bugfix where one ack file per segment was created
       body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
       msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -344,11 +344,11 @@ describe LavinMQ::Queue do
     end
 
     it "should not create ack files when cleaning up segments" do
+      data_dir = File.join(LavinMQ::Config.instance.data_dir, "msgstore")
+      Dir.mkdir_p data_dir
       # This spec verifies a bugfix where one ack file per segment was created
       body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
       msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
-      data_dir = File.tempname("lavin", ".spec")
-      Dir.mkdir_p data_dir
 
       store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
       2.times { store.push msg }
@@ -357,8 +357,6 @@ describe LavinMQ::Queue do
       # recreate store to let it read the segments and cleanup
       LavinMQ::Queue::MessageStore.new(data_dir, nil)
       Dir.glob(File.join(data_dir, "acks.*")).size.should eq 0
-    ensure
-      (dir = data_dir) && FileUtils.rm_rf dir
     end
 
     it "should yield fiber while purging" do

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -244,7 +244,6 @@ module LavinMQ
         next_id = @wfile_id + 1
         path = File.join(@data_dir, "msgs.#{next_id.to_s.rjust(10, '0')}")
         capacity = Math.max(Config.instance.segment_size, next_msg_size + 4)
-        pp capacity
         delete_unused_segments
         wfile = MFile.new(path, capacity)
         wfile.write_bytes Schema::VERSION

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -244,6 +244,7 @@ module LavinMQ
         next_id = @wfile_id + 1
         path = File.join(@data_dir, "msgs.#{next_id.to_s.rjust(10, '0')}")
         capacity = Math.max(Config.instance.segment_size, next_msg_size + 4)
+        pp capacity
         delete_unused_segments
         wfile = MFile.new(path, capacity)
         wfile.write_bytes Schema::VERSION
@@ -359,7 +360,7 @@ module LavinMQ
         @segments.reject! do |seg, mfile|
           next if seg == current_seg # don't the delete the segment still being written to
 
-          if @segment_msg_count[seg] == @acks[seg].size // sizeof(UInt32)
+          if (acks = @acks[seg]?) && @segment_msg_count[seg] == (acks.size // sizeof(UInt32))
             Log.info { "Deleting unused segment #{seg}" }
             @segment_msg_count.delete seg
             @deleted.delete seg


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes a bug where ack files for each segment was created during startup.

### HOW can this pull request be tested?
Run specs
