### PR TITLE
export delayed exchanges in a way that is compatible with rabbitmq

### DIFF
--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -309,7 +309,7 @@ module LavinMQ
                 {
                   "name":        e.name,
                   "vhost":       e.vhost.name,
-                  "type":        delayed ? type : e.type,
+                  "type":        delayed ? "x-delayed-exchange" : e.type,
                   "durable":     e.durable?,
                   "auto_delete": e.auto_delete?,
                   "internal":    e.internal?,

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -302,7 +302,7 @@ module LavinMQ
                 delayed = e.arguments["x-delayed-exchange"]?
                 if delayed
                   type = "x-delayed-exchange"
-                  arguments = { "x-delayed-type" => e.type }
+                  arguments = {"x-delayed-type" => e.type}
                 end
                 {
                   "name":        e.name,

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -302,7 +302,9 @@ module LavinMQ
                 delayed = e.arguments["x-delayed-exchange"]?
                 if delayed
                   type = "x-delayed-exchange"
-                  arguments = {"x-delayed-type" => e.type}
+                  arguments = e.arguments.dup
+                  arguments["x-delayed-type"] = e.type
+                  arguments.delete("x-delayed-exchange")
                 end
                 {
                   "name":        e.name,

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -299,14 +299,19 @@ module LavinMQ
           json.array do
             vhosts.each_value do |v|
               v.exchanges.each_value.reject(&.internal?).each do |e|
+                delayed = e.arguments["x-delayed-exchange"]?
+                if delayed
+                  type = "x-delayed-exchange"
+                  arguments = { "x-delayed-type" => e.type }
+                end
                 {
                   "name":        e.name,
                   "vhost":       e.vhost.name,
-                  "type":        e.type,
+                  "type":        delayed ? type : e.type,
                   "durable":     e.durable?,
                   "auto_delete": e.auto_delete?,
                   "internal":    e.internal?,
-                  "arguments":   e.arguments,
+                  "arguments":   delayed ? arguments : e.arguments,
                 }.to_json(json)
               end
             end

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -301,7 +301,6 @@ module LavinMQ
               v.exchanges.each_value.reject(&.internal?).each do |e|
                 delayed = e.arguments["x-delayed-exchange"]?
                 if delayed
-                  type = "x-delayed-exchange"
                   arguments = e.arguments.dup
                   arguments["x-delayed-type"] = e.type
                   arguments.delete("x-delayed-exchange")


### PR DESCRIPTION
### WHAT is this pull request doing?
rewrites `export_exchanges()` to change the type and arguments of a delayed exchange so it is compatible with RabbitMQ also. 
(we handle the conversion again on import for LavinMQ, so it will also be compatible for LavinMQ) 

### HOW can this pull request be tested?
add delayed exchange to LavinMQ and export, then import into RabbitMQ, make sure to have the x-delayed-exchange plugin enabled. 
