### PR TITLE
Reconnect clients that gets disconnected in lavinmqperf throughput

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   amqp-client:
     git: https://github.com/cloudamqp/amqp-client.cr.git
-    version: 1.2.3
+    version: 1.2.4
 
   lz4:
     git: https://github.com/84codes/lz4.cr.git


### PR DESCRIPTION
### WHAT is this pull request doing?

Automatically reconnect clients if they get disconnected while running `lavinmqperf throughput`. 


### HOW can this pull request be tested?

Run `lavinmqperf throughput`, then shutdown the server, and start it again, perf should reconnect and continue
