### PR TITLE
Refactor Reporter to not know about implementations

### DIFF
--- a/src/lavinmq/client/client.cr
+++ b/src/lavinmq/client/client.cr
@@ -11,11 +11,13 @@ require "../error"
 require "./amqp_connection"
 require "../config"
 require "../http/handler/websocket"
+require "../reporter"
 
 module LavinMQ
   class Client
     include Stats
     include SortableJSON
+    include Reportable
 
     getter vhost, channels, log, name
     getter user
@@ -36,6 +38,7 @@ module LavinMQ
     @last_sent_frame = RoughTime.monotonic
     rate_stats({"send_oct", "recv_oct"})
     DEFAULT_EX = "amq.default"
+    reportables channels
 
     def initialize(@socket : IO,
                    @connection_info : ConnectionInfo,

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -3,6 +3,7 @@ require "../segment_position"
 require "log"
 require "file_utils"
 require "../replication/server"
+require "../reporter"
 
 module LavinMQ
   class Queue
@@ -15,6 +16,9 @@ module LavinMQ
     # Messages are refered to as SegmentPositions
     # Deleted messages are written to acks.#{segment}
     class MessageStore
+      include Reportable
+
+      reportables @segments, @acks, @deleted, @segment_msg_count, @requeued
       PURGE_YIELD_INTERVAL = 16_384
       Log                  = ::Log.for("MessageStore")
       @segments = Hash(UInt32, MFile).new

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -9,6 +9,7 @@ require "../message"
 require "../error"
 require "./state"
 require "./event"
+require "../reporter"
 require "./message_store"
 
 module LavinMQ
@@ -17,6 +18,9 @@ module LavinMQ
     include Observable(QueueEvent)
     include Stats
     include SortableJSON
+    include Reportable
+
+    reportables @consumers, @deliveries, @msg_store
 
     @log : Log
     @message_ttl : Int64?

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -14,12 +14,16 @@ require "./connection_info"
 require "./proxy_protocol"
 require "./client/client"
 require "./stats"
+require "./reporter"
 
 module LavinMQ
   class Server
     getter vhosts, users, data_dir, parameters
     getter? closed, flow
     include ParameterTarget
+    include Reportable
+
+    reportables users, vhosts
 
     @start = Time.monotonic
     @closed = false

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -13,15 +13,19 @@ require "./queue"
 require "./schema"
 require "./event_type"
 require "./stats"
+require "./reporter"
 
 module LavinMQ
   class VHost
     include SortableJSON
     include Stats
+    include Reportable
 
     rate_stats({"channel_closed", "channel_created", "connection_closed", "connection_created",
                 "queue_declared", "queue_deleted", "ack", "deliver", "get", "publish", "confirm",
                 "redeliver", "reject", "consumer_added", "consumer_removed"})
+
+    reportables exchanges, queues, connections
 
     getter name, exchanges, queues, data_dir, operator_policies, policies, parameters, shovels,
       direct_reply_consumers, connections, dir, users


### PR DESCRIPTION
### WHAT is this pull request doing?
The `Reporter` class is an odd bird and only used for debugging purposes. It knows too much about classes (even accessing instance variables) which prevents refactoring.

This PR refactors `Reporter` to not know anything about any implementation; instead "reportable" entities must include the `Reportable` module and specify their reportable objects with the `reportables` macro.

The macro may look scary at a first glance, but it will generate a `__report` method that will report all specified "reportables" to the `Reporter` instance. This makes the `Reporter` only responsible for the output, while each entity is responsible for what to report.

### HOW can this pull request be tested?
Run lavinmq and send `USR1` to observe output.
