### PR TITLE
Rename MessageStore's @data_dir to @queue_data_dir

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -64,7 +64,7 @@ describe LavinMQ::Queue do
       Server.vhosts.create("/")
       v = Server.vhosts["/"].not_nil!
       v.declare_queue("q", true, false)
-      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
+      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
       Server.vhosts["/"].queues["q"].pause!
       File.exists?(File.join(data_dir, ".paused")).should be_true
       Server.restart
@@ -280,7 +280,7 @@ describe LavinMQ::Queue do
     with_channel do |ch|
       ch.queue "transient", durable: false
     end
-    data_dir = Server.vhosts["/"].queues["transient"].@msg_store.@data_dir
+    data_dir = Server.vhosts["/"].queues["transient"].@msg_store.@queue_data_dir
     Server.stop
     Dir.exists?(data_dir).should be_false
   end
@@ -290,7 +290,7 @@ describe LavinMQ::Queue do
     with_channel do |ch|
       q = ch.queue "transient", durable: false
       q.publish_confirm "foobar"
-      data_dir = Server.vhosts["/"].queues["transient"].@msg_store.@data_dir
+      data_dir = Server.vhosts["/"].queues["transient"].@msg_store.@queue_data_dir
       FileUtils.cp_r data_dir, "#{data_dir}.copy"
     end
     Server.stop
@@ -307,7 +307,7 @@ describe LavinMQ::Queue do
   it "should delete queue with auto_delete when the last consumer disconnects" do
     with_channel do |ch|
       q = ch.queue("q", auto_delete: true)
-      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@data_dir
+      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
       sub = q.subscribe(no_ack: true) { |_| }
       Dir.exists?(data_dir).should be_true
       q.unsubscribe(sub)

--- a/src/lavinmq/queue/message_store.cr
+++ b/src/lavinmq/queue/message_store.cr
@@ -26,7 +26,7 @@ module LavinMQ
       getter size = 0u32
       getter empty_change = Channel(Bool).new
 
-      def initialize(@data_dir : String, @replicator : Replication::Replicator?)
+      def initialize(@queue_data_dir : String, @replicator : Replication::Replicator?)
         @acks = Hash(UInt32, MFile).new { |acks, seg| acks[seg] = open_ack_file(seg) }
         load_segments_from_disk
         load_deleted_from_disk
@@ -191,7 +191,7 @@ module LavinMQ
         close
         @segments.each_value { |f| @replicator.try &.delete_file(f.path); f.delete }
         @acks.each_value { |f| @replicator.try &.delete_file(f.path); f.delete }
-        FileUtils.rm_rf @data_dir
+        FileUtils.rm_rf @queue_data_dir
       end
 
       def empty?
@@ -242,7 +242,7 @@ module LavinMQ
       private def open_new_segment(next_msg_size = 0) : MFile
         @wfile.unmap unless @wfile == @rfile
         next_id = @wfile_id + 1
-        path = File.join(@data_dir, "msgs.#{next_id.to_s.rjust(10, '0')}")
+        path = File.join(@queue_data_dir, "msgs.#{next_id.to_s.rjust(10, '0')}")
         capacity = Math.max(Config.instance.segment_size, next_msg_size + 4)
         delete_unused_segments
         wfile = MFile.new(path, capacity)
@@ -256,7 +256,7 @@ module LavinMQ
       end
 
       private def open_ack_file(id) : MFile
-        path = File.join(@data_dir, "acks.#{id.to_s.rjust(10, '0')}")
+        path = File.join(@queue_data_dir, "acks.#{id.to_s.rjust(10, '0')}")
         capacity = Config.instance.segment_size // BytesMessage::MIN_BYTESIZE * 4 + 4
         mfile = MFile.new(path, capacity, writeonly: true)
         @replicator.try &.register_file mfile
@@ -266,15 +266,15 @@ module LavinMQ
       private def load_deleted_from_disk
         count = 0u32
         ack_files = 0u32
-        Dir.each(@data_dir) do |f|
+        Dir.each(@queue_data_dir) do |f|
           ack_files += 1 if f.starts_with? "acks."
         end
 
-        Dir.each_child(@data_dir) do |child|
+        Dir.each_child(@queue_data_dir) do |child|
           next unless child.starts_with? "acks."
           seg = child[5, 10].to_u32
           acked = Array(UInt32).new
-          File.open(File.join(@data_dir, child), "a+") do |file|
+          File.open(File.join(@queue_data_dir, child), "a+") do |file|
             loop do
               pos = UInt32.from_io(file, IO::ByteFormat::SystemEndian)
               if pos.zero? # pos 0 doesn't exists (first valid is 4), must be a sparse file
@@ -294,7 +294,7 @@ module LavinMQ
 
       private def load_segments_from_disk : Nil
         ids = Array(UInt32).new
-        Dir.each_child(@data_dir) do |f|
+        Dir.each_child(@queue_data_dir) do |f|
           if f.starts_with? "msgs."
             ids << f[5, 10].to_u32
           end
@@ -305,7 +305,7 @@ module LavinMQ
         last_idx = ids.size - 1
         ids.each_with_index do |seg, idx|
           filename = "msgs.#{seg.to_s.rjust(10, '0')}"
-          path = File.join(@data_dir, filename)
+          path = File.join(@queue_data_dir, filename)
           file = if idx == last_idx
                    # expand the last segment
                    MFile.new(path, Config.instance.segment_size)

--- a/src/lavinmq/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/queue/stream_queue_message_store.cr
@@ -10,7 +10,7 @@ module LavinMQ
       getter last_offset : Int64
       @segment_last_ts = Hash(UInt32, Int64).new(0i64) # used for max-age
 
-      def initialize(@data_dir : String, @replicator : Replication::Replicator?)
+      def initialize(@queue_data_dir : String, @replicator : Replication::Replicator?)
         super
         @last_offset = get_last_offset
         drop_overflow


### PR DESCRIPTION
### WHAT is this pull request doing?
It's confusing that `@data_dir` is the queue's data dir and the server's data dir. This will rename `@data_dir` to `@queue_data_dir` in `MessageStore`.

### HOW can this pull request be tested?
Run specs
