### PR TITLE
Fix flaky spec: trigger updates instead of rely on sleeps

### DIFF
--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -37,7 +37,7 @@ describe "Flow" do
 
   it "should stop flow when disk is almost full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    Server.system_metrics(nil)
+    Server.update_system_metrics(nil)
     Server.disk_full?.should be_true
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
@@ -46,10 +46,10 @@ describe "Flow" do
 
   it "should resume flow when disk is no longer full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    Server.system_metrics(nil)
+    Server.update_system_metrics(nil)
     Server.disk_full?.should be_true
     LavinMQ::Config.instance.free_disk_min = 0
-    Server.system_metrics(nil)
+    Server.update_system_metrics(nil)
     Server.disk_full?.should be_false
   ensure
     LavinMQ::Config.instance.free_disk_min = 0

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -37,7 +37,7 @@ describe "Flow" do
 
   it "should stop flow when disk is almost full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    sleep 0.1
+    Server.system_metrics(nil)
     Server.disk_full?.should be_true
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
@@ -46,11 +46,10 @@ describe "Flow" do
 
   it "should resume flow when disk is no longer full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    sleep 0.1
+    Server.system_metrics(nil)
     Server.disk_full?.should be_true
-
     LavinMQ::Config.instance.free_disk_min = 0
-    sleep 0.1
+    Server.system_metrics(nil)
     Server.disk_full?.should be_false
   ensure
     LavinMQ::Config.instance.free_disk_min = 0

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -257,7 +257,7 @@ module LavinMQ
       end
     end
 
-    def system_metrics(statm)
+    def update_system_metrics(statm)
       interval = Config.instance.stats_interval.milliseconds.to_i
       log_size = Config.instance.stats_log_size
       rusage = System.resource_usage
@@ -315,7 +315,7 @@ module LavinMQ
             update_stats_rates
           end
           @stats_system_collection_duration_seconds = Time.measure do
-            system_metrics(statm)
+            update_system_metrics(statm)
           end
         end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
The `should resume flow when disk is no longer full` flow spec is flaky on macos. This PR try to fix the specs by triggering disk update instead of relying on sleeps and fiber work.

### HOW can this pull request be tested?
Run specs. For me it failed locally with seed 73372 before this patch.
