### PR TITLE
Bugfix: Make sure shovels reconnects after destination disconnects

### DIFF
--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -318,7 +318,6 @@ module LavinMQ
         loop do
           break if terminated?
           @state = State::Starting
-
           unless @source.started?
             if @source.last_unacked
               Log.error { "Restarted with unacked messages, message duplication possible" }

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -71,25 +71,16 @@ module LavinMQ
         if c = @conn
           c.close
         end
-        @conn = conn = ::AMQP::Client.new(@uri).connect
-        @ch = ch = conn.channel
-        ch.prefetch @prefetch
-        q_name = @queue || ""
-        @q = q = begin
-          ch.queue_declare(q_name, passive: true)
-        rescue ::AMQP::Client::Channel::ClosedException
-          @ch = ch = conn.channel
-          ch.queue_declare(q_name, passive: false)
-        end
-        if @exchange || @exchange_key
-          ch.queue_bind(q[:queue_name], @exchange || "", @exchange_key || "")
-        end
+        @conn = ::AMQP::Client.new(@uri).connect
+        open_channel
       end
 
       def stop
         # If we have any outstanding messages when closing, ack them first.
         @last_unacked.try { |delivery_tag| ack(delivery_tag, close: true) }
         @conn.try &.close(no_wait: false)
+        @q = nil
+        @ch = nil
       end
 
       private def at_end?(delivery_tag)
@@ -115,7 +106,24 @@ module LavinMQ
       end
 
       def started? : Bool
-        !@q.nil?
+        !@q.nil? && !@conn.try &.closed?
+      end
+
+      private def open_channel
+        @ch.try &.close
+        conn = @conn.not_nil!
+        @ch = ch = conn.channel
+        ch.prefetch @prefetch
+        q_name = @queue || ""
+        @q = q = begin
+          ch.queue_declare(q_name, passive: true)
+        rescue ::AMQP::Client::Channel::ClosedException
+          @ch = ch = conn.channel
+          ch.queue_declare(q_name, passive: false)
+        end
+        if @exchange || @exchange_key
+          ch.queue_bind(q[:queue_name], @exchange || "", @exchange_key || "")
+        end
       end
 
       def each(&blk : ::AMQP::Client::DeliverMessage -> Nil)
@@ -132,15 +140,14 @@ module LavinMQ
           tag: @tag) do |msg|
           blk.call(msg)
 
-          if @ack_mode.on_publish?
-            ack(msg.delivery_tag)
-          end
-
           if @ack_mode.no_ack? && @delete_after.queue_length? && at_end?(msg.delivery_tag)
             ch.basic_cancel(@tag)
           end
         rescue e : FailedDeliveryError
           msg.reject
+        rescue e
+          stop
+          raise e
         end
       end
     end
@@ -209,10 +216,11 @@ module LavinMQ
 
       def stop
         @conn.try &.close
+        @ch = nil
       end
 
       def started? : Bool
-        !@ch.nil?
+        !@ch.nil? && !@conn.try &.closed?
       end
 
       def push(msg, source)
@@ -311,11 +319,13 @@ module LavinMQ
           break if terminated?
           @state = State::Starting
 
-          if @source.last_unacked
-            Log.error { "Restarted with unacked messages, message duplication possible" }
+          unless @source.started?
+            if @source.last_unacked
+              Log.error { "Restarted with unacked messages, message duplication possible" }
+            end
+            @source.start
           end
-          @source.start
-          @destination.start
+          @destination.start unless @destination.started?
 
           break if terminated?
           Log.info { "started" }

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -310,13 +310,13 @@ module LavinMQ
         loop do
           break if terminated?
           @state = State::Starting
-          unless @source.started?
-            if @source.last_unacked
-              Log.error { "Restarted with unacked messages, message duplication possible" }
-            end
-            @source.start
+
+          if @source.last_unacked
+            Log.error { "Restarted with unacked messages, message duplication possible" }
           end
-          @destination.start unless @destination.started?
+          @source.start
+          @destination.start
+
           break if terminated?
           Log.info { "started" }
           @state = State::Running


### PR DESCRIPTION
### WHAT is this pull request doing?
The `started?` method only checks that q/ch is not nil. That is not enough to know that we can actually shovel messages. This updates the `started?` methods on both AMQPSource and AMQPDestination to check that the connection is not closed. Restarts the connection/channel if needed. 
We also stop the source if we encounter an error when trying to deliver, so that it can be restarted. 

### HOW can this pull request be tested?
Manual
