### PR TITLE
Allow array of URIs when creating shovel

### DIFF
--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -18,7 +18,7 @@ describe LavinMQ::Shovel do
     it "should shovel and stop when queue length is met" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -47,7 +47,7 @@ describe LavinMQ::Shovel do
     it "should shovel large messages" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "lm_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -64,7 +64,7 @@ describe LavinMQ::Shovel do
     end
 
     it "should shovel forever" do
-      source = LavinMQ::Shovel::AMQPSource.new("spec", URI.parse(SpecHelper.amqp_base_url), "sf_q1", direct_user: Server.users.direct_user)
+      source = LavinMQ::Shovel::AMQPSource.new("spec", [URI.parse(SpecHelper.amqp_base_url)], "sf_q1", direct_user: Server.users.direct_user)
       dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(SpecHelper.amqp_base_url), "sf_q2", direct_user: Server.users.direct_user)
       shovel = LavinMQ::Shovel::Runner.new(source, dest, "sf_shovel", vhost)
       with_channel do |ch|
@@ -89,7 +89,7 @@ describe LavinMQ::Shovel do
       ack_mode = LavinMQ::Shovel::AckMode::OnPublish
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "ap_q1",
         prefetch: 1_u16,
         ack_mode: ack_mode,
@@ -118,7 +118,7 @@ describe LavinMQ::Shovel do
       ack_mode = LavinMQ::Shovel::AckMode::NoAck
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "na_q1",
         ack_mode: ack_mode,
         direct_user: Server.users.direct_user
@@ -145,7 +145,7 @@ describe LavinMQ::Shovel do
     it "should shovel past prefetch" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "prefetch_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         prefetch: 21_u16,
@@ -176,7 +176,7 @@ describe LavinMQ::Shovel do
     it "should shovel once qs are declared" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "od_q1",
         direct_user: Server.users.direct_user
       )
@@ -238,7 +238,7 @@ describe LavinMQ::Shovel do
     it "should shovel over amqps" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse("#{SpecHelper.amqps_base_url}?verify=none"),
+        [URI.parse("#{SpecHelper.amqps_base_url}?verify=none")],
         "ssl_q1",
         direct_user: Server.users.direct_user
       )
@@ -264,7 +264,7 @@ describe LavinMQ::Shovel do
       prefetch = 9_u16
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "prefetch2_q1",
         prefetch: prefetch,
         direct_user: Server.users.direct_user
@@ -299,7 +299,7 @@ describe LavinMQ::Shovel do
         uri.password = "bar"
         source = LavinMQ::Shovel::AMQPSource.new(
           "spec",
-          uri,
+          [uri],
           "q1",
           direct_user: Server.users.direct_user
         )
@@ -321,7 +321,7 @@ describe LavinMQ::Shovel do
     it "should count messages shoveled" do
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "c_q1",
         direct_user: Server.users.direct_user
       )
@@ -350,7 +350,7 @@ describe LavinMQ::Shovel do
       consumer_args = {"x-stream-offset" => JSON::Any.new("first")}
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         q1_name,
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user,
@@ -399,7 +399,7 @@ describe LavinMQ::Shovel do
       long_prefix = "a" * 250
       source = LavinMQ::Shovel::AMQPSource.new(
         "#{long_prefix}q1",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "#{long_prefix}q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -447,7 +447,7 @@ describe LavinMQ::Shovel do
       # # Setup shovel source and destination
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user
@@ -495,7 +495,7 @@ describe LavinMQ::Shovel do
       # # Setup shovel source and destination
       source = LavinMQ::Shovel::AMQPSource.new(
         "spec",
-        URI.parse(SpecHelper.amqp_base_url),
+        [URI.parse(SpecHelper.amqp_base_url)],
         "ql_q1",
         delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
         direct_user: Server.users.direct_user

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -167,6 +167,7 @@ module LavinMQ
 
     class DestinationWrapper < Destination
       @current_dest : Destination?
+
       def initialize(@destinations : Array(Destination))
       end
 

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -39,23 +39,28 @@ module LavinMQ
 
       getter delete_after, last_unacked
 
-      def initialize(@name : String, @uri : URI, @queue : String?, @exchange : String? = nil,
+      def initialize(@name : String, @uris : Array(URI), @queue : String?, @exchange : String? = nil,
                      @exchange_key : String? = nil,
                      @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
                      @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
         @tag = "Shovel"
-        unless @uri.user
-          if direct_user
-            @uri.user = direct_user.name
-            @uri.password = direct_user.plain_text_password
-          else
-            raise ArgumentError.new("direct_user required")
+        cfg = Config.instance
+        raise ArgumentError.new("At least one source uri is required") if @uris.empty?
+        @uris.each do |uri|
+          uri.host ||= "#{cfg.amqp_bind}:#{cfg.amqp_port}"
+          unless uri.user
+            if direct_user
+              uri.user = direct_user.name
+              uri.password = direct_user.plain_text_password
+            else
+              raise ArgumentError.new("direct_user required")
+            end
           end
+          params = uri.query_params
+          params["name"] ||= "Shovel #{@name} source"
+          uri.query = params.to_s
         end
-        params = @uri.query_params
-        params["name"] ||= "Shovel #{@name} source"
-        @uri.query = params.to_s
         if @queue.nil? && @exchange.nil?
           raise ArgumentError.new("Shovel source requires a queue or an exchange")
         end
@@ -69,7 +74,7 @@ module LavinMQ
         if c = @conn
           c.close
         end
-        @conn = ::AMQP::Client.new(@uri).connect
+        @conn = ::AMQP::Client.new(@uris.sample).connect
         open_channel
       end
 
@@ -158,6 +163,35 @@ module LavinMQ
       abstract def push(msg, source)
 
       abstract def started? : Bool
+    end
+
+    class DestinationWrapper < Destination
+      @current_dest : Destination?
+      def initialize(@destinations : Array(Destination))
+      end
+
+      def start
+        next_dest = @destinations.sample
+        return unless next_dest
+        next_dest.start
+        @current_dest = next_dest
+      end
+
+      def stop
+        @current_dest.try &.stop
+        @current_dest = nil
+      end
+
+      def push(msg, source)
+        @current_dest.try &.push(msg, source)
+      end
+
+      def started? : Bool
+        if dest = @current_dest
+          return dest.started?
+        end
+        false
+      end
     end
 
     class AMQPDestination < Destination
@@ -335,7 +369,7 @@ module LavinMQ
           @vhost.delete_parameter("shovel", @name) if @source.delete_after.queue_length?
           break
         rescue ex : ::AMQP::Client::Connection::ClosedException | ::AMQP::Client::Channel::ClosedException | Socket::ConnectError
-          return if terminated?
+          break if terminated?
           @state = State::Error
           # Shoveled queue was deleted
           if ex.message.to_s.starts_with?("404")

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -165,7 +165,7 @@ module LavinMQ
       abstract def started? : Bool
     end
 
-    class DestinationWrapper < Destination
+    class MultiDestinationHandler < Destination
       @current_dest : Destination?
 
       def initialize(@destinations : Array(Destination))

--- a/src/lavinmq/shovel/shovel_store.cr
+++ b/src/lavinmq/shovel/shovel_store.cr
@@ -8,7 +8,7 @@ module LavinMQ
 
     forward_missing_to @shovels
 
-    def parse_uris(src_uri) : Array(URI)
+    def parse_uris(src_uri : JSON::Any) : Array(URI)
       uris = src_uri.as_s? ? [src_uri.as_s] : src_uri.as_a.map(&.as_s)
       uris.map do |uri|
         URI.parse(uri)
@@ -64,7 +64,7 @@ module LavinMQ
             direct_user: @vhost.users.direct_user)
         end
       end
-      Shovel::DestinationWrapper.new(destinations)
+      Shovel::MultiDestinationHandler.new(destinations)
     end
   end
 end

--- a/src/lavinmq/shovel/shovel_store.cr
+++ b/src/lavinmq/shovel/shovel_store.cr
@@ -8,6 +8,13 @@ module LavinMQ
 
     forward_missing_to @shovels
 
+    def parse_uris(src_uri) : Array(URI)
+      uris = src_uri.as_s? ? [src_uri.as_s] : src_uri.as_a.map(&.as_s)
+      uris.map do |uri|
+        URI.parse(uri)
+      end
+    end
+
     def create(name, config)
       @shovels[name]?.try &.terminate
       delete_after_str = config["src-delete-after"]?.try(&.as_s.delete("-")).to_s
@@ -16,7 +23,7 @@ module LavinMQ
       ack_mode = Shovel::AckMode.parse?(ack_mode_str) || Shovel::DEFAULT_ACK_MODE
       reconnect_delay = config["reconnect-delay"]?.try &.as_i || Shovel::DEFAULT_RECONNECT_DELAY
       prefetch = config["src-prefetch-count"]?.try(&.as_i.to_u16) || Shovel::DEFAULT_PREFETCH
-      src = Shovel::AMQPSource.new(name, URI.parse(config["src-uri"].as_s),
+      src = Shovel::AMQPSource.new(name, parse_uris(config["src-uri"]),
         config["src-queue"]?.try &.as_s?,
         config["src-exchange"]?.try &.as_s?,
         config["src-exchange-key"]?.try &.as_s?,
@@ -42,19 +49,22 @@ module LavinMQ
     end
 
     private def destination(name, config, ack_mode, delete_after, prefetch)
-      uri = URI.parse(config["dest-uri"].as_s)
-      case uri.scheme
-      when "http", "https"
-        Shovel::HTTPDestination.new(name, uri)
-      else
-        Shovel::AMQPDestination.new(name, uri,
-          config["dest-queue"]?.try &.as_s?,
-          config["dest-exchange"]?.try &.as_s?,
-          config["dest-exchange-key"]?.try &.as_s?,
-          delete_after: delete_after,
-          prefetch: prefetch,
-          direct_user: @vhost.users.direct_user)
+      uris = parse_uris(config["dest-uri"])
+      destinations = uris.map do |uri|
+        case uri.scheme
+        when "http", "https"
+          Shovel::HTTPDestination.new(name, uri)
+        else
+          Shovel::AMQPDestination.new(name, uri,
+            config["dest-queue"]?.try &.as_s?,
+            config["dest-exchange"]?.try &.as_s?,
+            config["dest-exchange-key"]?.try &.as_s?,
+            delete_after: delete_after,
+            prefetch: prefetch,
+            direct_user: @vhost.users.direct_user)
+        end
       end
+      Shovel::DestinationWrapper.new(destinations)
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
Allows for multiple URIs to be sent in when creating a shovel. This input can now be either a string, or an array of strings. If more than one uri string is provided, the shovel will randomly pick one URI from the list until one of the endpoints succeeds.
Needed for [compatibility](https://www.rabbitmq.com/docs/shovel-dynamic#:~:text=Note%20that%20this%20field%20can%20either%20be%20a%20string%2C%20or%20a%20list%20of%20strings.%20If%20more%20than%20one%20string%20is%20provided%2C%20the%20shovel%20will%20randomly%20pick%20one%20URI%20from%20the%20list%20until%20one%20of%20the%20endpoints%20succeeds.) with clients

still needs some small adjustments


### HOW can this pull request be tested?
Try to create a shovel and send in multiple uris
