### PR TITLE
TCP quick ack

### DIFF
--- a/src/lavinmq/client/channel.cr
+++ b/src/lavinmq/client/channel.cr
@@ -211,6 +211,7 @@ module LavinMQ
       end
 
       private def finish_publish(body_io)
+        @client.quickack
         @publish_count += 1
         @client.vhost.event_tick(EventType::ClientPublish)
         props = @next_msg_props.not_nil!

--- a/src/stdlib/socket.cr
+++ b/src/stdlib/socket.cr
@@ -1,0 +1,11 @@
+require "socket"
+
+lib LibC
+  TCP_QUICKACK = 12
+end
+
+class TCPSocket < IPSocket
+  def tcp_quickack=(val : Bool)
+    setsockopt_bool LibC::TCP_QUICKACK, val, level: Protocol::TCP
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?

Enable TCP quick ack after each frame that doesn't generates a reply, so that client's don't need to disable nagle's algorithm, in write-write-read scenarios. 

### HOW can this pull request be tested?

Send two frames, then wait for a response, eg Basic.consume with no_wait and then publish a message to that queue. Without TCP quick ack, or TCP no delay on the client side, the client will wait 40ms for the server to TCP ack the last basic.consume frame before sending the publish frames.

With TCP no delay on the client side the client don't wait for TCP acks from the server to send the next TCP packet, but it also means that it won't aggregate many small publishes in large TCP packets.

This PR currently has a performance hit for publish only workloads. 