### PR TITLE
Prometheus exception handling

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -40,7 +40,7 @@ describe LavinMQ::HTTP::ConsumersController do
       prefix = "abcdefghijklmnopqrstuvwxyz"
       response = get("/metrics?prefix=#{prefix}")
       response.status_code.should eq 400
-      response.body.should eq "{\"error\":\"bad_request\",\"reason\":\"prefix to long\"}"
+      response.body.should match /Prefix too long/
     end
   end
 

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -29,11 +29,10 @@ describe LavinMQ::HTTP::ConsumersController do
       prefix = "testing"
       response = get("/metrics?prefix=#{prefix}")
       lines = response.body.lines
+      lines.count(&.starts_with? "telemetry").should eq 2
       metric_lines = lines.reject(&.starts_with? "#")
       prefix_lines = lines.select(&.starts_with? prefix)
-      telemetry_lines = lines.select(&.starts_with? "telemetry")
       prefix_lines.size.should eq metric_lines.size - 2
-      telemetry_lines.size.should eq 2
     end
 
     it "should not support a prefix longer than 20" do

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -106,7 +106,11 @@ module LavinMQ
         mem = 0
         elapsed = Time.measure do
           mem = Benchmark.memory do
-            yield
+            begin
+              yield
+            rescue ex
+              Log.error(exception: ex) { "Error while reporting prometheus metrics" }
+            end
           end
         end
         writer = PrometheusWriter.new(io, "telemetry")

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -115,7 +115,7 @@ module LavinMQ
         end
         writer = PrometheusWriter.new(io, "telemetry")
         writer.write({name:  "scrape_duration_seconds",
-                      type:  "counter",
+                      type:  "gauge",
                       value: elapsed.total_seconds,
                       help:  "Duration for metrics collection in seconds"})
         writer.write({name:  "scrape_mem",
@@ -236,11 +236,11 @@ module LavinMQ
                       help: "Server uptime in seconds"})
         writer.write({name:  "cpu_system_time_total",
                       value: @amqp_server.sys_time,
-                      type:  "counter",
+                      type:  "gauge",
                       help:  "Total CPU system time"})
         writer.write({name:  "cpu_user_time_total",
                       value: @amqp_server.user_time,
-                      type:  "counter",
+                      type:  "gauge",
                       help:  "Total CPU user time"})
         writer.write({name:  "rss_bytes",
                       type:  "gauge",

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -9,6 +9,7 @@ module LavinMQ
       alias MetricLabels = Hash(String, String) |
                            NamedTuple(name: String) |
                            NamedTuple(channel: String) |
+                           NamedTuple(id: Int32) |
                            NamedTuple(queue: String, vhost: String)
       alias Metric = NamedTuple(name: String, value: MetricValue) |
                      NamedTuple(name: String, value: MetricValue, labels: MetricLabels) |
@@ -259,14 +260,15 @@ module LavinMQ
                       type:  "gauge",
                       help:  "Time it takes to collect system metrics"})
         writer.write({name:  "total_connected_followers",
-                      value: @amqp_server.@replicator.followers.size,
+                      value: @amqp_server.followers.size,
                       type:  "gauge",
                       help:  "Amount of follower nodes connected"})
-        @amqp_server.@replicator.followers.each_with_index do |f, i|
-          writer.write({name:  "follower_lag_#{i}",
-                        value: f.lag,
-                        type:  "gauge",
-                        help:  "Lag for follower on address: #{f.@socket.remote_address}"})
+        @amqp_server.followers.each_with_index do |f, i|
+          writer.write({name:   "follower_lag",
+                        labels: {id: i},
+                        value:  f.lag,
+                        type:   "gauge",
+                        help:   "Bytes that hasn't been synchronized with the follower yet"})
         end
       end
 

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -102,10 +102,12 @@ module LavinMQ
         end
       end
 
-      private def report(io, &blk)
+      private def report(io, &)
         mem = 0
         elapsed = Time.measure do
-          mem = Benchmark.memory(&blk)
+          mem = Benchmark.memory do
+            yield
+          end
         end
         writer = PrometheusWriter.new(io, "telemetry")
         writer.write({name:  "scrape_duration_seconds",

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -34,7 +34,7 @@ module LavinMQ
       end
 
       def write(m : Metric)
-        return unless m[:value]?
+        return if m[:value].nil?
         io = @io
         name = "#{@prefix}_#{m[:name]}"
         if t = m[:type]?
@@ -64,7 +64,7 @@ module LavinMQ
         get "/metrics" do |context, _|
           context.response.content_type = "text/plain"
           prefix = context.request.query_params["prefix"]? || "lavinmq"
-          bad_request(context, "prefix to long") if prefix.size > 20
+          bad_request(context, "Prefix too long (max 20 characters)") if prefix.bytesize > 20
           vhosts = target_vhosts(context)
           report(context.response) do
             writer = PrometheusWriter.new(context.response, prefix)
@@ -78,7 +78,7 @@ module LavinMQ
         get "/metrics/detailed" do |context, _|
           context.response.content_type = "text/plain"
           prefix = context.request.query_params["prefix"]? || "lavinmq"
-          bad_request(context, "prefix to long") if prefix.size > 20
+          bad_request(context, "Prefix too long (max 20 characters)") if prefix.bytesize > 20
           families = context.request.query_params.fetch_all("family")
           vhosts = target_vhosts(context)
           report(context.response) do


### PR DESCRIPTION
### WHAT is this pull request doing?

Reporting replication follower lag could raise exception. 
Exceptions while reporting metrics was swallowed.
Some metrics had the wrong type, counter instead of gauge.
Uses `String#bytesize` to validate string lengths (`#size` count multi byte utf8 chars as one)

### HOW can this pull request be tested

Specs
