### PR TITLE
Make Observable/Observer generic

### DIFF
--- a/spec/observable_spec.cr
+++ b/spec/observable_spec.cr
@@ -33,6 +33,29 @@ module ObservableSpec
 
   describe LavinMQ::Observable do
     describe "with one observable" do
+      describe "#register_observer" do
+        it "registers observers" do
+          observable = Observable(FooEvent).new
+
+          observable.register_observer(obs1 = Observer(FooEvent).new { |_, _| nil })
+          observable.register_observer(obs2 = Observer(FooEvent).new { |_, _| nil })
+
+          observable.@__t_observers.should eq Set{obs1, obs2}
+        end
+      end
+
+      describe "#unregister_observer" do
+        it "unregisters observers" do
+          observable = Observable(FooEvent).new
+
+          observable.register_observer(obs1 = Observer(FooEvent).new { |_, _| nil })
+          observable.register_observer(obs2 = Observer(FooEvent).new { |_, _| nil })
+          observable.unregister_observer(obs1)
+
+          observable.@__t_observers.should eq Set{obs2}
+        end
+      end
+
       it "notify observers" do
         observable = Observable(FooEvent).new
 

--- a/spec/observable_spec.cr
+++ b/spec/observable_spec.cr
@@ -1,0 +1,77 @@
+require "spec"
+require "../src/lavinmq/observable"
+
+module ObservableSpec
+  enum FooEvent
+    Foo1
+    Foo2
+  end
+  enum BarEvent
+    Bar1
+    Bar2
+  end
+
+  class Observer(T)
+    include LavinMQ::Observer(T)
+
+    def initialize(&@callback : (T, Int32) ->)
+    end
+
+    def on(event : T, data : Object?)
+      @callback.call(event, data.as(Int32))
+    end
+  end
+
+  class Observable(T)
+    include LavinMQ::Observable(T)
+  end
+
+  class Observable2(T, S)
+    include LavinMQ::Observable(T)
+    include LavinMQ::Observable(S)
+  end
+
+  describe LavinMQ::Observable do
+    describe "with one observable" do
+      it "notify observers" do
+        observable = Observable(FooEvent).new
+
+        events1 = Array({FooEvent, Int32}).new
+        events2 = Array({FooEvent, Int32}).new
+        observable.register_observer(Observer(FooEvent).new do |event, data|
+          events1 << {event, data}
+        end)
+        observable.register_observer(Observer(FooEvent).new do |event, data|
+          events2 << {event, data}
+        end)
+
+        observable.notify_observers(FooEvent::Foo1, 1)
+        observable.notify_observers(FooEvent::Foo2, 2)
+
+        events1.should eq [{FooEvent::Foo1, 1}, {FooEvent::Foo2, 2}]
+        events2.should eq [{FooEvent::Foo1, 1}, {FooEvent::Foo2, 2}]
+      end
+    end
+
+    describe "with two observable" do
+      it "notify right observers" do
+        observable = Observable2(FooEvent, BarEvent).new
+
+        events1 = Array({FooEvent, Int32}).new
+        events2 = Array({BarEvent, Int32}).new
+        observable.register_observer(Observer(FooEvent).new do |event, data|
+          events1 << {event, data}
+        end)
+        observable.register_observer(Observer(BarEvent).new do |event, data|
+          events2 << {event, data}
+        end)
+
+        observable.notify_observers(FooEvent::Foo1, 1)
+        observable.notify_observers(FooEvent::Foo2, 2)
+
+        events1.should eq [{FooEvent::Foo1, 1}, {FooEvent::Foo2, 2}]
+        events2.should be_empty
+      end
+    end
+  end
+end

--- a/src/lavinmq/exchange/event.cr
+++ b/src/lavinmq/exchange/event.cr
@@ -1,0 +1,7 @@
+module LavinMQ
+  enum ExchangeEvent
+    Bind
+    Unbind
+    Deleted
+  end
+end

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -1,12 +1,13 @@
 require "../observable"
 require "amqp-client"
 require "../sortable_json"
+require "../queue/event"
+require "../exchange/event"
 
 module LavinMQ
   module Federation
     class Upstream
       abstract class Link
-        include Observer
         include SortableJSON
         getter last_changed, error, state
 
@@ -59,7 +60,6 @@ module LavinMQ
         # Does not trigger reconnect, but a graceful close
         def terminate
           return if @state.terminated?
-          unregister_observer
           state(State::Terminating)
           @upstream_connection.try &.close
           @downstream_connection.try &.close
@@ -135,9 +135,7 @@ module LavinMQ
         end
 
         abstract def name : String
-        abstract def on(event : Symbol, data : Object)
         private abstract def start_link
-        private abstract def unregister_observer
 
         private def start_link_common(&)
           return if @state.terminated?
@@ -168,6 +166,7 @@ module LavinMQ
       end
 
       class QueueLink < Link
+        include Observer(QueueEvent)
         @consumer_available = Channel(Nil).new(1)
         EXCHANGE = ""
 
@@ -184,6 +183,7 @@ module LavinMQ
         end
 
         def terminate
+          @federated_q.unregister_observer(self)
           super
           @consumer_available.close
         end
@@ -195,24 +195,20 @@ module LavinMQ
           end
         end
 
-        def on(event, data)
+        def on(event : QueueEvent, data)
           return if @state.terminated? || @state.terminating?
           @log.debug { "event=#{event} data=#{data}" }
           case event
-          when :delete, :close
+          when .deleted?, .closed?
             @upstream.stop_link(@federated_q)
-          when :add_consumer
+          when .consumer_added?
             consumer_available
-          when :rm_consumer
+          when .consumer_removed?
             nil
           else raise "Unexpected event '#{event}'"
           end
         rescue e
           @log.error { "Could not process event=#{event} data=#{data} error=#{e.inspect_with_backtrace}" }
-        end
-
-        private def unregister_observer
-          @federated_q.unregister_observer(self)
         end
 
         private def setup_queue(upstream_client)
@@ -251,6 +247,7 @@ module LavinMQ
       end
 
       class ExchangeLink < Link
+        include Observer(ExchangeEvent)
         @consumer_q : ::AMQP::Client::Queue?
 
         def initialize(@upstream : Upstream, @federated_ex : Exchange, @upstream_q : String,
@@ -264,19 +261,19 @@ module LavinMQ
           @federated_ex.name
         end
 
-        def on(event, data)
+        def on(event : ExchangeEvent, data)
           return if @state.terminated? || @state.terminating?
           @log.debug { "event=#{event} data=#{data}" }
           case event
-          when :delete
+          when .deleted?
             @upstream.stop_link(@federated_ex)
-          when :bind
+          when .bind?
             with_consumer_q do |q|
               b = data_as_binding_details(data)
               args = b.arguments || ::AMQP::Client::Arguments.new
               q.bind(@upstream_exchange, b.routing_key, args: args)
             end
-          when :unbind
+          when .unbind?
             with_consumer_q do |q|
               b = data_as_binding_details(data)
               args = b.arguments || ::AMQP::Client::Arguments.new
@@ -304,6 +301,7 @@ module LavinMQ
 
         def terminate
           super
+          @federated_ex.unregister_observer(self)
           cleanup
         end
 
@@ -320,10 +318,6 @@ module LavinMQ
           end
         rescue e
           @log.warn(exception: e) { "cleanup interrupted " }
-        end
-
-        private def unregister_observer
-          @federated_ex.unregister_observer(self)
         end
 
         private def setup(upstream_client)

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -199,13 +199,12 @@ module LavinMQ
           return if @state.terminated? || @state.terminating?
           @log.debug { "event=#{event} data=#{data}" }
           case event
-          when .deleted?, .closed?
+          in .deleted?, .closed?
             @upstream.stop_link(@federated_q)
-          when .consumer_added?
+          in .consumer_added?
             consumer_available
-          when .consumer_removed?
+          in .consumer_removed?
             nil
-          else raise "Unexpected event '#{event}'"
           end
         rescue e
           @log.error { "Could not process event=#{event} data=#{data} error=#{e.inspect_with_backtrace}" }
@@ -265,21 +264,20 @@ module LavinMQ
           return if @state.terminated? || @state.terminating?
           @log.debug { "event=#{event} data=#{data}" }
           case event
-          when .deleted?
+          in .deleted?
             @upstream.stop_link(@federated_ex)
-          when .bind?
+          in .bind?
             with_consumer_q do |q|
               b = data_as_binding_details(data)
               args = b.arguments || ::AMQP::Client::Arguments.new
               q.bind(@upstream_exchange, b.routing_key, args: args)
             end
-          when .unbind?
+          in .unbind?
             with_consumer_q do |q|
               b = data_as_binding_details(data)
               args = b.arguments || ::AMQP::Client::Arguments.new
               q.unbind(@upstream_exchange, b.routing_key, args: args)
             end
-          else raise "Unexpected event '#{event}'"
           end
         rescue e
           @log.error { "Could not process event=#{event} data=#{data} error=#{e.inspect_with_backtrace}" }

--- a/src/lavinmq/observable.cr
+++ b/src/lavinmq/observable.cr
@@ -5,19 +5,19 @@ module LavinMQ
 
   module Observable(EventT)
     macro included
-      {% ivar_name = ("@__" + EventT.name.stringify.downcase.gsub(/[^a-z_]+/, "_") + "_observers").id %}
-      {{ivar_name}} = Set(LavinMQ::Observer({{EventT}})).new
+      {% ivar = ("@__" + EventT.name.stringify.downcase.gsub(/[^a-z_]+/, "_") + "_observers").id %}
+      {{ivar}} = Set(LavinMQ::Observer({{EventT}})).new
 
       def register_observer(observer : LavinMQ::Observer({{EventT}}))
-        {{ivar_name}}.add(observer)
+        {{ivar}}.add(observer)
       end
 
       def unregister_observer(observer : LavinMQ::Observer({{EventT}}))
-        {{ivar_name}}.delete(observer)
+        {{ivar}}.delete(observer)
       end
 
       def notify_observers(event : {{EventT}}, data : Object? = nil)
-        {{ivar_name}}.each &.on(event, data)
+        {{ivar}}.each &.on(event, data)
       end
     end
   end

--- a/src/lavinmq/observable.cr
+++ b/src/lavinmq/observable.cr
@@ -5,19 +5,19 @@ module LavinMQ
 
   module Observable(EventT)
     macro included
-      {% ivar = ("@__" + EventT.name.stringify.downcase.gsub(/[^a-z_]+/, "_") + "_observers").id %}
-      {{ivar}} = Set(LavinMQ::Observer({{EventT}})).new
+      {% observers_ivar = ("@__" + EventT.name.stringify.downcase.gsub(/[^a-z_]+/, "_") + "_observers").id %}
+      {{observers_ivar}} = Set(LavinMQ::Observer({{EventT}})).new
 
       def register_observer(observer : LavinMQ::Observer({{EventT}}))
-        {{ivar}}.add(observer)
+        {{observers_ivar}}.add(observer)
       end
 
       def unregister_observer(observer : LavinMQ::Observer({{EventT}}))
-        {{ivar}}.delete(observer)
+        {{observers_ivar}}.delete(observer)
       end
 
       def notify_observers(event : {{EventT}}, data : Object? = nil)
-        {{ivar}}.each &.on(event, data)
+        {{observers_ivar}}.each &.on(event, data)
       end
     end
   end

--- a/src/lavinmq/queue/event.cr
+++ b/src/lavinmq/queue/event.cr
@@ -1,0 +1,8 @@
+module LavinMQ
+  enum QueueEvent
+    Closed
+    Deleted
+    ConsumerAdded
+    ConsumerRemoved
+  end
+end

--- a/src/lavinmq/queue/state.cr
+++ b/src/lavinmq/queue/state.cr
@@ -1,0 +1,13 @@
+module LavinMQ
+  enum QueueState
+    Running
+    Paused
+    Flow
+    Closed
+    Deleted
+
+    def to_s
+      super.downcase
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?
This make the event type of Observable/Observer generic. By doing so it's possible to have multiple includes of these modules with different event types and use e.g. enums as events to make it typed.
It also enables different overloads of `Observer#on` for different event types.

### HOW can this pull request be tested?
Run specs
