### PR TITLE
Refactor: inject data dir to replication classes

### DIFF
--- a/spec/replication/actions_spec.cr
+++ b/spec/replication/actions_spec.cr
@@ -1,15 +1,5 @@
 require "../spec_helper"
 
-def with_datadir_tempfile(filename = "data.spec", &)
-  data_dir = File.tempname("lavinmq-data", "spec")
-  Dir.mkdir_p data_dir
-  yield data_dir, filename, File.join(data_dir, filename)
-ensure
-  if data_dir
-    FileUtils.rm_rf data_dir
-  end
-end
-
 def read_and_verify_filename(io, expected_filename)
   filename_size = io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
   filename = Bytes.new(filename_size)
@@ -43,8 +33,9 @@ describe LavinMQ::Replication::Action do
     describe "without @mfile" do
       describe "#send" do
         it "writes filename and data to IO" do
-          with_datadir_tempfile do |data_dir, filename, absolute|
-            File.write absolute, "foo"
+          with_datadir do |data_dir|
+            filename = "file1"
+            File.write File.join(data_dir, filename), "foo"
             action = LavinMQ::Replication::AddAction.new data_dir, filename
             io = IO::Memory.new
             action.send io
@@ -58,10 +49,11 @@ describe LavinMQ::Replication::Action do
 
       describe "#lag_size" do
         it "should count filename and filesize" do
-          with_datadir_tempfile("data") do |data_dir, filename, absolute|
-            File.write absolute, "foo"
+          with_datadir do |data_dir|
+            filename = "file1"
+            File.write File.join(data_dir, filename), "foo"
             action = LavinMQ::Replication::AddAction.new data_dir, filename
-            action.lag_size.should eq(sizeof(Int32) + "data".bytesize + sizeof(Int64) + "foo".bytesize)
+            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
           end
         end
       end
@@ -70,7 +62,9 @@ describe LavinMQ::Replication::Action do
     describe "with @mfile" do
       describe "#send" do
         it "writes filename and data to IO" do
-          with_datadir_tempfile do |data_dir, filename, absolute|
+          with_datadir do |data_dir|
+            filename = "file1"
+            absolute = File.join data_dir, filename
             File.write absolute, "foo"
             action = LavinMQ::Replication::AddAction.new data_dir, filename, MFile.new(absolute)
             io = IO::Memory.new
@@ -84,8 +78,9 @@ describe LavinMQ::Replication::Action do
       end
       describe "#lag_size" do
         it "should count filename and filesize" do
-          with_datadir_tempfile do |data_dir, filename, absolute|
-            File.write absolute, "foo"
+          with_datadir do |data_dir|
+            filename = "file1"
+            File.write File.join(data_dir, filename), "foo"
             action = LavinMQ::Replication::AddAction.new data_dir, filename
             action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
           end
@@ -98,23 +93,23 @@ describe LavinMQ::Replication::Action do
     describe "with Int32" do
       describe "#send" do
         it "writes filename and data to IO" do
-          with_datadir_tempfile do |data_dir, filename, _absolute|
-            action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123i32
-            io = IO::Memory.new
-            action.send io
-            io.rewind
+          filename = "file1"
+          data_dir = "/not/used"
+          action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123i32
+          io = IO::Memory.new
+          action.send io
+          io.rewind
 
-            read_and_verify_filename(io, filename)
-            read_and_verify_data(io, 123i32)
-          end
+          read_and_verify_filename(io, filename)
+          read_and_verify_data(io, 123i32)
         end
       end
       describe "#lag_size" do
         it "should count filename and size of Int32" do
-          with_datadir_tempfile do |data_dir, filename, _absolute|
-            action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123i32
-            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + sizeof(Int32))
-          end
+          filename = "file1"
+          data_dir = "/not/used"
+          action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123i32
+          action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + sizeof(Int32))
         end
       end
     end
@@ -122,23 +117,23 @@ describe LavinMQ::Replication::Action do
     describe "with UInt32" do
       describe "#send" do
         it "writes filename and data to IO" do
-          with_datadir_tempfile do |data_dir, filename, absolute|
-            action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123u32
-            io = IO::Memory.new
-            action.send io
-            io.rewind
+          filename = "file1"
+          data_dir = "/not/used"
+          action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123u32
+          io = IO::Memory.new
+          action.send io
+          io.rewind
 
-            read_and_verify_filename(io, filename)
-            read_and_verify_data(io, 123u32)
-          end
+          read_and_verify_filename(io, filename)
+          read_and_verify_data(io, 123u32)
         end
       end
       describe "#lag_size" do
         it "should count filename and size of UInt32" do
-          with_datadir_tempfile do |data_dir, filename, _absolute|
-            action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123u32
-            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + sizeof(UInt32))
-          end
+          data_dir = "/not/used"
+          filename = "file1"
+          action = LavinMQ::Replication::AppendAction.new data_dir, filename, 123u32
+          action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + sizeof(UInt32))
         end
       end
     end
@@ -146,10 +141,9 @@ describe LavinMQ::Replication::Action do
     describe "with Bytes" do
       describe "#send" do
         it "writes filename and data to IO" do
-          # with_datadir_tempfile do |data_dir, filename, _absolute|
           data = "foo"
           filename = "bar"
-          data_dir = "/data"
+          data_dir = "/not/used"
 
           action = LavinMQ::Replication::AppendAction.new data_dir, filename, data.to_slice
           io = IO::Memory.new
@@ -158,15 +152,14 @@ describe LavinMQ::Replication::Action do
 
           read_and_verify_filename(io, filename)
           read_and_verify_data(io, data.to_slice)
-          # end
         end
       end
       describe "#lag_size" do
         it "should count filename and size of Bytes" do
-          with_datadir_tempfile do |data_dir, filename, _absolute|
-            action = LavinMQ::Replication::AppendAction.new data_dir, filename, "foo".to_slice
-            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".to_slice.bytesize)
-          end
+          filename = "file1"
+          data_dir = "/not/used"
+          action = LavinMQ::Replication::AppendAction.new data_dir, filename, "foo".to_slice
+          action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".to_slice.bytesize)
         end
       end
     end
@@ -174,7 +167,9 @@ describe LavinMQ::Replication::Action do
     describe "with FileRange" do
       describe "#send" do
         it "writes filename and data to IO" do
-          with_datadir_tempfile do |data_dir, filename, absolute|
+          with_datadir do |data_dir|
+            filename = "file1"
+            absolute = File.join data_dir, filename
             File.write absolute, "baz foo bar"
             range = LavinMQ::Replication::FileRange.new(MFile.new(absolute), 4, 3)
             action = LavinMQ::Replication::AppendAction.new data_dir, filename, range
@@ -190,7 +185,9 @@ describe LavinMQ::Replication::Action do
       end
       describe "#lag_size" do
         it "should count filename and size of FileRange" do
-          with_datadir_tempfile do |data_dir, filename, absolute|
+          with_datadir do |data_dir|
+            filename = "file1"
+            absolute = File.join data_dir, filename
             File.write absolute, "foo bar baz"
             range = LavinMQ::Replication::FileRange.new(MFile.new(absolute), 4, 3)
             action = LavinMQ::Replication::AppendAction.new data_dir, filename, range

--- a/spec/replication/follower_spec.cr
+++ b/spec/replication/follower_spec.cr
@@ -2,14 +2,12 @@ require "../spec_helper"
 require "lz4"
 
 module FollowerSpec
-  def self.with_datadir_tempfile(filename, &)
-    relative_path = Path.new filename
-    absolute_path = Path.new(LavinMQ::Config.instance.data_dir).join relative_path
-    yield relative_path.to_s, absolute_path.to_s
+  def self.with_datadir(&)
+    data_dir = File.tempname("lavinmq", "spec")
+    Dir.mkdir_p data_dir
+    yield data_dir
   ensure
-    if absolute_path && File.exists? absolute_path
-      FileUtils.rm absolute_path
-    end
+    FileUtils.rm_rf data_dir if data_dir
   end
 
   def self.sha1(str : String)
@@ -24,18 +22,19 @@ module FollowerSpec
   class FakeFileIndex
     include LavinMQ::Replication::FileIndex
 
-    DEFAULT_FILES_WITH_HASH = {
-      "#{LavinMQ::Config.instance.data_dir}/file1" => FollowerSpec.sha1("hash1"),
-      "#{LavinMQ::Config.instance.data_dir}/file2" => FollowerSpec.sha1("hash2"),
-      "#{LavinMQ::Config.instance.data_dir}/file3" => FollowerSpec.sha1("hash3"),
-    } of String => Bytes
-
     alias FileType = MFile | File
 
     DEFAULT_WITH_FILE = {} of String => FileType
 
-    def initialize(@files_with_hash : Hash(String, Bytes) = DEFAULT_FILES_WITH_HASH,
+    @files_with_hash : Hash(String, Bytes)
+
+    def initialize(data_dir : String, files_with_hash : Hash(String, Bytes)? = nil,
                    @with_file : Hash(String, FileType) = DEFAULT_WITH_FILE)
+      @files_with_hash = files_with_hash || Hash(String, Bytes){
+        File.join(data_dir, "file1") => FollowerSpec.sha1("hash1"),
+        File.join(data_dir, "file2") => FollowerSpec.sha1("hash2"),
+        File.join(data_dir, "file3") => FollowerSpec.sha1("hash3"),
+      }
     end
 
     def files_with_hash(& : Tuple(String, Bytes) -> Nil)
@@ -70,181 +69,203 @@ module FollowerSpec
   describe LavinMQ::Replication::Follower do
     describe "#negotiate!" do
       it "should raise InvalidStartHeaderError on invalid start header" do
-        follower_socket, client_socket = FakeSocket.pair
-        file_index = FakeFileIndex.new
-        follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
+        FollowerSpec.with_datadir do |data_dir|
+          follower_socket, client_socket = FakeSocket.pair
+          file_index = FakeFileIndex.new(data_dir)
+          follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
 
-        invalid_start = Bytes[0, 1, 2, 3, 4, 5, 6, 7]
-        client_socket.write invalid_start
+          invalid_start = Bytes[0, 1, 2, 3, 4, 5, 6, 7]
+          client_socket.write invalid_start
 
-        expect_raises(LavinMQ::Replication::InvalidStartHeaderError) do
-          follower.negotiate!("foo")
+          expect_raises(LavinMQ::Replication::InvalidStartHeaderError) do
+            follower.negotiate!("foo")
+          end
         end
       end
 
       it "should raise AuthenticationError and send 1 on wrong password" do
-        follower_socket, client_socket = FakeSocket.pair
-        file_index = FakeFileIndex.new
-        follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
+        FollowerSpec.with_datadir do |data_dir|
+          follower_socket, client_socket = FakeSocket.pair
+          file_index = FakeFileIndex.new(data_dir)
+          follower = LavinMQ::Replication::Follower.new(follower_socket, "/tmp", file_index)
 
-        password = "foo"
-        client_socket.write LavinMQ::Replication::Start
-        client_socket.write_bytes password.bytesize.to_u8, IO::ByteFormat::LittleEndian
-        client_socket.write password.to_slice
+          password = "foo"
+          client_socket.write LavinMQ::Replication::Start
+          client_socket.write_bytes password.bytesize.to_u8, IO::ByteFormat::LittleEndian
+          client_socket.write password.to_slice
 
-        expect_raises(LavinMQ::Replication::AuthenticationError) do
-          follower.negotiate!("bar")
+          expect_raises(LavinMQ::Replication::AuthenticationError) do
+            follower.negotiate!("bar")
+          end
+
+          response = client_socket.read_bytes UInt8, IO::ByteFormat::LittleEndian
+          response.should eq 1u8
         end
-
-        response = client_socket.read_bytes UInt8, IO::ByteFormat::LittleEndian
-        response.should eq 1u8
       end
 
       it "should send 0 on succesful negotiation" do
-        follower_socket, client_socket = FakeSocket.pair
-        file_index = FakeFileIndex.new
-        follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
+        FollowerSpec.with_datadir do |data_dir|
+          follower_socket, client_socket = FakeSocket.pair
+          file_index = FakeFileIndex.new(data_dir)
+          follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
 
-        password = "foo"
-        client_socket.write LavinMQ::Replication::Start
-        client_socket.write_bytes password.bytesize.to_u8, IO::ByteFormat::LittleEndian
-        client_socket.write password.to_slice
+          password = "foo"
+          client_socket.write LavinMQ::Replication::Start
+          client_socket.write_bytes password.bytesize.to_u8, IO::ByteFormat::LittleEndian
+          client_socket.write password.to_slice
 
-        follower.negotiate!("foo")
+          follower.negotiate!("foo")
 
-        response = client_socket.read_bytes UInt8, IO::ByteFormat::LittleEndian
-        response.should eq 0u8
+          response = client_socket.read_bytes UInt8, IO::ByteFormat::LittleEndian
+          response.should eq 0u8
+        end
       end
     end
   end
 
   describe "#full_sync" do
     it "should send file list" do
-      follower_socket, client_socket = FakeSocket.pair
-      client_lz4 = Compress::LZ4::Reader.new(client_socket)
-      file_index = FakeFileIndex.new
-      follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
+      FollowerSpec.with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        client_lz4 = Compress::LZ4::Reader.new(client_socket)
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
 
-      spawn { follower.full_sync }
+        spawn { follower.full_sync }
 
-      file_list = Hash(String, Bytes).new
-      done = Channel(Nil).new
-      spawn do
-        loop do
-          len = client_lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
-          break if len == 0
-          hash = Bytes.new(20)
-          path = client_lz4.read_string len
-          client_lz4.read_fully hash
-          file_list[path] = hash
+        file_list = Hash(String, Bytes).new
+        done = Channel(Nil).new
+        spawn do
+          loop do
+            len = client_lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
+            break if len == 0
+            hash = Bytes.new(20)
+            path = client_lz4.read_string len
+            client_lz4.read_fully hash
+            file_list[path] = hash
+          end
+          done.send nil
         end
-        done.send nil
-      end
 
-      select
-      when done.receive
-      when timeout(1.second)
-        fail "timeout reading file list"
-      end
+        select
+        when done.receive
+        when timeout(1.second)
+          fail "timeout reading file list"
+        end
 
-      file_list = file_list.transform_keys do |k|
-        "#{LavinMQ::Config.instance.data_dir}/#{k}"
-      end
+        file_list = file_list.transform_keys do |k|
+          File.join data_dir, k
+        end
 
-      file_list.should eq file_index.@files_with_hash
+        file_list.should eq file_index.@files_with_hash
+      end
     end
   end
 
   describe "#close" do
     it "should let followers sync" do
-      follower_socket, client_socket = FakeSocket.pair
-      file_index = FakeFileIndex.new
-      follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
-      client_lz4 = Compress::LZ4::Reader.new(client_socket)
+      FollowerSpec.with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
+        client_lz4 = Compress::LZ4::Reader.new(client_socket)
 
-      spawn { follower.read_acks }
+        spawn { follower.read_acks }
 
-      ack_size = 0i64
-      FollowerSpec.with_datadir_tempfile("file1") do |_rel_path, abs_path|
-        File.write abs_path, "foo"
-        follower.add(abs_path)
+        file = File.join data_dir, "file1"
+        File.write file, "foo"
+        follower.add file
+
+        ack_size = 0i64
         filename_size = client_lz4.read_bytes(Int32, IO::ByteFormat::LittleEndian)
         ack_size += filename_size + sizeof(Int32)
         client_lz4.skip filename_size
         data_size = client_lz4.read_bytes(Int64, IO::ByteFormat::LittleEndian)
         client_lz4.skip data_size
         ack_size += data_size + sizeof(Int64)
-      end
-      let_sync = Channel({LavinMQ::Replication::Follower, Bool}).new
-      spawn { follower.close(let_sync) }
-      spawn { client_socket.write_bytes ack_size, IO::ByteFormat::LittleEndian }
+        let_sync = Channel({LavinMQ::Replication::Follower, Bool}).new
 
-      select
-      when res = let_sync.receive
-        follower, in_sync = res
-        in_sync.should eq true
-      when timeout(1.second)
-        fail "timeout close"
+        spawn { follower.close(let_sync) }
+        spawn { client_socket.write_bytes ack_size, IO::ByteFormat::LittleEndian }
+
+        select
+        when res = let_sync.receive
+          follower, in_sync = res
+          in_sync.should eq true
+        when timeout(1.second)
+          fail "timeout close"
+        end
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
       end
-    ensure
-      follower_socket.try &.close
-      client_socket.try &.close
     end
 
     it "should close even when sync fails" do
-      follower_socket, client_socket = FakeSocket.pair
-      file_index = FakeFileIndex.new
-      follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
-      client_lz4 = Compress::LZ4::Reader.new(client_socket)
+      FollowerSpec.with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
+        client_lz4 = Compress::LZ4::Reader.new(client_socket)
 
-      spawn { follower.read_acks }
-      data_size = 0i64
-      FollowerSpec.with_datadir_tempfile("file1") do |_rel_path, abs_path|
-        File.write abs_path, "foo"
-        follower.add(abs_path)
+        spawn { follower.read_acks }
+
+        # Add a file to the follower to create some lag
+        file = File.join data_dir, "file1"
+        File.write file, "foo"
+        follower.add file
+
+        # Read and ack the to make follower in sync
         filename_size = client_lz4.read_bytes(Int32, IO::ByteFormat::LittleEndian)
         client_lz4.skip filename_size
         data_size = client_lz4.read_bytes(Int64, IO::ByteFormat::LittleEndian)
         client_lz4.skip data_size
-      end
-      let_sync = Channel({LavinMQ::Replication::Follower, Bool}).new
-      spawn { follower.close(let_sync) }
-      spawn { follower_socket.close }
+        let_sync = Channel({LavinMQ::Replication::Follower, Bool}).new
 
-      select
-      when res = let_sync.receive
-        follower, in_sync = res
-        in_sync.should eq false
-      when timeout(1.second)
-        fail "timeout close"
+        spawn do
+          follower.close(let_sync)
+        end
+        spawn { follower_socket.close }
+
+        select
+        when res = let_sync.receive
+          follower, in_sync = res
+          in_sync.should eq false
+        when timeout(1.second)
+          fail "timeout close"
+        end
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
       end
-    ensure
-      follower_socket.try &.close
-      client_socket.try &.close
     end
   end
 
   describe "#lag" do
     it "should count bytes added to action queue" do
-      follower_socket, _client_socket = FakeSocket.pair
-      file_index = FakeFileIndex.new
-      follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
-      filename = "#{LavinMQ::Config.instance.data_dir}/file1"
-      size = follower.append filename, Bytes.new(10)
-      follower.lag.should eq size
+      FollowerSpec.with_datadir do |data_dir|
+        follower_socket, _client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
+        filename = File.join data_dir, "file1"
+        size = follower.append filename, Bytes.new(10)
+        follower.lag.should eq size
+      end
     end
 
     it "should subtract acked bytes from lag" do
-      follower_socket, client_socket = FakeSocket.pair
-      file_index = FakeFileIndex.new
-      follower = LavinMQ::Replication::Follower.new(follower_socket, file_index)
-      filename = "#{LavinMQ::Config.instance.data_dir}/file1"
-      size = follower.append filename, Bytes.new(10)
-      size2 = follower.append filename, Bytes.new(20)
-      # send ack for first message
-      client_socket.write_bytes size.to_i64, IO::ByteFormat::LittleEndian
-      follower.read_ack
-      follower.lag.should eq size2
+      FollowerSpec.with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
+        filename = File.join data_dir, "file1"
+        size = follower.append filename, Bytes.new(10)
+        size2 = follower.append filename, Bytes.new(20)
+        # send ack for first message
+        client_socket.write_bytes size.to_i64, IO::ByteFormat::LittleEndian
+        follower.read_ack
+        follower.lag.should eq size2
+      end
     end
   end
 end

--- a/spec/replication/follower_spec.cr
+++ b/spec/replication/follower_spec.cr
@@ -2,14 +2,6 @@ require "../spec_helper"
 require "lz4"
 
 module FollowerSpec
-  def self.with_datadir(&)
-    data_dir = File.tempname("lavinmq", "spec")
-    Dir.mkdir_p data_dir
-    yield data_dir
-  ensure
-    FileUtils.rm_rf data_dir if data_dir
-  end
-
   def self.sha1(str : String)
     sha1 = Digest::SHA1.new
     hash = Bytes.new(sha1.digest_size)
@@ -69,7 +61,7 @@ module FollowerSpec
   describe LavinMQ::Replication::Follower do
     describe "#negotiate!" do
       it "should raise InvalidStartHeaderError on invalid start header" do
-        FollowerSpec.with_datadir do |data_dir|
+        with_datadir do |data_dir|
           follower_socket, client_socket = FakeSocket.pair
           file_index = FakeFileIndex.new(data_dir)
           follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
@@ -84,7 +76,7 @@ module FollowerSpec
       end
 
       it "should raise AuthenticationError and send 1 on wrong password" do
-        FollowerSpec.with_datadir do |data_dir|
+        with_datadir do |data_dir|
           follower_socket, client_socket = FakeSocket.pair
           file_index = FakeFileIndex.new(data_dir)
           follower = LavinMQ::Replication::Follower.new(follower_socket, "/tmp", file_index)
@@ -104,7 +96,7 @@ module FollowerSpec
       end
 
       it "should send 0 on succesful negotiation" do
-        FollowerSpec.with_datadir do |data_dir|
+        with_datadir do |data_dir|
           follower_socket, client_socket = FakeSocket.pair
           file_index = FakeFileIndex.new(data_dir)
           follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
@@ -125,7 +117,7 @@ module FollowerSpec
 
   describe "#full_sync" do
     it "should send file list" do
-      FollowerSpec.with_datadir do |data_dir|
+      with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         client_lz4 = Compress::LZ4::Reader.new(client_socket)
         file_index = FakeFileIndex.new(data_dir)
@@ -164,7 +156,7 @@ module FollowerSpec
 
   describe "#close" do
     it "should let followers sync" do
-      FollowerSpec.with_datadir do |data_dir|
+      with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
@@ -202,7 +194,7 @@ module FollowerSpec
     end
 
     it "should close even when sync fails" do
-      FollowerSpec.with_datadir do |data_dir|
+      with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
@@ -243,7 +235,7 @@ module FollowerSpec
 
   describe "#lag" do
     it "should count bytes added to action queue" do
-      FollowerSpec.with_datadir do |data_dir|
+      with_datadir do |data_dir|
         follower_socket, _client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)
@@ -254,7 +246,7 @@ module FollowerSpec
     end
 
     it "should subtract acked bytes from lag" do
-      FollowerSpec.with_datadir do |data_dir|
+      with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Replication::Follower.new(follower_socket, data_dir, file_index)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -38,6 +38,14 @@ end
 require "../src/lavinmq/server"
 require "../src/lavinmq/http/http_server"
 
+def with_datadir(&)
+  data_dir = File.tempname("lavinmq", "spec")
+  Dir.mkdir_p data_dir
+  yield data_dir
+ensure
+  FileUtils.rm_rf data_dir if data_dir
+end
+
 def with_channel(file = __FILE__, line = __LINE__, **args, &)
   name = "lavinmq-spec-#{file}:#{line}"
   args = {port: LavinMQ::Config.instance.amqp_port, name: name}.merge(args)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -29,7 +29,7 @@ module LavinMQ
     def initialize(@data_dir : String)
       @log = Log.for "amqpserver"
       Dir.mkdir_p @data_dir
-      @replicator = Replication::Server.new
+      @replicator = Replication::Server.new(@data_dir)
       Schema.migrate(@data_dir, @replicator)
       @users = UserStore.new(@data_dir, @replicator)
       @vhosts = VHostStore.new(@data_dir, @users, @replicator)


### PR DESCRIPTION
### WHAT is this pull request doing?
This is to get rid of some references to `Config.instance` so simplify specs and future refactoring.

Instead of injecting the config instance the data dir is injected. Data dir shouldn't change during runtime, so no need to read data dir from a config instance that may change values on a reload.

`Config.instance` is still referenced from Follower, so maybe we should inject the config instance to `Replication::Server` and `Replication::Follower`, but that can be done in another round.

### HOW can this pull request be tested?
Run specs
