### PR TITLE
Handle empty msg files on start

### DIFF
--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -29,7 +29,7 @@ describe LavinMQ::SchemaVersion do
         file.resize(LavinMQ::Config.instance.segment_size)
         # init new message store
         msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
-        msg_store.@segments.first[1].size.should eq 4
+        msg_store.@segments.first_value.size.should eq 4
       end
     end
 

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -3,11 +3,11 @@ require "../src/lavinmq/schema"
 
 describe LavinMQ::SchemaVersion do
   describe "Schema version" do
-    it "Empty file should raise EmptyFile" do
+    it "Empty file should raise IO::EOFError" do
       with_datadir do |data_dir|
         path = File.join(data_dir, "test_schema_version")
         file = MFile.new(path, 12)
-        expect_raises(LavinMQ::EmptyFile) do
+        expect_raises(IO::EOFError) do
           LavinMQ::SchemaVersion.verify(file, :message)
         end
       end

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -1,0 +1,23 @@
+require "./spec_helper"
+require "../src/lavinmq/schema"
+
+describe LavinMQ::SchemaVersion do
+  describe "Schema version" do
+    it "Empty file should raise EmptyFile" do
+      data_dir = "/tmp/lavinmq-spec"
+      path = File.join(data_dir, "test_schema_version")
+      file = MFile.new(path, 12)
+      expect_raises(LavinMQ::EmptyFile) do
+        LavinMQ::SchemaVersion.verify(file, :message)
+      end
+    end
+
+    it "Should verify schema version" do
+      data_dir = "/tmp/lavinmq-spec"
+      path = File.join(data_dir, "test_schema_version")
+      file = MFile.new(path, 12)
+      file.write_bytes LavinMQ::Schema::VERSION
+      LavinMQ::SchemaVersion.verify(file, :message).should eq LavinMQ::SchemaVersion::VERSIONS[:message]
+    end
+  end
+end

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -19,5 +19,27 @@ describe LavinMQ::SchemaVersion do
       file.write_bytes LavinMQ::Schema::VERSION
       LavinMQ::SchemaVersion.verify(file, :message).should eq LavinMQ::SchemaVersion::VERSIONS[:message]
     end
+
+    it "Deletes empty file and creates a new when it is the first file" do
+      data_dir = "/tmp/lavinmq-spec"
+      path = File.join(data_dir, "msgs.0000000001")
+      file = MFile.new(path, LavinMQ::Config.instance.segment_size)
+      file.resize(LavinMQ::Config.instance.segment_size)
+      # init new message store
+      msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
+      msg_store.@segments.first[1].size.should eq 4
+    end
+
+    it "Deletes empty file when it is second file" do
+      v = Server.vhosts["/"].not_nil!
+      v.declare_queue("q", true, false)
+      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
+      path = File.join(data_dir, "msgs.0000000002")
+      file = MFile.new(path, LavinMQ::Config.instance.segment_size)
+      file.resize(LavinMQ::Config.instance.segment_size)
+      # init new message store
+      msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
+      msg_store.@segments.size.should eq 1
+    end
   end
 end

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -4,8 +4,7 @@ require "../src/lavinmq/schema"
 describe LavinMQ::SchemaVersion do
   describe "Schema version" do
     it "Empty file should raise EmptyFile" do
-      with_amqp_server do |_s|
-        data_dir = "/tmp/lavinmq-spec"
+      with_datadir do |data_dir|
         path = File.join(data_dir, "test_schema_version")
         file = MFile.new(path, 12)
         expect_raises(LavinMQ::EmptyFile) do
@@ -15,8 +14,7 @@ describe LavinMQ::SchemaVersion do
     end
 
     it "Should verify schema version" do
-      with_amqp_server do |_s|
-        data_dir = "/tmp/lavinmq-spec"
+      with_datadir do |data_dir|
         path = File.join(data_dir, "test_schema_version")
         file = MFile.new(path, 12)
         file.write_bytes LavinMQ::Schema::VERSION
@@ -25,8 +23,7 @@ describe LavinMQ::SchemaVersion do
     end
 
     it "Deletes empty file and creates a new when it is the first file" do
-      with_amqp_server do |_s|
-        data_dir = "/tmp/lavinmq-spec"
+      with_datadir do |data_dir|
         path = File.join(data_dir, "msgs.0000000001")
         file = MFile.new(path, LavinMQ::Config.instance.segment_size)
         file.resize(LavinMQ::Config.instance.segment_size)

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -4,42 +4,50 @@ require "../src/lavinmq/schema"
 describe LavinMQ::SchemaVersion do
   describe "Schema version" do
     it "Empty file should raise EmptyFile" do
-      data_dir = "/tmp/lavinmq-spec"
-      path = File.join(data_dir, "test_schema_version")
-      file = MFile.new(path, 12)
-      expect_raises(LavinMQ::EmptyFile) do
-        LavinMQ::SchemaVersion.verify(file, :message)
+      with_amqp_server do |_s|
+        data_dir = "/tmp/lavinmq-spec"
+        path = File.join(data_dir, "test_schema_version")
+        file = MFile.new(path, 12)
+        expect_raises(LavinMQ::EmptyFile) do
+          LavinMQ::SchemaVersion.verify(file, :message)
+        end
       end
     end
 
     it "Should verify schema version" do
-      data_dir = "/tmp/lavinmq-spec"
-      path = File.join(data_dir, "test_schema_version")
-      file = MFile.new(path, 12)
-      file.write_bytes LavinMQ::Schema::VERSION
-      LavinMQ::SchemaVersion.verify(file, :message).should eq LavinMQ::SchemaVersion::VERSIONS[:message]
+      with_amqp_server do |_s|
+        data_dir = "/tmp/lavinmq-spec"
+        path = File.join(data_dir, "test_schema_version")
+        file = MFile.new(path, 12)
+        file.write_bytes LavinMQ::Schema::VERSION
+        LavinMQ::SchemaVersion.verify(file, :message).should eq LavinMQ::SchemaVersion::VERSIONS[:message]
+      end
     end
 
     it "Deletes empty file and creates a new when it is the first file" do
-      data_dir = "/tmp/lavinmq-spec"
-      path = File.join(data_dir, "msgs.0000000001")
-      file = MFile.new(path, LavinMQ::Config.instance.segment_size)
-      file.resize(LavinMQ::Config.instance.segment_size)
-      # init new message store
-      msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
-      msg_store.@segments.first[1].size.should eq 4
+      with_amqp_server do |_s|
+        data_dir = "/tmp/lavinmq-spec"
+        path = File.join(data_dir, "msgs.0000000001")
+        file = MFile.new(path, LavinMQ::Config.instance.segment_size)
+        file.resize(LavinMQ::Config.instance.segment_size)
+        # init new message store
+        msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
+        msg_store.@segments.first[1].size.should eq 4
+      end
     end
 
     it "Deletes empty file when it is second file" do
-      v = Server.vhosts["/"].not_nil!
-      v.declare_queue("q", true, false)
-      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
-      path = File.join(data_dir, "msgs.0000000002")
-      file = MFile.new(path, LavinMQ::Config.instance.segment_size)
-      file.resize(LavinMQ::Config.instance.segment_size)
-      # init new message store
-      msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
-      msg_store.@segments.size.should eq 1
+      with_amqp_server do |s|
+        v = s.vhosts["/"]
+        v.declare_queue("q", true, false)
+        data_dir = s.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
+        path = File.join(data_dir, "msgs.0000000002")
+        file = MFile.new(path, LavinMQ::Config.instance.segment_size)
+        file.resize(LavinMQ::Config.instance.segment_size)
+        # init new message store
+        msg_store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
+        msg_store.@segments.size.should eq 1
+      end
     end
   end
 end

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -321,6 +321,14 @@ module LavinMQ
           end
           file.pos = 4
           @segments[seg] = file
+        rescue EmptyFile
+          Log.warn { "Empty file at #{path}, setting schema version to #{Schema::VERSION}" }
+          file = file.not_nil!
+          file.resize(0)
+          file.write_bytes Schema::VERSION
+          @replicator.not_nil!.try &.append path.not_nil!, Schema::VERSION
+          file.pos = 4
+          @segments[seg] = file
         end
       end
 

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -324,7 +324,7 @@ module LavinMQ
               Log.warn { "Empty file at #{path}, deleting it" }
               file.delete.close
               @replicator.try &.delete_file(path)
-              if idx == 0
+              if idx == 0 # Recreate the file if it's the first segment because we need at least one segment to exist
                 file = MFile.new(path, Config.instance.segment_size)
                 file.write_bytes Schema::VERSION
                 @replicator.try &.append path, Schema::VERSION

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -319,7 +319,7 @@ module LavinMQ
           else
             begin
               SchemaVersion.verify(file, :message)
-            rescue EmptyFile
+            rescue IO::EOFError
               # delete empty file, it will be recreated if it's needed
               Log.warn { "Empty file at #{path}, deleting it" }
               file.delete.close

--- a/src/lavinmq/schema.cr
+++ b/src/lavinmq/schema.cr
@@ -325,5 +325,5 @@ module LavinMQ
     end
   end
 
-class EmptyFile < Exception; end
+  class EmptyFile < Exception; end
 end

--- a/src/lavinmq/schema.cr
+++ b/src/lavinmq/schema.cr
@@ -325,6 +325,5 @@ module LavinMQ
     end
   end
 
-  class EmptyFile < Exception
-  end
+class EmptyFile < Exception; end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
Handles empty msg files on startup and sets Schema version to default. 

I think this can happen if a queue is created and lavinmq is killed before anything is written to the file. 

Fixes #624 

### HOW can this pull request be tested?
Run specs