### PR TITLE
MFile: unmap on finalize

### DIFF
--- a/spec/mfile_spec.cr
+++ b/spec/mfile_spec.cr
@@ -1,63 +1,15 @@
 require "spec"
 require "../src/lavinmq/mfile"
 
-module MFileSpec
-  def self.with_file(&)
+describe MFile do
+  it "can be double closed" do
     file = File.tempfile "mfile_spec"
-    yield file
-  ensure
-    file.delete unless file.nil?
-  end
-
-  describe MFile do
-    describe "#write" do
-      it "should raise ClosedError if closed" do
-        with_file do |file|
-          mfile = MFile.new file.path
-          mfile.close
-          expect_raises(MFile::ClosedError) { mfile.write "foo".to_slice }
-        end
-      end
-    end
-    describe "#read" do
-      it "should raise ClosedError if closed" do
-        with_file do |file|
-          mfile = MFile.new file.path
-          mfile.close
-          data = Bytes.new(1)
-          expect_raises(MFile::ClosedError) { mfile.read data }
-        end
-      end
-    end
-    describe "#to_slice" do
-      describe "without position and size" do
-        it "should raise ClosedError if closed" do
-          with_file do |file|
-            mfile = MFile.new file.path
-            mfile.close
-            expect_raises(MFile::ClosedError) { mfile.to_slice }
-          end
-        end
-      end
-      describe "with position and size" do
-        it "should raise ClosedError if closed" do
-          with_file do |file|
-            mfile = MFile.new file.path
-            mfile.close
-            expect_raises(MFile::ClosedError) { mfile.to_slice(1, 1) }
-          end
-        end
-      end
-    end
-    describe "#copy_to" do
-      it "should raise ClosedError if closed" do
-        with_file do |file|
-          mfile = MFile.new file.path
-          mfile.close
-          data = IO::Memory.new
-          expect_raises(MFile::ClosedError) { mfile.copy_to data }
-        end
-      end
+    begin
+      mfile = MFile.new file.path
+      mfile.close
+      mfile.close
+    ensure
+      file.delete
     end
   end
 end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -25,7 +25,6 @@ class MFile < IO
   end
 
   getter pos : Int64 = 0i64
-  getter? closed : Bool = false
   getter size : Int64 = 0i64
   getter capacity : Int64 = 0i64
   getter path : String
@@ -98,22 +97,16 @@ class MFile < IO
     self
   end
 
-  # Unmapping the file
   # The file will be truncated to the current position unless readonly or deleted
   def close(truncate_to_size = true)
-    return if @closed
-    @closed = true
-    begin
-      unmap
-
-      return if @readonly || @deleted || !truncate_to_size
-      code = LibC.ftruncate(@fd, @size)
-      raise File::Error.from_errno("Error truncating file", file: @path) if code < 0
-    ensure
-      code = LibC.close(@fd)
-      raise File::Error.from_errno("Error closing file", file: @path) if code < 0
-      @fd = -1
-    end
+    # unmap occurs on finalize
+    return if @fd < 0 || @readonly || @deleted || !truncate_to_size
+    code = LibC.ftruncate(@fd, @size)
+    raise File::Error.from_errno("Error truncating file", file: @path) if code < 0
+  ensure
+    code = LibC.close(@fd)
+    raise File::Error.from_errno("Error closing file", file: @path) if code < 0
+    @fd = -1
   end
 
   def flush
@@ -142,8 +135,8 @@ class MFile < IO
   # Copies the file to another IO
   # Won't mmap the file if it's unmapped already
   def copy_to(output : IO, size = @size) : Int64
-    raise ClosedError.new if @closed
     if unmapped? # don't remap unmapped files
+      raise ClosedError.new if @fd < 0
       io = IO::FileDescriptor.new(@fd, blocking: true, close_on_finalize: false)
       io.rewind
       IO.copy(io, output, size) == size || raise IO::EOFError.new
@@ -177,7 +170,6 @@ class MFile < IO
   end
 
   def write(slice : Bytes) : Nil
-    raise ClosedError.new if @closed
     size = @size
     new_size = size + slice.size
     raise IO::EOFError.new if new_size > @capacity
@@ -186,7 +178,6 @@ class MFile < IO
   end
 
   def read(slice : Bytes)
-    raise ClosedError.new if @closed
     pos = @pos
     new_pos = pos + slice.size
     raise IO::EOFError.new if new_pos > @size
@@ -232,12 +223,10 @@ class MFile < IO
   end
 
   def to_slice
-    raise ClosedError.new if @closed
     Bytes.new(buffer, @size, read_only: true)
   end
 
   def to_slice(pos, size)
-    raise ClosedError.new if @closed
     raise IO::EOFError.new if pos + size > @size
     Bytes.new(buffer + pos, size, read_only: true)
   end


### PR DESCRIPTION
### WHAT is this pull request doing?
Unmap `MFile` on `finalize` instead of on `close`, so that Replication and other that still references the `MFile` won't get a seg fault. Downside is that memory might not be released as fast to the OS. `unmap` is now only done with the GC runs. 

### HOW can this pull request be tested?

Test different scenarios to see memory impact.
