### PR TITLE
set colspan of pagination to nr of columns in the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Empty ack files created for all segments [#658](https://github.com/cloudamqp/lavinmq/pull/658)
+- UI: Set proper width (colspan) for pagination cell  [#662](https://github.com/cloudamqp/lavinmq/pull/662)
 
 ## [1.2.10] - 2024-03-25
 

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -21,6 +21,7 @@ function renderTable (id, options = {}, renderRow) {
   if (options.pagination) {
     const paginationCell = table.createTFoot().insertRow().insertCell()
     const paginationContainer = document.createElement('div')
+    paginationCell.colSpan = table.tHead.rows[0].children.length
     paginationCell.appendChild(paginationContainer)
     paginationContainer.classList.add('pagination')
     Pagination.create(paginationContainer, dataSource)


### PR DESCRIPTION
### WHAT is this pull request doing?
Sets colspan of pagination td to nr of columns in the table to stop it from making the first column in every table very wide if it has enough rows to require pagination. 

before: 
![before](https://github.com/cloudamqp/lavinmq/assets/10939363/57ee8442-7fc8-482b-a59c-279ee5dd76db)

after: 
![after](https://github.com/cloudamqp/lavinmq/assets/10939363/63dc6188-40b5-469f-a65f-15ae94e7a909)

### HOW can this pull request be tested?
Look in UI