### PR TITLE
Dont run append if @followers is empty

### DIFF
--- a/src/lavinmq/replication/server.cr
+++ b/src/lavinmq/replication/server.cr
@@ -54,12 +54,12 @@ module LavinMQ
       end
 
       def append(path : String, file : MFile, position : Int32, length : Int32)
-        return if @followers.size.zero?
+        return if @followers.empty?
         append path, FileRange.new(file, position, length)
       end
 
       def append(path : String, obj)
-        return if @followers.size.zero?
+        return if @followers.empty?
         Log.debug { "appending #{obj} to #{path}" }
         each_follower &.append(path, obj)
       end

--- a/src/lavinmq/replication/server.cr
+++ b/src/lavinmq/replication/server.cr
@@ -54,10 +54,12 @@ module LavinMQ
       end
 
       def append(path : String, file : MFile, position : Int32, length : Int32)
+        return if @followers.size.zero?
         append path, FileRange.new(file, position, length)
       end
 
       def append(path : String, obj)
+        return if @followers.size.zero?
         Log.debug { "appending #{obj} to #{path}" }
         each_follower &.append(path, obj)
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
Replication::Server#append is called from several places, sometimes with `append(path : String, file : MFile, position : Int32, length : Int32)`. That creates a new FileRange even though there are no followers, using unnecessary resources. This returns early from append if the follower array is empty. 

### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
