### PR TITLE
Fixes for crystal 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint: lib
 
 .PHONY: test
 test: lib
-	crystal spec --order random $(if $(nocolor),--no-color)
+	crystal spec --order random $(if $(nocolor),--no-color) --verbose
 
 .PHONY: format
 format:

--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   amqp-client:
     git: https://github.com/cloudamqp/amqp-client.cr.git
-    version: 1.2.2
+    version: 1.2.3
 
   lz4:
     git: https://github.com/84codes/lz4.cr.git

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -42,9 +42,15 @@ require "../src/lavinmq/http/http_server"
 
 def with_channel(**args, &)
   name = nil
-  if formatter = Spec.formatters[0].as?(Spec::VerboseFormatter)
-    name = formatter.@last_description
-  end
+  {% if Spec::CLI.resolve? %}
+    if formatter = Spec.cli.formatters[0].as?(Spec::VerboseFormatter)
+      name = formatter.@last_description
+    end
+  {% else %}
+    if formatter = Spec.formatters[0].as?(Spec::VerboseFormatter)
+      name = formatter.@last_description
+    end
+  {% end %}
   args = {port: LavinMQ::Config.instance.amqp_port, name: name}.merge(args)
   conn = AMQP::Client.new(**args).connect
   ch = conn.channel

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,7 +7,11 @@ require "string_scanner"
 
 Log.setup_from_env
 
-Spec.override_default_formatter(Spec::VerboseFormatter.new)
+{% if Spec::CLI.resolve? %}
+  Spec.cli.override_default_formatter(Spec::VerboseFormatter.new)
+{% else %}
+  Spec.override_default_formatter(Spec::VerboseFormatter.new)
+{% end %}
 
 DATA_DIR = "/tmp/lavinmq-spec"
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,12 +7,6 @@ require "string_scanner"
 
 Log.setup_from_env
 
-{% if Spec::CLI.resolve? %}
-  Spec.cli.override_default_formatter(Spec::VerboseFormatter.new)
-{% else %}
-  Spec.override_default_formatter(Spec::VerboseFormatter.new)
-{% end %}
-
 DATA_DIR = "/tmp/lavinmq-spec"
 
 Dir.mkdir_p DATA_DIR

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -44,17 +44,8 @@ end
 require "../src/lavinmq/server"
 require "../src/lavinmq/http/http_server"
 
-def with_channel(**args, &)
-  name = nil
-  {% if Spec::CLI.resolve? %}
-    if formatter = Spec.cli.formatters[0].as?(Spec::VerboseFormatter)
-      name = formatter.@last_description
-    end
-  {% else %}
-    if formatter = Spec.formatters[0].as?(Spec::VerboseFormatter)
-      name = formatter.@last_description
-    end
-  {% end %}
+def with_channel(file = __FILE__, line = __LINE__, **args, &)
+  name = "lavinmq-spec-#{file}:#{line}"
   args = {port: LavinMQ::Config.instance.amqp_port, name: name}.merge(args)
   conn = AMQP::Client.new(**args).connect
   ch = conn.channel

--- a/src/lavinmq/client/amqp_connection.cr
+++ b/src/lavinmq/client/amqp_connection.cr
@@ -8,7 +8,7 @@ module LavinMQ
     def self.start(socket, connection_info, vhosts, users) : Client?
       remote_address = connection_info.src
       Log.context.set(address: remote_address.to_s)
-      socket.read_timeout = 15
+      socket.read_timeout = 15.seconds
       if confirm_header(socket)
         if start_ok = start(socket)
           if user = authenticate(socket, remote_address, users, start_ok)
@@ -31,7 +31,7 @@ module LavinMQ
 
     private def self.heartbeat_timeout(tune_ok)
       if tune_ok.heartbeat > 0
-        tune_ok.heartbeat / 2
+        (tune_ok.heartbeat / 2).seconds
       end
     end
 

--- a/src/lavinmq/http/handler/websocket.cr
+++ b/src/lavinmq/http/handler/websocket.cr
@@ -52,7 +52,12 @@ module LavinMQ
       @ws.close
     end
 
-    def read_timeout=(timeout)
+    # TODO: remove when amqp-client is updated
+    def read_timeout=(timeout : Number)
+      self.read_timeout = timeout.seconds
+    end
+
+    def read_timeout=(timeout : Time::Span?)
       @r.read_timeout = timeout
     end
   end

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -20,7 +20,7 @@ module LavinMQ
       # PROXY TCP6 ffff:f...f:ffff ffff:f...f:ffff 65535 65535\r\n
       # PROXY UNKNOWN\r\n
       def self.parse(io)
-        io.read_timeout = 15
+        io.read_timeout = 15.seconds
         header = io.gets('\n', 107) || raise IO::EOFError.new
 
         src_addr = "127.0.0.1"

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -53,7 +53,7 @@ module LavinMQ
       SIGNATURE = StaticArray[13u8, 10u8, 13u8, 10u8, 0u8, 13u8, 10u8, 81u8, 85u8, 73u8, 84u8, 10u8]
 
       def self.parse(io)
-        io.read_timeout = 15
+        io.read_timeout = 15.seconds
         buffer = uninitialized UInt8[16]
         io.read(buffer.to_slice)
         signature = buffer.to_slice[0, 12]

--- a/src/lavinmq/replication/follower.cr
+++ b/src/lavinmq/replication/follower.cr
@@ -17,8 +17,8 @@ module LavinMQ
         Log.context.set(address: @socket.remote_address.to_s)
         @name = @socket.remote_address.to_s
         @closed = false
-        @socket.write_timeout = 5
-        @socket.read_timeout = 5
+        @socket.write_timeout = 5.seconds
+        @socket.read_timeout = 5.seconds
         @socket.buffer_size = 64 * 1024
         @lz4 = Compress::LZ4::Writer.new(@socket, Compress::LZ4::CompressOptions.new(auto_flush: false, block_mode_linked: true))
       end

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -242,8 +242,8 @@ module LavinMQ
 
       def start
         client = ::HTTP::Client.new @uri
-        client.connect_timeout = 10
-        client.read_timeout = 30
+        client.connect_timeout = 10.seconds
+        client.read_timeout = 30.seconds
         client.basic_auth(@uri.user, @uri.password || "") if @uri.user
         @client = client
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes deprecation warnings and spec compilation error.

We should probably move away from using `Spec.cli.formatters`/`Spec.formatters`. Maybe use `__FILE__` and `__LINE__` instead?

### HOW can this pull request be tested?
Run spec
