### PR TITLE
Start a new AMQP server for each spec

### DIFF
--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -3,172 +3,202 @@ require "../spec_helper"
 describe LavinMQ::HTTP::BindingsController do
   describe "GET /api/bindings" do
     it "should return all bindings" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
-      Server.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
-      response = get("/api/bindings")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["source", "vhost", "destination", "destination_type", "routing_key", "arguments",
-              "properties_key"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
+        s.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
+        response = http.get("/api/bindings")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["source", "vhost", "destination", "destination_type", "routing_key", "arguments",
+                "properties_key"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
   end
 
   describe "GET /api/bindings/vhost" do
     it "should return all bindings for a vhost" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
-      Server.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
-      response = get("/api/bindings/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
+        s.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
+        response = http.get("/api/bindings/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
 
   describe "GET /api/bindings/vhost/e/exchange/q/queue" do
     it "should return bindings" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
-      Server.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
-      response = get("/api/bindings/%2f/e/be1/q/bindings_q1")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
+        s.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
+        response = http.get("/api/bindings/%2f/e/be1/q/bindings_q1")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
 
     it "should return 404 if exchange does not exist" do
-      response = get("/api/bindings/%2f/e/404/q/404")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/bindings/%2f/e/404/q/404")
+        response.status_code.should eq 404
+      end
     end
   end
 
   describe "POST /api/bindings/vhost/e/exchange/q/queue" do
     it "should create binding" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
-      body = %({
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
+        body = %({
         "routing_key": "rk",
         "arguments": {}
       })
-      response = post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
-      response.status_code.should eq 201
-      response.headers["Location"].should eq "bindings_q1/rk"
-      Server.vhosts["/"].exchanges["be1"].queue_bindings.last_key.first.should eq "rk"
+        response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
+        response.status_code.should eq 201
+        response.headers["Location"].should eq "bindings_q1/rk"
+        s.vhosts["/"].exchanges["be1"].queue_bindings.last_key.first.should eq "rk"
+      end
     end
 
     it "should inform about required fields" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
 
-      response = post("/api/bindings/%2f/e/be1/q/bindings_q1", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Field .+ is required/)
+        response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Field .+ is required/)
+      end
     end
 
     it "should return 404 if exchange does not exist" do
-      response = get("/api/bindings/%2f/e/404/q/404")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/bindings/%2f/e/404/q/404")
+        response.status_code.should eq 404
+      end
     end
 
     it "should return forbidden for the default exchange" do
-      Server.vhosts["/"].declare_queue("bindings_q2", false, false)
-      body = %({
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("bindings_q2", false, false)
+        body = %({
         "routing_key": "rk",
         "arguments": {}
       })
-      response = post("/api/bindings/%2f/e/amq.default/q/bindings_q2", body: body)
-      response.status_code.should eq 403
+        response = http.post("/api/bindings/%2f/e/amq.default/q/bindings_q2", body: body)
+        response.status_code.should eq 403
+      end
     end
   end
 
   describe "GET /api/bindings/vhost/e/exchange/q/queue/props" do
     it "should return binding" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
-      Server.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
-      response = get("/api/bindings/%2f/e/be1/q/bindings_q1")
-      binding = JSON.parse(response.body)
-      props = binding[0]["properties_key"].as_s
-      response = get("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
+        s.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
+        response = http.get("/api/bindings/%2f/e/be1/q/bindings_q1")
+        binding = JSON.parse(response.body)
+        props = binding[0]["properties_key"].as_s
+        response = http.get("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
+        response.status_code.should eq 200
+      end
     end
   end
 
   describe "DELETE /api/bindings/vhost/e/exchange/q/queue/props" do
     it "should delete binding" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_queue("bindings_q1", false, false)
-      Server.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
-      response = get("/api/bindings/%2f/e/be1/q/bindings_q1")
-      binding = JSON.parse(response.body)
-      props = binding[0]["properties_key"].as_s
-      response = delete("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
-      response.status_code.should eq 204
-      Server.vhosts["/"].exchanges["be1"].queue_bindings.empty?.should be_true
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_queue("bindings_q1", false, false)
+        s.vhosts["/"].bind_queue("bindings_q1", "be1", ".*")
+        response = http.get("/api/bindings/%2f/e/be1/q/bindings_q1")
+        binding = JSON.parse(response.body)
+        props = binding[0]["properties_key"].as_s
+        response = http.delete("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
+        response.status_code.should eq 204
+        s.vhosts["/"].exchanges["be1"].queue_bindings.empty?.should be_true
+      end
     end
   end
 
   describe "GET /api/bindings/vhost/e/source/e/destination" do
     it "should return bindings" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_exchange("be2", "topic", false, false)
-      Server.vhosts["/"].bind_exchange("be2", "be1", ".*")
-      response = get("/api/bindings/%2f/e/be1/e/be2")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_exchange("be2", "topic", false, false)
+        s.vhosts["/"].bind_exchange("be2", "be1", ".*")
+        response = http.get("/api/bindings/%2f/e/be1/e/be2")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
 
   describe "POST /api/bindings/vhost/e/source/e/destination" do
     it "should create binding" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_exchange("be2", "topic", false, false)
-      body = %({
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_exchange("be2", "topic", false, false)
+        body = %({
         "routing_key": "rk",
         "arguments": {}
       })
-      response = post("/api/bindings/%2f/e/be1/e/be2", body: body)
-      response.status_code.should eq 201
+        response = http.post("/api/bindings/%2f/e/be1/e/be2", body: body)
+        response.status_code.should eq 201
+      end
     end
 
     it "should return forbidden for the default exchange" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "routing_key": "rk",
         "arguments": {}
       })
-      response = post("/api/bindings/%2f/e/amq.default/e/amq.direct", body: body)
-      response.status_code.should eq 403
+        response = http.post("/api/bindings/%2f/e/amq.default/e/amq.direct", body: body)
+        response.status_code.should eq 403
+      end
     end
   end
 
   describe "GET /api/bindings/vhost/e/source/e/destination/props" do
     it "should return binding" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_exchange("be2", "topic", false, false)
-      Server.vhosts["/"].bind_exchange("be2", "be1", ".*")
-      response = get("/api/bindings/%2f/e/be1/e/be2")
-      binding = JSON.parse(response.body)
-      props = binding[0]["properties_key"].as_s
-      response = get("/api/bindings/%2f/e/be1/e/be2/#{props}")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_exchange("be2", "topic", false, false)
+        s.vhosts["/"].bind_exchange("be2", "be1", ".*")
+        response = http.get("/api/bindings/%2f/e/be1/e/be2")
+        binding = JSON.parse(response.body)
+        props = binding[0]["properties_key"].as_s
+        response = http.get("/api/bindings/%2f/e/be1/e/be2/#{props}")
+        response.status_code.should eq 200
+      end
     end
   end
 
   describe "DELETE /api/bindings/vhost/e/source/e/destination/props" do
     it "should delete binding" do
-      Server.vhosts["/"].declare_exchange("be1", "topic", false, false)
-      Server.vhosts["/"].declare_exchange("be2", "topic", false, false)
-      Server.vhosts["/"].bind_exchange("be2", "be1", ".*")
-      response = get("/api/bindings/%2f/e/be1/e/be2")
-      binding = JSON.parse(response.body)
-      props = binding[0]["properties_key"].as_s
-      response = delete("/api/bindings/%2f/e/be1/e/be2/#{props}")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("be1", "topic", false, false)
+        s.vhosts["/"].declare_exchange("be2", "topic", false, false)
+        s.vhosts["/"].bind_exchange("be2", "be1", ".*")
+        response = http.get("/api/bindings/%2f/e/be1/e/be2")
+        binding = JSON.parse(response.body)
+        props = binding[0]["properties_key"].as_s
+        response = http.delete("/api/bindings/%2f/e/be1/e/be2/#{props}")
+        response.status_code.should eq 204
+      end
     end
   end
 end

--- a/spec/api/channels_spec.cr
+++ b/spec/api/channels_spec.cr
@@ -4,52 +4,60 @@ require "uri"
 describe LavinMQ::HTTP::ChannelsController do
   describe "GET /api/channels" do
     it "should return all channels" do
-      with_channel do
-        response = get("/api/channels")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_false
-        keys = ["vhost", "user", "number", "name", "connection_details", "state", "prefetch_count",
-                "global_prefetch_count", "consumer_count", "confirm", "transactional"]
-        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        with_channel(s) do
+          response = http.get("/api/channels")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_false
+          keys = ["vhost", "user", "number", "name", "connection_details", "state", "prefetch_count",
+                  "global_prefetch_count", "consumer_count", "confirm", "transactional"]
+          body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+        end
       end
     end
   end
 
   describe "GET /api/vhosts/vhost/channels" do
     it "should return all channels for a vhost" do
-      Server.vhosts.create("my-connection")
-      Server.users.add_permission("guest", "my-connection", /.*/, /.*/, /.*/)
-      with_channel(vhost: "my-connection") do
-        response = get("/api/vhosts/my-connection/channels")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.size.should eq 1
+      with_http_server do |http, s|
+        s.vhosts.create("my-connection")
+        s.users.add_permission("guest", "my-connection", /.*/, /.*/, /.*/)
+        with_channel(s, vhost: "my-connection") do
+          response = http.get("/api/vhosts/my-connection/channels")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.size.should eq 1
+        end
       end
     end
 
     it "should return empty array if no connections" do
-      Server.vhosts.create("no-conns")
-      response = get("/api/vhosts/no-conns/channels")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_true
+      with_http_server do |http, s|
+        s.vhosts.create("no-conns")
+        response = http.get("/api/vhosts/no-conns/channels")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_true
+      end
     end
   end
 
   describe "GET /api/channels/channel" do
     it "should return channel" do
-      with_channel do
-        response = get("/api/channels")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        name = URI.encode_www_form(body[0]["name"].as_s)
-        response = get("/api/channels/#{name}")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        expected_keys = ["consumer_details"]
-        actual_keys = body.as_h.keys
-        expected_keys.each { |k| actual_keys.should contain(k) }
+      with_http_server do |http, s|
+        with_channel(s) do
+          response = http.get("/api/channels")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          name = URI.encode_www_form(body[0]["name"].as_s)
+          response = http.get("/api/channels/#{name}")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          expected_keys = ["consumer_details"]
+          actual_keys = body.as_h.keys
+          expected_keys.each { |k| actual_keys.should contain(k) }
+        end
       end
     end
   end

--- a/spec/api/connections_spec.cr
+++ b/spec/api/connections_spec.cr
@@ -3,126 +3,147 @@ require "../spec_helper"
 describe LavinMQ::HTTP::ConnectionsController do
   describe "GET /api/connections" do
     it "should return network connections" do
-      with_channel do
-        response = get("/api/connections")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        with_channel(s) do
+          response = http.get("/api/connections")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_false
+        end
       end
     end
 
     it "should only show own connections for policymaker" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      with_channel do
-        response = get("/api/connections", headers: hdrs)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_true
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        with_channel(s) do
+          response = http.get("/api/connections", headers: hdrs)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_true
+        end
       end
     end
 
     it "should show all connections for monitoring" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::Monitoring])
-      hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      with_channel do
-        response = get("/api/connections", headers: hdrs)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Monitoring])
+        hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        with_channel(s) do
+          response = http.get("/api/connections", headers: hdrs)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_false
+        end
       end
     end
   end
 
   describe "GET /api/vhosts/vhost/connections" do
     it "should return network connections for vhost" do
-      with_channel do
-        response = get("/api/vhosts/%2f/connections")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_false
-        keys = ["channels", "connected_at", "type", "channel_max", "timeout", "client_properties",
-                "vhost", "user", "protocol", "auth_mechanism", "host", "port", "name", "ssl",
-                "state"]
-        val = body.as_a.last
-        keys.each { |k| val.as_h.keys.should contain(k) }
+      with_http_server do |http, s|
+        with_channel(s) do
+          response = http.get("/api/vhosts/%2f/connections")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_false
+          keys = ["channels", "connected_at", "type", "channel_max", "timeout", "client_properties",
+                  "vhost", "user", "protocol", "auth_mechanism", "host", "port", "name", "ssl",
+                  "state"]
+          val = body.as_a.last
+          keys.each { |k| val.as_h.keys.should contain(k) }
+        end
       end
     end
 
     it "should return 404 if vhosts does not exist" do
-      response = get("/api/vhosts/vhost/connections")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/vhosts/vhost/connections")
+        response.status_code.should eq 404
+      end
     end
   end
-
   describe "GET /api/connections/name" do
     it "should return connection" do
-      with_channel do
-        response = get("/api/vhosts/%2f/connections")
-        body = JSON.parse(response.body)
-        name = URI.encode_www_form(body.as_a.last["name"].as_s)
-        response = get("/api/connections/#{name}")
-        response.status_code.should eq 200
+      with_http_server do |http, s|
+        with_channel(s) do
+          response = http.get("/api/vhosts/%2f/connections")
+          body = JSON.parse(response.body)
+          name = URI.encode_www_form(body.as_a.last["name"].as_s)
+          response = http.get("/api/connections/#{name}")
+          response.status_code.should eq 200
+        end
       end
     end
 
     it "should return 404 if connection does not exist" do
-      response = get("/api/connections/name")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/connections/name")
+        response.status_code.should eq 404
+      end
     end
 
     it "should return 403 if user doesn't have access" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      with_channel do
-        response = get("/api/vhosts/%2f/connections")
-        body = JSON.parse(response.body)
-        name = URI.encode_www_form(body.as_a.last["name"].as_s)
-        response = get("/api/connections/#{name}", headers: hdrs)
-        response.status_code.should eq 403
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        with_channel(s) do
+          response = http.get("/api/vhosts/%2f/connections")
+          body = JSON.parse(response.body)
+          name = URI.encode_www_form(body.as_a.last["name"].as_s)
+          response = http.get("/api/connections/#{name}", headers: hdrs)
+          response.status_code.should eq 403
+        end
       end
     end
   end
 
   describe "GET /api/connections/name/channels" do
     it "should return channels for a connection" do
-      with_channel do
-        response = get("/api/vhosts/%2f/connections")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        name = URI.encode_www_form(body.as_a.last["name"].as_s)
-        response = get("/api/connections/#{name}/channels")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.size.should eq 1
+      with_http_server do |http, s|
+        with_channel(s) do
+          response = http.get("/api/vhosts/%2f/connections")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          name = URI.encode_www_form(body.as_a.last["name"].as_s)
+          response = http.get("/api/connections/#{name}/channels")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.size.should eq 1
+        end
       end
     end
   end
 
   describe "GET /api/connections/username/:username" do
     it "returns connections for a specific user" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::Administrator])
-      hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      with_channel do
-        response = get("/api/connections/username/arnold", headers: hdrs)
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_true
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Administrator])
+        hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        with_channel(s) do
+          response = http.get("/api/connections/username/arnold", headers: hdrs)
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_true
+        end
       end
     end
   end
 
   describe "DELETE /api/connections/username/:username" do
     it "deletes connections for a specific user" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::Administrator])
-      Server.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
-      hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      with_channel(user: "arnold", password: "pw") do
-        response = delete("/api/connections/username/arnold", headers: hdrs)
-        response.status_code.should eq 204
-        sleep 0.1
-        response = get("/api/connections/username/arnold", headers: hdrs)
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_true
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Administrator])
+        s.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
+        hdrs = HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        with_channel(user: "arnold", password: "pw") do
+          response = http.delete("/api/connections/username/arnold", headers: hdrs)
+          response.status_code.should eq 204
+          sleep 0.1
+          response = http.get("/api/connections/username/arnold", headers: hdrs)
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_true
+        end
       end
     end
   end

--- a/spec/api/consumers_spec.cr
+++ b/spec/api/consumers_spec.cr
@@ -3,91 +3,107 @@ require "../spec_helper"
 describe LavinMQ::HTTP::ConsumersController do
   describe "GET /api/consumers" do
     it "should return all consumers" do
-      with_channel do |ch|
-        q = ch.queue("")
-        q.subscribe { }
-        response = get("/api/consumers")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_false
-        keys = ["prefetch_count", "ack_required", "exclusive", "consumer_tag", "channel_details",
-                "queue"]
-        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("")
+          q.subscribe { }
+          response = http.get("/api/consumers")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_false
+          keys = ["prefetch_count", "ack_required", "exclusive", "consumer_tag", "channel_details",
+                  "queue"]
+          body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+        end
       end
     end
 
     it "should return empty array if no consumers" do
-      response = get("/api/consumers")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_true
+      with_http_server do |http, _|
+        response = http.get("/api/consumers")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_true
+      end
     end
   end
 
   describe "GET /api/consumers/vhost" do
     it "should return all consumers for a vhost" do
-      with_channel do |ch|
-        q = ch.queue("")
-        q.subscribe { }
-        sleep 0.01
-        response = get("/api/consumers/%2f")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.size.should eq 1
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("")
+          q.subscribe { }
+          sleep 0.01
+          response = http.get("/api/consumers/%2f")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.size.should eq 1
+        end
       end
     end
 
     it "should return empty array if no consumers" do
-      response = get("/api/consumers/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_true
+      with_http_server do |http, _|
+        response = http.get("/api/consumers/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_true
+      end
     end
   end
 
   describe "DELETE /api/consumers/vhost/connection/channel/consumer" do
     it "should return 204 when successful" do
-      with_channel do |ch|
-        q = ch.queue("")
-        consumer = q.subscribe { }
-        sleep 0.01
-        conn = Server.connections.to_a.last.name
-        response = delete("/api/consumers/%2f/#{URI.encode_path(conn)}/#{ch.id}/#{consumer}")
-        response.status_code.should eq 204
-        wait_for { ch.has_subscriber?(consumer) == false }
-        ch.has_subscriber?(consumer).should be_false
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("")
+          consumer = q.subscribe { }
+          sleep 0.01
+          conn = s.connections.to_a.last.name
+          response = http.delete("/api/consumers/%2f/#{URI.encode_path(conn)}/#{ch.id}/#{consumer}")
+          response.status_code.should eq 204
+          wait_for { ch.has_subscriber?(consumer) == false }
+          ch.has_subscriber?(consumer).should be_false
+        end
       end
     end
 
     it "should return 404 if connection does not exist" do
-      with_channel do |ch|
-        q = ch.queue("")
-        consumer = q.subscribe { }
-        sleep 0.01
-        response = delete("/api/consumers/%2f/#{URI.encode_path("abc")}/#{ch.id}/#{consumer}")
-        response.status_code.should eq 404
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("")
+          consumer = q.subscribe { }
+          sleep 0.01
+          response = http.delete("/api/consumers/%2f/#{URI.encode_path("abc")}/#{ch.id}/#{consumer}")
+          response.status_code.should eq 404
+        end
       end
     end
 
     it "should return 404 if channel does not exist" do
-      with_channel do |ch|
-        conn = Server.connections.first.name
-        q = ch.queue("")
-        consumer = q.subscribe { }
-        sleep 0.01
-        response = delete("/api/consumers/%2f/#{URI.encode_path(conn)}/123/#{consumer}")
-        response.status_code.should eq 404
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          conn = s.connections.first.name
+          q = ch.queue("")
+          consumer = q.subscribe { }
+          sleep 0.01
+          response = http.delete("/api/consumers/%2f/#{URI.encode_path(conn)}/123/#{consumer}")
+          response.status_code.should eq 404
+        end
       end
     end
 
     it "should return 404 if consumer does not exist" do
-      with_channel do |ch|
-        conn = Server.connections.first.name
-        q = ch.queue("")
-        q.subscribe { }
-        sleep 0.01
-        response = delete("/api/consumers/%2f/#{URI.encode_path(conn)}/#{ch.id}/test")
-        response.status_code.should eq 404
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          conn = s.connections.first.name
+          q = ch.queue("")
+          q.subscribe { }
+          sleep 0.01
+          response = http.delete("/api/consumers/%2f/#{URI.encode_path(conn)}/#{ch.id}/test")
+          response.status_code.should eq 404
+        end
       end
     end
   end

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -3,39 +3,48 @@ require "../spec_helper"
 describe LavinMQ::HTTP::ExchangesController do
   describe "GET /api/exchanges" do
     it "should return all exchanges" do
-      response = get("/api/exchanges")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["arguments", "internal", "auto_delete", "durable", "type", "vhost", "name"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, _|
+        response = http.get("/api/exchanges")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["arguments", "internal", "auto_delete", "durable", "type", "vhost", "name"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
   end
 
   describe "GET /api/exchanges/vhost" do
     it "should return all exchanges for a vhost" do
-      response = get("/api/exchanges/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, _|
+        response = http.get("/api/exchanges/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
 
   describe "GET /api/exchanges/vhost/name" do
     it "should return exchange" do
-      response = get("/api/exchanges/%2f/amq.topic")
-      response.status_code.should eq 200
+      with_http_server do |http, _|
+        response = http.get("/api/exchanges/%2f/amq.topic")
+        response.status_code.should eq 200
+      end
     end
 
     it "should return 404 if exchange does not exist" do
-      response = get("/api/exchanges/%2f/404")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/exchanges/%2f/404")
+        response.status_code.should eq 404
+      end
     end
   end
 
   describe "PUT /api/exchanges/vhost/name" do
     it "should create exchange" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "type": "topic",
         "durable": false,
         "internal": false,
@@ -44,80 +53,96 @@ describe LavinMQ::HTTP::ExchangesController do
           "alternate-exchange": "spexchange"
         }
       })
-      response = put("/api/exchanges/%2f/spechange", body: body)
-      response.status_code.should eq 201
-      response = get("/api/exchanges/%2f/spechange")
-      response.status_code.should eq 200
+        response = http.put("/api/exchanges/%2f/spechange", body: body)
+        response.status_code.should eq 201
+        response = http.get("/api/exchanges/%2f/spechange")
+        response.status_code.should eq 200
+      end
     end
 
     it "should require type" do
-      response = put("/api/exchanges/%2f/faulty", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Field 'type' is required/)
+      with_http_server do |http, _|
+        response = http.put("/api/exchanges/%2f/faulty", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Field 'type' is required/)
+      end
     end
 
     it "should require a known type" do
-      body = %({ "type": "tut" })
-      response = put("/api/exchanges/%2f/faulty", body: body)
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/invalid exchange type/)
+      with_http_server do |http, _|
+        body = %({ "type": "tut" })
+        response = http.put("/api/exchanges/%2f/faulty", body: body)
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/invalid exchange type/)
+      end
     end
 
     it "should require arguments if the type demands it" do
-      body = %({ "type": "x-delayed-message" })
-      response = put("/api/exchanges/%2f/faulty", body: body)
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Missing required argument/)
+      with_http_server do |http, _|
+        body = %({ "type": "x-delayed-message" })
+        response = http.put("/api/exchanges/%2f/faulty", body: body)
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Missing required argument/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/exchanges/%2f/faulty", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      with_http_server do |http, _|
+        response = http.put("/api/exchanges/%2f/faulty", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/exchanges/%2f/faulty", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/exchanges/%2f/faulty", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
 
     it "should require durable to be the same when overwriting" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "type": "topic",
         "durable": true,
         "arguments": {
           "alternate-exchange": "tjotjo"
         }
       })
-      response = put("/api/exchanges/%2f/spechange", body: body)
-      response.status_code.should eq 201
-      body = %({
+        response = http.put("/api/exchanges/%2f/spechange", body: body)
+        response.status_code.should eq 201
+        body = %({
         "type": "topic",
         "durable": false,
         "arguments": {
           "alternate-exchange": "tjotjo"
         }
       })
-      response = put("/api/exchanges/%2f/spechange", body: body)
-      response.status_code.should eq 400
+        response = http.put("/api/exchanges/%2f/spechange", body: body)
+        response.status_code.should eq 400
+      end
     end
 
     it "should not be possible to declare amq. prefixed exchanges" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "type": "topic"
       })
-      response = put("/api/exchanges/%2f/amq.test", body: body)
-      response.status_code.should eq 400
+        response = http.put("/api/exchanges/%2f/amq.test", body: body)
+        response.status_code.should eq 400
+      end
     end
 
     it "should redeclare identical delayed_message_exchange" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "type": "x-delayed-message",
         "durable": true,
         "internal": false,
@@ -127,134 +152,155 @@ describe LavinMQ::HTTP::ExchangesController do
           "test": "hello"
         }
       })
-      response = put("/api/exchanges/%2f/spechange", body: body)
-      response.status_code.should eq 201
-      response = put("/api/exchanges/%2f/spechange", body: body)
-      response.status_code.should eq 204
+        response = http.put("/api/exchanges/%2f/spechange", body: body)
+        response.status_code.should eq 201
+        response = http.put("/api/exchanges/%2f/spechange", body: body)
+        response.status_code.should eq 204
+      end
     end
 
     it "should require config access to declare" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "type": "topic"
       })
-      hdrs = HTTP::Headers{"Authorization" => "Basic dGVzdF9wZXJtOnB3"}
-      response = put("/api/exchanges/%2f/test_perm", headers: hdrs, body: body)
-      response.status_code.should eq 401
+        hdrs = HTTP::Headers{"Authorization" => "Basic dGVzdF9wZXJtOnB3"}
+        response = http.put("/api/exchanges/%2f/test_perm", headers: hdrs, body: body)
+        response.status_code.should eq 401
+      end
     end
   end
 
   describe "DELETE /api/exchanges/vhost/name" do
     it "should delete exchange" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      response = delete("/api/exchanges/%2f/spechange")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        response = http.delete("/api/exchanges/%2f/spechange")
+        response.status_code.should eq 204
+      end
     end
 
     it "should not delete exchange if in use as source when query param if-unused is set" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      Server.vhosts["/"].declare_queue("ex_q1", false, false)
-      Server.vhosts["/"].bind_queue("ex_q1", "spechange", ".*")
-      response = delete("/api/exchanges/%2f/spechange?if-unused=true")
-      response.status_code.should eq 400
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        s.vhosts["/"].declare_queue("ex_q1", false, false)
+        s.vhosts["/"].bind_queue("ex_q1", "spechange", ".*")
+        response = http.delete("/api/exchanges/%2f/spechange?if-unused=true")
+        response.status_code.should eq 400
+      end
     end
 
     it "should not delete exchange if in use as destination when query param if-unused is set" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      Server.vhosts["/"].declare_exchange("spechange2", "topic", false, false)
-      Server.vhosts["/"].bind_exchange("spechange", "spechange2", ".*")
-      response = delete("/api/exchanges/%2f/spechange?if-unused=true")
-      response.status_code.should eq 400
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        s.vhosts["/"].declare_exchange("spechange2", "topic", false, false)
+        s.vhosts["/"].bind_exchange("spechange", "spechange2", ".*")
+        response = http.delete("/api/exchanges/%2f/spechange?if-unused=true")
+        response.status_code.should eq 400
+      end
     end
   end
 
   describe "GET /api/exchanges/vhost/name/bindings/source" do
     it "should list bindings" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      Server.vhosts["/"].declare_queue("ex_q1", false, false)
-      Server.vhosts["/"].bind_queue("ex_q1", "spechange", ".*")
-      response = get("/api/exchanges/%2f/spechange/bindings/source")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.size.should eq 1
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        s.vhosts["/"].declare_queue("ex_q1", false, false)
+        s.vhosts["/"].bind_queue("ex_q1", "spechange", ".*")
+        response = http.get("/api/exchanges/%2f/spechange/bindings/source")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.size.should eq 1
+      end
     end
   end
 
   describe "GET /api/exchanges/vhost/name/bindings/destination" do
     it "should list bindings" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      Server.vhosts["/"].declare_exchange("spechange2", "topic", false, false)
-      Server.vhosts["/"].bind_exchange("spechange", "spechange2", ".*")
-      response = get("/api/exchanges/%2f/spechange/bindings/destination")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.size.should eq 1
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        s.vhosts["/"].declare_exchange("spechange2", "topic", false, false)
+        s.vhosts["/"].bind_exchange("spechange", "spechange2", ".*")
+        response = http.get("/api/exchanges/%2f/spechange/bindings/destination")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.size.should eq 1
+      end
     end
   end
 
   describe "POST /api/exchanges/vhost/name/publish" do
     it "should publish" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      Server.vhosts["/"].declare_queue("q1p", false, false)
-      Server.vhosts["/"].bind_queue("q1p", "spechange", "*")
-      body = %({
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        s.vhosts["/"].declare_queue("q1p", false, false)
+        s.vhosts["/"].bind_queue("q1p", "spechange", "*")
+        body = %({
         "properties": {},
         "routing_key": "rk",
         "payload": "test",
         "payload_encoding": "string"
       })
-      response = post("/api/exchanges/%2f/spechange/publish", body: body)
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body["routed"].as_bool.should be_true
-      Server.vhosts["/"].queues["q1p"].message_count.should eq 1
+        response = http.post("/api/exchanges/%2f/spechange/publish", body: body)
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["routed"].as_bool.should be_true
+        s.vhosts["/"].queues["q1p"].message_count.should eq 1
+      end
     end
 
     it "should require all args" do
-      Server.vhosts["/"].declare_exchange("spechange", "topic", false, false)
-      response = post("/api/exchanges/%2f/spechange/publish", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Fields .+ are required/)
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
+        response = http.post("/api/exchanges/%2f/spechange/publish", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Fields .+ are required/)
+      end
     end
 
     it "should handle string encoding" do
-      body = %({
+      with_http_server do |http, s|
+        body = %({
         "properties": {},
         "routing_key": "rk",
         "payload": "test",
         "payload_encoding": "string"
       })
-      with_channel do |ch|
-        q = ch.queue("q2", durable: false)
-        x = ch.exchange("str_enc", "topic", passive: false)
-        q.bind(x.name, "*")
-        response = post("/api/exchanges/%2f/str_enc/publish", body: body)
-        response.status_code.should eq 200
-        msgs = [] of AMQP::Client::DeliverMessage
-        q.subscribe { |msg| msgs << msg }
-        wait_for { msgs.size == 1 }
-        msgs.first.not_nil!.body_io.to_s.should eq("test")
+        with_channel(s) do |ch|
+          q = ch.queue("q2", durable: false)
+          x = ch.exchange("str_enc", "topic", passive: false)
+          q.bind(x.name, "*")
+          response = http.post("/api/exchanges/%2f/str_enc/publish", body: body)
+          response.status_code.should eq 200
+          msgs = [] of AMQP::Client::DeliverMessage
+          q.subscribe { |msg| msgs << msg }
+          wait_for { msgs.size == 1 }
+          msgs.first.not_nil!.body_io.to_s.should eq("test")
+        end
       end
     end
 
     it "should handle base64 encoding" do
-      payload = Base64.urlsafe_encode("test")
-      body = %({
+      with_http_server do |http, s|
+        payload = Base64.urlsafe_encode("test")
+        body = %({
         "properties": {},
         "routing_key": "rk",
         "payload": "#{payload}",
         "payload_encoding": "base64"
       })
-      with_channel do |ch|
-        q = ch.queue("q2", durable: false)
-        x = ch.exchange("str_enc", "topic", passive: false)
-        q.bind(x.name, "*")
-        response = post("/api/exchanges/%2f/str_enc/publish", body: body)
-        response.status_code.should eq 200
-        msgs = [] of AMQP::Client::DeliverMessage
-        q.subscribe { |msg| msgs << msg }
-        wait_for { msgs.size == 1 }
-        msgs.first.not_nil!.body_io.to_s.should eq("test")
+        with_channel(s) do |ch|
+          q = ch.queue("q2", durable: false)
+          x = ch.exchange("str_enc", "topic", passive: false)
+          q.bind(x.name, "*")
+          response = http.post("/api/exchanges/%2f/str_enc/publish", body: body)
+          response.status_code.should eq 200
+          msgs = [] of AMQP::Client::DeliverMessage
+          q.subscribe { |msg| msgs << msg }
+          wait_for { msgs.size == 1 }
+          msgs.first.not_nil!.body_io.to_s.should eq("test")
+        end
       end
     end
   end

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -3,182 +3,208 @@ require "../spec_helper"
 describe LavinMQ::HTTP::Server do
   describe "GET /api/overview" do
     it "should refuse access if no basic auth header" do
-      response = ::HTTP::Client.get("#{SpecHelper.http_base_url}/api/overview")
-      response.status_code.should eq 401
+      with_http_server do |http, _|
+        response = ::HTTP::Client.get("#{http.addr}/api/overview")
+        response.status_code.should eq 401
+      end
     end
 
     it "should refuse access if user does not exist" do
-      Server.users.delete("arnold")
-      # arnold:pw
-      response = get("/api/overview",
-        headers: ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"})
-      response.status_code.should eq 401
+      with_http_server do |http, s|
+        s.users.delete("arnold")
+        # arnold:pw
+        response = http.get("/api/overview",
+          headers: ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"})
+        response.status_code.should eq 401
+      end
     end
 
     it "should refuse access if password does not match" do
-      # guest:pw
-      response = get("/api/overview",
-        headers: ::HTTP::Headers{"Authorization" => "Basic Z3Vlc3Q6cHc="})
-      response.status_code.should eq 401
+      with_http_server do |http, _|
+        # guest:pw
+        response = http.get("/api/overview",
+          headers: ::HTTP::Headers{"Authorization" => "Basic Z3Vlc3Q6cHc="})
+        response.status_code.should eq 401
+      end
     end
 
     it "should allow access if user is correct" do
-      response = get("/api/overview")
-      response.status_code.should eq 200
+      with_http_server do |http, _|
+        response = http.get("/api/overview")
+        response.status_code.should eq 200
+      end
     end
 
     it "should filter stats if x-vhost header is set" do
-      response = get("/api/whoami")
-      response.status_code.should eq 200
+      with_http_server do |http, _|
+        response = http.get("/api/whoami")
+        response.status_code.should eq 200
+      end
     end
 
     it "should return sum of all published messages" do
-      response = get("/api/overview")
-      before_count = JSON.parse(response.body).dig("message_stats", "publish")
+      with_http_server do |http, s|
+        response = http.get("/api/overview")
+        before_count = JSON.parse(response.body).dig("message_stats", "publish")
 
-      with_channel do |ch|
-        q1 = ch.queue("stats_q1", exclusive: true)
-        q2 = ch.queue("stats_q2", exclusive: true)
-        5.times do
-          q1.publish_confirm "m"
-          q2.publish_confirm "m"
+        with_channel(s) do |ch|
+          q1 = ch.queue("stats_q1", exclusive: true)
+          q2 = ch.queue("stats_q2", exclusive: true)
+          5.times do
+            q1.publish_confirm "m"
+            q2.publish_confirm "m"
+          end
         end
-      end
 
-      response = get("/api/overview")
-      count = JSON.parse(response.body).dig("message_stats", "publish")
-      count.should eq(before_count.as_i + 10)
+        response = http.get("/api/overview")
+        count = JSON.parse(response.body).dig("message_stats", "publish")
+        count.should eq(before_count.as_i + 10)
+      end
     end
 
     it "should return the number of published messages" do
-      response = get("/api/overview")
-      before_count = JSON.parse(response.body).dig("message_stats", "publish")
+      with_http_server do |http, s|
+        response = http.get("/api/overview")
+        before_count = JSON.parse(response.body).dig("message_stats", "publish")
 
-      with_channel do |ch|
-        x = ch.fanout_exchange
-        q1 = ch.queue("stats_q1", exclusive: true)
-        q2 = ch.queue("stats_q2", exclusive: true)
-        q3 = ch.queue("stats_q3", exclusive: true)
-        ch.queue_bind(q1.name, x.name, "#")
-        ch.queue_bind(q2.name, x.name, "#")
-        ch.queue_bind(q3.name, x.name, "#")
-        5.times do
-          x.publish_confirm("m", "stats")
+        with_channel(s) do |ch|
+          x = ch.fanout_exchange
+          q1 = ch.queue("stats_q1", exclusive: true)
+          q2 = ch.queue("stats_q2", exclusive: true)
+          q3 = ch.queue("stats_q3", exclusive: true)
+          ch.queue_bind(q1.name, x.name, "#")
+          ch.queue_bind(q2.name, x.name, "#")
+          ch.queue_bind(q3.name, x.name, "#")
+          5.times do
+            x.publish_confirm("m", "stats")
+          end
         end
-      end
 
-      response = get("/api/overview")
-      count = JSON.parse(response.body).dig("message_stats", "publish")
-      count.should eq(before_count.as_i + 5)
+        response = http.get("/api/overview")
+        count = JSON.parse(response.body).dig("message_stats", "publish")
+        count.should eq(before_count.as_i + 5)
+      end
     end
 
     it "should return the number of acked and delivered messages" do
-      response = get("/api/overview")
-      before_ack_count = JSON.parse(response.body).dig("message_stats", "ack")
-      before_deliver_count = JSON.parse(response.body).dig("message_stats", "deliver")
+      with_http_server do |http, s|
+        response = http.get("/api/overview")
+        before_ack_count = JSON.parse(response.body).dig("message_stats", "ack")
+        before_deliver_count = JSON.parse(response.body).dig("message_stats", "deliver")
 
-      with_channel do |ch|
-        q1 = ch.queue("stats_q1", exclusive: true)
-        5.times do
-          q1.publish_confirm("m")
+        with_channel(s) do |ch|
+          q1 = ch.queue("stats_q1", exclusive: true)
+          5.times do
+            q1.publish_confirm("m")
+          end
+          c = 0
+          q1.subscribe(no_ack: false) do |msg|
+            ch.basic_ack(msg.delivery_tag)
+            c += 1
+          end
+          wait_for { c == 5 }
         end
-        c = 0
-        q1.subscribe(no_ack: false) do |msg|
-          ch.basic_ack(msg.delivery_tag)
-          c += 1
-        end
-        wait_for { c == 5 }
+
+        response = http.get("/api/overview")
+        count = JSON.parse(response.body).dig("message_stats", "ack")
+        count.should eq(before_ack_count.as_i + 5)
+        count = JSON.parse(response.body).dig("message_stats", "deliver")
+        count.should eq(before_deliver_count.as_i + 5)
       end
-
-      response = get("/api/overview")
-      count = JSON.parse(response.body).dig("message_stats", "ack")
-      count.should eq(before_ack_count.as_i + 5)
-      count = JSON.parse(response.body).dig("message_stats", "deliver")
-      count.should eq(before_deliver_count.as_i + 5)
     end
 
     it "should return the number of rejected and redelivered messages" do
-      response = get("/api/overview")
-      before_redeliver_count = JSON.parse(response.body).dig("message_stats", "redeliver")
-      before_reject_count = JSON.parse(response.body).dig("message_stats", "reject")
-      rejected = false
+      with_http_server do |http, s|
+        response = http.get("/api/overview")
+        before_redeliver_count = JSON.parse(response.body).dig("message_stats", "redeliver")
+        before_reject_count = JSON.parse(response.body).dig("message_stats", "reject")
+        rejected = false
 
-      with_channel do |ch|
-        q1 = ch.queue("stats_q1", exclusive: true)
-        q1.publish_confirm("m")
-        q1.subscribe(no_ack: false) do |msg|
-          msg.reject(requeue: true) unless rejected
-          msg.ack if rejected
-          rejected = true
+        with_channel(s) do |ch|
+          q1 = ch.queue("stats_q1", exclusive: true)
+          q1.publish_confirm("m")
+          q1.subscribe(no_ack: false) do |msg|
+            msg.reject(requeue: true) unless rejected
+            msg.ack if rejected
+            rejected = true
+          end
+          wait_for { ch.queue_declare("stats_q1", passive: true)[:message_count] == 0 }
         end
-        wait_for { ch.queue_declare("stats_q1", passive: true)[:message_count] == 0 }
-      end
 
-      response = get("/api/overview")
-      count = JSON.parse(response.body).dig("message_stats", "redeliver")
-      count.should eq(before_redeliver_count.as_i + 1)
-      count = JSON.parse(response.body).dig("message_stats", "reject")
-      count.should eq(before_reject_count.as_i + 1)
+        response = http.get("/api/overview")
+        count = JSON.parse(response.body).dig("message_stats", "redeliver")
+        count.should eq(before_redeliver_count.as_i + 1)
+        count = JSON.parse(response.body).dig("message_stats", "reject")
+        count.should eq(before_reject_count.as_i + 1)
+      end
     end
 
     it "should return the number of message gets" do
-      response = get("/api/overview")
-      before_count = JSON.parse(response.body).dig("message_stats", "get")
+      with_http_server do |http, s|
+        response = http.get("/api/overview")
+        before_count = JSON.parse(response.body).dig("message_stats", "get")
 
-      with_channel do |ch|
-        q1 = ch.queue("stats_q1", exclusive: true)
-        5.times do
-          q1.publish_confirm("m")
+        with_channel(s) do |ch|
+          q1 = ch.queue("stats_q1", exclusive: true)
+          5.times do
+            q1.publish_confirm("m")
+          end
+          5.times do
+            q1.get.not_nil!
+          end
         end
-        5.times do
-          q1.get.not_nil!
-        end
+
+        response = http.get("/api/overview")
+        count = JSON.parse(response.body).dig("message_stats", "get")
+        count.should eq(before_count.as_i + 5)
       end
-
-      response = get("/api/overview")
-      count = JSON.parse(response.body).dig("message_stats", "get")
-      count.should eq(before_count.as_i + 5)
     end
   end
-
   describe "GET /api/aliveness-test/vhost" do
     it "should run aliveness-test" do
-      response = get("/api/aliveness-test/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body["status"].as_s.should eq "ok"
+      with_http_server do |http, _|
+        response = http.get("/api/aliveness-test/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["status"].as_s.should eq "ok"
+      end
     end
   end
-
   describe "Pagination" do
     it "should page results" do
-      response = get("/api/vhosts?page=1&page_size=1")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      keys = ["filtered_count", "items", "item_count", "page", "page_size", "total_count"]
-      keys.each { |k| body.as_h.keys.should contain(k) }
+      with_http_server do |http, _|
+        response = http.get("/api/vhosts?page=1&page_size=1")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        keys = ["filtered_count", "items", "item_count", "page", "page_size", "total_count"]
+        keys.each { |k| body.as_h.keys.should contain(k) }
+      end
     end
   end
 
   describe "Sorting" do
     it "should sort results" do
-      Server.vhosts.create("x-vhost")
-      Server.vhosts.create("a-vhost")
-      response = get("/api/vhosts?page=1&sort=name")
-      response.status_code.should eq 200
-      items = JSON.parse(response.body).as_h["items"].as_a
-      items.first["name"].should eq "/"
-      items.last["name"].should eq "x-vhost"
+      with_http_server do |http, s|
+        s.vhosts.create("x-vhost")
+        s.vhosts.create("a-vhost")
+        response = http.get("/api/vhosts?page=1&sort=name")
+        response.status_code.should eq 200
+        items = JSON.parse(response.body).as_h["items"].as_a
+        items.first["name"].should eq "/"
+        items.last["name"].should eq "x-vhost"
+      end
     end
 
     it "should sort reverse results" do
-      Server.vhosts.create("a-vhost")
-      Server.vhosts.create("x-vhost")
-      response = get("/api/vhosts?page=1&sort=name&sort_reverse=true")
-      response.status_code.should eq 200
-      items = JSON.parse(response.body).as_h["items"].as_a
-      items.first["name"].should eq "x-vhost"
-      items.last["name"].should eq "/"
+      with_http_server do |http, s|
+        s.vhosts.create("a-vhost")
+        s.vhosts.create("x-vhost")
+        response = http.get("/api/vhosts?page=1&sort=name&sort_reverse=true")
+        response.status_code.should eq 200
+        items = JSON.parse(response.body).as_h["items"].as_a
+        items.first["name"].should eq "x-vhost"
+        items.last["name"].should eq "/"
+      end
     end
   end
 end

--- a/spec/api/node_spec.cr
+++ b/spec/api/node_spec.cr
@@ -4,14 +4,16 @@ require "../../src/lavinmq/config"
 describe LavinMQ::HTTP::NodesController do
   describe "GET /api/nodes" do
     it "should return nodes data" do
-      response = get("/api/nodes")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      data = body.as_a.first.as_h
-      keys = ["connection_created", "connection_closed", "messages_ready", "messages_unacknowledged"]
-      keys.each do |key|
-        data.has_key?(key).should be_true
+      with_http_server do |http, _|
+        response = http.get("/api/nodes")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        data = body.as_a.first.as_h
+        keys = ["connection_created", "connection_closed", "messages_ready", "messages_unacknowledged"]
+        keys.each do |key|
+          data.has_key?(key).should be_true
+        end
       end
     end
   end

--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -3,296 +3,342 @@ require "../spec_helper"
 describe LavinMQ::HTTP::ParametersController do
   describe "GET /api/parameters" do
     it "should return all vhost scoped parameters for policymaker" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      Server.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
-      Server.vhosts["/"].add_parameter(p)
-      response = get("/api/parameters", headers: hdrs)
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["name", "component", "vhost", "value"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        s.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
+        s.vhosts["/"].add_parameter(p)
+        response = http.get("/api/parameters", headers: hdrs)
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["name", "component", "vhost", "value"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
 
     it "should refuse monitoring and management" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::Management, LavinMQ::Tag::Monitoring])
-      Server.users.rm_permission("arnold", "/")
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = get("/api/parameters", headers: hdrs)
-      response.status_code.should eq 403
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management, LavinMQ::Tag::Monitoring])
+        s.users.rm_permission("arnold", "/")
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/parameters", headers: hdrs)
+        response.status_code.should eq 403
+      end
     end
   end
 
   describe "GET /api/parameters/component" do
     it "should return all parameters for a component" do
-      p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
-      Server.vhosts["/"].add_parameter(p)
-      response = get("/api/parameters/test")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
+        s.vhosts["/"].add_parameter(p)
+        response = http.get("/api/parameters/test")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
-
   describe "GET /api/parameters/component/vhost" do
     it "should return all parameters for a component on vhost" do
-      p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
-      Server.vhosts["/"].add_parameter(p)
-      response = get("/api/parameters/test/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
+        s.vhosts["/"].add_parameter(p)
+        response = http.get("/api/parameters/test/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
-
   describe "GET /api/parameters/component/vhost/name" do
     it "should return parameter" do
-      p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
-      Server.vhosts["/"].add_parameter(p)
-      response = get("/api/parameters/test/%2f/name")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
+        s.vhosts["/"].add_parameter(p)
+        response = http.get("/api/parameters/test/%2f/name")
+        response.status_code.should eq 200
+      end
     end
   end
-
   describe "PUT /api/parameters/component/vhost/name" do
     it "should create parameters for a component on vhost" do
-      body = %({
+      with_http_server do |http, s|
+        body = %({
         "value": { "key": "value" }
       })
-      response = put("/api/parameters/test/%2f/name", body: body)
-      response.status_code.should eq 201
-      Server.vhosts["/"].parameters[{"test", "name"}].value.should eq({"key" => "value"})
+        response = http.put("/api/parameters/test/%2f/name", body: body)
+        response.status_code.should eq 201
+        s.vhosts["/"].parameters[{"test", "name"}].value.should eq({"key" => "value"})
+      end
     end
 
     it "should update parameters for a component on vhost" do
-      p = LavinMQ::Parameter.new("test", "name", JSON::Any.new(%({ "key": "old value" })))
-      Server.vhosts["/"].add_parameter(p)
-      body = %({
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new("test", "name", JSON::Any.new(%({ "key": "old value" })))
+        s.vhosts["/"].add_parameter(p)
+        body = %({
         "value": { "key": "new value" }
       })
-      response = put("/api/parameters/test/%2f/name", body: body)
-      response.status_code.should eq 204
-      Server.vhosts["/"].parameters[{"test", "name"}].value.should eq({"key" => "new value"})
+        response = http.put("/api/parameters/test/%2f/name", body: body)
+        response.status_code.should eq 204
+        s.vhosts["/"].parameters[{"test", "name"}].value.should eq({"key" => "new value"})
+      end
     end
 
     it "should handle request with empty body" do
-      response = put("/api/parameters/test/%2f/name", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Field .+ is required/)
+      with_http_server do |http, _|
+        response = http.put("/api/parameters/test/%2f/name", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Field .+ is required/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/parameters/test/%2f/name", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      with_http_server do |http, _|
+        response = http.put("/api/parameters/test/%2f/name", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/parameters/test/%2f/name", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/parameters/test/%2f/name", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
   end
-
   describe "DELETE /api/parameters/component/vhost/name" do
     it "should delete parameter for a component on vhost" do
-      p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
-      Server.vhosts["/"].add_parameter(p)
-      response = delete("/api/parameters/test/%2f/name")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new("test", "name", JSON::Any.new({} of String => JSON::Any))
+        s.vhosts["/"].add_parameter(p)
+        response = http.delete("/api/parameters/test/%2f/name")
+        response.status_code.should eq 204
+      end
     end
   end
-
   describe "GET /api/global-parameters" do
     it "should return all global parameters" do
-      p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
-      Server.add_parameter(p)
-      response = get("/api/global-parameters")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["name", "value"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
+        s.add_parameter(p)
+        response = http.get("/api/global-parameters")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["name", "value"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
   end
-
   describe "GET /api/global-parameters/name" do
     it "should return parameter" do
-      p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
-      Server.add_parameter(p)
-      response = get("/api/global-parameters/name")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
+        s.add_parameter(p)
+        response = http.get("/api/global-parameters/name")
+        response.status_code.should eq 200
+      end
     end
   end
-
   describe "PUT /api/global-parameters/name" do
     it "should create global parameter" do
-      Server.delete_parameter(nil, "name")
-      body = %({
+      with_http_server do |http, s|
+        s.delete_parameter(nil, "name")
+        body = %({
         "value": {}
       })
-      response = put("/api/global-parameters/name", body: body)
-      response.status_code.should eq 201
+        response = http.put("/api/global-parameters/name", body: body)
+        response.status_code.should eq 201
+      end
     end
 
     it "should update global parameter" do
-      p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new(%({ "key": "old value" })))
-      Server.add_parameter(p)
-      body = %({
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new(%({ "key": "old value" })))
+        s.add_parameter(p)
+        body = %({
         "value": { "key": "new value" }
       })
-      response = put("/api/global-parameters/name", body: body)
-      response.status_code.should eq 204
-      Server.parameters[{nil, "name"}].value.should eq({"key" => "new value"})
+        response = http.put("/api/global-parameters/name", body: body)
+        response.status_code.should eq 204
+        s.parameters[{nil, "name"}].value.should eq({"key" => "new value"})
+      end
     end
 
     it "should handle request with empty body" do
-      response = put("/api/global-parameters/name", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Field .+ is required/)
+      with_http_server do |http, _|
+        response = http.put("/api/global-parameters/name", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Field .+ is required/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/global-parameters/name", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      with_http_server do |http, _|
+        response = http.put("/api/global-parameters/name", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/global-parameters/name", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/global-parameters/name", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
   end
-
   describe "DELETE /api/global-parameters/name" do
     it "should delete parameter" do
-      p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
-      Server.add_parameter(p)
-      response = delete("/api/global-parameters/name")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
+        s.add_parameter(p)
+        response = http.delete("/api/global-parameters/name")
+        response.status_code.should eq 204
+      end
     end
   end
-
   describe "GET /api/policies" do
     it "should return all policies" do
-      definitions = {
-        "max-length"         => JSON::Any.new(10_i64),
-        "alternate-exchange" => JSON::Any.new("dead-letters"),
-      }
-      Server.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
-      response = get("/api/policies")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["name", "vhost", "definition", "priority", "apply-to"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        definitions = {
+          "max-length"         => JSON::Any.new(10_i64),
+          "alternate-exchange" => JSON::Any.new("dead-letters"),
+        }
+        s.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
+        response = http.get("/api/policies")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["name", "vhost", "definition", "priority", "apply-to"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
   end
-
   describe "GET /api/policies/vhost" do
     it "should return policies for vhost" do
-      definitions = {
-        "max-length"         => JSON::Any.new(10_i64),
-        "alternate-exchange" => JSON::Any.new("dead-letters"),
-      }
-      Server.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
-      response = get("/api/policies/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        definitions = {
+          "max-length"         => JSON::Any.new(10_i64),
+          "alternate-exchange" => JSON::Any.new("dead-letters"),
+        }
+        s.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
+        response = http.get("/api/policies/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
-
   describe "GET /api/policies/vhost/name" do
     it "should return policy" do
-      definitions = {
-        "max-length"         => JSON::Any.new(10_i64),
-        "alternate-exchange" => JSON::Any.new("dead-letters"),
-      }
-      Server.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
-      response = get("/api/policies/%2f/test")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        definitions = {
+          "max-length"         => JSON::Any.new(10_i64),
+          "alternate-exchange" => JSON::Any.new("dead-letters"),
+        }
+        s.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
+        response = http.get("/api/policies/%2f/test")
+        response.status_code.should eq 200
+      end
     end
   end
-
   describe "PUT /api/policies/vhost/name" do
     it "should create policy" do
-      body = %({
+      with_http_server do |http, s|
+        body = %({
         "apply-to": "queues",
         "priority": 4,
         "definition": { "max-length": 10 },
         "pattern": ".*"
       })
-      response = put("/api/policies/%2f/name", body: body)
-      response.status_code.should eq 201
-      Server.vhosts["/"].policies["name"].definition["max-length"].as_i.should eq 10
+        response = http.put("/api/policies/%2f/name", body: body)
+        response.status_code.should eq 201
+        s.vhosts["/"].policies["name"].definition["max-length"].as_i.should eq 10
+      end
     end
 
     it "should update policy" do
-      policy_name = "test"
-      definitions = {"max-length" => JSON::Any.new(10_i64)}
-      Server.vhosts["/"].add_policy(policy_name, "^.*$", "all", definitions, -10_i8)
+      with_http_server do |http, s|
+        policy_name = "test"
+        definitions = {"max-length" => JSON::Any.new(10_i64)}
+        s.vhosts["/"].add_policy(policy_name, "^.*$", "all", definitions, -10_i8)
 
-      body = %({
+        body = %({
         "pattern": ".*",
         "definition": { "max-length": 20 }
       })
-      response = put("/api/policies/%2f/#{policy_name}", body: body)
-      response.status_code.should eq 204
-      Server.vhosts["/"].policies[policy_name].definition["max-length"].as_i.should eq 20
+        response = http.put("/api/policies/%2f/#{policy_name}", body: body)
+        response.status_code.should eq 204
+        s.vhosts["/"].policies[policy_name].definition["max-length"].as_i.should eq 20
+      end
     end
 
     it "should handle request with empty body" do
-      response = put("/api/policies/%2f/name", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Fields .+ are required/)
+      with_http_server do |http, _|
+        response = http.put("/api/policies/%2f/name", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Fields .+ are required/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/policies/%2f/name", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      with_http_server do |http, _|
+        response = http.put("/api/policies/%2f/name", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/policies/%2f/name", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/policies/%2f/name", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
 
     it "should handle invalid definition types" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "apply-to": "queues",
         "priority": 0,
         "definition": { "max-length": "String" },
         "pattern": ".*"
       })
-      response = put("/api/policies/%2f/name", body: body)
-      response.status_code.should eq 400
+        response = http.put("/api/policies/%2f/name", body: body)
+        response.status_code.should eq 400
+      end
     end
   end
 
   describe "DELETE /api/policies/vhost/name" do
     it "should delete policy" do
-      definitions = {
-        "max-length"         => JSON::Any.new(10_i64),
-        "alternate-exchange" => JSON::Any.new("dead-letters"),
-      }
-      Server.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
-      response = delete("/api/policies/%2f/test")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        definitions = {
+          "max-length"         => JSON::Any.new(10_i64),
+          "alternate-exchange" => JSON::Any.new("dead-letters"),
+        }
+        s.vhosts["/"].add_policy("test", "^.*$", "all", definitions, -10_i8)
+        response = http.delete("/api/policies/%2f/test")
+        response.status_code.should eq 204
+      end
     end
   end
 end

--- a/spec/api/permissions_spec.cr
+++ b/spec/api/permissions_spec.cr
@@ -3,87 +3,104 @@ require "../spec_helper"
 describe LavinMQ::HTTP::PermissionsController do
   describe "GET /api/permissions" do
     it "should return all permissions" do
-      response = get("/api/permissions")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["user", "vhost", "configure", "read", "write"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, _|
+        response = http.get("/api/permissions")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["user", "vhost", "configure", "read", "write"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
 
     it "should refuse non administrators" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = get("/api/permissions", headers: hdrs)
-      response.status_code.should eq 403
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/permissions", headers: hdrs)
+        response.status_code.should eq 403
+      end
     end
   end
-
   describe "GET /api/permissions/vhost/user" do
     it "should return all permissions for a user and vhost" do
-      response = get("/api/permissions/%2f/guest")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_h.empty?.should be_false
+      with_http_server do |http, _|
+        response = http.get("/api/permissions/%2f/guest")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_h.empty?.should be_false
+      end
     end
   end
 
   describe "PUT /api/permissions/vhost/user" do
     it "should create permission for a user and vhost" do
-      Server.users.create("test_user", "pw")
-      Server.vhosts.create("test_vhost")
-      body = %({
+      with_http_server do |http, s|
+        s.users.create("test_user", "pw")
+        s.vhosts.create("test_vhost")
+        body = %({
         "configure": ".*",
         "read": ".*",
         "write": ".*"
       })
-      response = put("/api/permissions/test_vhost/test_user", body: body)
-      response.status_code.should eq 201
-      Server.users["test_user"].permissions["test_vhost"].should eq({config: /.*/, read: /.*/, write: /.*/})
+        response = http.put("/api/permissions/test_vhost/test_user", body: body)
+        response.status_code.should eq 201
+        s.users["test_user"].permissions["test_vhost"].should eq({config: /.*/, read: /.*/, write: /.*/})
+      end
     end
 
     it "should update permission for a user and vhost" do
-      Server.vhosts.create("test_vhost")
-      Server.users.add_permission("guest", "test_vhost", /.*/, /.*/, /.*/)
+      with_http_server do |http, s|
+        s.vhosts.create("test_vhost")
+        s.users.add_permission("guest", "test_vhost", /.*/, /.*/, /.*/)
 
-      body = %({
+        body = %({
         "configure": ".*",
         "read": ".*",
         "write": "^tut"
       })
-      response = put("/api/permissions/test_vhost/guest", body: body)
-      response.status_code.should eq 204
-      Server.users["guest"].permissions["test_vhost"]["write"].should eq(/^tut/)
+        response = http.put("/api/permissions/test_vhost/guest", body: body)
+        response.status_code.should eq 204
+        s.users["guest"].permissions["test_vhost"]["write"].should eq(/^tut/)
+      end
     end
 
     it "should handle request with empty body" do
-      response = put("/api/permissions/%2f/guest", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Fields .+ are required/)
+      with_http_server do |http, _|
+        response = http.put("/api/permissions/%2f/guest", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Fields .+ are required/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/permissions/%2f/guest", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      with_http_server do |http, _|
+        response = http.put("/api/permissions/%2f/guest", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/permissions/%2f/guest", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/permissions/%2f/guest", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
   end
 
   describe "DELETE /api/permissions/vhost/user" do
     it "should delete permission for a user and vhost" do
-      Server.vhosts.create("test")
-      Server.users.add_permission("guest", "test", /.*/, /.*/, /.*/)
-      response = delete("/api/permissions/test/guest")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        s.vhosts.create("test")
+        s.users.add_permission("guest", "test", /.*/, /.*/, /.*/)
+        response = http.delete("/api/permissions/test/guest")
+        response.status_code.should eq 204
+      end
     end
   end
 end

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -4,69 +4,80 @@ require "string_scanner"
 describe LavinMQ::HTTP::ConsumersController do
   describe "GET /metrics" do
     it "should return metrics in prometheus style" do
-      response = get("/metrics")
-      response.status_code.should eq 200
-      response.body.lines.any?(&.starts_with? "telemetry_scrape_duration_seconds").should be_true
+      with_http_server do |http, _|
+        response = http.get("/metrics")
+        response.status_code.should eq 200
+        response.body.lines.any?(&.starts_with? "telemetry_scrape_duration_seconds").should be_true
+      end
     end
 
     it "should perform sanity check on sampled metrics" do
-      vhost = Server.vhosts.create("pmths")
-      vhost.declare_queue("test1", true, false)
-      vhost.delete_queue("test1")
-      vhost.declare_queue("test2", true, false)
-      raw = get("/metrics").body
-      parsed_metrics = PrometheusSpecHelper.parse_prometheus(raw)
-      parsed_metrics.each do |metric|
-        case metric[:key]
-        when "lavinmq_queues_declared_total"
-          metric[:value].should eq 2
-        when "lavinmq_queues"
-          metric[:value].should eq 1
+      with_http_server do |http, s|
+        vhost = s.vhosts.create("pmths")
+        vhost.declare_queue("test1", true, false)
+        vhost.delete_queue("test1")
+        vhost.declare_queue("test2", true, false)
+        raw = http.get("/metrics").body
+        parsed_metrics = PrometheusSpecHelper.parse_prometheus(raw)
+        parsed_metrics.each do |metric|
+          case metric[:key]
+          when "lavinmq_queues_declared_total"
+            metric[:value].should eq 2
+          when "lavinmq_queues"
+            metric[:value].should eq 1
+          end
         end
       end
     end
 
     it "should support specifying prefix" do
-      prefix = "testing"
-      response = get("/metrics?prefix=#{prefix}")
-      lines = response.body.lines
-      lines.count(&.starts_with? "telemetry").should eq 2
-      metric_lines = lines.reject(&.starts_with? "#")
-      prefix_lines = lines.select(&.starts_with? prefix)
-      prefix_lines.size.should eq metric_lines.size - 2
+      with_http_server do |http, _|
+        prefix = "testing"
+        response = http.get("/metrics?prefix=#{prefix}")
+        lines = response.body.lines
+        lines.count(&.starts_with? "telemetry").should eq 2
+        metric_lines = lines.reject(&.starts_with? "#")
+        prefix_lines = lines.select(&.starts_with? prefix)
+        prefix_lines.size.should eq metric_lines.size - 2
+      end
     end
 
     it "should not support a prefix longer than 20" do
-      prefix = "abcdefghijklmnopqrstuvwxyz"
-      response = get("/metrics?prefix=#{prefix}")
-      response.status_code.should eq 400
-      response.body.should match /Prefix too long/
+      with_http_server do |http, _|
+        prefix = "abcdefghijklmnopqrstuvwxyz"
+        response = http.get("/metrics?prefix=#{prefix}")
+        response.status_code.should eq 400
+        response.body.should match /Prefix too long/
+      end
     end
   end
 
   describe "GET /metrics/detailed" do
     it "should support specifying families" do
-      response = get("/metrics/detailed?family=connection_churn_metrics")
-      response.status_code.should eq 200
-      lines = response.body.lines
-      lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_true
+      with_http_server do |http, _|
+        response = http.get("/metrics/detailed?family=connection_churn_metrics")
+        response.status_code.should eq 200
+        lines = response.body.lines
+        lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_true
 
-      response = get("/metrics/detailed?family=family=queue_coarse_metrics")
-      response.status_code.should eq 200
-      lines = response.body.lines
-      lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_false
+        response = http.get("/metrics/detailed?family=family=queue_coarse_metrics")
+        response.status_code.should eq 200
+        lines = response.body.lines
+        lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_false
+      end
     end
 
     it "should perform sanity check on sampled metrics" do
-      Server.vhosts.create("pmths")
-      conn1 = AMQP::Client.new(SpecHelper.amqp_base_url).connect
-      conn2 = AMQP::Client.new(SpecHelper.amqp_base_url).connect
-      conn1.close(no_wait: true)
-      raw = get("/metrics/detailed?family=connection_churn_metrics").body
-      parsed_metrics = PrometheusSpecHelper.parse_prometheus(raw)
-      parsed_metrics.find! { |metric| metric[:key] == "lavinmq_detailed_connections_opened_total" }[:value].should eq 2
-      parsed_metrics.find! { |metric| metric[:key] == "lavinmq_detailed_connections_closed_total" }[:value].should eq 1
-      conn2.close(no_wait: true)
+      with_http_server do |http, s|
+        with_channel(s) do |_|
+        end
+        with_channel(s) do |_|
+          raw = http.get("/metrics/detailed?family=connection_churn_metrics").body
+          parsed_metrics = PrometheusSpecHelper.parse_prometheus(raw)
+          parsed_metrics.find! { |metric| metric[:key] == "lavinmq_detailed_connections_opened_total" }[:value].should eq 2
+          parsed_metrics.find! { |metric| metric[:key] == "lavinmq_detailed_connections_closed_total" }[:value].should eq 1
+        end
+      end
     end
   end
 end

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -4,312 +4,352 @@ require "compress/deflate"
 describe LavinMQ::HTTP::QueuesController do
   describe "GET /api/queues" do
     it "should return all queues" do
-      Server.vhosts["/"].declare_queue("q0", false, false)
-      response = get("/api/queues")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["name", "durable", "exclusive", "auto_delete", "arguments", "consumers", "vhost",
-              "messages", "ready", "unacked", "policy", "exclusive_consumer_tag", "state",
-              "effective_policy_definition"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("q0", false, false)
+        response = http.get("/api/queues")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["name", "durable", "exclusive", "auto_delete", "arguments", "consumers", "vhost",
+                "messages", "ready", "unacked", "policy", "exclusive_consumer_tag", "state",
+                "effective_policy_definition"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
   end
-
   describe "GET /api/queues/vhost" do
     it "should return all queues for a vhost" do
-      Server.vhosts["/"].declare_queue("q0", false, false)
-      response = get("/api/queues/%2f")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("q0", false, false)
+        response = http.get("/api/queues/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
-
   describe "GET /api/queues/vhost/name" do
     it "should return queue" do
-      Server.vhosts["/"].declare_queue("q0", false, false)
-      response = get("/api/queues/%2f/q0")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("q0", false, false)
+        response = http.get("/api/queues/%2f/q0")
+        response.status_code.should eq 200
+      end
     end
 
     it "should return 404 if queue does not exist" do
-      response = get("/api/queues/%2f/404")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/queues/%2f/404")
+        response.status_code.should eq 404
+      end
     end
 
     it "should return message stats" do
-      with_channel do |ch|
-        q = ch.queue("stats_q")
-        q.publish "m1"
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("stats_q")
+          q.publish "m1"
+        end
+        response = http.get("/api/queues/%2f/stats_q")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["message_stats"]["publish_details"]["rate"].nil?.should be_false
       end
-      response = get("/api/queues/%2f/stats_q")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body["message_stats"]["publish_details"]["rate"].nil?.should be_false
     end
 
     it "should return no persistent message count" do
-      with_channel do |ch|
-        q = ch.queue("stats_q", auto_delete: false, durable: false, exclusive: false)
-        q.publish "m1"
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("stats_q", auto_delete: false, durable: false, exclusive: false)
+          q.publish "m1"
+        end
+        response = http.get("/api/queues/%2f/stats_q")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["messages"].should eq 1
+        body["messages_persistent"].should eq 0
       end
-      response = get("/api/queues/%2f/stats_q")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body["messages"].should eq 1
-      body["messages_persistent"].should eq 0
     end
 
     it "should return persistent message count" do
-      with_channel do |ch|
-        q = ch.queue("stats_q", auto_delete: false, durable: true, exclusive: false)
-        q.publish "m1"
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("stats_q", auto_delete: false, durable: true, exclusive: false)
+          q.publish "m1"
+        end
+        response = http.get("/api/queues/%2f/stats_q")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["messages"].should eq 1
+        body["messages_persistent"].should eq 1
       end
-      response = get("/api/queues/%2f/stats_q")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body["messages"].should eq 1
-      body["messages_persistent"].should eq 1
     end
   end
-
   describe "GET /api/queues/vhost/name/bindings" do
     it "should return queue bindings" do
-      Server.vhosts["/"].declare_queue("q0", false, false)
-      Server.vhosts["/"].bind_queue("q0", "amq.direct", "foo")
-      response = get("/api/queues/%2f/q0/bindings?page=1&page_size=100")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body["items"].as_a.size.should eq 2
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("q0", false, false)
+        s.vhosts["/"].bind_queue("q0", "amq.direct", "foo")
+        response = http.get("/api/queues/%2f/q0/bindings?page=1&page_size=100")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["items"].as_a.size.should eq 2
+      end
     end
   end
-
   describe "PUT /api/queues/vhost/name" do
     it "should create queue" do
-      body = {
-        "durable"     => false,
-        "auto_delete" => true,
-        "arguments"   => {
-          "max-length" => 10,
-        },
-      }
-      response = put("/api/queues/%2f/putqueue", body: body.to_json)
-      response.status_code.should eq 201
-      response = get("/api/queues/%2f/putqueue")
-      response.status_code.should eq 200
-      json = JSON.parse(response.body)
-      json["name"].should eq "putqueue"
-      body.each do |key, value|
-        json[key].should eq value
+      with_http_server do |http, _|
+        body = {
+          "durable"     => false,
+          "auto_delete" => true,
+          "arguments"   => {
+            "max-length" => 10,
+          },
+        }
+        response = http.put("/api/queues/%2f/putqueue", body: body.to_json)
+        response.status_code.should eq 201
+        response = http.get("/api/queues/%2f/putqueue")
+        response.status_code.should eq 200
+        json = JSON.parse(response.body)
+        json["name"].should eq "putqueue"
+        body.each do |key, value|
+          json[key].should eq value
+        end
       end
     end
 
     it "should not require any body" do
-      response = put("/api/queues/%2f/okq")
-      response.status_code.should eq 201
+      with_http_server do |http, _|
+        response = http.put("/api/queues/%2f/okq")
+        response.status_code.should eq 201
+      end
     end
 
     it "should require durable to be the same when overwriting" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "durable": true
       })
-      response = put("/api/queues/%2f/q1d", body: body)
-      response.status_code.should eq 201
-      body = %({
+        response = http.put("/api/queues/%2f/q1d", body: body)
+        response.status_code.should eq 201
+        body = %({
         "durable": false
       })
-      response = put("/api/queues/%2f/q1d", body: body)
-      response.status_code.should eq 400
+        response = http.put("/api/queues/%2f/q1d", body: body)
+        response.status_code.should eq 400
+      end
     end
 
     it "should not be possible to declare amq. prefixed queues" do
-      response = put("/api/queues/%2f/amq.test", body: %({}))
-      response.status_code.should eq 400
+      with_http_server do |http, _|
+        response = http.put("/api/queues/%2f/amq.test", body: %({}))
+        response.status_code.should eq 400
+      end
     end
 
     it "should respond with 400 for PreconditionFailed errors" do
-      # supplying 'x-dead-letter-routing-key' is only valid if
-      # 'x-dead-letter-exchange' is also in the request
-      # so this request generates a Error::PreconditionFailed
-      body = %({
+      with_http_server do |http, _|
+        # supplying 'x-dead-letter-routing-key' is only valid if
+        # 'x-dead-letter-exchange' is also in the request
+        # so this request generates a Error::PreconditionFailed
+        body = %({
         "arguments": {"x-dead-letter-routing-key": "value"}
       })
-      response = put("/api/queues/%2f/precond-failed", body: body)
-      response.status_code.should eq 400
+        response = http.put("/api/queues/%2f/precond-failed", body: body)
+        response.status_code.should eq 400
+      end
     end
 
     it "should require config access to declare" do
-      hdrs = HTTP::Headers{"Authorization" => "Basic dGVzdF9wZXJtOnB3"}
-      response = put("/api/queues/%2f/test_perm", headers: hdrs, body: %({}))
-      response.status_code.should eq 401
+      with_http_server do |http, _|
+        hdrs = HTTP::Headers{"Authorization" => "Basic dGVzdF9wZXJtOnB3"}
+        response = http.put("/api/queues/%2f/test_perm", headers: hdrs, body: %({}))
+        response.status_code.should eq 401
+      end
     end
   end
-
   describe "DELETE /api/queues/vhost/name" do
     it "should delete queue" do
-      Server.vhosts["/"].declare_queue("delq", false, false)
-      response = delete("/api/queues/%2f/delq")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("delq", false, false)
+        response = http.delete("/api/queues/%2f/delq")
+        response.status_code.should eq 204
+      end
     end
 
     it "should not delete queue if it has messasge when query param if-unused is set" do
-      with_channel do |ch|
-        q = ch.queue("q3", auto_delete: false, durable: true, exclusive: false)
-        q.publish "m1"
-        sleep 0.05
-        body = %({
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q3", auto_delete: false, durable: true, exclusive: false)
+          q.publish "m1"
+          sleep 0.05
+          body = %({
           "count": 1,
           "ack_mode": "reject_requeue_true",
           "encoding": "auto"
         })
-        response = post("/api/queues/%2f/q3/get", body: body)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.empty?.should be_false
-        keys = ["payload_bytes", "redelivered", "exchange", "routing_key", "message_count",
-                "properties", "payload", "payload_encoding"]
-        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
-        Server.vhosts["/"].queues["q3"].message_count.should be > 0
+          response = http.post("/api/queues/%2f/q3/get", body: body)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.empty?.should be_false
+          keys = ["payload_bytes", "redelivered", "exchange", "routing_key", "message_count",
+                  "properties", "payload", "payload_encoding"]
+          body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+          s.vhosts["/"].queues["q3"].message_count.should be > 0
+        end
       end
     end
   end
-
   describe "POST /api/queues/vhost/name/get" do
     it "should get plain text messages" do
-      with_channel do |ch|
-        q = ch.queue("q4")
-        q4 = Server.vhosts["/"].queues["q4"]
-        q.publish "m1"
-        wait_for { q4.message_count == 1 }
-        body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
-        response = post("/api/queues/%2f/q4/get", body: body)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body[0]["payload"].should eq "m1"
-        q4.empty?.should be_true
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q4")
+          q4 = s.vhosts["/"].queues["q4"]
+          q.publish "m1"
+          wait_for { q4.message_count == 1 }
+          body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
+          response = http.post("/api/queues/%2f/q4/get", body: body)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body[0]["payload"].should eq "m1"
+          q4.empty?.should be_true
+        end
       end
     end
 
     it "should get encoded messages" do
-      with_channel do |ch|
-        q = ch.queue("q4")
-        q4 = Server.vhosts["/"].queues["q4"]
-        mem_io = IO::Memory.new
-        Compress::Deflate::Writer.open(mem_io, Compress::Deflate::BEST_SPEED) { |deflate| deflate.print("m1") }
-        encoded_msg = mem_io.to_s
-        q.publish encoded_msg, props: AMQP::Client::Properties.new(content_encoding: "deflate")
-        wait_for { q4.message_count == 1 }
-        body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
-        response = post("/api/queues/%2f/q4/get", body: body)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body[0]["payload"].should eq Base64.urlsafe_encode(encoded_msg)
-        body[0]["payload_encoding"].should eq "base64"
-        q4.empty?.should be_true
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q4")
+          q4 = s.vhosts["/"].queues["q4"]
+          mem_io = IO::Memory.new
+          Compress::Deflate::Writer.open(mem_io, Compress::Deflate::BEST_SPEED) { |deflate| deflate.print("m1") }
+          encoded_msg = mem_io.to_s
+          q.publish encoded_msg, props: AMQP::Client::Properties.new(content_encoding: "deflate")
+          wait_for { q4.message_count == 1 }
+          body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
+          response = http.post("/api/queues/%2f/q4/get", body: body)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body[0]["payload"].should eq Base64.urlsafe_encode(encoded_msg)
+          body[0]["payload_encoding"].should eq "base64"
+          q4.empty?.should be_true
+        end
       end
     end
 
     it "should handle count > message_count" do
-      with_channel do |ch|
-        q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
-        q.publish "m1"
-        sleep 0.05
-        body = %({
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
+          q.publish "m1"
+          sleep 0.05
+          body = %({
           "count": 2,
           "ack_mode": "get",
           "encoding": "auto"
         })
-        response = post("/api/queues/%2f/q5/get", body: body)
-        response.status_code.should eq 200
+          response = http.post("/api/queues/%2f/q5/get", body: body)
+          response.status_code.should eq 200
+        end
       end
     end
 
     it "should handle empty q" do
-      with_channel do |ch|
-        ch.queue("q6")
-        body = %({
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          ch.queue("q6")
+          body = %({
           "count": 1,
           "ack_mode": "get",
           "encoding": "auto"
         })
-        response = post("/api/queues/%2f/q6/get", body: body)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.should be_empty
+          response = http.post("/api/queues/%2f/q6/get", body: body)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.as_a.should be_empty
+        end
       end
     end
 
     it "should handle base64 encoding" do
-      with_channel do |ch|
-        q = ch.queue("q7")
-        q.publish "m1"
-        sleep 0.05
-        body = %({
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q7")
+          q.publish "m1"
+          sleep 0.05
+          body = %({
           "count": 1,
           "ack_mode": "get",
           "encoding": "base64"
         })
-        response = post("/api/queues/%2f/q7/get", body: body)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        Base64.decode_string(body[0]["payload"].as_s).should eq "m1"
+          response = http.post("/api/queues/%2f/q7/get", body: body)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          Base64.decode_string(body[0]["payload"].as_s).should eq "m1"
+        end
       end
     end
 
     it "should not allow get and requeue" do
-      with_channel do |ch|
-        q = ch.queue("q8")
-        q.publish "m1"
-        sleep 0.05
-        body = %({
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q8")
+          q.publish "m1"
+          sleep 0.05
+          body = %({
           "count": 1,
           "ack_mode": "get",
           "requeue": true,
           "encoding": "base64"
         })
-        response = post("/api/queues/%2f/q8/get", body: body)
-        response.status_code.should eq 400
-        body = JSON.parse(response.body)
-        body["reason"].should eq "Cannot requeue message on get"
+          response = http.post("/api/queues/%2f/q8/get", body: body)
+          response.status_code.should eq 400
+          body = JSON.parse(response.body)
+          body["reason"].should eq "Cannot requeue message on get"
+        end
       end
     end
   end
-
   describe "PUT /api/queues/vhost/name/pause" do
     it "should pause the queue" do
-      with_channel do |ch|
-        ch.queue("confqueue")
-        response = put("/api/queues/%2f/confqueue/pause")
-        response.status_code.should eq 204
-        response = get("/api/queues/%2f/confqueue")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body["state"].should eq "paused"
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          ch.queue("confqueue")
+          response = http.put("/api/queues/%2f/confqueue/pause")
+          response.status_code.should eq 204
+          response = http.get("/api/queues/%2f/confqueue")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body["state"].should eq "paused"
+        end
       end
     end
   end
-
   describe "PUT /api/queues/vhost/name/resume" do
     it "should resume the queue" do
-      with_channel do |ch|
-        ch.queue("confqueue")
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          ch.queue("confqueue")
 
-        q = Server.vhosts["/"].queues["confqueue"]
-        q.pause!
+          q = s.vhosts["/"].queues["confqueue"]
+          q.pause!
 
-        response = get("/api/queues/%2f/confqueue")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body["state"].should eq "paused"
+          response = http.get("/api/queues/%2f/confqueue")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body["state"].should eq "paused"
 
-        response = put("/api/queues/%2f/confqueue/resume")
-        response.status_code.should eq 204
+          response = http.put("/api/queues/%2f/confqueue/resume")
+          response.status_code.should eq 204
 
-        response = get("/api/queues/%2f/confqueue")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body["state"].should eq "running"
+          response = http.get("/api/queues/%2f/confqueue")
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body["state"].should eq "running"
+        end
       end
     end
   end

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -3,183 +3,217 @@ require "../spec_helper"
 describe LavinMQ::HTTP::UsersController do
   describe "GET /api/users" do
     it "should return all users" do
-      response = get("/api/users")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["name", "password_hash", "hashing_algorithm"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, _|
+        response = http.get("/api/users")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["name", "password_hash", "hashing_algorithm"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
 
     it "should refuse non administrators" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = get("/api/users", headers: hdrs)
-      response.status_code.should eq 403
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/users", headers: hdrs)
+        response.status_code.should eq 403
+      end
     end
   end
-
   describe "GET /api/users/without-permissions" do
     it "should return users without access to any vhost" do
-      Server.users.create("alan", "alan")
-      response = get("/api/users/without-permissions")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, s|
+        s.users.create("alan", "alan")
+        response = http.get("/api/users/without-permissions")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
-
   describe "POST /api/users/bulk-delete" do
     it "should delete users in bulk" do
-      Server.users.create("alan1", "alan")
-      Server.users.create("alan2", "alan")
-      body = %({
+      with_http_server do |http, s|
+        s.users.create("alan1", "alan")
+        s.users.create("alan2", "alan")
+        body = %({
         "users": ["alan1", "alan2"]
       })
-      response = post("/api/users/bulk-delete", body: body)
-      response.status_code.should eq 204
+        response = http.post("/api/users/bulk-delete", body: body)
+        response.status_code.should eq 204
+      end
     end
 
     it "should handle request with empty body" do
-      response = put("/api/users/bulk-delete", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Field .+ is required/)
+      with_http_server do |http, _|
+        response = http.put("/api/users/bulk-delete", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Field .+ is required/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/users/bulk-delete", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      with_http_server do |http, _|
+        response = http.put("/api/users/bulk-delete", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Input needs to be a JSON object.")
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/users/bulk-delete", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/users/bulk-delete", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
   end
-
   describe "GET /api/users/name" do
     it "should return user" do
-      Server.users.create("alan", "alan")
-      response = get("/api/users/alan")
-      response.status_code.should eq 200
+      with_http_server do |http, s|
+        s.users.create("alan", "alan")
+        response = http.get("/api/users/alan")
+        response.status_code.should eq 200
+      end
     end
   end
-
   describe "PUT /api/users/name" do
     it "should create user with password" do
-      body = %({
+      with_http_server do |http, s|
+        body = %({
         "password": "test"
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 201
-      u = Server.users["alan"]
-      ok = u.not_nil!.password.try &.verify("test")
-      ok.should be_true
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 201
+        u = s.users["alan"]
+        ok = u.not_nil!.password.try &.verify("test")
+        ok.should be_true
+      end
     end
 
     it "should create user with password_hash" do
-      body = %({
+      with_http_server do |http, s|
+        body = %({
         "password_hash": "kI3GCqW5JLMJa4iX1lo7X4D6XbYqlLgxIs30+P6tENUV2POR"
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 201
-      u = Server.users["alan"]
-      u.not_nil!.password.not_nil!.verify("test12").should be_true
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 201
+        u = s.users["alan"]
+        u.not_nil!.password.not_nil!.verify("test12").should be_true
+      end
     end
 
     it "should create user with empty password_hash" do
-      body = %({
+      with_http_server do |http, _|
+        body = %({
         "password_hash": ""
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 201
-      hrds = HTTP::Headers{"Authorization" => "Basic YWxhbjo="} # alan:
-      response = get("/api/users/alan", headers: hrds)
-      response.status_code.should eq 401
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 201
+        hrds = HTTP::Headers{"Authorization" => "Basic YWxhbjo="} # alan:
+        response = http.get("/api/users/alan", headers: hrds)
+        response.status_code.should eq 401
+      end
     end
 
     it "should create user with uniq tags" do
-      body = %({
+      with_http_server do |http, s|
+        body = %({
         "password": "test",
         "tags": "management,management"
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 201
-      Server.users["alan"].tags.size.should eq 1
-      Server.users["alan"].tags.should eq([LavinMQ::Tag::Management])
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 201
+        s.users["alan"].tags.size.should eq 1
+        s.users["alan"].tags.should eq([LavinMQ::Tag::Management])
+      end
     end
 
     it "should update user" do
-      Server.users.create("alan", "pw")
-      body = %({
+      with_http_server do |http, s|
+        s.users.create("alan", "pw")
+        body = %({
         "password": "test",
         "tags": "management"
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 204
-      Server.users["alan"].tags.should eq([LavinMQ::Tag::Management])
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 204
+        s.users["alan"].tags.should eq([LavinMQ::Tag::Management])
+      end
     end
 
     it "should update user with uniq tags" do
-      Server.users.create("alan", "pw")
-      body = %({
+      with_http_server do |http, s|
+        s.users.create("alan", "pw")
+        body = %({
         "password": "test",
         "tags": "management,management"
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 204
-      Server.users["alan"].tags.size.should eq 1
-      Server.users["alan"].tags.should eq([LavinMQ::Tag::Management])
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 204
+        s.users["alan"].tags.size.should eq 1
+        s.users["alan"].tags.should eq([LavinMQ::Tag::Management])
+      end
     end
 
     it "should handle request with empty body" do
-      response = put("/api/users/alice", body: "")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should match(/Field .+ is required/)
+      with_http_server do |http, _|
+        response = http.put("/api/users/alice", body: "")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should match(/Field .+ is required/)
+      end
     end
 
     it "should handle unexpected input" do
-      response = put("/api/users/alice", body: "\"{}\"")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq "Input needs to be a JSON object."
+      with_http_server do |http, _|
+        response = http.put("/api/users/alice", body: "\"{}\"")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq "Input needs to be a JSON object."
+      end
     end
 
     it "should handle invalid JSON" do
-      response = put("/api/users/alice", body: "a")
-      response.status_code.should eq 400
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Malformed JSON.")
+      with_http_server do |http, _|
+        response = http.put("/api/users/alice", body: "a")
+        response.status_code.should eq 400
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Malformed JSON.")
+      end
     end
 
     it "should not create user if disk is full" do
-      Server.flow(false)
-      body = %({
+      with_http_server do |http, s|
+        s.flow(false)
+        body = %({
         "password": "test"
       })
-      response = put("/api/users/alan", body: body)
-      response.status_code.should eq 412
-      body = JSON.parse(response.body)
-      body["reason"].as_s.should eq("Server low on disk space, can not create new user")
-    ensure
-      Server.flow(true)
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 412
+        body = JSON.parse(response.body)
+        body["reason"].as_s.should eq("Server low on disk space, can not create new user")
+      ensure
+        s.flow(true)
+      end
     end
   end
 
   describe "GET /api/users/user/permissions" do
     it "should return permissions for user" do
-      response = get("/api/users/guest/permissions")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["user", "vhost", "configure", "write", "read"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, _|
+        response = http.get("/api/users/guest/permissions")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["user", "vhost", "configure", "write", "read"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
   end
 end

--- a/spec/api/vhosts_spec.cr
+++ b/spec/api/vhosts_spec.cr
@@ -3,102 +3,122 @@ require "../spec_helper"
 describe LavinMQ::HTTP::VHostsController do
   describe "GET /api/vhosts" do
     it "should return all vhosts" do
-      response = get("/api/vhosts")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
-      keys = ["name", "dir", "messages", "messages_unacknowledged", "messages_ready"]
-      body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      with_http_server do |http, _|
+        response = http.get("/api/vhosts")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+        keys = ["name", "dir", "messages", "messages_unacknowledged", "messages_ready"]
+        body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
+      end
     end
 
     it "only return vhosts user has access to if mangement tag" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::Management])
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = get("/api/vhosts", headers: hdrs)
-      response.status_code.should eq 200
-      JSON.parse(response.body).as_a.size.should eq 0
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/vhosts", headers: hdrs)
+        response.status_code.should eq 200
+        JSON.parse(response.body).as_a.size.should eq 0
+      end
     end
 
     it "should list vhosts for monitoring users" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::Monitoring])
-      Server.vhosts.create("test")
-      Server.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = get("/api/vhosts", headers: hdrs)
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.any? { |v| v["name"].as_s == "/" }.should be_true
-      body.as_a.any? { |v| v["name"].as_s == "test" }.should be_true
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Monitoring])
+        s.vhosts.create("test")
+        s.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/vhosts", headers: hdrs)
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.any? { |v| v["name"].as_s == "/" }.should be_true
+        body.as_a.any? { |v| v["name"].as_s == "test" }.should be_true
+      end
     end
   end
-
   describe "GET /api/vhosts/vhost" do
     it "should return vhost" do
-      response = get("/api/vhosts/%2f")
-      response.status_code.should eq 200
+      with_http_server do |http, _|
+        response = http.get("/api/vhosts/%2f")
+        response.status_code.should eq 200
+      end
     end
 
     it "should return 404 if vhost does not exist" do
-      response = get("/api/vhosts/404")
-      response.status_code.should eq 404
+      with_http_server do |http, _|
+        response = http.get("/api/vhosts/404")
+        response.status_code.should eq 404
+      end
     end
   end
-
   describe "PUT /api/vhosts/vhost" do
     it "should create vhost" do
-      response = put("/api/vhosts/test")
-      response.status_code.should eq 201
+      with_http_server do |http, _|
+        response = http.put("/api/vhosts/test")
+        response.status_code.should eq 201
+      end
     end
 
     it "should update vhost" do
-      Server.vhosts.create("test")
-      response = put("/api/vhosts/test")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        s.vhosts.create("test")
+        response = http.put("/api/vhosts/test")
+        response.status_code.should eq 204
+      end
     end
 
     it "should only allow administrators to create vhost" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = put("/api/vhosts/test", headers: hdrs)
-      response.status_code.should eq 403
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.put("/api/vhosts/test", headers: hdrs)
+        response.status_code.should eq 403
+      end
     end
 
     it "should create a vhost with full permissions to user" do
-      vhost = "test-vhost"
-      username = "arnold"
+      with_http_server do |http, s|
+        vhost = "test-vhost"
+        username = "arnold"
 
-      user = Server.users.create(username, "pw", [LavinMQ::Tag::Administrator])
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = put("/api/vhosts/#{vhost}", headers: hdrs)
-      response.status_code.should eq 201
-      p = user.permissions[vhost]
-      p[:config].should eq /.*/
-      p[:read].should eq /.*/
-      p[:write].should eq /.*/
+        user = s.users.create(username, "pw", [LavinMQ::Tag::Administrator])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.put("/api/vhosts/#{vhost}", headers: hdrs)
+        response.status_code.should eq 201
+        p = user.permissions[vhost]
+        p[:config].should eq /.*/
+        p[:read].should eq /.*/
+        p[:write].should eq /.*/
+      end
     end
   end
-
   describe "DELETE /api/vhosts/vhost" do
     it "should delete vhost" do
-      Server.vhosts.create("test")
-      response = delete("/api/vhosts/test")
-      response.status_code.should eq 204
+      with_http_server do |http, s|
+        s.vhosts.create("test")
+        response = http.delete("/api/vhosts/test")
+        response.status_code.should eq 204
+      end
     end
 
     it "should only allow administrators to delete vhost" do
-      Server.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
-      hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
-      response = delete("/api/vhosts/test", headers: hdrs)
-      response.status_code.should eq 403
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.delete("/api/vhosts/test", headers: hdrs)
+        response.status_code.should eq 403
+      end
     end
   end
-
   describe "GET /api/vhosts/vhost/permissions" do
     it "should return permissions for vhosts" do
-      response = get("/api/vhosts/%2f/permissions")
-      response.status_code.should eq 200
-      body = JSON.parse(response.body)
-      body.as_a.empty?.should be_false
+      with_http_server do |http, _|
+        response = http.get("/api/vhosts/%2f/permissions")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.empty?.should be_false
+      end
     end
   end
 end

--- a/spec/consumer_spec.cr
+++ b/spec/consumer_spec.cr
@@ -4,141 +4,155 @@ require "./../src/lavinmq/queue"
 describe LavinMQ::Client::Channel::Consumer do
   describe "without x-priority" do
     it "should round-robin" do
-      with_channel do |ch|
-        q = ch.queue("consumer-priority")
-        ch.prefetch 1
-        msgs = Channel(Int32).new
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("consumer-priority")
+          ch.prefetch 1
+          msgs = Channel(Int32).new
 
-        q.subscribe(no_ack: false) do |msg|
-          msgs.send 1
-          msg.ack
+          q.subscribe(no_ack: false) do |msg|
+            msgs.send 1
+            msg.ack
+          end
+
+          q.subscribe(no_ack: false) do |msg|
+            msgs.send 2
+            msg.ack
+          end
+
+          q.publish("priority")
+          q.publish("priority")
+          msgs.receive.should eq 1
+          msgs.receive.should eq 2
         end
-
-        q.subscribe(no_ack: false) do |msg|
-          msgs.send 2
-          msg.ack
-        end
-
-        q.publish("priority")
-        q.publish("priority")
-        msgs.receive.should eq 1
-        msgs.receive.should eq 2
       end
     end
   end
 
   describe "with x-priority" do
     it "should respect priority" do
-      with_channel do |ch|
-        q = ch.queue("consumer-priority")
-        ch.prefetch 1
-        subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
-        msgs = Channel(AMQP::Client::DeliverMessage?).new(1)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("consumer-priority")
+          ch.prefetch 1
+          subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
+          msgs = Channel(AMQP::Client::DeliverMessage?).new(1)
 
-        q.subscribe(no_ack: false) do |_|
-          msgs.send nil
-        end
+          q.subscribe(no_ack: false) do |_|
+            msgs.send nil
+          end
 
-        q.subscribe(no_ack: false, args: subscriber_args) do |msg|
-          msgs.send msg
-        end
+          q.subscribe(no_ack: false, args: subscriber_args) do |msg|
+            msgs.send msg
+          end
 
-        q.publish_confirm("priority")
-        m = msgs.receive
-        m.should be_truthy
-        if m.is_a?(AMQP::Client::DeliverMessage)
-          m.ack
-          m.body_io.to_s.should eq "priority"
+          q.publish_confirm("priority")
+          m = msgs.receive
+          m.should be_truthy
+          if m.is_a?(AMQP::Client::DeliverMessage)
+            m.ack
+            m.body_io.to_s.should eq "priority"
+          end
         end
       end
     end
 
     it "should send to prioritized consumer if ready" do
-      with_channel do |ch|
-        q = ch.queue("consumer-priority")
-        ch.prefetch 1
-        subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
-        msgs = Channel(AMQP::Client::DeliverMessage?).new(1)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("consumer-priority")
+          ch.prefetch 1
+          subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
+          msgs = Channel(AMQP::Client::DeliverMessage?).new(1)
 
-        q.subscribe(no_ack: false) do |_|
-          msgs.send nil
-        end
+          q.subscribe(no_ack: false) do |_|
+            msgs.send nil
+          end
 
-        q.subscribe(no_ack: false, args: subscriber_args) do |msg|
-          msgs.send msg
-        end
+          q.subscribe(no_ack: false, args: subscriber_args) do |msg|
+            msgs.send msg
+          end
 
-        q.publish_confirm("priority")
-        m = msgs.receive
-        m.should be_truthy
-        if m.is_a?(AMQP::Client::DeliverMessage)
-          m.ack
-          m.body_io.to_s.should eq "priority"
-        end
+          q.publish_confirm("priority")
+          m = msgs.receive
+          m.should be_truthy
+          if m.is_a?(AMQP::Client::DeliverMessage)
+            m.ack
+            m.body_io.to_s.should eq "priority"
+          end
 
-        q.publish_confirm("priority")
-        m = msgs.receive
-        m.should be_truthy
-        if m.is_a?(AMQP::Client::DeliverMessage)
-          m.ack
-          m.body_io.to_s.should eq "priority"
+          q.publish_confirm("priority")
+          m = msgs.receive
+          m.should be_truthy
+          if m.is_a?(AMQP::Client::DeliverMessage)
+            m.ack
+            m.body_io.to_s.should eq "priority"
+          end
         end
       end
     end
 
     it "should round-robin to high priority consumers" do
-      with_channel do |ch|
-        q = ch.queue("consumer-priority")
-        ch.prefetch 1
-        subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("consumer-priority")
+          ch.prefetch 1
+          subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
 
-        msgs = Channel(Int32).new
-        q.subscribe(no_ack: false, args: subscriber_args) do |msg|
-          msgs.send 1
-          msg.ack
-        end
+          msgs = Channel(Int32).new
+          q.subscribe(no_ack: false, args: subscriber_args) do |msg|
+            msgs.send 1
+            msg.ack
+          end
 
-        q.subscribe(no_ack: false, args: subscriber_args) do |msg|
-          msgs.send 2
-          msg.ack
-        end
+          q.subscribe(no_ack: false, args: subscriber_args) do |msg|
+            msgs.send 2
+            msg.ack
+          end
 
-        100.times { q.publish("priority") }
-        50.times do
-          msgs.receive.should eq 1
-          msgs.receive.should eq 2
+          100.times { q.publish("priority") }
+          50.times do
+            msgs.receive.should eq 1
+            msgs.receive.should eq 2
+          end
         end
       end
     end
 
     it "should accept any integer as x-priority" do
-      with_channel do |ch|
-        q = ch.queue
-        q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": Int8::MIN})) { |_| }
-        q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": Int16::MAX})) { |_| }
-        q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": 1i64})) { |_| }
-      end
-
-      with_channel do |ch|
-        expect_raises(AMQP::Client::Channel::ClosedException, /out of bounds/) do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
           q = ch.queue
-          q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": Int64::MAX})) { |_| }
+          q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": Int8::MIN})) { |_| }
+          q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": Int16::MAX})) { |_| }
+          q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": 1i64})) { |_| }
+        end
+
+        with_channel(s) do |ch|
+          expect_raises(AMQP::Client::Channel::ClosedException, /out of bounds/) do
+            q = ch.queue
+            q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": Int64::MAX})) { |_| }
+          end
         end
       end
     end
 
     it "should not accept any thing but integers as x-priority" do
-      with_channel do |ch|
-        expect_raises(AMQP::Client::Channel::ClosedException, /must be an integer/) do
-          q = ch.queue
-          q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": "a"})) { |_| }
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          expect_raises(AMQP::Client::Channel::ClosedException, /must be an integer/) do
+            q = ch.queue
+            q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": "a"})) { |_| }
+          end
         end
       end
 
-      with_channel do |ch|
-        expect_raises(AMQP::Client::Channel::ClosedException, /must be an integer/) do
-          q = ch.queue
-          q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": 0.1})) { |_| }
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          expect_raises(AMQP::Client::Channel::ClosedException, /must be an integer/) do
+            q = ch.queue
+            q.subscribe(args: AMQP::Client::Arguments.new({"x-priority": 0.1})) { |_| }
+          end
         end
       end
     end

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -7,104 +7,116 @@ describe "Delayed Message Exchange" do
 
   describe "internal queue" do
     it "should be created with x-dead-letter-exchange" do
-      with_channel do |ch|
-        ch.exchange(x_name, "topic", args: x_args)
-        q = Server.vhosts["/"].queues[delay_q_name]?
-        q.should_not be_nil
-        dlx_exchange = q.not_nil!.arguments["x-dead-letter-exchange"]?.try &.as?(String)
-        dlx_exchange.should eq x_name
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.exchange(x_name, "topic", args: x_args)
+          q = s.vhosts["/"].queues[delay_q_name]?
+          q.should_not be_nil
+          dlx_exchange = q.not_nil!.arguments["x-dead-letter-exchange"]?.try &.as?(String)
+          dlx_exchange.should eq x_name
+        end
       end
     end
   end
 
   q_name = "delayed_q"
   it "should delay 1 message" do
-    with_channel do |ch|
-      x = ch.exchange(x_name, "topic", args: x_args)
-      q = ch.queue(q_name)
-      q.bind(x.name, "#")
-      hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
-      x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-      queue = Server.vhosts["/"].queues[q_name]
-      queue.message_count.should eq 0
-      wait_for { queue.message_count == 1 }
-      queue.message_count.should eq 1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange(x_name, "topic", args: x_args)
+        q = ch.queue(q_name)
+        q.bind(x.name, "#")
+        hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
+        x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        queue = s.vhosts["/"].queues[q_name]
+        queue.message_count.should eq 0
+        wait_for { queue.message_count == 1 }
+        queue.message_count.should eq 1
+      end
     end
   end
 
   q_name = "delayed_q"
   it "should delay 2 messages" do
-    with_channel do |ch|
-      x = ch.exchange(x_name, "topic", args: x_args)
-      q = ch.queue(q_name)
-      q.bind(x.name, "#")
-      hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
-      x.publish "test message 1", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-      x.publish "test message 2", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-      queue = Server.vhosts["/"].queues[q_name]
-      queue.message_count.should eq 0
-      wait_for { queue.message_count == 2 }
-      queue.message_count.should eq 2
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 1")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 2")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange(x_name, "topic", args: x_args)
+        q = ch.queue(q_name)
+        q.bind(x.name, "#")
+        hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
+        x.publish "test message 1", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        x.publish "test message 2", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        queue = s.vhosts["/"].queues[q_name]
+        queue.message_count.should eq 0
+        wait_for { queue.message_count == 2 }
+        queue.message_count.should eq 2
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 1")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 2")
+      end
     end
   end
 
   it "should deliver in correct order" do
-    with_channel do |ch|
-      x = ch.exchange(x_name, "topic", args: x_args)
-      q = ch.queue(q_name)
-      q.bind(x.name, "#")
-      hdrs = AMQP::Client::Arguments.new({"x-delay" => 1000})
-      x.publish "delay-long", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-      hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
-      x.publish "delay-short", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-      queue = Server.vhosts["/"].queues[q_name]
-      queue.message_count.should eq 0
-      wait_for { queue.message_count >= 1 }
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-short")
-      wait_for { queue.message_count == 1 }
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-long")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange(x_name, "topic", args: x_args)
+        q = ch.queue(q_name)
+        q.bind(x.name, "#")
+        hdrs = AMQP::Client::Arguments.new({"x-delay" => 1000})
+        x.publish "delay-long", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
+        x.publish "delay-short", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        queue = s.vhosts["/"].queues[q_name]
+        queue.message_count.should eq 0
+        wait_for { queue.message_count >= 1 }
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-short")
+        wait_for { queue.message_count == 1 }
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-long")
+      end
     end
   end
 
   it "should support x-delayed-message as exchange type" do
-    with_channel do |ch|
-      xdm_args = AMQP::Client::Arguments.new({"x-delayed-type" => "topic"})
-      x = ch.exchange(x_name, "x-delayed-message", args: xdm_args)
-      q = ch.queue(q_name)
-      q.bind(x.name, "rk")
-      hdrs = AMQP::Client::Arguments.new({"x-delay" => 5})
-      x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-      queue = Server.vhosts["/"].queues[q_name]
-      queue.message_count.should eq 0
-      wait_for(200.milliseconds) { queue.message_count == 1 }
-      queue.message_count.should eq 1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        xdm_args = AMQP::Client::Arguments.new({"x-delayed-type" => "topic"})
+        x = ch.exchange(x_name, "x-delayed-message", args: xdm_args)
+        q = ch.queue(q_name)
+        q.bind(x.name, "rk")
+        hdrs = AMQP::Client::Arguments.new({"x-delay" => 5})
+        x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        queue = s.vhosts["/"].queues[q_name]
+        queue.message_count.should eq 0
+        wait_for(200.milliseconds) { queue.message_count == 1 }
+        queue.message_count.should eq 1
+      end
     end
   end
 
   it "should not set dead letter headers" do
-    with_channel do |ch|
-      x = ch.exchange(x_name, "topic", args: x_args)
-      q = ch.queue(q_name)
-      q.bind(x.name, "#")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange(x_name, "topic", args: x_args)
+        q = ch.queue(q_name)
+        q.bind(x.name, "#")
 
-      hdrs = AMQP::Client::Arguments.new({
-        "x-delay"                   => 100,
-        "x-dead-letter-exchange"    => "amq.fanout",
-        "x-dead-letter-routing-key" => "dead-lettered",
-      })
-      x.publish "delay", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+        hdrs = AMQP::Client::Arguments.new({
+          "x-delay"                   => 100,
+          "x-dead-letter-exchange"    => "amq.fanout",
+          "x-dead-letter-routing-key" => "dead-lettered",
+        })
+        x.publish "delay", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
 
-      msgs = Channel(AMQP::Client::DeliverMessage).new
-      q.subscribe { |msg| msgs.send msg }
-      msg = msgs.receive
-      headers = msg.properties.headers.should_not be_nil
-      header_keys = headers.to_h.keys
-      header_keys.should_not contain "x-first-death-reason"
-      header_keys.should_not contain "x-first-death-queue"
-      header_keys.should_not contain "x-first-death-exchange"
-      header_keys.should_not contain "x-death"
+        msgs = Channel(AMQP::Client::DeliverMessage).new
+        q.subscribe { |msg| msgs.send msg }
+        msg = msgs.receive
+        headers = msg.properties.headers.should_not be_nil
+        header_keys = headers.to_h.keys
+        header_keys.should_not contain "x-first-death-reason"
+        header_keys.should_not contain "x-first-death-queue"
+        header_keys.should_not contain "x-first-death-exchange"
+        header_keys.should_not contain "x-death"
+      end
     end
   end
 end

--- a/spec/dlx_spec.cr
+++ b/spec/dlx_spec.cr
@@ -10,95 +10,101 @@ describe "Dead lettering" do
   # Verifies bugfix for Sub-table memory corruption in amq-protocol.cr
   # https://github.com/cloudamqp/amq-protocol.cr/pull/14
   it "should be able to read messages that has been dead lettered multiple times" do
-    with_channel do |ch|
-      q_delayed_2 = ch.queue(q_name_delayed_2, args: AMQP::Client::Arguments.new(
-        {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => q_name_delayed}
-      ))
-      q_delayed = ch.queue(q_name_delayed, args: AMQP::Client::Arguments.new(
-        {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => q_name}
-      ))
-      q = ch.queue(q_name)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q_delayed_2 = ch.queue(q_name_delayed_2, args: AMQP::Client::Arguments.new(
+          {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => q_name_delayed}
+        ))
+        q_delayed = ch.queue(q_name_delayed, args: AMQP::Client::Arguments.new(
+          {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => q_name}
+        ))
+        q = ch.queue(q_name)
 
-      x = ch.default_exchange
-      x.publish_confirm("ttl", q_delayed_2.name)
-      msg = wait_for { q.get }
+        x = ch.default_exchange
+        x.publish_confirm("ttl", q_delayed_2.name)
+        msg = wait_for { q.get }
 
-      x_death = msg.properties.headers.not_nil!["x-death"].as(Array(AMQ::Protocol::Field))
-      x_death.inspect.should be_a(String) # checks that message and headers can be read
-      x_death.size.should eq 2
-      x_death[0].as(AMQ::Protocol::Table)["queue"].should eq q_delayed.name
-      x_death[1].as(AMQ::Protocol::Table)["queue"].should eq q_delayed_2.name
+        x_death = msg.properties.headers.not_nil!["x-death"].as(Array(AMQ::Protocol::Field))
+        x_death.inspect.should be_a(String) # checks that message and headers can be read
+        x_death.size.should eq 2
+        x_death[0].as(AMQ::Protocol::Table)["queue"].should eq q_delayed.name
+        x_death[1].as(AMQ::Protocol::Table)["queue"].should eq q_delayed_2.name
+      end
     end
   end
 
   it "should update message timestamp on publish" do
-    v = Server.vhosts.create("test")
-    q_args = AMQ::Protocol::Table.new({
-      "x-message-ttl"             => 200,
-      "x-dead-letter-exchange"    => "",
-      "x-dead-letter-routing-key" => "q2",
-    })
-    v.declare_queue("q", true, false, q_args)
-    v.declare_queue("q2", true, false, AMQ::Protocol::Table.new)
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      q_args = AMQ::Protocol::Table.new({
+        "x-message-ttl"             => 200,
+        "x-dead-letter-exchange"    => "",
+        "x-dead-letter-routing-key" => "q2",
+      })
+      v.declare_queue("q", true, false, q_args)
+      v.declare_queue("q2", true, false, AMQ::Protocol::Table.new)
 
-    ts = RoughTime.unix_ms
-    msg = LavinMQ::Message.new(ts, "", "q", AMQ::Protocol::Properties.new, 0, IO::Memory.new)
+      ts = RoughTime.unix_ms
+      msg = LavinMQ::Message.new(ts, "", "q", AMQ::Protocol::Properties.new, 0, IO::Memory.new)
 
-    v.publish msg
+      v.publish msg
 
-    select
-    when v.queues["q2"].empty_change.receive
-    when timeout(1.second)
-      fail "timeout: message not dead lettered?"
+      select
+      when v.queues["q2"].empty_change.receive
+      when timeout(1.second)
+        fail "timeout: message not dead lettered?"
+      end
+
+      v.queues["q2"].basic_get(no_ack: true) do |env|
+        msg = env.message
+      end
+
+      msg.timestamp.should be > ts
     end
-
-    v.queues["q2"].basic_get(no_ack: true) do |env|
-      msg = env.message
-    end
-
-    msg.timestamp.should be > ts
   end
 
   it "should update count in x-death" do
-    with_channel do |ch|
-      q_name = "q_dlx"
-      q = ch.queue(q_name, args: AMQP::Client::Arguments.new(
-        {"x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "#{q_name}2"}
-      ))
-      _q2 = ch.queue("#{q_name}2", args: AMQP::Client::Arguments.new(
-        {"x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => q_name, "x-message-ttl" => 1}
-      ))
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q_name = "q_dlx"
+        q = ch.queue(q_name, args: AMQP::Client::Arguments.new(
+          {"x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "#{q_name}2"}
+        ))
+        _q2 = ch.queue("#{q_name}2", args: AMQP::Client::Arguments.new(
+          {"x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => q_name, "x-message-ttl" => 1}
+        ))
 
-      done = Channel(AMQP::Client::DeliverMessage).new
-      i = 0
-      q.subscribe(no_ack: false) do |env|
-        env.reject
-        if i == 10
-          env.ack
-          done.send env
+        done = Channel(AMQP::Client::DeliverMessage).new
+        i = 0
+        q.subscribe(no_ack: false) do |env|
+          env.reject
+          if i == 10
+            env.ack
+            done.send env
+          end
+          i += 1
         end
-        i += 1
-      end
-      ch.default_exchange.publish_confirm("msg", q.name)
+        ch.default_exchange.publish_confirm("msg", q.name)
 
-      msg = done.receive
-      headers = msg.properties.headers.should_not be_nil
-      x_death = headers["x-death"].as?(Array(AMQ::Protocol::Field)).should_not be_nil
-      x_death_q_dlx_rejected = x_death.find do |xd|
-        xd = xd.as(AMQ::Protocol::Table)
-        xd["queue"] == q_name &&
-          xd["reason"] == "rejected"
-      end
-      x_death_q_dlx_rejected = x_death_q_dlx_rejected.as?(AMQ::Protocol::Table).should_not be_nil
-      x_death_q_dlx_rejected["count"].should eq 10
+        msg = done.receive
+        headers = msg.properties.headers.should_not be_nil
+        x_death = headers["x-death"].as?(Array(AMQ::Protocol::Field)).should_not be_nil
+        x_death_q_dlx_rejected = x_death.find do |xd|
+          xd = xd.as(AMQ::Protocol::Table)
+          xd["queue"] == q_name &&
+            xd["reason"] == "rejected"
+        end
+        x_death_q_dlx_rejected = x_death_q_dlx_rejected.as?(AMQ::Protocol::Table).should_not be_nil
+        x_death_q_dlx_rejected["count"].should eq 10
 
-      x_death_q_dlx2_expired = x_death.find do |xd|
-        xd = xd.as(AMQ::Protocol::Table)
-        xd["queue"] == "#{q_name}2" &&
-          xd["reason"] == "expired"
+        x_death_q_dlx2_expired = x_death.find do |xd|
+          xd = xd.as(AMQ::Protocol::Table)
+          xd["queue"] == "#{q_name}2" &&
+            xd["reason"] == "expired"
+        end
+        x_death_q_dlx2_expired = x_death_q_dlx2_expired.as?(AMQ::Protocol::Table).should_not be_nil
+        x_death_q_dlx2_expired["count"].should eq 10
       end
-      x_death_q_dlx2_expired = x_death_q_dlx2_expired.as?(AMQ::Protocol::Table).should_not be_nil
-      x_death_q_dlx2_expired["count"].should eq 10
     end
   end
 end

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -19,7 +19,7 @@ describe LavinMQ::Etcd do
     cluster.run do
       etcd = LavinMQ::Etcd.new(cluster.endpoints)
       w = Channel(String?).new
-      spawn do
+      spawn(name: "etcd watch spec") do
         etcd.watch("foo") do |val|
           w.send val
         end
@@ -39,7 +39,7 @@ describe LavinMQ::Etcd do
       etcd = LavinMQ::Etcd.new(cluster.endpoints)
       leader = Channel(String).new
       key = "foo/#{rand}"
-      spawn do
+      spawn(name: "etcd elect leader spec") do
         etcd.elect_listen(key) do |value|
           leader.send value
         end

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -3,32 +3,34 @@ require "./spec_helper"
 describe LavinMQ::Exchange do
   describe "Exchange => Exchange binding" do
     it "should allow multiple e2e bindings" do
-      with_channel do |ch|
-        x1 = ch.exchange("e1", "topic", auto_delete: true)
-        x2 = ch.exchange("e2", "topic", auto_delete: true)
-        x2.bind(x1.name, "#")
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x1 = ch.exchange("e1", "topic", auto_delete: true)
+          x2 = ch.exchange("e2", "topic", auto_delete: true)
+          x2.bind(x1.name, "#")
 
-        q1 = ch.queue
-        q1.bind(x2.name, "#")
+          q1 = ch.queue
+          q1.bind(x2.name, "#")
 
-        x1.publish "test message", "some-rk"
+          x1.publish "test message", "some-rk"
 
-        q1.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
-        q1.get(no_ack: true).should be_nil
+          q1.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+          q1.get(no_ack: true).should be_nil
 
-        x3 = ch.exchange("e3", "topic", auto_delete: true)
-        x3.bind(x1.name, "#")
+          x3 = ch.exchange("e3", "topic", auto_delete: true)
+          x3.bind(x1.name, "#")
 
-        q2 = ch.queue
-        q2.bind(x3.name, "#")
+          q2 = ch.queue
+          q2.bind(x3.name, "#")
 
-        x1.publish "test message", "some-rk"
+          x1.publish "test message", "some-rk"
 
-        q1.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
-        q1.get(no_ack: true).should be_nil
+          q1.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+          q1.get(no_ack: true).should be_nil
 
-        q2.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
-        q2.get(no_ack: true).should be_nil
+          q2.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+          q2.get(no_ack: true).should be_nil
+        end
       end
     end
   end
@@ -36,39 +38,44 @@ describe LavinMQ::Exchange do
   describe "metrics" do
     x_name = "metrics"
     it "should count unroutable metrics" do
-      with_channel do |ch|
-        x_args = AMQP::Client::Arguments.new
-        x = ch.exchange(x_name, "topic", args: x_args)
-        x.publish_confirm "test message 1", "none"
-        Server.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x_args = AMQP::Client::Arguments.new
+          x = ch.exchange(x_name, "topic", args: x_args)
+          x.publish_confirm "test message 1", "none"
+          s.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+        end
       end
     end
 
     it "should count unroutable metrics" do
-      with_channel do |ch|
-        x_args = AMQP::Client::Arguments.new
-        x = ch.exchange(x_name, "topic", args: x_args)
-        q = ch.queue
-        q.bind(x.name, q.name)
-        x.publish_confirm "test message 1", "none"
-        x.publish_confirm "test message 2", q.name
-        Server.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x_args = AMQP::Client::Arguments.new
+          x = ch.exchange(x_name, "topic", args: x_args)
+          q = ch.queue
+          q.bind(x.name, q.name)
+          x.publish_confirm "test message 1", "none"
+          x.publish_confirm "test message 2", q.name
+          s.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+        end
       end
     end
   end
-
   describe "auto delete exchange" do
     it "should delete the exhchange when the last binding is removed" do
-      with_channel do |ch|
-        x = ch.exchange("ad", "topic", auto_delete: true)
-        q = ch.queue
-        q.bind(x.name, q.name)
-        q2 = ch.queue
-        q2.bind(x.name, q2.name)
-        q.unbind(x.name, q.name)
-        q2.unbind(x.name, q2.name)
-        expect_raises(AMQP::Client::Channel::ClosedException) do
-          ch.exchange("ad", "topic", passive: true)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x = ch.exchange("ad", "topic", auto_delete: true)
+          q = ch.queue
+          q.bind(x.name, q.name)
+          q2 = ch.queue
+          q2.bind(x.name, q2.name)
+          q.unbind(x.name, q.name)
+          q2.unbind(x.name, q2.name)
+          expect_raises(AMQP::Client::Channel::ClosedException) do
+            ch.exchange("ad", "topic", passive: true)
+          end
         end
       end
     end
@@ -79,32 +86,40 @@ describe LavinMQ::Exchange do
     illegal_dmx_args = AMQP::Client::Arguments.new({"test" => "hello"})
 
     it "should declare delayed message exchange" do
-      with_channel do |ch|
-        ch.exchange("test", "x-delayed-message", args: dmx_args)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.exchange("test", "x-delayed-message", args: dmx_args)
+        end
       end
     end
 
     it "should raise and not declare delayed message exchange if missing x-delayed-type argument" do
-      with_channel do |ch|
-        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-          ch.exchange("test2", "x-delayed-message", args: illegal_dmx_args)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+            ch.exchange("test2", "x-delayed-message", args: illegal_dmx_args)
+          end
+          s.vhosts["/"].exchanges["test2"]?.should be_nil
         end
-        Server.vhosts["/"].exchanges["test2"]?.should be_nil
       end
     end
 
     it "should redeclare same delayed message exchange" do
-      with_channel do |ch|
-        ch.exchange("test3", "x-delayed-message", args: dmx_args)
-        ch.exchange("test3", "x-delayed-message", args: dmx_args)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.exchange("test3", "x-delayed-message", args: dmx_args)
+          ch.exchange("test3", "x-delayed-message", args: dmx_args)
+        end
       end
     end
 
     it "should raise exception when redeclaring exchange with mismatched arguments" do
-      with_channel do |ch|
-        ch.exchange("test4", "x-delayed-message", args: dmx_args)
-        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-          ch.exchange("test4", "x-delayed-message", args: illegal_dmx_args)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.exchange("test4", "x-delayed-message", args: dmx_args)
+          expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+            ch.exchange("test4", "x-delayed-message", args: illegal_dmx_args)
+          end
         end
       end
     end

--- a/spec/flow_spec.cr
+++ b/spec/flow_spec.cr
@@ -3,56 +3,60 @@ require "benchmark"
 
 describe "Flow" do
   it "should support consumer flow" do
-    with_channel do |ch|
-      q = ch.queue
-      ch.prefetch 1
-      q.publish "msg"
-      msgs = [] of AMQP::Client::DeliverMessage
-      q.subscribe(no_ack: false) do |msg|
-        msgs << msg
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        ch.prefetch 1
+        q.publish "msg"
+        msgs = [] of AMQP::Client::DeliverMessage
+        q.subscribe(no_ack: false) do |msg|
+          msgs << msg
+        end
+        wait_for { msgs.size == 1 }
+        ch.flow(false)
+        msgs.pop.ack
+        q.publish "msg"
+        sleep 0.05 # wait little so a new message could be delivered
+        msgs.size.should eq 0
+        ch.flow(true)
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
       end
-      wait_for { msgs.size == 1 }
-      ch.flow(false)
-      msgs.pop.ack
-      q.publish "msg"
-      sleep 0.05 # wait little so a new message could be delivered
-      msgs.size.should eq 0
-      ch.flow(true)
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
     end
   end
 
   it "should support server flow" do
-    Server.flow(false)
-    expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED/) do
-      with_channel do |ch|
-        q = ch.queue
-        q.publish_confirm("m1").should be_false
+    with_amqp_server do |s|
+      s.flow(false)
+      expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED/) do
+        with_channel(s) do |ch|
+          q = ch.queue
+          q.publish_confirm("m1").should be_false
+        end
       end
     end
-  ensure
-    Server.flow(true)
   end
 
   it "should stop flow when disk is almost full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    Server.update_system_metrics(nil)
-    Server.disk_full?.should be_true
+    with_amqp_server do |s|
+      s.update_system_metrics(nil)
+      s.disk_full?.should be_true
+    end
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
-    Server.flow(true)
   end
 
   it "should resume flow when disk is no longer full" do
     LavinMQ::Config.instance.free_disk_min = Int64::MAX
-    Server.update_system_metrics(nil)
-    Server.disk_full?.should be_true
-    LavinMQ::Config.instance.free_disk_min = 0
-    Server.update_system_metrics(nil)
-    Server.disk_full?.should be_false
+    with_amqp_server do |s|
+      s.update_system_metrics(nil)
+      s.disk_full?.should be_true
+      LavinMQ::Config.instance.free_disk_min = 0
+      s.update_system_metrics(nil)
+      s.disk_full?.should be_false
+    end
   ensure
     LavinMQ::Config.instance.free_disk_min = 0
-    Server.flow(true)
   end
 end

--- a/spec/http_static_spec.cr
+++ b/spec/http_static_spec.cr
@@ -2,15 +2,19 @@ require "./spec_helper"
 
 describe LavinMQ::HTTP::StaticController do
   it "GET /robots.txt" do
-    response = ::HTTP::Client.get "#{SpecHelper.http_base_url}/robots.txt"
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/plain")
-    response.body.should contain("Disallow")
+    with_http_server do |http, _|
+      response = ::HTTP::Client.get "http://#{http.addr}/robots.txt"
+      response.status_code.should eq 200
+      response.headers["Content-Type"].should contain("text/plain")
+      response.body.should contain("Disallow")
+    end
   end
 
   it "GET /img/favicon.png" do
-    response = ::HTTP::Client.get "#{SpecHelper.http_base_url}/img/favicon.png"
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("image/png")
+    with_http_server do |http, _|
+      response = ::HTTP::Client.get "http://#{http.addr}/img/favicon.png"
+      response.status_code.should eq 200
+      response.headers["Content-Type"].should contain("image/png")
+    end
   end
 end

--- a/spec/http_views_spec.cr
+++ b/spec/http_views_spec.cr
@@ -2,30 +2,38 @@ require "./spec_helper"
 
 describe LavinMQ::HTTP::MainController do
   it "GET /" do
-    response = ::HTTP::Client.get SpecHelper.http_base_url
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should contain("LavinMQ")
+    with_http_server do |http, _|
+      response = ::HTTP::Client.get "http://#{http.addr}"
+      response.status_code.should eq 200
+      response.headers["Content-Type"].should contain("text/html")
+      response.body.should contain("LavinMQ")
+    end
   end
 
   it "GET / includes head partial" do
-    response = ::HTTP::Client.get SpecHelper.http_base_url
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should contain("<title>")
+    with_http_server do |http, _|
+      response = ::HTTP::Client.get "http://#{http.addr}"
+      response.status_code.should eq 200
+      response.headers["Content-Type"].should contain("text/html")
+      response.body.should contain("<title>")
+    end
   end
 
   it "GET / includes header partial" do
-    response = ::HTTP::Client.get SpecHelper.http_base_url
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should contain("<header>")
+    with_http_server do |http, _|
+      response = ::HTTP::Client.get "http://#{http.addr}"
+      response.status_code.should eq 200
+      response.headers["Content-Type"].should contain("text/html")
+      response.body.should contain("<header>")
+    end
   end
 
   it "GET / includes footer partial" do
-    response = ::HTTP::Client.get SpecHelper.http_base_url
-    response.status_code.should eq 200
-    response.headers["Content-Type"].should contain("text/html")
-    response.body.should contain("<footer>")
+    with_http_server do |http, _|
+      response = ::HTTP::Client.get "http://#{http.addr}"
+      response.status_code.should eq 200
+      response.headers["Content-Type"].should contain("text/html")
+      response.body.should contain("<footer>")
+    end
   end
 end

--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -14,280 +14,293 @@ end
 
 describe LavinMQ::DirectExchange do
   it "matches exact rk" do
-    vhost = Server.vhosts.create("x")
-    q1 = LavinMQ::Queue.new(vhost, "q1")
-    x = LavinMQ::DirectExchange.new(vhost, "")
-    x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
-    x.matches("q1").should eq(Set{q1})
+    with_amqp_server do |s|
+      vhost = s.vhosts.create("x")
+      q1 = LavinMQ::Queue.new(vhost, "q1")
+      x = LavinMQ::DirectExchange.new(vhost, "")
+      x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
+      x.matches("q1").should eq(Set{q1})
+    end
   end
 
   it "matches no rk" do
-    vhost = Server.vhosts.create("x")
-    x = LavinMQ::DirectExchange.new(vhost, "")
-    x.matches("q1").should be_empty
+    with_amqp_server do |s|
+      vhost = s.vhosts.create("x")
+      x = LavinMQ::DirectExchange.new(vhost, "")
+      x.matches("q1").should be_empty
+    end
   end
 end
 
 describe LavinMQ::FanoutExchange do
   it "matches any rk" do
-    vhost = Server.vhosts.create("x")
-    q1 = LavinMQ::Queue.new(vhost, "q1")
-    x = LavinMQ::FanoutExchange.new(vhost, "")
-    x.bind(q1, "")
-    x.matches("any").should eq(Set{q1})
+    with_amqp_server do |s|
+      vhost = s.vhosts.create("x")
+      q1 = LavinMQ::Queue.new(vhost, "q1")
+      x = LavinMQ::FanoutExchange.new(vhost, "")
+      x.bind(q1, "")
+      x.matches("any").should eq(Set{q1})
+    end
   end
 
   it "matches no rk" do
-    vhost = Server.vhosts.create("x")
-    x = LavinMQ::FanoutExchange.new(vhost, "")
-    x.matches("q1").should be_empty
+    with_amqp_server do |s|
+      vhost = s.vhosts.create("x")
+      x = LavinMQ::FanoutExchange.new(vhost, "")
+      x.matches("q1").should be_empty
+    end
   end
 end
 
 describe LavinMQ::TopicExchange do
-  vhost = Server.vhosts.create("x")
-  x = LavinMQ::TopicExchange.new(vhost, "t", false, false, true)
+  with_amqp_server do |s|
+    vhost = s.vhosts.create("x")
+    x = LavinMQ::TopicExchange.new(vhost, "t", false, false, true)
 
-  it "matches prefixed star-wildcard" do
-    q1 = LavinMQ::Queue.new(vhost, "q1")
-    x.bind(q1, "*.test")
-    x.matches("rk2.test").should eq(Set{q1})
-    x.unbind(q1, "*.test")
-  end
+    it "matches prefixed star-wildcard" do
+      q1 = LavinMQ::Queue.new(vhost, "q1")
+      x.bind(q1, "*.test")
+      x.matches("rk2.test").should eq(Set{q1})
+      x.unbind(q1, "*.test")
+    end
 
-  it "matches exact rk" do
-    q1 = LavinMQ::Queue.new(vhost, "q1")
-    x.bind(q1, "rk1")
-    x.matches("rk1", nil).should eq(Set{q1})
-    x.unbind(q1, "rk1")
-  end
+    it "matches exact rk" do
+      q1 = LavinMQ::Queue.new(vhost, "q1")
+      x.bind(q1, "rk1")
+      x.matches("rk1", nil).should eq(Set{q1})
+      x.unbind(q1, "rk1")
+    end
 
-  it "matches star-wildcards" do
-    q2 = LavinMQ::Queue.new(vhost, "q2")
-    x.bind(q2, "*")
-    x.matches("rk2").should eq(Set{q2})
-    x.unbind(q2, "*")
-  end
+    it "matches star-wildcards" do
+      q2 = LavinMQ::Queue.new(vhost, "q2")
+      x.bind(q2, "*")
+      x.matches("rk2").should eq(Set{q2})
+      x.unbind(q2, "*")
+    end
 
-  it "matches star-wildcards but not too much" do
-    q22 = LavinMQ::Queue.new(vhost, "q22")
-    x.bind(q22, "*")
-    x.matches("rk2.a").should be_empty
-    x.unbind(q22, "*")
-  end
+    it "matches star-wildcards but not too much" do
+      q22 = LavinMQ::Queue.new(vhost, "q22")
+      x.bind(q22, "*")
+      x.matches("rk2.a").should be_empty
+      x.unbind(q22, "*")
+    end
 
-  it "should not match with too many star-wildcards" do
-    q3 = LavinMQ::Queue.new(vhost, "q3")
-    x.bind(q3, "a.*")
-    x.matches("b.c").should be_empty
-    x.unbind(q3, "a.*")
-  end
+    it "should not match with too many star-wildcards" do
+      q3 = LavinMQ::Queue.new(vhost, "q3")
+      x.bind(q3, "a.*")
+      x.matches("b.c").should be_empty
+      x.unbind(q3, "a.*")
+    end
 
-  it "should match star-wildcards in the middle" do
-    q4 = LavinMQ::Queue.new(vhost, "q4")
-    x.bind(q4, "c.*.d")
-    x.matches("c.a.d").should eq(Set{q4})
-    x.unbind(q4, "c.*.d")
-  end
+    it "should match star-wildcards in the middle" do
+      q4 = LavinMQ::Queue.new(vhost, "q4")
+      x.bind(q4, "c.*.d")
+      x.matches("c.a.d").should eq(Set{q4})
+      x.unbind(q4, "c.*.d")
+    end
 
-  it "should match catch-all" do
-    q5 = LavinMQ::Queue.new(vhost, "q5")
-    x.bind(q5, "d.#")
-    x.matches("d.a.d").should eq(Set{q5})
-    x.unbind(q5, "d.#")
-  end
+    it "should match catch-all" do
+      q5 = LavinMQ::Queue.new(vhost, "q5")
+      x.bind(q5, "d.#")
+      x.matches("d.a.d").should eq(Set{q5})
+      x.unbind(q5, "d.#")
+    end
 
-  it "should match multiple bindings" do
-    q6 = LavinMQ::Queue.new(vhost, "q6")
-    q7 = LavinMQ::Queue.new(vhost, "q7")
-    ex = LavinMQ::TopicExchange.new(vhost, "t55", false, false, true)
-    ex.bind(q6, "rk")
-    ex.bind(q7, "rk")
-    ex.matches("rk").should eq(Set{q6, q7})
-    ex.unbind(q6, "rk")
-    ex.unbind(q7, "rk")
-  end
+    it "should match multiple bindings" do
+      q6 = LavinMQ::Queue.new(vhost, "q6")
+      q7 = LavinMQ::Queue.new(vhost, "q7")
+      ex = LavinMQ::TopicExchange.new(vhost, "t55", false, false, true)
+      ex.bind(q6, "rk")
+      ex.bind(q7, "rk")
+      ex.matches("rk").should eq(Set{q6, q7})
+      ex.unbind(q6, "rk")
+      ex.unbind(q7, "rk")
+    end
 
-  it "should not get index out of bound when matching routing keys" do
-    q8 = LavinMQ::Queue.new(vhost, "q63")
-    ex = LavinMQ::TopicExchange.new(vhost, "t63", false, false, true)
-    ex.bind(q8, "rk63.rk63")
-    ex.matches("rk63").should be_empty
-    ex.unbind(q8, "rk63.rk63")
-  end
+    it "should not get index out of bound when matching routing keys" do
+      q8 = LavinMQ::Queue.new(vhost, "q63")
+      ex = LavinMQ::TopicExchange.new(vhost, "t63", false, false, true)
+      ex.bind(q8, "rk63.rk63")
+      ex.matches("rk63").should be_empty
+      ex.unbind(q8, "rk63.rk63")
+    end
 
-  it "# should consider what's comes after" do
-    q9 = LavinMQ::Queue.new(vhost, "q9")
-    x.bind(q9, "#.a")
-    x.matches("a.a.b").should be_empty
-    x.matches("a.a.a").should eq(Set{q9})
-    x.unbind(q9, "#.a")
-  end
+    it "# should consider what's comes after" do
+      q9 = LavinMQ::Queue.new(vhost, "q9")
+      x.bind(q9, "#.a")
+      x.matches("a.a.b").should be_empty
+      x.matches("a.a.a").should eq(Set{q9})
+      x.unbind(q9, "#.a")
+    end
 
-  it "# can be followed by *" do
-    q0 = LavinMQ::Queue.new(vhost, "q0")
-    x.bind(q0, "#.*.d")
-    x.matches("a.d.a").should be_empty
-    x.matches("a.a.d").should eq(Set{q0})
-    x.unbind(q0, "#.*.d")
-  end
+    it "# can be followed by *" do
+      q0 = LavinMQ::Queue.new(vhost, "q0")
+      x.bind(q0, "#.*.d")
+      x.matches("a.d.a").should be_empty
+      x.matches("a.a.d").should eq(Set{q0})
+      x.unbind(q0, "#.*.d")
+    end
 
-  it "can handle multiple #" do
-    q11 = LavinMQ::Queue.new(vhost, "q11")
-    x.bind(q11, "#.a.#")
-    x.matches("a.b.a").should be_empty
-    x.matches("b.b.a.b.b").should eq(Set{q11})
-    x.unbind(q11, "#.a.#")
-  end
+    it "can handle multiple #" do
+      q11 = LavinMQ::Queue.new(vhost, "q11")
+      x.bind(q11, "#.a.#")
+      x.matches("a.b.a").should be_empty
+      x.matches("b.b.a.b.b").should eq(Set{q11})
+      x.unbind(q11, "#.a.#")
+    end
 
-  it "should match double star-wildcards" do
-    q12 = LavinMQ::Queue.new(vhost, "q12")
-    x.bind(q12, "c.*.*")
-    x.matches("c.a.d").should eq(Set{q12})
-    x.unbind(q12, "c.*.*")
-  end
+    it "should match double star-wildcards" do
+      q12 = LavinMQ::Queue.new(vhost, "q12")
+      x.bind(q12, "c.*.*")
+      x.matches("c.a.d").should eq(Set{q12})
+      x.unbind(q12, "c.*.*")
+    end
 
-  it "should match triple star-wildcards" do
-    q13 = LavinMQ::Queue.new(vhost, "q13")
-    x.bind(q13, "c.*.*.*")
-    x.matches("c.a.d.e").should eq(Set{q13})
-    x.unbind(q13, "c.*.*.*")
-  end
+    it "should match triple star-wildcards" do
+      q13 = LavinMQ::Queue.new(vhost, "q13")
+      x.bind(q13, "c.*.*.*")
+      x.matches("c.a.d.e").should eq(Set{q13})
+      x.unbind(q13, "c.*.*.*")
+    end
 
-  it "can differentiate a.b.c from a.b" do
-    q = LavinMQ::Queue.new(vhost, "")
-    x.bind(q, "a.b.c")
-    x.matches("a.b.c").should eq(Set{q})
-    x.matches("a.b").should be_empty
-    x.unbind(q, "a.b.c")
-    x.bind(q, "a.b")
-    x.matches("a.b").should eq(Set{q})
-    x.matches("a.b.c").should be_empty
+    it "can differentiate a.b.c from a.b" do
+      q = LavinMQ::Queue.new(vhost, "")
+      x.bind(q, "a.b.c")
+      x.matches("a.b.c").should eq(Set{q})
+      x.matches("a.b").should be_empty
+      x.unbind(q, "a.b.c")
+      x.bind(q, "a.b")
+      x.matches("a.b").should eq(Set{q})
+      x.matches("a.b.c").should be_empty
+    end
   end
 end
 
 describe LavinMQ::HeadersExchange do
-  vhost = Server.vhosts.create("x")
-  x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-  before_each do
-    vhost = Server.vhosts.create("x")
+  with_amqp_server do |s|
+    vhost = s.vhosts.create("x")
+
     x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-  end
-
-  hdrs_all = LavinMQ::AMQP::Table.new({
-    "x-match" => "all",
-    "org"     => "84codes",
-    "user"    => "test",
-  })
-  hdrs_any = LavinMQ::AMQP::Table.new({
-    "x-match" => "any",
-    "org"     => "84codes",
-    "user"    => "test",
-  })
-
-  describe "match all" do
-    it "should match if same args" do
+    before_each do
+      vhost = s.vhosts.create("x")
       x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-      q6 = LavinMQ::Queue.new(vhost, "q6")
-      x.bind(q6, "", hdrs_all)
-      x.matches("", hdrs_all).should eq(Set{q6})
     end
 
-    it "should not match if not all args are the same" do
-      x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-      q7 = LavinMQ::Queue.new(vhost, "q7")
-      x.bind(q7, "", hdrs_all)
-      msg_hdrs = hdrs_all.dup
-      msg_hdrs.delete "x-match"
-      msg_hdrs["org"] = "google"
-      x.matches("", msg_hdrs).size.should eq 0
-    end
-  end
-
-  describe "match any" do
-    it "should match if any args are the same" do
-      x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-      q8 = LavinMQ::Queue.new(vhost, "q8")
-      x.bind(q8, "", hdrs_any)
-      msg_hdrs = hdrs_any.dup
-      msg_hdrs.delete "x-match"
-      msg_hdrs["org"] = "google"
-      x.matches("", msg_hdrs).should eq(Set{q8})
-    end
-
-    it "should not match if no args are the same" do
-      x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-      q9 = LavinMQ::Queue.new(vhost, "q9")
-      x.bind(q9, "", hdrs_any)
-      msg_hdrs = hdrs_any.dup
-      msg_hdrs.delete "x-match"
-      msg_hdrs["org"] = "google"
-      msg_hdrs["user"] = "hest"
-      x.matches("", msg_hdrs).size.should eq 0
-    end
-
-    it "should match nestled amq-protocol tables" do
-      x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-      q10 = LavinMQ::Queue.new(vhost, "q10")
-      bind_hdrs = LavinMQ::AMQP::Table.new({
-        "x-match" => "any",
-        "tbl"     => LavinMQ::AMQP::Table.new({"foo": "bar"}),
-      })
-      x.bind(q10, "", bind_hdrs) # to_h because that's what's done in VHost
-      msg_hdrs = bind_hdrs.clone
-      msg_hdrs.delete("x-match")
-      x.matches("", msg_hdrs).size.should eq 1
-    end
-  end
-
-  it "should handle multiple bindings" do
-    q10 = LavinMQ::Queue.new(vhost, "q10")
-    x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-    hdrs1 = LavinMQ::AMQP::Table.new({"x-match" => "any", "org" => "84codes", "user" => "test"})
-    hdrs2 = LavinMQ::AMQP::Table.new({"x-match" => "all", "org" => "google", "user" => "test"})
-
-    x.bind(q10, "", hdrs1)
-    x.bind(q10, "", hdrs2)
-    hdrs1.delete "x-match"
-    hdrs2.delete "x-match"
-    x.matches("", hdrs1).should eq Set{q10}
-    x.matches("", hdrs2).should eq Set{q10}
-  end
-
-  it "should handle all Field types" do
-    q11 = LavinMQ::Queue.new(vhost, "q11")
-    x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-    hsh = {"k" => "v"} of String => LavinMQ::AMQP::Field
-    arrf = [1] of LavinMQ::AMQP::Field
-    arru = [1_u8] of LavinMQ::AMQP::Field
-    hdrs = LavinMQ::AMQP::Table.new({
-      "Nil" => nil, "Bool" => true, "UInt8" => 1_u8, "UInt16" => 1_u16, "UInt32" => 1_u32,
-      "Int16" => 1_u16, "Int32" => 1_i32, "Int64" => 1_i64, "Float32" => 1_f32,
-      "Float64" => 1_f64, "String" => "String", "Array(Field)" => arrf,
-      "Array(UInt8)" => arru, "Time" => Time.utc, "Hash(String, Field)" => hsh,
+    hdrs_all = LavinMQ::AMQP::Table.new({
       "x-match" => "all",
+      "org"     => "84codes",
+      "user"    => "test",
     })
-    x.bind(q11, "", hdrs)
-    x.matches("", hdrs).should eq Set{q11}
-  end
-
-  it "should handle unbind" do
-    q12 = LavinMQ::Queue.new(vhost, "q12")
-    x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-    hdrs1 = LavinMQ::AMQP::Table.new({
-      "x-match" => "any", "org" => "84codes", "user" => "test",
+    hdrs_any = LavinMQ::AMQP::Table.new({
+      "x-match" => "any",
+      "org"     => "84codes",
+      "user"    => "test",
     })
-    x.bind(q12, "", hdrs1)
-    x.unbind(q12, "", hdrs1)
-    x.matches("", hdrs1).size.should eq 0
-  end
 
-  describe "match empty" do
-    it "should match if both args and headers are empty" do
+    describe "match all" do
+      it "should match if same args" do
+        x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+        q6 = LavinMQ::Queue.new(vhost, "q6")
+        x.bind(q6, "", hdrs_all)
+        x.matches("", hdrs_all).should eq(Set{q6})
+      end
+
+      it "should not match if not all args are the same" do
+        x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+        q7 = LavinMQ::Queue.new(vhost, "q7")
+        x.bind(q7, "", hdrs_all)
+        msg_hdrs = hdrs_all.dup
+        msg_hdrs.delete "x-match"
+        msg_hdrs["org"] = "google"
+        x.matches("", msg_hdrs).size.should eq 0
+      end
+    end
+
+    describe "match any" do
+      it "should match if any args are the same" do
+        x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+        q8 = LavinMQ::Queue.new(vhost, "q8")
+        x.bind(q8, "", hdrs_any)
+        msg_hdrs = hdrs_any.dup
+        msg_hdrs.delete "x-match"
+        msg_hdrs["org"] = "google"
+        x.matches("", msg_hdrs).should eq(Set{q8})
+      end
+
+      it "should not match if no args are the same" do
+        x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+        q9 = LavinMQ::Queue.new(vhost, "q9")
+        x.bind(q9, "", hdrs_any)
+        msg_hdrs = hdrs_any.dup
+        msg_hdrs.delete "x-match"
+        msg_hdrs["org"] = "google"
+        msg_hdrs["user"] = "hest"
+        x.matches("", msg_hdrs).size.should eq 0
+      end
+
+      it "should match nestled amq-protocol tables" do
+        x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+        q10 = LavinMQ::Queue.new(vhost, "q10")
+        bind_hdrs = LavinMQ::AMQP::Table.new({
+          "x-match" => "any",
+          "tbl"     => LavinMQ::AMQP::Table.new({"foo": "bar"}),
+        })
+        x.bind(q10, "", bind_hdrs) # to_h because that's what's done in VHost
+        msg_hdrs = bind_hdrs.clone
+        msg_hdrs.delete("x-match")
+        x.matches("", msg_hdrs).size.should eq 1
+      end
+    end
+
+    it "should handle multiple bindings" do
+      q10 = LavinMQ::Queue.new(vhost, "q10")
       x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
-      q13 = LavinMQ::Queue.new(vhost, "q13")
-      x.bind(q13, "", nil)
-      x.matches("", nil).size.should eq 1
+      hdrs1 = LavinMQ::AMQP::Table.new({"x-match" => "any", "org" => "84codes", "user" => "test"})
+      hdrs2 = LavinMQ::AMQP::Table.new({"x-match" => "all", "org" => "google", "user" => "test"})
+
+      x.bind(q10, "", hdrs1)
+      x.bind(q10, "", hdrs2)
+      hdrs1.delete "x-match"
+      hdrs2.delete "x-match"
+      x.matches("", hdrs1).should eq Set{q10}
+      x.matches("", hdrs2).should eq Set{q10}
+    end
+
+    it "should handle all Field types" do
+      q11 = LavinMQ::Queue.new(vhost, "q11")
+      x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+      hsh = {"k" => "v"} of String => LavinMQ::AMQP::Field
+      arrf = [1] of LavinMQ::AMQP::Field
+      arru = [1_u8] of LavinMQ::AMQP::Field
+      hdrs = LavinMQ::AMQP::Table.new({
+        "Nil" => nil, "Bool" => true, "UInt8" => 1_u8, "UInt16" => 1_u16, "UInt32" => 1_u32,
+        "Int16" => 1_u16, "Int32" => 1_i32, "Int64" => 1_i64, "Float32" => 1_f32,
+        "Float64" => 1_f64, "String" => "String", "Array(Field)" => arrf,
+        "Array(UInt8)" => arru, "Time" => Time.utc, "Hash(String, Field)" => hsh,
+        "x-match" => "all",
+      })
+      x.bind(q11, "", hdrs)
+      x.matches("", hdrs).should eq Set{q11}
+    end
+
+    it "should handle unbind" do
+      q12 = LavinMQ::Queue.new(vhost, "q12")
+      x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+      hdrs1 = LavinMQ::AMQP::Table.new({
+        "x-match" => "any", "org" => "84codes", "user" => "test",
+      })
+      x.bind(q12, "", hdrs1)
+      x.unbind(q12, "", hdrs1)
+      x.matches("", hdrs1).size.should eq 0
+    end
+
+    describe "match empty" do
+      it "should match if both args and headers are empty" do
+        x = LavinMQ::HeadersExchange.new(vhost, "h", false, false, true)
+        q13 = LavinMQ::Queue.new(vhost, "q13")
+        x.bind(q13, "", nil)
+        x.matches("", nil).size.should eq 1
+      end
     end
   end
 end

--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -1,262 +1,300 @@
 require "./spec_helper"
 
+class PoliciesSpec
+  def self.with_vhost(&)
+    with_amqp_server do |s|
+      vhost = s.vhosts.create("add_policy")
+      yield vhost
+    end
+  end
+end
+
 describe LavinMQ::VHost do
   definitions = {
     "max-length"         => JSON::Any.new(10_i64),
     "alternate-exchange" => JSON::Any.new("dead-letters"),
     "unsupported"        => JSON::Any.new("unsupported"),
   }
-  vhost = Server.vhosts.create("add_policy")
-
-  before_each do
-    vhost = Server.vhosts.create("add_policy")
-  end
 
   it "should be able to add policy" do
-    vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
-    vhost.policies.size.should eq 1
-    vhost.delete_policy("test")
+    PoliciesSpec.with_vhost do |vhost|
+      vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
+      vhost.policies.size.should eq 1
+      vhost.delete_policy("test")
+    end
   end
 
   it "should remove policy from resource when deleted" do
-    vhost.queues["test1"] = LavinMQ::Queue.new(vhost, "test")
-    vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
-    sleep 0.01
-    vhost.queues["test1"].policy.try(&.name).should eq "test"
-    vhost.delete_policy("test")
-    sleep 0.01
-    vhost.queues["test1"].policy.should be_nil
+    PoliciesSpec.with_vhost do |vhost|
+      vhost.queues["test1"] = LavinMQ::Queue.new(vhost, "test")
+      vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
+      sleep 0.01
+      vhost.queues["test1"].policy.try(&.name).should eq "test"
+      vhost.delete_policy("test")
+      sleep 0.01
+      vhost.queues["test1"].policy.should be_nil
+    end
   end
 
   it "should be able to list policies" do
-    vhost2 = Server.vhosts.create("add_remove_policy")
-    vhost2.add_policy("test", "^.*$", "all", definitions, -10_i8)
-    vhost2.delete_policy("test")
-    vhost2.policies.size.should eq 0
-    Server.vhosts.delete("add_remove_policy")
+    PoliciesSpec.with_vhost do |vhost|
+      vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
+      vhost.delete_policy("test")
+      vhost.policies.size.should eq 0
+    end
   end
 
   it "should overwrite policy with same name" do
-    vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
-    vhost.add_policy("test", "^.*$", "exchanges", definitions, 10_i8)
-    vhost.policies.size.should eq 1
-    vhost.policies["test"].apply_to.should eq LavinMQ::Policy::Target::Exchanges
-    vhost.delete_policy("test")
+    PoliciesSpec.with_vhost do |vhost|
+      vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
+      vhost.add_policy("test", "^.*$", "exchanges", definitions, 10_i8)
+      vhost.policies.size.should eq 1
+      vhost.policies["test"].apply_to.should eq LavinMQ::Policy::Target::Exchanges
+      vhost.delete_policy("test")
+    end
   end
 
   it "should apply policy" do
-    defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-    vhost.queues["test"] = LavinMQ::Queue.new(vhost, "test")
-    vhost.add_policy("ml", "^.*$", "queues", defs, 11_i8)
-    sleep 0.01
-    vhost.queues["test"].policy.not_nil!.name.should eq "ml"
+    PoliciesSpec.with_vhost do |vhost|
+      defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+      vhost.queues["test"] = LavinMQ::Queue.new(vhost, "test")
+      vhost.add_policy("ml", "^.*$", "queues", defs, 11_i8)
+      sleep 0.01
+      vhost.queues["test"].policy.not_nil!.name.should eq "ml"
+    end
   end
 
   it "should respect priority" do
-    defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-    vhost.queues["test2"] = LavinMQ::Queue.new(vhost, "test")
-    vhost.add_policy("ml2", "^.*$", "queues", defs, 1_i8)
-    vhost.add_policy("ml1", "^.*$", "queues", defs, 0_i8)
-    sleep 0.01
-    vhost.queues["test2"].policy.not_nil!.name.should eq "ml2"
+    PoliciesSpec.with_vhost do |vhost|
+      defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+      vhost.queues["test2"] = LavinMQ::Queue.new(vhost, "test")
+      vhost.add_policy("ml2", "^.*$", "queues", defs, 1_i8)
+      vhost.add_policy("ml1", "^.*$", "queues", defs, 0_i8)
+      sleep 0.01
+      vhost.queues["test2"].policy.not_nil!.name.should eq "ml2"
+    end
   end
 
   it "should remove effect of deleted policy" do
-    defs = {"max-length" => JSON::Any.new(10_i64)} of String => JSON::Any
-    Server.vhosts["/"].add_policy("mld", "^.*$", "all", defs, 12_i8)
-    with_channel do |ch|
-      q = ch.queue("mld")
-      11.times do
+    with_amqp_server do |s|
+      defs = {"max-length" => JSON::Any.new(10_i64)} of String => JSON::Any
+      s.vhosts["/"].add_policy("mld", "^.*$", "all", defs, 12_i8)
+      with_channel(s) do |ch|
+        q = ch.queue("mld")
+        11.times do
+          q.publish_confirm "body"
+        end
+        ch.queue_declare("mld", passive: true)[:message_count].should eq 10
+        s.vhosts["/"].delete_policy("mld")
         q.publish_confirm "body"
+        ch.queue_declare("mld", passive: true)[:message_count].should eq 11
       end
-      ch.queue_declare("mld", passive: true)[:message_count].should eq 10
-      Server.vhosts["/"].delete_policy("mld")
-      q.publish_confirm "body"
-      ch.queue_declare("mld", passive: true)[:message_count].should eq 11
     end
   end
 
   it "should apply message TTL policy on existing queue" do
-    defs = {"message-ttl" => JSON::Any.new(0_i64)} of String => JSON::Any
-    with_channel do |ch|
-      q = ch.queue("policy-ttl")
-      10.times do
-        q.publish_confirm "body"
+    with_amqp_server do |s|
+      defs = {"message-ttl" => JSON::Any.new(0_i64)} of String => JSON::Any
+      with_channel(s) do |ch|
+        q = ch.queue("policy-ttl")
+        10.times do
+          q.publish_confirm "body"
+        end
+        ch.queue_declare("policy-ttl", passive: true)[:message_count].should eq 10
+        s.vhosts["/"].add_policy("ttl", "^.*$", "all", defs, 12_i8)
+        sleep 0.01
+        ch.queue_declare("policy-ttl", passive: true)[:message_count].should eq 0
+        s.vhosts["/"].delete_policy("ttl")
       end
-      ch.queue_declare("policy-ttl", passive: true)[:message_count].should eq 10
-      Server.vhosts["/"].add_policy("ttl", "^.*$", "all", defs, 12_i8)
-      sleep 0.01
-      ch.queue_declare("policy-ttl", passive: true)[:message_count].should eq 0
-      Server.vhosts["/"].delete_policy("ttl")
     end
   end
 
   it "should apply queue TTL policy on existing queue" do
-    defs = {"expires" => JSON::Any.new(0_i64)} of String => JSON::Any
-    with_channel do |ch|
-      q = ch.queue("qttl")
-      q.publish_confirm ""
-      Server.vhosts["/"].add_policy("qttl", "^.*$", "all", defs, 12_i8)
-      sleep 0.01
-      expect_raises(AMQP::Client::Channel::ClosedException) do
-        ch.queue_declare("qttl", passive: true)
+    with_amqp_server do |s|
+      defs = {"expires" => JSON::Any.new(0_i64)} of String => JSON::Any
+      with_channel(s) do |ch|
+        q = ch.queue("qttl")
+        q.publish_confirm ""
+        s.vhosts["/"].add_policy("qttl", "^.*$", "all", defs, 12_i8)
+        sleep 0.01
+        expect_raises(AMQP::Client::Channel::ClosedException) do
+          ch.queue_declare("qttl", passive: true)
+        end
       end
     end
   end
 
   it "should refresh queue last_get_time when expire policy applied" do
-    defs = {"expires" => JSON::Any.new(50_i64)} of String => JSON::Any
-    with_channel do |ch|
-      ch.queue("qttl")
-      queue = Server.vhosts["/"].queues["qttl"]
-      first = queue.last_get_time
-      sleep 0.1
-      Server.vhosts["/"].add_policy("qttl", "^.*$", "all", defs, 12_i8)
-      sleep 0.1
-      last = queue.last_get_time
-      last.should be > first
+    with_amqp_server do |s|
+      defs = {"expires" => JSON::Any.new(50_i64)} of String => JSON::Any
+      with_channel(s) do |ch|
+        ch.queue("qttl")
+        queue = s.vhosts["/"].queues["qttl"]
+        first = queue.last_get_time
+        sleep 0.1
+        s.vhosts["/"].add_policy("qttl", "^.*$", "all", defs, 12_i8)
+        sleep 0.1
+        last = queue.last_get_time
+        last.should be > first
+      end
     end
   end
 
   it "should apply max-length-bytes on existing queue" do
-    defs = {"max-length-bytes" => JSON::Any.new(100_i64)} of String => JSON::Any
-    with_channel do |ch|
-      q = ch.queue("max-length-bytes", exclusive: true)
-      q.publish_confirm "short1"
-      q.publish_confirm "short2"
-      q.publish_confirm "long"
-      ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 3
-      sleep 0.02
-      Server.vhosts["/"].add_policy("max-length-bytes", "^.*$", "all", defs, 12_i8)
-      sleep 0.01
-      ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("short2")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("long")
-      Server.vhosts["/"].delete_policy("max-length-bytes")
+    with_amqp_server do |s|
+      defs = {"max-length-bytes" => JSON::Any.new(100_i64)} of String => JSON::Any
+      with_channel(s) do |ch|
+        q = ch.queue("max-length-bytes", exclusive: true)
+        q.publish_confirm "short1"
+        q.publish_confirm "short2"
+        q.publish_confirm "long"
+        ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 3
+        sleep 0.02
+        s.vhosts["/"].add_policy("max-length-bytes", "^.*$", "all", defs, 12_i8)
+        sleep 0.01
+        ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("short2")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("long")
+        s.vhosts["/"].delete_policy("max-length-bytes")
+      end
     end
   end
 
   it "should remove head if queue to large" do
-    defs = {"max-length-bytes" => JSON::Any.new(100_i64)} of String => JSON::Any
-    with_channel do |ch|
-      q = ch.queue("max-length-bytes", exclusive: true)
-      Server.vhosts["/"].add_policy("max-length-bytes", "^.*$", "all", defs, 12_i8)
-      sleep 0.01
-      q.publish_confirm "short1"
-      q.publish_confirm "short2"
-      q.publish_confirm "long"
-      ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("short2")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("long")
-      Server.vhosts["/"].delete_policy("max-length-bytes")
+    with_amqp_server do |s|
+      defs = {"max-length-bytes" => JSON::Any.new(100_i64)} of String => JSON::Any
+      with_channel(s) do |ch|
+        q = ch.queue("max-length-bytes", exclusive: true)
+        s.vhosts["/"].add_policy("max-length-bytes", "^.*$", "all", defs, 12_i8)
+        sleep 0.01
+        q.publish_confirm "short1"
+        q.publish_confirm "short2"
+        q.publish_confirm "long"
+        ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("short2")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("long")
+        s.vhosts["/"].delete_policy("max-length-bytes")
+      end
     end
   end
 
   it "should not enqueue messages that make the queue to large" do
-    defs = {"max-length-bytes" => JSON::Any.new(100_i64),
-            "overflow"         => JSON::Any.new("reject-publish")} of String => JSON::Any
-    with_channel do |ch|
-      q = ch.queue("max-length-bytes", exclusive: true)
-      Server.vhosts["/"].add_policy("max-length-bytes", "^.*$", "all", defs, 12_i8)
-      sleep 0.01
-      q.publish_confirm "short1"
-      q.publish_confirm "short2"
-      q.publish_confirm "long"
-      ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("short1")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("short2")
-      Server.vhosts["/"].delete_policy("max-length-bytes")
+    with_amqp_server do |s|
+      defs = {"max-length-bytes" => JSON::Any.new(100_i64),
+              "overflow"         => JSON::Any.new("reject-publish")} of String => JSON::Any
+      with_channel(s) do |ch|
+        q = ch.queue("max-length-bytes", exclusive: true)
+        s.vhosts["/"].add_policy("max-length-bytes", "^.*$", "all", defs, 12_i8)
+        sleep 0.01
+        q.publish_confirm "short1"
+        q.publish_confirm "short2"
+        q.publish_confirm "long"
+        ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("short1")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("short2")
+        s.vhosts["/"].delete_policy("max-length-bytes")
+      end
     end
   end
 
   describe "with max-length-bytes policy applied" do
     it "should replace with max-length" do
-      defs = {"max-length-bytes" => JSON::Any.new(100_i64)} of String => JSON::Any
-      with_channel do |ch|
-        q = ch.queue("max-length-bytes", exclusive: true)
-        Server.vhosts["/"].add_policy("max-length-bytes", "^.*$", "queues", defs, 12_i8)
-        q.publish_confirm "short1"
-        q.publish_confirm "short2"
-        q.publish_confirm "long"
-        ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
+      with_amqp_server do |s|
+        defs = {"max-length-bytes" => JSON::Any.new(100_i64)} of String => JSON::Any
+        with_channel(s) do |ch|
+          q = ch.queue("max-length-bytes", exclusive: true)
+          s.vhosts["/"].add_policy("max-length-bytes", "^.*$", "queues", defs, 12_i8)
+          q.publish_confirm "short1"
+          q.publish_confirm "short2"
+          q.publish_confirm "long"
+          ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 2
 
-        defs = {"max-length" => JSON::Any.new(10_i64)} of String => JSON::Any
-        Server.vhosts["/"].add_policy("max-length-bytes", "^.*$", "queues", defs, 12_i8)
-        10.times do
-          q.publish_confirm "msg"
+          defs = {"max-length" => JSON::Any.new(10_i64)} of String => JSON::Any
+          s.vhosts["/"].add_policy("max-length-bytes", "^.*$", "queues", defs, 12_i8)
+          10.times do
+            q.publish_confirm "msg"
+          end
+          ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 10
+          s.vhosts["/"].delete_policy("max-length-bytes")
         end
-        ch.queue_declare("max-length-bytes", passive: true)[:message_count].should eq 10
-        Server.vhosts["/"].delete_policy("max-length-bytes")
       end
     end
   end
 
   describe "operator policies" do
     it "merges with normal polices" do
-      ml_2 = {"max-length" => JSON::Any.new(2_i64)} of String => JSON::Any
-      ml_1 = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      Server.vhosts["/"].add_policy("ml", ".*", "all", ml_2, 0_i8)
-      with_channel do |ch|
-        q = ch.queue
-        3.times do
-          q.publish_confirm "body"
-        end
-        ch.queue_declare(q.name, passive: true)[:message_count].should eq 2
-        Server.vhosts["/"].add_operator_policy("ml1", ".*", "all", ml_1, 0_i8)
-        ch.queue_declare(q.name, passive: true)[:message_count].should eq 1
+      with_amqp_server do |s|
+        ml_2 = {"max-length" => JSON::Any.new(2_i64)} of String => JSON::Any
+        ml_1 = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+        s.vhosts["/"].add_policy("ml", ".*", "all", ml_2, 0_i8)
+        with_channel(s) do |ch|
+          q = ch.queue
+          3.times do
+            q.publish_confirm "body"
+          end
+          ch.queue_declare(q.name, passive: true)[:message_count].should eq 2
+          s.vhosts["/"].add_operator_policy("ml1", ".*", "all", ml_1, 0_i8)
+          ch.queue_declare(q.name, passive: true)[:message_count].should eq 1
 
-        # deleting operator policy should make normal policy active again
-        Server.vhosts["/"].delete_operator_policy("ml1")
-        3.times do
-          q.publish_confirm "body"
+          # deleting operator policy should make normal policy active again
+          s.vhosts["/"].delete_operator_policy("ml1")
+          3.times do
+            q.publish_confirm "body"
+          end
+          ch.queue_declare(q.name, passive: true)[:message_count].should eq 2
         end
-        ch.queue_declare(q.name, passive: true)[:message_count].should eq 2
       end
     end
 
     it "effective_policy_definition should not include unsupported policies" do
-      supported_policies = {"max-length", "max-length-bytes",
-                            "message-ttl", "expires", "overflow",
-                            "dead-letter-exchange", "dead-letter-routing-key",
-                            "federation-upstream", "federation-upstream-set",
-                            "delivery-limit", "max-age", "alternate-exchange",
-                            "delayed-message"}
-      vhost.queues["test"] = LavinMQ::Queue.new(vhost, "test")
-      vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
-      sleep 0.01
-      vhost.queues["test"].details_tuple[:effective_policy_definition].as(Hash(String, JSON::Any)).each_key do |k|
-        supported_policies.includes?(k).should be_true
+      PoliciesSpec.with_vhost do |vhost|
+        supported_policies = {"max-length", "max-length-bytes",
+                              "message-ttl", "expires", "overflow",
+                              "dead-letter-exchange", "dead-letter-routing-key",
+                              "federation-upstream", "federation-upstream-set",
+                              "delivery-limit", "max-age", "alternate-exchange",
+                              "delayed-message"}
+        vhost.queues["test"] = LavinMQ::Queue.new(vhost, "test")
+        vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
+        sleep 0.01
+        vhost.queues["test"].details_tuple[:effective_policy_definition].as(Hash(String, JSON::Any)).each_key do |k|
+          supported_policies.includes?(k).should be_true
+        end
+        vhost.delete_policy("test")
       end
-      vhost.delete_policy("test")
     end
   end
 
   describe "together with arguments" do
     it "arguments should have priority for non numeric arguments" do
-      vhost.exchanges["no-ae"] = LavinMQ::DirectExchange.new(vhost, "no-ae")
-      vhost.exchanges["x-with-ae"] = LavinMQ::DirectExchange.new(vhost, "x-with-ae",
-        arguments: AMQ::Protocol::Table.new({"x-alternate-exchange": "ae2"}))
-      vhost.add_policy("test", ".*", "all", definitions, 100_i8)
-      sleep 0.01
-      vhost.exchanges["no-ae"].@alternate_exchange.should eq "dead-letters"
-      vhost.exchanges["x-with-ae"].@alternate_exchange.should eq "ae2"
-      vhost.delete_policy("test")
-      sleep 0.01
-      vhost.exchanges["no-ae"].@alternate_exchange.should be_nil
-      vhost.exchanges["x-with-ae"].@alternate_exchange.should eq "ae2"
+      PoliciesSpec.with_vhost do |vhost|
+        vhost.exchanges["no-ae"] = LavinMQ::DirectExchange.new(vhost, "no-ae")
+        vhost.exchanges["x-with-ae"] = LavinMQ::DirectExchange.new(vhost, "x-with-ae",
+          arguments: AMQ::Protocol::Table.new({"x-alternate-exchange": "ae2"}))
+        vhost.add_policy("test", ".*", "all", definitions, 100_i8)
+        sleep 0.01
+        vhost.exchanges["no-ae"].@alternate_exchange.should eq "dead-letters"
+        vhost.exchanges["x-with-ae"].@alternate_exchange.should eq "ae2"
+        vhost.delete_policy("test")
+        sleep 0.01
+        vhost.exchanges["no-ae"].@alternate_exchange.should be_nil
+        vhost.exchanges["x-with-ae"].@alternate_exchange.should eq "ae2"
+      end
     end
 
     it "should use the lowest value" do
-      vhost.queues["test1"] = LavinMQ::Queue.new(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64}))
-      vhost.queues["test2"] = LavinMQ::Queue.new(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64}))
-      vhost.add_policy("test", ".*", "all", definitions, 100_i8)
-      sleep 0.01
-      vhost.queues["test1"].@max_length.should eq 1
-      vhost.queues["test2"].@max_length.should eq 10
-      vhost.delete_policy("test")
-      sleep 0.01
-      vhost.queues["test1"].@max_length.should eq 1
-      vhost.queues["test2"].@max_length.should eq 11
+      PoliciesSpec.with_vhost do |vhost|
+        vhost.queues["test1"] = LavinMQ::Queue.new(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64}))
+        vhost.queues["test2"] = LavinMQ::Queue.new(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64}))
+        vhost.add_policy("test", ".*", "all", definitions, 100_i8)
+        sleep 0.01
+        vhost.queues["test1"].@max_length.should eq 1
+        vhost.queues["test2"].@max_length.should eq 10
+        vhost.delete_policy("test")
+        sleep 0.01
+        vhost.queues["test1"].@max_length.should eq 1
+        vhost.queues["test2"].@max_length.should eq 11
+      end
     end
   end
 end

--- a/spec/prefetch_spec.cr
+++ b/spec/prefetch_spec.cr
@@ -3,63 +3,71 @@ require "./spec_helper"
 describe LavinMQ::Server do
   describe "Consumer with prefetch" do
     it "should receive prefetch number of messages" do
-      with_channel do |ch|
-        ch.prefetch 2
-        pmsg = "m1"
-        q = ch.queue
-        3.times { q.publish pmsg }
-        msgs = [] of AMQP::Client::DeliverMessage
-        q.subscribe(no_ack: false) { |msg| msgs << msg }
-        wait_for { msgs.size == 2 }
-        msgs.size.should eq 2
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 2
+          pmsg = "m1"
+          q = ch.queue
+          3.times { q.publish pmsg }
+          msgs = [] of AMQP::Client::DeliverMessage
+          q.subscribe(no_ack: false) { |msg| msgs << msg }
+          wait_for { msgs.size == 2 }
+          msgs.size.should eq 2
+        end
       end
     end
 
     it "should receive more after acks" do
-      with_channel do |ch|
-        ch.prefetch 1
-        q = ch.queue
-        4.times { q.publish "m1" }
-        c = 0
-        q.subscribe(no_ack: false) do |msg|
-          c += 1
-          msg.ack
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 1
+          q = ch.queue
+          4.times { q.publish "m1" }
+          c = 0
+          q.subscribe(no_ack: false) do |msg|
+            c += 1
+            msg.ack
+          end
+          wait_for { c == 4 }
+          c.should eq 4
         end
-        wait_for { c == 4 }
-        c.should eq 4
       end
     end
 
     it "should be applied separately to each new consumer on the channel when global is false" do
-      with_channel do |ch|
-        ch.prefetch 2
-        pmsg = "m1"
-        q = ch.queue
-        4.times { q.publish pmsg }
-        msgs_c1 = [] of AMQP::Client::DeliverMessage
-        msgs_c2 = [] of AMQP::Client::DeliverMessage
-        q.subscribe(no_ack: false) { |msg| msgs_c1 << msg }
-        q.subscribe(no_ack: false) { |msg| msgs_c2 << msg }
-        wait_for { msgs_c2.size == 2 }
-        msgs_c1.size.should eq 2
-        msgs_c2.size.should eq 2
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 2
+          pmsg = "m1"
+          q = ch.queue
+          4.times { q.publish pmsg }
+          msgs_c1 = [] of AMQP::Client::DeliverMessage
+          msgs_c2 = [] of AMQP::Client::DeliverMessage
+          q.subscribe(no_ack: false) { |msg| msgs_c1 << msg }
+          q.subscribe(no_ack: false) { |msg| msgs_c2 << msg }
+          wait_for { msgs_c2.size == 2 }
+          msgs_c1.size.should eq 2
+          msgs_c2.size.should eq 2
+        end
       end
     end
 
     it "should be shared across all consumers on the channel when global is true" do
-      with_channel do |ch|
-        ch.prefetch 2, true
-        pmsg = "m1"
-        q = ch.queue
-        4.times { q.publish pmsg }
-        msgs_c1 = [] of AMQP::Client::DeliverMessage
-        msgs_c2 = [] of AMQP::Client::DeliverMessage
-        q.subscribe(no_ack: false) { |msg| msgs_c1 << msg }
-        wait_for { msgs_c1.size == 2 }
-        q.subscribe(no_ack: false) { |msg| msgs_c2 << msg }
-        sleep 5.milliseconds
-        msgs_c1.size.should eq 2
-        msgs_c2.size.should eq 0
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 2, true
+          pmsg = "m1"
+          q = ch.queue
+          4.times { q.publish pmsg }
+          msgs_c1 = [] of AMQP::Client::DeliverMessage
+          msgs_c2 = [] of AMQP::Client::DeliverMessage
+          q.subscribe(no_ack: false) { |msg| msgs_c1 << msg }
+          wait_for { msgs_c1.size == 2 }
+          q.subscribe(no_ack: false) { |msg| msgs_c2 << msg }
+          sleep 5.milliseconds
+          msgs_c1.size.should eq 2
+          msgs_c2.size.should eq 0
+        end
       end
     end
   end

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -2,76 +2,88 @@ require "./spec_helper"
 
 describe LavinMQ::PriorityQueue do
   it "should prioritize messages" do
-    with_channel do |ch|
-      q_args = AMQP::Client::Arguments.new({"x-max-priority" => 10})
-      q = ch.queue("", args: q_args)
-      q.publish "prio2", props: AMQP::Client::Properties.new(priority: 2)
-      q.publish "prio1", props: AMQP::Client::Properties.new(priority: 1)
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("prio2")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("prio1")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q_args = AMQP::Client::Arguments.new({"x-max-priority" => 10})
+        q = ch.queue("", args: q_args)
+        q.publish "prio2", props: AMQP::Client::Properties.new(priority: 2)
+        q.publish "prio1", props: AMQP::Client::Properties.new(priority: 1)
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("prio2")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("prio1")
+      end
     end
   end
 
   it "should prioritize messages as 0 if no prio is set" do
-    with_channel do |ch|
-      q_args = AMQP::Client::Arguments.new({"x-max-priority" => 10})
-      q = ch.queue("", args: q_args)
-      q.publish "prio0"
-      q.publish "prio1", props: AMQP::Client::Properties.new(priority: 1)
-      q.publish "prio00"
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("prio1")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("prio0")
-      q.get(no_ack: true).try(&.body_io.to_s).should eq("prio00")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q_args = AMQP::Client::Arguments.new({"x-max-priority" => 10})
+        q = ch.queue("", args: q_args)
+        q.publish "prio0"
+        q.publish "prio1", props: AMQP::Client::Properties.new(priority: 1)
+        q.publish "prio00"
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("prio1")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("prio0")
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("prio00")
+      end
     end
   end
 
   it "should only accept int32 as priority" do
-    with_channel do |ch|
-      expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-        q_args = AMQP::Client::Arguments.new({"x-max-priority" => "a"})
-        ch.queue("", args: q_args)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          q_args = AMQP::Client::Arguments.new({"x-max-priority" => "a"})
+          ch.queue("", args: q_args)
+        end
       end
     end
   end
 
   it "should only accept priority >= 0" do
-    with_channel do |ch|
-      q_args = AMQP::Client::Arguments.new({"x-max-priority" => 0})
-      ch.queue("", args: q_args)
-      expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-        q_args = AMQP::Client::Arguments.new({"x-max-priority" => -1})
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q_args = AMQP::Client::Arguments.new({"x-max-priority" => 0})
         ch.queue("", args: q_args)
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          q_args = AMQP::Client::Arguments.new({"x-max-priority" => -1})
+          ch.queue("", args: q_args)
+        end
       end
     end
   end
 
   it "should only accept priority <= 255" do
-    with_channel do |ch|
-      q_args = AMQP::Client::Arguments.new({"x-max-priority" => 255})
-      ch.queue("", args: q_args)
-      expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-        q_args = AMQP::Client::Arguments.new({"x-max-priority" => 256})
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q_args = AMQP::Client::Arguments.new({"x-max-priority" => 255})
         ch.queue("", args: q_args)
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          q_args = AMQP::Client::Arguments.new({"x-max-priority" => 256})
+          ch.queue("", args: q_args)
+        end
       end
     end
   end
 
   context "after restart" do
     it "can restore the priority queue" do
-      with_channel do |ch|
-        q = ch.queue("pq", args: AMQP::Client::Arguments.new({"x-max-priority": 9}))
-        q.publish "m1"
-        q.publish "m2", props: AMQP::Client::Properties.new(priority: 9)
-        q.get(no_ack: false).try(&.body_io.to_s).should eq "m2"
-        q.get(no_ack: false).try(&.body_io.to_s).should eq "m1"
-      end
-      Server.restart
-      with_channel do |ch|
-        q = ch.queue("pq", args: AMQP::Client::Arguments.new({"x-max-priority": 9}))
-        q.publish "m3", props: AMQP::Client::Properties.new(priority: 8)
-        q.get(no_ack: false).try(&.body_io.to_s).should eq "m2"
-        q.get(no_ack: false).try(&.body_io.to_s).should eq "m3"
-        q.get(no_ack: false).try(&.body_io.to_s).should eq "m1"
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("pq", args: AMQP::Client::Arguments.new({"x-max-priority": 9}))
+          q.publish "m1"
+          q.publish "m2", props: AMQP::Client::Properties.new(priority: 9)
+          q.get(no_ack: false).try(&.body_io.to_s).should eq "m2"
+          q.get(no_ack: false).try(&.body_io.to_s).should eq "m1"
+        end
+        s.restart
+        with_channel(s) do |ch|
+          q = ch.queue("pq", args: AMQP::Client::Arguments.new({"x-max-priority": 9}))
+          q.publish "m3", props: AMQP::Client::Properties.new(priority: 8)
+          q.get(no_ack: false).try(&.body_io.to_s).should eq "m2"
+          q.get(no_ack: false).try(&.body_io.to_s).should eq "m3"
+          q.get(no_ack: false).try(&.body_io.to_s).should eq "m1"
+        end
       end
     end
   end

--- a/spec/queue_factory_spec.cr
+++ b/spec/queue_factory_spec.cr
@@ -3,48 +3,58 @@ require "./spec_helper"
 
 describe LavinMQ::QueueFactory do
   it "should create a non_durable queue" do
-    durable = false
-    queue_args = AMQ::Protocol::Table.new({"t" => 1})
-    frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-      false, false, queue_args)
-    q = LavinMQ::QueueFactory.make(Server.vhosts["/"], frame)
-    q.is_a?(LavinMQ::Queue).should be_true
+    with_amqp_server do |s|
+      durable = false
+      queue_args = AMQ::Protocol::Table.new({"t" => 1})
+      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
+        false, false, queue_args)
+      q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+      q.is_a?(LavinMQ::Queue).should be_true
+    end
   end
 
   it "should create a durable queue" do
-    durable = true
-    queue_args = AMQ::Protocol::Table.new({"t" => 1})
-    frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-      false, false, queue_args)
-    q = LavinMQ::QueueFactory.make(Server.vhosts["/"], frame)
-    q.is_a?(LavinMQ::DurableQueue).should be_true
+    with_amqp_server do |s|
+      durable = true
+      queue_args = AMQ::Protocol::Table.new({"t" => 1})
+      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
+        false, false, queue_args)
+      q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+      q.is_a?(LavinMQ::DurableQueue).should be_true
+    end
   end
 
   describe "priority queues" do
     it "should create a non_durable queue" do
-      durable = false
-      queue_args = AMQ::Protocol::Table.new({"x-max-priority" => 1})
-      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-        false, false, queue_args)
-      q = LavinMQ::QueueFactory.make(Server.vhosts["/"], frame)
-      q.is_a?(LavinMQ::PriorityQueue).should be_true
+      with_amqp_server do |s|
+        durable = false
+        queue_args = AMQ::Protocol::Table.new({"x-max-priority" => 1})
+        frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
+          false, false, queue_args)
+        q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+        q.is_a?(LavinMQ::PriorityQueue).should be_true
+      end
     end
 
     it "should create a durable queue" do
-      durable = true
-      queue_args = AMQ::Protocol::Table.new({"x-max-priority" => 1})
-      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-        false, false, queue_args)
-      q = LavinMQ::QueueFactory.make(Server.vhosts["/"], frame)
-      q.is_a?(LavinMQ::DurablePriorityQueue).should be_true
+      with_amqp_server do |s|
+        durable = true
+        queue_args = AMQ::Protocol::Table.new({"x-max-priority" => 1})
+        frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
+          false, false, queue_args)
+        q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+        q.is_a?(LavinMQ::DurablePriorityQueue).should be_true
+      end
     end
 
     it "should create a stream queue" do
-      queue_args = AMQ::Protocol::Table.new({"x-queue-type" => "stream"})
-      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, true, false,
-        false, false, queue_args)
-      q = LavinMQ::QueueFactory.make(Server.vhosts["/"], frame)
-      q.should be_a LavinMQ::StreamQueue
+      with_amqp_server do |s|
+        queue_args = AMQ::Protocol::Table.new({"x-queue-type" => "stream"})
+        frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, true, false,
+          false, false, queue_args)
+        q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+        q.should be_a LavinMQ::StreamQueue
+      end
     end
   end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -3,41 +3,47 @@ require "./../src/lavinmq/queue"
 
 describe LavinMQ::Queue do
   it "Should dead letter expired messages" do
-    with_channel do |ch|
-      q = ch.queue("ttl", args: AMQP::Client::Arguments.new(
-        {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "dlq"}
-      ))
-      dlq = ch.queue("dlq")
-      x = ch.default_exchange
-      x.publish_confirm("ttl", q.name)
-      msg = wait_for { dlq.get }
-      msg.not_nil!.body_io.to_s.should eq "ttl"
-      q.get.should eq nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("ttl", args: AMQP::Client::Arguments.new(
+          {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "dlq"}
+        ))
+        dlq = ch.queue("dlq")
+        x = ch.default_exchange
+        x.publish_confirm("ttl", q.name)
+        msg = wait_for { dlq.get }
+        msg.not_nil!.body_io.to_s.should eq "ttl"
+        q.get.should eq nil
+      end
     end
   end
 
   it "Should not dead letter messages to it self due to queue length" do
-    with_channel do |ch|
-      q1 = ch.queue("", args: AMQP::Client::Arguments.new(
-        {"x-max-length" => 1, "x-dead-letter-exchange" => ""}
-      ))
-      q1.publish_confirm ""
-      q1.publish_confirm ""
-      q1.get.should_not be_nil
-      q1.get.should be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q1 = ch.queue("", args: AMQP::Client::Arguments.new(
+          {"x-max-length" => 1, "x-dead-letter-exchange" => ""}
+        ))
+        q1.publish_confirm ""
+        q1.publish_confirm ""
+        q1.get.should_not be_nil
+        q1.get.should be_nil
+      end
     end
   end
 
   it "Should dead letter messages to it self only if rejected" do
     queue_name = Random::Secure.hex
-    with_channel do |ch|
-      q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new(
-        {"x-dead-letter-exchange" => ""}
-      ))
-      ch.default_exchange.publish_confirm("", queue_name)
-      msg = q1.get(no_ack: false).not_nil!
-      msg.reject(requeue: false)
-      q1.get(no_ack: false).should_not be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new(
+          {"x-dead-letter-exchange" => ""}
+        ))
+        ch.default_exchange.publish_confirm("", queue_name)
+        msg = q1.get(no_ack: false).not_nil!
+        msg.reject(requeue: false)
+        q1.get(no_ack: false).should_not be_nil
+      end
     end
   end
 
@@ -45,94 +51,102 @@ describe LavinMQ::Queue do
     x_name = "paused"
     q_name = "paused"
     it "should pause the queue by setting it in flow (get)" do
-      with_channel do |ch|
-        x = ch.exchange(x_name, "direct")
-        q = ch.queue(q_name)
-        q.bind(x.name, q.name)
-        x.publish_confirm "test message", q.name
-        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x = ch.exchange(x_name, "direct")
+          q = ch.queue(q_name)
+          q.bind(x.name, q.name)
+          x.publish_confirm "test message", q.name
+          q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-        iq = Server.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
-        iq.pause!
+          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq.pause!
 
-        x.publish_confirm "test message 2", q.name
-        q.get(no_ack: true).should be_nil
+          x.publish_confirm "test message 2", q.name
+          q.get(no_ack: true).should be_nil
+        end
       end
     end
 
     it "should be able to declare queue as paused" do
-      Server.vhosts.create("/")
-      v = Server.vhosts["/"].not_nil!
-      v.declare_queue("q", true, false)
-      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
-      Server.vhosts["/"].queues["q"].pause!
-      File.exists?(File.join(data_dir, ".paused")).should be_true
-      Server.restart
-      Server.vhosts["/"].queues["q"].state.paused?.should be_true
-      Server.vhosts["/"].queues["q"].resume!
-      File.exists?(File.join(data_dir, ".paused")).should be_false
+      with_amqp_server do |s|
+        s.vhosts.create("/")
+        v = s.vhosts["/"].not_nil!
+        v.declare_queue("q", true, false)
+        data_dir = s.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
+        s.vhosts["/"].queues["q"].pause!
+        File.exists?(File.join(data_dir, ".paused")).should be_true
+        s.restart
+        s.vhosts["/"].queues["q"].state.paused?.should be_true
+        s.vhosts["/"].queues["q"].resume!
+        File.exists?(File.join(data_dir, ".paused")).should be_false
+      end
     end
 
     it "should pause the queue by setting it in flow (consume)" do
-      with_channel do |ch|
-        x = ch.exchange(x_name, "direct")
-        q = ch.queue(q_name)
-        q.bind(x.name, q.name)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x = ch.exchange(x_name, "direct")
+          q = ch.queue(q_name)
+          q.bind(x.name, q.name)
 
-        x.publish_confirm "test message", q.name
-        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+          x.publish_confirm "test message", q.name
+          q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-        iq = Server.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
-        iq.pause!
+          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq.pause!
 
-        x.publish_confirm "test message 2", q.name
-        channel = Channel(String).new
+          x.publish_confirm "test message 2", q.name
+          channel = Channel(String).new
 
-        # Subscribe on the queue
-        # Wait 1 second and unpause the queue, fail test if we get message during that time
-        # Make sure the queue continues
-        q.subscribe(no_ack: false) do |msg|
-          channel.send msg.body_io.to_s
-          ch.basic_ack(msg.delivery_tag)
+          # Subscribe on the queue
+          # Wait 1 second and unpause the queue, fail test if we get message during that time
+          # Make sure the queue continues
+          q.subscribe(no_ack: false) do |msg|
+            channel.send msg.body_io.to_s
+            ch.basic_ack(msg.delivery_tag)
+          end
+          select
+          when msg = channel.receive
+            fail "Consumer should not get a message '#{msg}'"
+          when timeout 2.seconds
+            iq.resume!
+          end
+          channel.receive.should eq "test message 2"
         end
-        select
-        when msg = channel.receive
-          fail "Consumer should not get a message '#{msg}'"
-        when timeout 2.seconds
-          iq.resume!
-        end
-        channel.receive.should eq "test message 2"
       end
     end
 
     it "should be able to get messages from paused queue with force flag" do
-      with_channel do |ch|
-        x = ch.exchange(x_name, "direct")
-        q = ch.queue(q_name)
-        q.bind(x.name, q.name)
-        x.publish_confirm "test message", q.name
-        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          x = ch.exchange(x_name, "direct")
+          q = ch.queue(q_name)
+          q.bind(x.name, q.name)
+          x.publish_confirm "test message", q.name
+          q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-        iq = Server.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
-        iq.pause!
+          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq.pause!
 
-        x.publish_confirm "test message 2", q.name
-        x.publish_confirm "test message 3", q.name
+          x.publish_confirm "test message 2", q.name
+          x.publish_confirm "test message 3", q.name
 
-        # cannot get from client, queue is paused
-        q.get(no_ack: true).should be_nil
+          # cannot get from client, queue is paused
+          q.get(no_ack: true).should be_nil
 
-        body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
-        response = post("/api/queues/%2f/#{q_name}/get", body: body)
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.size.should eq 1
-        # can get from UI/API even though queue is paused
-        body[0]["payload"].should eq "test message 2"
+          body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
+          response = http.post("/api/queues/%2f/#{q_name}/get", body: body)
+          response.status_code.should eq 200
+          body = JSON.parse(response.body)
+          body.size.should eq 1
+          # can get from UI/API even though queue is paused
+          body[0]["payload"].should eq "test message 2"
 
-        # resume queue and consume next msg
-        iq.resume!
-        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 3")
+          # resume queue and consume next msg
+          iq.resume!
+          q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 3")
+        end
       end
     end
   end
@@ -140,19 +154,21 @@ describe LavinMQ::Queue do
   describe "Close" do
     q_name = "close"
     it "should cancel consumer" do
-      tag = "consumer-to-be-canceled"
-      with_channel do |ch|
-        q = ch.queue(q_name)
-        queue = Server.vhosts["/"].queues[q_name].as(LavinMQ::DurableQueue)
-        q.publish_confirm "m1"
+      with_amqp_server do |s|
+        tag = "consumer-to-be-canceled"
+        with_channel(s) do |ch|
+          q = ch.queue(q_name)
+          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::DurableQueue)
+          q.publish_confirm "m1"
 
-        # Should get canceled
-        q.subscribe(tag: tag, no_ack: false, &.ack)
-        queue.close
-      end
+          # Should get canceled
+          q.subscribe(tag: tag, no_ack: false, &.ack)
+          queue.close
+        end
 
-      with_channel do |ch|
-        ch.has_subscriber?(tag).should eq false
+        with_channel(s) do |ch|
+          ch.has_subscriber?(tag).should eq false
+        end
       end
     end
   end
@@ -161,42 +177,46 @@ describe LavinMQ::Queue do
     x_name = "purge"
     q_name = "purge"
     it "should purge the queue" do
-      with_channel do |ch|
-        x = ch.exchange(x_name, "direct")
-        q = ch.queue(q_name, durable: true)
-        q.bind(x.name, q.name)
-        x.publish_confirm "test message 1", q.name
-        x.publish_confirm "test message 2", q.name
-        x.publish_confirm "test message 3", q.name
-        x.publish_confirm "test message 4", q.name
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          x = ch.exchange(x_name, "direct")
+          q = ch.queue(q_name, durable: true)
+          q.bind(x.name, q.name)
+          x.publish_confirm "test message 1", q.name
+          x.publish_confirm "test message 2", q.name
+          x.publish_confirm "test message 3", q.name
+          x.publish_confirm "test message 4", q.name
 
-        internal_queue = Server.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
-        internal_queue.message_count.should eq 4
+          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue.message_count.should eq 4
 
-        response = delete("/api/queues/%2f/#{q_name}/contents")
-        response.status_code.should eq 204
+          response = http.delete("/api/queues/%2f/#{q_name}/contents")
+          response.status_code.should eq 204
 
-        internal_queue.message_count.should eq 0
+          internal_queue.message_count.should eq 0
+        end
       end
     end
 
     it "should purge only X messages from queue" do
-      with_channel do |ch|
-        x = ch.exchange(x_name, "direct")
-        q = ch.queue(q_name, durable: true)
-        q.bind(x.name, q.name)
-        10.times do |i|
-          x.publish_confirm "test message #{i}", q.name
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          x = ch.exchange(x_name, "direct")
+          q = ch.queue(q_name, durable: true)
+          q.bind(x.name, q.name)
+          10.times do |i|
+            x.publish_confirm "test message #{i}", q.name
+          end
+
+          vhost = s.vhosts["/"]
+          internal_queue = vhost.exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue.message_count.should eq 10
+
+          response = http.delete("/api/queues/%2f/#{q_name}/contents?count=5")
+          response.status_code.should eq 204
+
+          internal_queue.message_count.should eq 5
         end
-
-        vhost = Server.vhosts["/"]
-        internal_queue = vhost.exchanges[x_name].queue_bindings[{q.name, nil}].first
-        internal_queue.message_count.should eq 10
-
-        response = delete("/api/queues/%2f/#{q_name}/contents?count=5")
-        response.status_code.should eq 204
-
-        internal_queue.message_count.should eq 5
       end
     end
   end
@@ -205,127 +225,139 @@ describe LavinMQ::Queue do
     x_name = "purge_and_close"
     q_name = "purge_and_close"
     it "should cancel all consumers on the queue" do
-      with_channel do |ch|
-        ch.prefetch 5
-        x = ch.exchange(x_name, "direct")
-        q = ch.queue(q_name, durable: true)
-        q.bind(x.name, q.name)
-        10.times do |i|
-          x.publish_confirm "test message #{i}", q.name
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 5
+          x = ch.exchange(x_name, "direct")
+          q = ch.queue(q_name, durable: true)
+          q.bind(x.name, q.name)
+          10.times do |i|
+            x.publish_confirm "test message #{i}", q.name
+          end
+
+          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+
+          internal_queue.message_count.should eq 10
+
+          channel = Channel(String).new(1)
+          # Get one message of the queue
+          q.subscribe(no_ack: false) do |msg|
+            channel.send msg.body_io.to_s
+            ch.basic_ack(msg.delivery_tag)
+          end
+
+          # 10 messages in total, 5 unacked and 5 ready
+          internal_queue.message_count.should eq 5
+
+          # Here we have one active consumer with 5 unacked messages.
+          internal_queue.consumers.first.unacked.should eq 5
+
+          # Purge should remove all of those
+          internal_queue.purge_and_close_consumers
+
+          # No messages left in the queue
+          internal_queue.message_count.should eq 0
+
+          # No consumers lest on the queue and therefore no unacked
+          internal_queue.consumers.empty?.should be_true
         end
-
-        internal_queue = Server.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
-
-        internal_queue.message_count.should eq 10
-
-        channel = Channel(String).new(1)
-        # Get one message of the queue
-        q.subscribe(no_ack: false) do |msg|
-          channel.send msg.body_io.to_s
-          ch.basic_ack(msg.delivery_tag)
-        end
-
-        # 10 messages in total, 5 unacked and 5 ready
-        internal_queue.message_count.should eq 5
-
-        # Here we have one active consumer with 5 unacked messages.
-        internal_queue.consumers.first.unacked.should eq 5
-
-        # Purge should remove all of those
-        internal_queue.purge_and_close_consumers
-
-        # No messages left in the queue
-        internal_queue.message_count.should eq 0
-
-        # No consumers lest on the queue and therefore no unacked
-        internal_queue.consumers.empty?.should be_true
       end
     end
   end
 
   it "should keep track of unacked basic_get messages" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm "a"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm "a"
 
-      msg = q.get(no_ack: false)
-      msg.should_not be_nil
-      sq = Server.vhosts["/"].queues[q.name]
-      sq.unacked_count.should eq 1
-      msg.not_nil!.ack
-      sleep 0.01
-      sq.unacked_count.should eq 0
+        msg = q.get(no_ack: false)
+        msg.should_not be_nil
+        sq = s.vhosts["/"].queues[q.name]
+        sq.unacked_count.should eq 1
+        msg.not_nil!.ack
+        sleep 0.01
+        sq.unacked_count.should eq 0
+      end
     end
   end
 
   it "should keep track of unacked deliviered messages" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm "a"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm "a"
 
-      done = Channel(AMQP::Client::DeliverMessage).new
-      q.subscribe(no_ack: false) do |msg|
-        done.send msg
+        done = Channel(AMQP::Client::DeliverMessage).new
+        q.subscribe(no_ack: false) do |msg|
+          done.send msg
+        end
+        msg = done.receive
+        sq = s.vhosts["/"].queues[q.name]
+        sq.unacked_count.should eq 1
+        msg.ack
+        sleep 0.01
+        sq.unacked_count.should eq 0
       end
-      msg = done.receive
-      sq = Server.vhosts["/"].queues[q.name]
-      sq.unacked_count.should eq 1
-      msg.ack
-      sleep 0.01
-      sq.unacked_count.should eq 0
     end
   end
 
   it "should delete transient queues on Server stop" do
-    with_channel do |ch|
-      ch.queue "transient", durable: false
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.queue "transient", durable: false
+      end
+      data_dir = s.vhosts["/"].queues["transient"].@msg_store.@queue_data_dir
+      s.stop
+      Dir.exists?(data_dir).should be_false
     end
-    data_dir = Server.vhosts["/"].queues["transient"].@msg_store.@queue_data_dir
-    Server.stop
-    Dir.exists?(data_dir).should be_false
   end
 
   it "should delete left over transient queue data on Server start" do
-    data_dir = ""
-    with_channel do |ch|
-      q = ch.queue "transient", durable: false
-      q.publish_confirm "foobar"
-      data_dir = Server.vhosts["/"].queues["transient"].@msg_store.@queue_data_dir
-      FileUtils.cp_r data_dir, "#{data_dir}.copy"
-    end
-    Server.stop
-    FileUtils.cp_r "#{data_dir}.copy", data_dir
-    Server.restart
-    with_channel do |ch|
-      q = ch.queue_declare "transient", durable: false
-      q[:message_count].should eq 0
-      q = ch.queue_declare "transient", passive: true
-      q[:message_count].should eq 0
+    with_amqp_server do |s|
+      data_dir = ""
+      with_channel(s) do |ch|
+        q = ch.queue "transient", durable: false
+        q.publish_confirm "foobar"
+        data_dir = s.vhosts["/"].queues["transient"].@msg_store.@queue_data_dir
+        FileUtils.cp_r data_dir, "#{data_dir}.copy"
+      end
+      s.stop
+      FileUtils.cp_r "#{data_dir}.copy", data_dir
+      s.restart
+      with_channel(s) do |ch|
+        q = ch.queue_declare "transient", durable: false
+        q[:message_count].should eq 0
+        q = ch.queue_declare "transient", passive: true
+        q[:message_count].should eq 0
+      end
     end
   end
 
   it "should delete queue with auto_delete when the last consumer disconnects" do
-    with_channel do |ch|
-      q = ch.queue("q", auto_delete: true)
-      data_dir = Server.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
-      sub = q.subscribe(no_ack: true) { |_| }
-      Dir.exists?(data_dir).should be_true
-      q.unsubscribe(sub)
-      sleep 0.1
-      Dir.exists?(data_dir).should be_false
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("q", auto_delete: true)
+        data_dir = s.vhosts["/"].queues["q"].@msg_store.@queue_data_dir
+        sub = q.subscribe(no_ack: true) { |_| }
+        Dir.exists?(data_dir).should be_true
+        q.unsubscribe(sub)
+        sleep 0.1
+        Dir.exists?(data_dir).should be_false
+      end
     end
   end
 
   describe "Flow" do
     it "should stop queues from being declared when disk is full" do
-      Server.flow(false)
-      with_channel do |ch|
-        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-          ch.queue("test_queue_flow", durable: true)
+      with_amqp_server do |s|
+        s.flow(false)
+        with_channel(s) do |ch|
+          expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+            ch.queue("test_queue_flow", durable: true)
+          end
         end
       end
-    ensure
-      Server.flow(true)
     end
   end
 
@@ -335,28 +367,37 @@ describe LavinMQ::Queue do
     it "should remove unused segments after being consumed" do
       data_dir = File.join(LavinMQ::Config.instance.data_dir, "msgstore")
       Dir.mkdir_p data_dir
-      store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
-      body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
-      msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
-      sps = Array(LavinMQ::SegmentPosition).new(10) { store.push msg }
-      sps.each { |sp| store.delete sp }
-      store.@segments.size.should be <= 2
+      begin
+        store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
+        body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
+        msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
+        sps = Array(LavinMQ::SegmentPosition).new(10) { store.push msg }
+        sps.each { |sp| store.delete sp }
+        Fiber.yield
+        store.@segments.size.should be <= 2
+      ensure
+        FileUtils.rm_rf data_dir
+      end
     end
 
     it "should not create ack files when cleaning up segments" do
       # This spec verifies a bugfix where one ack file per segment was created
-      data_dir = File.join(LavinMQ::Config.instance.data_dir, "msgstore")
+      data_dir = File.join(LavinMQ::Config.instance.data_dir, "msgstore2")
       Dir.mkdir_p data_dir
-      body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
-      msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
+      begin
+        body = IO::Memory.new(Random::DEFAULT.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
+        msg = LavinMQ::Message.new(0i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
 
-      store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
-      2.times { store.push msg }
-      store.close
+        store = LavinMQ::Queue::MessageStore.new(data_dir, nil)
+        2.times { store.push msg }
+        store.close
 
-      # recreate store to let it read the segments and cleanup
-      LavinMQ::Queue::MessageStore.new(data_dir, nil)
-      Dir.glob(File.join(data_dir, "acks.*")).size.should eq 0
+        # recreate store to let it read the segments and cleanup
+        LavinMQ::Queue::MessageStore.new(data_dir, nil)
+        Dir.glob(File.join(data_dir, "acks.*")).should eq [] of String
+      ensure
+        FileUtils.rm_rf data_dir
+      end
     end
 
     it "should yield fiber while purging" do

--- a/spec/random_spec.cr
+++ b/spec/random_spec.cr
@@ -3,30 +3,32 @@ require "./spec_helper"
 describe LavinMQ do
   describe "random" do
     pending "disconnects" do
-      with_channel do |ch|
-        q = ch.queue(qname)
-        loop do
-          q.publish "a" * 5000
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue(qname)
+          loop do
+            q.publish "a" * 5000
+          end
         end
-      end
-      with_channel do |ch|
-        conn = ch.@connection.@io.as(TCPSocket)
-        conn.linger = 0
-        q = ch.queue(qname)
-        count = 0
-        q.subscribe(no_ack: false) do |_msg|
-          count += 1
-        end
-        q.publish "1"
-        q.publish "2"
-        Fiber.yield
-        conn.close
-        Fiber.yield
-        count.should eq 0
+        with_channel(s) do |ch|
+          conn = ch.@connection.@io.as(TCPSocket)
+          conn.linger = 0
+          q = ch.queue(qname)
+          count = 0
+          q.subscribe(no_ack: false) do |_msg|
+            count += 1
+          end
+          q.publish "1"
+          q.publish "2"
+          Fiber.yield
+          conn.close
+          Fiber.yield
+          count.should eq 0
 
-        Fiber.yield
-        Server.vhosts["/"].queues[qname].@ready.size.should eq 2
-        Server.vhosts["/"].queues[qname].@unacked.size.should eq 0
+          Fiber.yield
+          Server.vhosts["/"].queues[qname].@ready.size.should eq 2
+          Server.vhosts["/"].queues[qname].@unacked.size.should eq 0
+        end
       end
     end
   end

--- a/spec/reply_to_spec.cr
+++ b/spec/reply_to_spec.cr
@@ -3,94 +3,112 @@ require "./spec_helper"
 describe LavinMQ::Server do
   describe "amq.direct.reply-to" do
     it "should allow amq.direct.reply-to to be declared" do
-      with_channel do |ch|
-        q = ch.queue("amq.direct.reply-to")
-        q.name.should eq "amq.direct.reply-to"
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("amq.direct.reply-to")
+          q.name.should eq "amq.direct.reply-to"
+        end
       end
     end
 
     it "should allow amq.rabbitmq.reply-to to be declared" do
-      with_channel do |ch|
-        q = ch.queue("amq.rabbitmq.reply-to")
-        q.name.should eq "amq.rabbitmq.reply-to"
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("amq.rabbitmq.reply-to")
+          q.name.should eq "amq.rabbitmq.reply-to"
+        end
       end
     end
 
     it "should be able to consume amq.direct.reply-to" do
-      with_channel do |ch|
-        consumer_tag = ch.queue("amq.direct.reply-to").subscribe("tag", no_ack: true) { }
-        consumer_tag.should eq "tag"
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          consumer_tag = ch.queue("amq.direct.reply-to").subscribe("tag", no_ack: true) { }
+          consumer_tag.should eq "tag"
+        end
       end
     end
 
     it "should be able to consume amq.rabbitmq.reply-to" do
-      with_channel do |ch|
-        consumer_tag = ch.queue("amq.rabbitmq.reply-to").subscribe("tag", no_ack: true) { }
-        consumer_tag.should eq "tag"
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          consumer_tag = ch.queue("amq.rabbitmq.reply-to").subscribe("tag", no_ack: true) { }
+          consumer_tag.should eq "tag"
+        end
       end
     end
 
     it "should require consumer to be in no-ack mode" do
       expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED/) do
-        with_channel do |ch|
-          ch.queue("amq.direct.reply-to").subscribe(no_ack: false) { }
+        with_amqp_server do |s|
+          with_channel(s) do |ch|
+            ch.queue("amq.direct.reply-to").subscribe(no_ack: false) { }
+          end
         end
       end
     end
 
     it "should set reply-to" do
-      with_channel do |ch|
-        ch.queue("amq.direct.reply-to").subscribe(no_ack: true) { }
-        q = ch.queue("test")
-        props = AMQ::Protocol::Properties.new(reply_to: "amq.direct.reply-to")
-        q.publish_confirm("test", props: props)
-        reply_to = q.get.not_nil!.properties.reply_to
-        reply_to.should match /^amq\.direct\.reply-to\..+$/
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.queue("amq.direct.reply-to").subscribe(no_ack: true) { }
+          q = ch.queue("test")
+          props = AMQ::Protocol::Properties.new(reply_to: "amq.direct.reply-to")
+          q.publish_confirm("test", props: props)
+          reply_to = q.get.not_nil!.properties.reply_to
+          reply_to.should match /^amq\.direct\.reply-to\..+$/
+        end
       end
     end
 
     it "should reject publish if no amq.direct.reply-to consumer" do
       expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED/) do
-        with_channel do |ch|
-          props = AMQ::Protocol::Properties.new(reply_to: "amq.direct.reply-to")
-          ch.queue("test")
-          e = ch.exchange("", "direct")
-          e.publish_confirm("test", "test", props: props)
+        with_amqp_server do |s|
+          with_channel(s) do |ch|
+            props = AMQ::Protocol::Properties.new(reply_to: "amq.direct.reply-to")
+            ch.queue("test")
+            e = ch.exchange("", "direct")
+            e.publish_confirm("test", "test", props: props)
+          end
         end
       end
     end
 
     it "should be ok to declare reply-to queue to check if consumer is connected" do
-      reply_to = ""
-      with_channel do |ch|
-        ch.queue("amq.direct.reply-to").subscribe(no_ack: true) { }
-        q = ch.queue("test")
-        props = AMQ::Protocol::Properties.new(reply_to: "amq.direct.reply-to")
-        q.publish_confirm("test", props: props)
-        reply_to = q.get.not_nil!.properties.reply_to.not_nil!
-        with_channel do |ch2|
-          drt = ch2.queue_declare(reply_to, passive: true)
-          drt[:consumer_count].should eq 1
+      with_amqp_server do |s|
+        reply_to = ""
+        with_channel(s) do |ch|
+          ch.queue("amq.direct.reply-to").subscribe(no_ack: true) { }
+          q = ch.queue("test")
+          props = AMQ::Protocol::Properties.new(reply_to: "amq.direct.reply-to")
+          q.publish_confirm("test", props: props)
+          reply_to = q.get.not_nil!.properties.reply_to.not_nil!
+          with_channel(s) do |ch2|
+            drt = ch2.queue_declare(reply_to, passive: true)
+            drt[:consumer_count].should eq 1
+          end
         end
-      end
 
-      expect_raises(AMQP::Client::Channel::ClosedException, /NOT_FOUND/) do
-        with_channel do |ch|
-          ch.queue_declare(reply_to)
+        expect_raises(AMQP::Client::Channel::ClosedException, /NOT_FOUND/) do
+          with_channel(s) do |ch|
+            ch.queue_declare(reply_to)
+          end
         end
       end
     end
 
     it "should return on mandatory publish to a reply routing key" do
-      with_channel do |ch|
-        ch1 = Channel(Tuple(UInt16, String)).new
-        ch.on_return do |msg|
-          ch1.send({msg.reply_code, msg.reply_text})
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch1 = Channel(Tuple(UInt16, String)).new
+          ch.on_return do |msg|
+            ch1.send({msg.reply_code, msg.reply_text})
+          end
+          ch.basic_publish("m1", "amq.direct", "amq.direct.reply-to.random", mandatory: true)
+          reply_code, reply_text = ch1.receive
+          reply_code.should eq 312
+          reply_text.should eq "NO_ROUTE"
         end
-        ch.basic_publish("m1", "amq.direct", "amq.direct.reply-to.random", mandatory: true)
-        reply_code, reply_text = ch1.receive
-        reply_code.should eq 312
-        reply_text.should eq "NO_ROUTE"
       end
     end
   end

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -2,991 +2,1121 @@ require "./spec_helper"
 
 describe LavinMQ::Server do
   it "accepts connections" do
-    with_channel do |ch|
-      x = ch.exchange("amq.topic", "topic", auto_delete: false, durable: true, internal: true, passive: true)
-      q = ch.queue
-      q.bind(x.name, "#")
-      pmsg = "test message"
-      x.publish pmsg, q.name
-      msg = q.get(no_ack: true).not_nil!
-      msg.body_io.to_s.should eq("test message")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange("amq.topic", "topic", auto_delete: false, durable: true, internal: true, passive: true)
+        q = ch.queue
+        q.bind(x.name, "#")
+        pmsg = "test message"
+        x.publish pmsg, q.name
+        msg = q.get(no_ack: true).not_nil!
+        msg.body_io.to_s.should eq("test message")
+      end
     end
   end
 
   it "can delete queue" do
-    with_channel do |ch|
-      q = ch.queue("del_q")
-      q.publish "m1"
-      q.delete
-    end
-    with_channel do |ch|
-      pmsg = "m2"
-      q = ch.queue("del_q")
-      q.publish pmsg
-      msg = q.get.not_nil!
-      msg.body_io.to_s.should eq("m2")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("del_q")
+        q.publish "m1"
+        q.delete
+      end
+      with_channel(s) do |ch|
+        pmsg = "m2"
+        q = ch.queue("del_q")
+        q.publish pmsg
+        msg = q.get.not_nil!
+        msg.body_io.to_s.should eq("m2")
+      end
     end
   end
 
   it "can reject message" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish "m1"
-      m1 = q.get(no_ack: false)
-      m1.try(&.reject)
-      m1 = q.get(no_ack: false)
-      m1.should eq(nil)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish "m1"
+        m1 = q.get(no_ack: false)
+        m1.try(&.reject)
+        m1 = q.get(no_ack: false)
+        m1.should eq(nil)
+      end
     end
   end
 
   it "can reject and requeue message" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish "m1"
-      m1 = q.get(no_ack: false)
-      m1.try(&.reject(requeue: true))
-      m1 = q.get(no_ack: false)
-      m1.not_nil!.body_io.to_s.should eq("m1")
-      m1.not_nil!.redelivered.should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish "m1"
+        m1 = q.get(no_ack: false)
+        m1.try(&.reject(requeue: true))
+        m1 = q.get(no_ack: false)
+        m1.not_nil!.body_io.to_s.should eq("m1")
+        m1.not_nil!.redelivered.should be_true
+      end
     end
   end
 
   it "can reject while consuming" do
-    done = ::Channel(Nil).new(1)
-    data = Bytes.new(1000)
-    spawn do
-      with_channel do |ch|
-        q = ch.queue("reject")
-        200.times do
-          q.publish data
+    with_amqp_server do |s|
+      done = ::Channel(Nil).new(1)
+      data = Bytes.new(1000)
+      spawn do
+        with_channel(s) do |ch|
+          q = ch.queue("reject")
+          200.times do
+            q.publish data
+          end
         end
       end
-    end
-    spawn do
-      with_channel do |ch|
-        ch.prefetch 10
-        q = ch.queue("reject")
-        q.subscribe(no_ack: false, block: true) do |msg|
-          msg.reject(requeue: false)
-          done.send nil
+      spawn do
+        with_channel(s) do |ch|
+          ch.prefetch 10
+          q = ch.queue("reject")
+          q.subscribe(no_ack: false, block: true) do |msg|
+            msg.reject(requeue: false)
+            done.send nil
+          end
         end
       end
-    end
-    timeout = false
-    200.times do
-      select
-      when done.receive
-      when timeout 1.seconds
-        timeout = true
+      timeout = false
+      200.times do
+        select
+        when done.receive
+        when timeout 1.seconds
+          timeout = true
+        end
       end
-    end
-    timeout.should be_false
-    with_channel do |ch|
-      ch.queue_declare("reject", passive: true)[:message_count].should eq 0
+      timeout.should be_false
+      with_channel(s) do |ch|
+        ch.queue_declare("reject", passive: true)[:message_count].should eq 0
+      end
     end
   end
 
   it "rejects all unacked msgs when disconnecting" do
-    with_channel do |ch|
-      pmsg = "m1"
-      q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
-      q.publish pmsg
-      q.get(no_ack: false)
-    end
-    with_channel do |ch|
-      q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
-      m1 = q.get(no_ack: true)
-      m1.not_nil!.body_io.to_s.should eq("m1")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        pmsg = "m1"
+        q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
+        q.publish pmsg
+        q.get(no_ack: false)
+      end
+      with_channel(s) do |ch|
+        q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
+        m1 = q.get(no_ack: true)
+        m1.not_nil!.body_io.to_s.should eq("m1")
+      end
     end
   end
 
   it "can delete exchange" do
-    with_channel do |ch|
-      x = ch.exchange("test_delete_exchange", "topic", durable: true)
-      x.delete
-      expect_raises(AMQP::Client::Channel::ClosedException) do
-        ch.exchange("test_delete_exchange", "topic", durable: true, passive: true)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange("test_delete_exchange", "topic", durable: true)
+        x.delete
+        expect_raises(AMQP::Client::Channel::ClosedException) do
+          ch.exchange("test_delete_exchange", "topic", durable: true, passive: true)
+        end
       end
     end
   end
 
   it "can auto delete exchange" do
-    with_channel do |ch|
-      ch.confirm_select
-      code = Channel(UInt16).new
-      ch.on_close do |c, _reply|
-        code.send c
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.confirm_select
+        code = Channel(UInt16).new
+        ch.on_close do |c, _reply|
+          code.send c
+        end
+        x = ch.exchange("test_ad_exchange", "topic", durable: false, auto_delete: true)
+        q = ch.queue
+        q.bind(x.name, "")
+        q.unbind(x.name, "")
+        x.publish("m1", q.name)
+        code.receive.should eq 404
+        sleep 0.01
+        ch.closed?.should be_true
       end
-      x = ch.exchange("test_ad_exchange", "topic", durable: false, auto_delete: true)
-      q = ch.queue
-      q.bind(x.name, "")
-      q.unbind(x.name, "")
-      x.publish("m1", q.name)
-      code.receive.should eq 404
-      sleep 0.01
-      ch.closed?.should be_true
     end
   end
 
   it "can purge a queue" do
-    with_channel do |ch|
-      q = ch.queue
-      4.times { q.publish "" }
-      q.purge[:message_count].should eq 4
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        4.times { q.publish "" }
+        q.purge[:message_count].should eq 4
+      end
     end
   end
 
   it "supports publisher confirms" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm("m1").should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm("m1").should be_true
+      end
     end
   end
 
   it "supports mandatory publish flag" do
-    with_channel do |ch|
-      pmsg = "m1"
-      ch1 = Channel(Tuple(UInt16, String)).new
-      ch.on_return do |msg|
-        ch1.send({msg.reply_code, msg.reply_text})
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        pmsg = "m1"
+        ch1 = Channel(Tuple(UInt16, String)).new
+        ch.on_return do |msg|
+          ch1.send({msg.reply_code, msg.reply_text})
+        end
+        ch.basic_publish(pmsg, "amq.direct", "none", mandatory: true)
+        reply_code, reply_text = ch1.receive
+        reply_code.should eq 312
+        reply_text.should eq "NO_ROUTE"
       end
-      ch.basic_publish(pmsg, "amq.direct", "none", mandatory: true)
-      reply_code, reply_text = ch1.receive
-      reply_code.should eq 312
-      reply_text.should eq "NO_ROUTE"
     end
   end
 
   it "can handle messages going to no queue" do
-    with_channel do |ch|
-      ch.basic_publish_confirm("m1", "amq.direct", "none").should eq true
-      ch.basic_publish_confirm("m2", "amq.direct", "none").should eq true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.basic_publish_confirm("m1", "amq.direct", "none").should eq true
+        ch.basic_publish_confirm("m2", "amq.direct", "none").should eq true
+      end
     end
   end
 
   it "expires messages" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm "expired", props: AMQP::Client::Properties.new(expiration: "0")
-      msg = q.get(no_ack: true)
-      msg.should be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm "expired", props: AMQP::Client::Properties.new(expiration: "0")
+        msg = q.get(no_ack: true)
+        msg.should be_nil
+      end
     end
   end
 
   it "expires multiple messages" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm "expired", props: AMQP::Client::Properties.new(expiration: "1")
-      sleep 0.2
-      q.publish_confirm "expired", props: AMQP::Client::Properties.new(expiration: "1")
-      sleep 0.2
-      msg = q.get(no_ack: true)
-      msg.should be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm "expired", props: AMQP::Client::Properties.new(expiration: "1")
+        sleep 0.2
+        q.publish_confirm "expired", props: AMQP::Client::Properties.new(expiration: "1")
+        sleep 0.2
+        msg = q.get(no_ack: true)
+        msg.should be_nil
+      end
     end
   end
 
   it "expires messages with message TTL on queue declaration" do
-    with_channel do |ch|
-      q, dlq = create_ttl_and_dl_queues(ch)
-      ttl_msg = "queue dlx"
-      q.publish_confirm ttl_msg
-      msg = wait_for { dlq.get(no_ack: true) }
-      msg.not_nil!.body_io.to_s.should eq(ttl_msg)
-      Server.vhosts["/"].queues[q.name].empty?.should be_true
-      q.publish_confirm ttl_msg
-      msg = wait_for { dlq.get(no_ack: true) }
-      msg.not_nil!.body_io.to_s.should eq(ttl_msg)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q, dlq = create_ttl_and_dl_queues(ch)
+        ttl_msg = "queue dlx"
+        q.publish_confirm ttl_msg
+        msg = wait_for { dlq.get(no_ack: true) }
+        msg.not_nil!.body_io.to_s.should eq(ttl_msg)
+        s.vhosts["/"].queues[q.name].empty?.should be_true
+        q.publish_confirm ttl_msg
+        msg = wait_for { dlq.get(no_ack: true) }
+        msg.not_nil!.body_io.to_s.should eq(ttl_msg)
+      end
     end
   end
 
   it "expires messages with TTL on requeue" do
-    with_channel do |ch|
-      q, dlq = create_ttl_and_dl_queues(ch, queue_ttl: 500)
-      r_msg = "requeue msg"
-      q.publish_confirm r_msg
-      msg = q.get(no_ack: false).not_nil!
-      msg.reject(requeue: true)
-      msg = wait_for { dlq.get(no_ack: true) }
-      msg.not_nil!.body_io.to_s.should eq(r_msg)
-      Server.vhosts["/"].queues[q.name].empty?.should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q, dlq = create_ttl_and_dl_queues(ch, queue_ttl: 500)
+        r_msg = "requeue msg"
+        q.publish_confirm r_msg
+        msg = q.get(no_ack: false).not_nil!
+        msg.reject(requeue: true)
+        msg = wait_for { dlq.get(no_ack: true) }
+        msg.not_nil!.body_io.to_s.should eq(r_msg)
+        s.vhosts["/"].queues[q.name].empty?.should be_true
+      end
     end
   end
 
   it "can publish and consume messages larger than 128kb" do
-    with_channel do |ch|
-      lmsg = "a" * 5_00_000
-      q = ch.queue "lmsg_q"
-      q.publish_confirm lmsg
-      q.subscribe(no_ack: true) do |msg|
-        msg.should_not be_nil
-        msg.body_io.to_s.should eq(lmsg)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        lmsg = "a" * 5_00_000
+        q = ch.queue "lmsg_q"
+        q.publish_confirm lmsg
+        q.subscribe(no_ack: true) do |msg|
+          msg.should_not be_nil
+          msg.body_io.to_s.should eq(lmsg)
+        end
       end
     end
   end
 
   it "does not requeue messages on consumer close" do
-    with_channel do |ch|
-      q = ch.queue "msg_q"
-      q.publish_confirm "no requeue"
-      done = Channel(Nil).new
-      tag = q.subscribe(no_ack: false) { |_| done.send nil }
-      done.receive
-      q.unsubscribe(tag)
-      Server.vhosts["/"].queues["msg_q"].empty?.should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue "msg_q"
+        q.publish_confirm "no requeue"
+        done = Channel(Nil).new
+        tag = q.subscribe(no_ack: false) { |_| done.send nil }
+        done.receive
+        q.unsubscribe(tag)
+        s.vhosts["/"].queues["msg_q"].empty?.should be_true
+      end
     end
   end
 
   it "dead-letter expired messages" do
-    with_channel do |ch|
-      dlq = ch.queue
-      ch.queue("exp")
-
-      hdrs = AMQP::Client::Arguments.new
-      hdrs["x-dead-letter-exchange"] = ""
-      hdrs["x-dead-letter-routing-key"] = dlq.name
-      x = ch.exchange("", "direct", passive: true)
-      x.publish_confirm "dead letter", "exp", props: AMQP::Client::Properties.new(expiration: "0", headers: hdrs)
-      msg = wait_for { dlq.get(no_ack: true) }
-      msg.not_nil!.body_io.to_s.should eq("dead letter")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        dlq = ch.queue
+        ch.queue("exp")
+        hdrs = AMQP::Client::Arguments.new
+        hdrs["x-dead-letter-exchange"] = ""
+        hdrs["x-dead-letter-routing-key"] = dlq.name
+        x = ch.exchange("", "direct", passive: true)
+        x.publish_confirm "dead letter", "exp", props: AMQP::Client::Properties.new(expiration: "0", headers: hdrs)
+        msg = wait_for { dlq.get(no_ack: true) }
+        msg.not_nil!.body_io.to_s.should eq("dead letter")
+      end
     end
   end
 
   it "dead-letter expired messages to non existing exchange" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 1
-      args["x-dead-letter-exchange"] = "not_found"
-      q = ch.queue "", durable: false, exclusive: true, args: args
-
-      q.publish_confirm "1"
-      q.publish_confirm "2"
-      q.publish_confirm "3"
-      msg = q.get(no_ack: true)
-      msg.should_not be_nil
-      msg.not_nil!.body_io.to_s.should eq "3"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 1
+        args["x-dead-letter-exchange"] = "not_found"
+        q = ch.queue "", durable: false, exclusive: true, args: args
+        q.publish_confirm "1"
+        q.publish_confirm "2"
+        q.publish_confirm "3"
+        msg = q.get(no_ack: true)
+        msg.should_not be_nil
+        msg.not_nil!.body_io.to_s.should eq "3"
+      end
     end
   end
 
   it "dead-letter preserves headers" do
-    with_channel do |ch|
-      dlq = ch.queue
-      ch.queue("exp")
-
-      hdrs = AMQP::Client::Arguments.new
-      hdrs["custom1"] = "v1"
-      hdrs["custom2"] = "v2"
-      hdrs["x-dead-letter-exchange"] = ""
-      hdrs["x-dead-letter-routing-key"] = dlq.name
-      x = ch.exchange("", "direct", passive: true)
-      x.publish_confirm "dead letter", "exp", props: AMQP::Client::Properties.new(expiration: "0", headers: hdrs)
-      msg = wait_for { dlq.get(no_ack: true) }
-      headers = msg.properties.headers.should_not be_nil
-      headers.has_key?("custom1").should be_true
-      headers.has_key?("custom2").should be_true
-      headers["custom1"].should eq "v1"
-      headers["custom2"].should eq "v2"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        dlq = ch.queue
+        ch.queue("exp")
+        hdrs = AMQP::Client::Arguments.new
+        hdrs["custom1"] = "v1"
+        hdrs["custom2"] = "v2"
+        hdrs["x-dead-letter-exchange"] = ""
+        hdrs["x-dead-letter-routing-key"] = dlq.name
+        x = ch.exchange("", "direct", passive: true)
+        x.publish_confirm "dead letter", "exp", props: AMQP::Client::Properties.new(expiration: "0", headers: hdrs)
+        msg = wait_for { dlq.get(no_ack: true) }
+        headers = msg.properties.headers.should_not be_nil
+        headers.has_key?("custom1").should be_true
+        headers.has_key?("custom2").should be_true
+        headers["custom1"].should eq "v1"
+        headers["custom2"].should eq "v2"
+      end
     end
   end
 
   it "can publish to queues with max-length 0 if there's consumers" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 0
-      q = ch.queue "", durable: false, exclusive: true, args: args
-      mch = Channel(AMQP::Client::DeliverMessage).new(2)
-      q.subscribe(no_ack: true) do |msg|
-        mch.send msg
-      end
-      q.publish "1"
-      q.publish "2"
-      2.times do
-        select
-        when msg = mch.receive?
-          msg.should_not be_nil
-        when timeout 2.seconds
-          raise "timeout"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 0
+        q = ch.queue "", durable: false, exclusive: true, args: args
+        mch = Channel(AMQP::Client::DeliverMessage).new(2)
+        q.subscribe(no_ack: true) do |msg|
+          mch.send msg
+        end
+        q.publish "1"
+        q.publish "2"
+        2.times do
+          select
+          when msg = mch.receive?
+            msg.should_not be_nil
+          when timeout 2.seconds
+            raise "timeout"
+          end
         end
       end
     end
   end
 
   it "should still drop_overflow even with slow consumers" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 2
-      q = ch.queue "", durable: false, exclusive: true, args: args
-      mch = Channel(AMQP::Client::DeliverMessage).new(10)
-      ch.prefetch 1
-      q.subscribe(no_ack: false) do |msg|
-        mch.send msg
-        sleep 0.2
-        msg.ack
-      end
-      10.times do |i|
-        q.publish_confirm i.to_s
-      end
-      mch.close
-      if m = mch.receive?
-        m.body_io.to_s.should eq "0"
-      end
-      if m = mch.receive?
-        m.body_io.to_s.should eq "8"
-      end
-      if m = mch.receive?
-        m.body_io.to_s.should eq "9"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 2
+        q = ch.queue "", durable: false, exclusive: true, args: args
+        mch = Channel(AMQP::Client::DeliverMessage).new(10)
+        ch.prefetch 1
+        q.subscribe(no_ack: false) do |msg|
+          mch.send msg
+          sleep 0.2
+          msg.ack
+        end
+        10.times do |i|
+          q.publish_confirm i.to_s
+        end
+        mch.close
+        if m = mch.receive?
+          m.body_io.to_s.should eq "0"
+        end
+        if m = mch.receive?
+          m.body_io.to_s.should eq "8"
+        end
+        if m = mch.receive?
+          m.body_io.to_s.should eq "9"
+        end
       end
     end
   end
 
   it "msgs publish to queue w/o consumers with max-length 0 will be dropped" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 0
-      q = ch.queue "", durable: false, exclusive: true, args: args
-      q.publish_confirm "1"
-      q.publish_confirm "2"
-      q.get.should be_nil
-      q.get.should be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 0
+        q = ch.queue "", durable: false, exclusive: true, args: args
+        q.publish_confirm "1"
+        q.publish_confirm "2"
+        q.get.should be_nil
+        q.get.should be_nil
+      end
     end
   end
 
   it "handle immediate flag" do
-    with_channel do |ch|
-      pmsg = "m1"
-      reply_code = 0
-      reply_msg = nil
-      ch.on_return do |msg|
-        reply_code = msg.reply_code
-        reply_msg = msg.reply_text
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        pmsg = "m1"
+        reply_code = 0
+        reply_msg = nil
+        ch.on_return do |msg|
+          reply_code = msg.reply_code
+          reply_msg = msg.reply_text
+        end
+        ch.basic_publish(pmsg, "amq.topic", "rk", mandatory: false, immediate: true)
+        wait_for { reply_code == 313 }
+        reply_code.should eq 313
       end
-      ch.basic_publish(pmsg, "amq.topic", "rk", mandatory: false, immediate: true)
-      wait_for { reply_code == 313 }
-      reply_code.should eq 313
     end
   end
 
   it "can cancel consumers" do
-    {% if flag?(:freebsd) %} pending! {% end %}
-    with_channel do |ch|
-      q = ch.queue("", auto_delete: false, durable: true, exclusive: false)
-      q.publish "m1"
-      msgs = [] of AMQP::Client::DeliverMessage
-      tag = q.subscribe { |msg| msgs << msg }
-      q.unsubscribe(tag)
-      sleep 0.01
-      ch.has_subscriber?(tag).should eq false
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("", auto_delete: false, durable: true, exclusive: false)
+        q.publish "m1"
+        msgs = [] of AMQP::Client::DeliverMessage
+        tag = q.subscribe { |msg| msgs << msg }
+        q.unsubscribe(tag)
+        sleep 0.01
+        ch.has_subscriber?(tag).should eq false
+      end
     end
   end
 
   it "supports header exchange all" do
-    with_channel do |ch|
-      q = ch.queue
-      hdrs = AMQP::Client::Arguments.new
-      hdrs["x-match"] = "all"
-      hdrs["org"] = "84codes"
-      hdrs["user"] = "test"
-      x = ch.exchange("asdasdasd", "headers", passive: false, args: hdrs)
-      q.bind(x.name, "")
-      x.publish_confirm "m1", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
-      hdrs["user"] = "hest"
-      x.publish_confirm "m2", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
-      q.get.should_not be_nil
-      q.get.should be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        hdrs = AMQP::Client::Arguments.new
+        hdrs["x-match"] = "all"
+        hdrs["org"] = "84codes"
+        hdrs["user"] = "test"
+        x = ch.exchange("asdasdasd", "headers", passive: false, args: hdrs)
+        q.bind(x.name, "")
+        x.publish_confirm "m1", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
+        hdrs["user"] = "hest"
+        x.publish_confirm "m2", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
+        q.get.should_not be_nil
+        q.get.should be_nil
+      end
     end
   end
 
   it "supports header exchange any" do
-    with_channel do |ch|
-      q = ch.queue
-      hdrs = AMQP::Client::Arguments.new
-      hdrs["x-match"] = "any"
-      hdrs["org"] = "84codes"
-      hdrs["user"] = "test"
-      x = ch.exchange("hx1", "headers", passive: false, args: hdrs)
-      q.bind(x.name, "")
-      x.publish "m1", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
-      hdrs["user"] = "hest"
-      x.publish "m2", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
-      msgs = Channel(AMQP::Client::DeliverMessage).new(2)
-      q.subscribe { |msg| msgs.send msg }
-      spawn { sleep 5; msgs.close }
-      2.times { msgs.receive?.should_not be_nil }
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        hdrs = AMQP::Client::Arguments.new
+        hdrs["x-match"] = "any"
+        hdrs["org"] = "84codes"
+        hdrs["user"] = "test"
+        x = ch.exchange("hx1", "headers", passive: false, args: hdrs)
+        q.bind(x.name, "")
+        x.publish "m1", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
+        hdrs["user"] = "hest"
+        x.publish "m2", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
+        msgs = Channel(AMQP::Client::DeliverMessage).new(2)
+        q.subscribe { |msg| msgs.send msg }
+        spawn { sleep 5; msgs.close }
+        2.times { msgs.receive?.should_not be_nil }
+      end
     end
   end
 
   it "validates header exchange x-match" do
-    with_channel do |ch|
-      hdrs = AMQP::Client::Arguments.new
-      hdrs["x-match"] = "fail"
-      expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-        ch.exchange("hx1", "headers", passive: false, args: hdrs)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        hdrs = AMQP::Client::Arguments.new
+        hdrs["x-match"] = "fail"
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          ch.exchange("hx1", "headers", passive: false, args: hdrs)
+        end
       end
     end
   end
 
   it "validates header exchange binding with x-match" do
-    with_channel do |ch|
-      hdrs = AMQP::Client::Arguments.new
-      hdrs["x-match"] = 123
-      q = ch.queue
-      expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-        q.bind("amq.headers", "", args: hdrs)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        hdrs = AMQP::Client::Arguments.new
+        hdrs["x-match"] = 123
+        q = ch.queue
+        expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+          q.bind("amq.headers", "", args: hdrs)
+        end
       end
     end
   end
 
   it "should persist exchange-exchange binding" do
-    hdrs = AMQP::Client::Arguments.new
-    hdrs["x-match"] = "all"
-    hdrs["org"] = "84codes"
-    hdrs["user"] = "test"
+    with_amqp_server do |s|
+      hdrs = AMQP::Client::Arguments.new
+      hdrs["org"] = "84codes"
+      hdrs["user"] = "test"
+      with_channel(s) do |ch|
+        topic_x = ch.exchange("topic_exchange", "topic", passive: false)
+        headers_x = ch.exchange("headers_exchange", "headers", passive: false)
+        topic_x.bind(exchange: headers_x.name, routing_key: "", args: hdrs)
+      end
+      s.restart
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.bind("topic_exchange", "#")
 
-    with_channel do |ch|
-      topic_x = ch.exchange("topic_exchange", "topic", passive: false)
-      headers_x = ch.exchange("headers_exchange", "headers", passive: false)
-      topic_x.bind(exchange: headers_x.name, routing_key: "", args: hdrs)
-    end
+        ch.basic_publish_confirm "m1", "headers_exchange", "test", props: AMQP::Client::Properties.new(headers: hdrs)
 
-    Server.restart
+        hdrs["user"] = "hest"
+        ch.basic_publish_confirm "m2", "headers_exchange", "test", props: AMQP::Client::Properties.new(headers: hdrs)
 
-    with_channel do |ch|
-      q = ch.queue
-      q.bind("topic_exchange", "#")
-
-      ch.basic_publish_confirm "m1", "headers_exchange", "test", props: AMQP::Client::Properties.new(headers: hdrs)
-
-      hdrs["user"] = "hest"
-      ch.basic_publish_confirm "m2", "headers_exchange", "test", props: AMQP::Client::Properties.new(headers: hdrs)
-
-      q.get.should_not be_nil
-      q.get.should be_nil
+        q.get.should_not be_nil
+        q.get.should be_nil
+      end
     end
   end
 
   it "splits frames into max frame sizes" do
-    with_channel(frame_max: 4096_u32) do |ch|
-      2.times do
-        msg_size = (2**17 + 1)
-        pmsg1 = "m" * msg_size
-        sha1 = Digest::SHA1.digest pmsg1
-        q = ch.queue
-        q.purge
-        q.publish_confirm pmsg1
-        msg = q.get(no_ack: true)
-        msg.not_nil!.body_io.size.should eq msg_size
-        Digest::SHA1.digest(msg.not_nil!.body_io).should eq sha1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        2.times do
+          msg_size = (2**17 + 1)
+          pmsg1 = "m" * msg_size
+          sha1 = Digest::SHA1.digest pmsg1
+          q = ch.queue
+          q.purge
+          q.publish_confirm pmsg1
+          msg = q.get(no_ack: true)
+          msg.not_nil!.body_io.size.should eq msg_size
+          Digest::SHA1.digest(msg.not_nil!.body_io).should eq sha1
+        end
       end
     end
   end
 
   it "can receive and deliver multiple large messages" do
     pmsg = "a" * 150_000
-    with_channel do |ch|
-      2.times do
-        q = ch.queue
-        q.publish pmsg
-        msg = q.get
-        msg.not_nil!.body_io.to_s.should eq pmsg
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        2.times do
+          q = ch.queue
+          q.publish pmsg
+          msg = q.get
+          msg.not_nil!.body_io.to_s.should eq pmsg
+        end
       end
     end
   end
 
   it "acking an invalid delivery tag should close the channel" do
-    with_channel do |ch|
-      cch = Channel(Tuple(UInt16, String)).new
-      ch.on_close do |code, text|
-        cch.send({code, text})
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        cch = Channel(Tuple(UInt16, String)).new
+        ch.on_close do |code, text|
+          cch.send({code, text})
+        end
+        ch.basic_ack(999_u64)
+        c, _ = cch.receive
+        c.should eq 406
       end
-      ch.basic_ack(999_u64)
-      c, _ = cch.receive
-      c.should eq 406
     end
   end
 
   it "acking tag 0 with multiple=true should not close the channel" do
-    with_channel do |ch|
-      ch.basic_ack(0, multiple: true)
-      sleep 0.01
-      ch.basic_ack(0, multiple: true)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.basic_ack(0, multiple: true)
+        sleep 0.01
+        ch.basic_ack(0, multiple: true)
+      end
     end
   end
 
   it "can bind exchanges to exchanges" do
-    with_channel do |ch|
-      x1 = ch.exchange("x1", "direct")
-      x2 = ch.exchange("x2", "direct")
-      x2.bind(x1.name, "e2e")
-      q = ch.queue("e2e", auto_delete: true, durable: false, exclusive: false)
-      q.bind(x2.name, "e2e")
-      pmsg = "test message"
-      x1.publish_confirm pmsg, "e2e"
-      Fiber.yield
-      msg = q.get(no_ack: true)
-      msg.not_nil!.body_io.to_s.should eq("test message")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x1 = ch.exchange("x1", "direct")
+        x2 = ch.exchange("x2", "direct")
+        x2.bind(x1.name, "e2e")
+        q = ch.queue("e2e", auto_delete: true, durable: false, exclusive: false)
+        q.bind(x2.name, "e2e")
+        pmsg = "test message"
+        x1.publish_confirm pmsg, "e2e"
+        Fiber.yield
+        msg = q.get(no_ack: true)
+        msg.not_nil!.body_io.to_s.should eq("test message")
+      end
     end
   end
 
   it "supports x-max-length drop-head" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 1_i64
-      q = ch.queue("", args: args)
-      q.publish_confirm "m1"
-      q.publish_confirm "m2"
-      msgs = [] of AMQP::Client::DeliverMessage
-      q.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size >= 1 }
-      msgs.size.should eq 1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 1_i64
+        q = ch.queue("", args: args)
+        q.publish_confirm "m1"
+        q.publish_confirm "m2"
+        msgs = [] of AMQP::Client::DeliverMessage
+        q.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size >= 1 }
+        msgs.size.should eq 1
+      end
     end
   end
 
   it "supports x-max-length reject-publish" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 1_i64
-      args["x-overflow"] = "reject-publish"
-      q1 = ch.queue("test1", durable: true, args: args)
-      q2 = ch.queue("test2", durable: true)
-      x1 = ch.exchange("x345", "topic")
-      q1.bind(x1.name, "rk")
-      q2.bind(x1.name, "rk")
-      x1.publish_confirm("m1", "rk").should be_true
-      x1.publish_confirm("m2", "rk").should be_false
-      q1.publish_confirm("m3").should be_false
-      q2.publish_confirm("m4").should be_true
-      msgs = [] of AMQP::Client::DeliverMessage
-      q1.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 1_i64
+        args["x-overflow"] = "reject-publish"
+        q1 = ch.queue("test1", durable: true, args: args)
+        q2 = ch.queue("test2", durable: true)
+        x1 = ch.exchange("x345", "topic")
+        q1.bind(x1.name, "rk")
+        q2.bind(x1.name, "rk")
+        x1.publish_confirm("m1", "rk").should be_true
+        x1.publish_confirm("m2", "rk").should be_false
+        q1.publish_confirm("m3").should be_false
+        q2.publish_confirm("m4").should be_true
+        msgs = [] of AMQP::Client::DeliverMessage
+        q1.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+      end
     end
   end
 
   it "drop overflow when max-length is applied" do
-    with_channel do |ch|
-      q = ch.queue("mlq")
-      q.publish_confirm("m1").should be_true
-      q.publish_confirm("m2").should be_true
-      definitions = {
-        "max-length" => JSON::Any.new(1_i64),
-      } of String => JSON::Any
-      Server.vhosts["/"].add_policy("test", "^mlq$", "queues", definitions, 10_i8)
-      sleep 0.01
-      Server.vhosts["/"].queues["mlq"].message_count.should eq 1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("mlq")
+        q.publish_confirm("m1").should be_true
+        q.publish_confirm("m2").should be_true
+        definitions = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+        s.vhosts["/"].add_policy("test", "^mlq$", "queues", definitions, 10_i8)
+        sleep 0.01
+        s.vhosts["/"].queues["mlq"].message_count.should eq 1
+      end
     end
   end
 
   it "disallows creating queues starting with amq." do
     expect_raises(AMQP::Client::Channel::ClosedException, /REFUSED/) do
-      with_channel do |ch|
-        ch.queue("amq.test")
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.queue("amq.test")
+        end
       end
     end
   end
 
   it "disallows deleting exchanges named amq.*" do
-    expect_raises(AMQP::Client::Channel::ClosedException, /REFUSED/) do
-      with_channel do |ch|
-        ch.exchange("amq.topic", "topic", passive: true).delete
+    with_amqp_server do |s|
+      expect_raises(AMQP::Client::Channel::ClosedException, /REFUSED/) do
+        with_channel(s) do |ch|
+          ch.exchange("amq.topic", "topic", passive: true).delete
+        end
       end
-    end
-    with_channel do |ch|
-      ch.exchange("amq.topic", "topic", passive: true).should_not be_nil
+      with_channel(s) do |ch|
+        ch.exchange("amq.topic", "topic", passive: true).should_not be_nil
+      end
     end
   end
 
   it "disallows creating new exchanges named amq.*" do
     expect_raises(AMQP::Client::Channel::ClosedException, /REFUSED/) do
-      with_channel do |ch|
-        ch.exchange("amq.topic2", "topic")
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.exchange("amq.topic2", "topic")
+        end
       end
     end
   end
 
   it "only allow one consumer on when exlusive consumers flag is set" do
-    with_channel do |ch|
-      q = ch.queue("exlusive_consumer", auto_delete: true)
-      q.subscribe(exclusive: true) { }
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("exlusive_consumer", auto_delete: true)
+        q.subscribe(exclusive: true) { }
 
-      expect_raises(AMQP::Client::Channel::ClosedException, /ACCESS_REFUSED/) do
-        with_channel do |ch2|
-          q2 = ch2.queue("exlusive_consumer", passive: true)
-          q2.subscribe { }
+        expect_raises(AMQP::Client::Channel::ClosedException, /ACCESS_REFUSED/) do
+          with_channel(s) do |ch2|
+            q2 = ch2.queue("exlusive_consumer", passive: true)
+            q2.subscribe { }
+          end
         end
       end
-    end
-    with_channel do |ch|
-      q = ch.queue("exlusive_consumer", auto_delete: true)
-      q.subscribe { }
+      with_channel(s) do |ch|
+        q = ch.queue("exlusive_consumer", auto_delete: true)
+        q.subscribe { }
+      end
     end
   end
 
   it "only allow one connection access an exlusive queues" do
-    with_channel do |ch|
-      ch.queue("exlusive_queue", durable: true, exclusive: true)
-      expect_raises(AMQP::Client::Channel::ClosedException, /RESOURCE_LOCKED/) do
-        with_channel do |ch2|
-          ch2.queue("exlusive_queue", passive: true)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.queue("exlusive_queue", durable: true, exclusive: true)
+        expect_raises(AMQP::Client::Channel::ClosedException, /RESOURCE_LOCKED/) do
+          with_channel(s) do |ch2|
+            ch2.queue("exlusive_queue", passive: true)
+          end
         end
       end
     end
   end
 
   it "it does persists transient msgs between restarts" do
-    with_channel do |ch|
-      ch.confirm_select
-      q = ch.queue("durable_queue", durable: true)
-      1000.times do |i|
-        delivery_mode = i % 2 == 0 ? 2_u8 : 0_u8
-        props = AMQP::Client::Properties.new(delivery_mode: delivery_mode)
-        q.publish(i.to_s, props: props)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.confirm_select
+        q = ch.queue("durable_queue", durable: true)
+        1000.times do |i|
+          delivery_mode = i % 2 == 0 ? 2_u8 : 0_u8
+          props = AMQP::Client::Properties.new(delivery_mode: delivery_mode)
+          q.publish(i.to_s, props: props)
+        end
+        ch.wait_for_confirms
       end
-      ch.wait_for_confirms
-    end
-    Server.restart
-    with_channel do |ch|
-      q = ch.queue("durable_queue", durable: true)
-      deleted_msgs = q.delete
-      deleted_msgs[:message_count].should eq 1000
+      s.restart
+      with_channel(s) do |ch|
+        q = ch.queue("durable_queue", durable: true)
+        deleted_msgs = q.delete
+        deleted_msgs[:message_count].should eq 1000
+      end
     end
   end
 
   it "it does remeber acked msgs between restarts" do
-    with_channel do |ch|
-      ch.confirm_select
-      q = ch.queue("q")
-      1000.times do |i|
-        q.publish("a")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.confirm_select
+        q = ch.queue("q")
+        1000.times do
+          q.publish("a")
+        end
+        ch.wait_for_confirms
+        q.message_count.should eq 1000
+        q.subscribe(no_ack: false, tag: "c", block: true) do |msg|
+          msg.ack
+          q.unsubscribe("c") if msg.delivery_tag == 1000
+        end
+        q.message_count.should eq 0
       end
-      ch.wait_for_confirms
-      q.message_count.should eq 1000
-      q.subscribe(no_ack: false, tag: "c", block: true) do |msg|
-        msg.ack
-        q.unsubscribe("c") if msg.delivery_tag == 1000
+      s.restart
+      with_channel(s) do |ch|
+        q = ch.queue("q")
+        q.message_count.should eq 0
       end
-      q.message_count.should eq 0
-    end
-    Server.restart
-    with_channel do |ch|
-      q = ch.queue("q")
-      q.message_count.should eq 0
     end
   end
 
   it "supports max-length" do
-    definitions = {"max-length" => JSON::Any.new(1_i64)}
-    Server.vhosts["/"].add_policy("ml", "^.*$", "queues", definitions, 10_i8)
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm("m1").should be_true
-      q.publish_confirm("m2").should be_true
-      msgs = [] of AMQP::Client::DeliverMessage
-      q.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
+    with_amqp_server do |s|
+      definitions = {"max-length" => JSON::Any.new(1_i64)}
+      s.vhosts["/"].add_policy("ml", "^.*$", "queues", definitions, 10_i8)
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm("m1").should be_true
+        q.publish_confirm("m2").should be_true
+        msgs = [] of AMQP::Client::DeliverMessage
+        q.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+      end
     end
   end
 
   it "supports alternate-exchange" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["alternate-exchange"] = "ae"
-      x1 = ch.exchange("x1", "topic", args: args)
-      ae = ch.exchange("ae", "topic")
-      q = ch.queue
-      q.bind(ae.name, "*")
-      x1.publish("m1", "rk")
-      msg = q.get(no_ack: true)
-      msg.not_nil!.body_io.to_s.should eq("m1")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["alternate-exchange"] = "ae"
+        x1 = ch.exchange("x1", "topic", args: args)
+        ae = ch.exchange("ae", "topic")
+        q = ch.queue
+        q.bind(ae.name, "*")
+        x1.publish("m1", "rk")
+        msg = q.get(no_ack: true)
+        msg.not_nil!.body_io.to_s.should eq("m1")
+      end
     end
   end
 
   it "supports x-alternate-exchange" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-alternate-exchange"] = "ae"
-      x1 = ch.exchange("x1", "topic", args: args)
-      ae = ch.exchange("ae", "topic")
-      q = ch.queue
-      q.bind(ae.name, "*")
-      x1.publish("m1", "rk")
-      msg = q.get(no_ack: true)
-      msg.not_nil!.body_io.to_s.should eq("m1")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-alternate-exchange"] = "ae"
+        x1 = ch.exchange("x1", "topic", args: args)
+        ae = ch.exchange("ae", "topic")
+        q = ch.queue
+        q.bind(ae.name, "*")
+        x1.publish("m1", "rk")
+        msg = q.get(no_ack: true)
+        msg.not_nil!.body_io.to_s.should eq("m1")
+      end
     end
   end
 
   it "supports expires" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-expires"] = 1
-      ch.queue("test", args: args)
-      sleep 5.milliseconds
-      Fiber.yield
-      Server.vhosts["/"].queues.has_key?("test").should be_false
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-expires"] = 1
+        ch.queue("test", args: args)
+        sleep 5.milliseconds
+        Fiber.yield
+        s.vhosts["/"].queues.has_key?("test").should be_false
+      end
     end
   end
 
   it "does not expire queue when consumer are still there" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-expires"] = 50
-      q = ch.queue("test", args: args)
-      q.subscribe(no_ack: true) { |_| }
-      sleep 50.milliseconds
-      Fiber.yield
-      Server.vhosts["/"].queues.has_key?("test").should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-expires"] = 50
+        q = ch.queue("test", args: args)
+        q.subscribe(no_ack: true) { |_| }
+        sleep 50.milliseconds
+        Fiber.yield
+        s.vhosts["/"].queues.has_key?("test").should be_true
+      end
     end
   end
 
   it "should deliver to all matching queues" do
-    with_channel do |ch|
-      q1 = ch.queue
-      q2 = ch.queue
-      x1 = ch.exchange("x122", "topic")
-      q1.bind(x1.name, "rk")
-      q2.bind(x1.name, "rk")
-      x1.publish("m1", "rk")
-      sleep 0.05
-      msg_q1 = q1.get(no_ack: true)
-      msg_q2 = q2.get(no_ack: true)
-      msg_q1.not_nil!.body_io.to_s.should eq("m1")
-      msg_q2.not_nil!.body_io.to_s.should eq("m1")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q1 = ch.queue
+        q2 = ch.queue
+        x1 = ch.exchange("x122", "topic")
+        q1.bind(x1.name, "rk")
+        q2.bind(x1.name, "rk")
+        x1.publish("m1", "rk")
+        sleep 0.05
+        msg_q1 = q1.get(no_ack: true)
+        msg_q2 = q2.get(no_ack: true)
+        msg_q1.not_nil!.body_io.to_s.should eq("m1")
+        msg_q2.not_nil!.body_io.to_s.should eq("m1")
+      end
     end
   end
 
   it "supports auto ack consumers" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish "m1"
-      msgs = [] of AMQP::Client::DeliverMessage
-      q.subscribe(no_ack: true) { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish "m1"
+        msgs = [] of AMQP::Client::DeliverMessage
+        q.subscribe(no_ack: true) { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+      end
     end
   end
 
   it "sets correct message timestamp" do
     LavinMQ::Config.instance.set_timestamp = true
-    with_channel do |ch|
-      q = ch.queue
-      t = Time.utc.to_unix
-      q.publish "m1"
-      msg = nil
-      q.subscribe(no_ack: true) { |m| msg = m }
-      wait_for { msg }
-      msg.not_nil!.properties.timestamp.not_nil!.to_unix.should be_close(t, 1)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        t = Time.utc.to_unix
+        q.publish "m1"
+        msg = nil
+        q.subscribe(no_ack: true) { |m| msg = m }
+        wait_for { msg }
+        msg.not_nil!.properties.timestamp.not_nil!.to_unix.should be_close(t, 1)
+      end
+      LavinMQ::Config.instance.set_timestamp = false
     end
-    LavinMQ::Config.instance.set_timestamp = false
   end
 
   it "supports recover requeue" do
-    with_channel do |ch|
-      q = ch.queue("recover", exclusive: true)
-      5.times { q.publish "" }
-      delivered = 0
-      tag = q.subscribe(no_ack: false) { |_m| delivered += 1 }
-      sleep 0.05
-      q.unsubscribe(tag)
-      sleep 0.05
-      ch.basic_recover(requeue: true)
-      sleep 0.05
-      q.delete[:message_count].should eq 5
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("recover", exclusive: true)
+        5.times { q.publish "" }
+        delivered = 0
+        tag = q.subscribe(no_ack: false) { |_m| delivered += 1 }
+        sleep 0.05
+        q.unsubscribe(tag)
+        sleep 0.05
+        ch.basic_recover(requeue: true)
+        sleep 0.05
+        q.delete[:message_count].should eq 5
+      end
     end
   end
 
   it "supports recover redeliver" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish "m1"
-      msgs = Channel(AMQP::Client::DeliverMessage).new
-      q.subscribe(no_ack: false) { |m| msgs.send m }
-      msgs.receive
-      ch.basic_recover(requeue: true)
-      msgs.receive.redelivered.should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish "m1"
+        msgs = Channel(AMQP::Client::DeliverMessage).new
+        q.subscribe(no_ack: false) { |m| msgs.send m }
+        msgs.receive
+        ch.basic_recover(requeue: true)
+        msgs.receive.redelivered.should be_true
+      end
     end
   end
 
   it "basic_recover requeues messages for cancelled consumers" do
-    with_channel do |ch|
-      q = ch.queue("q")
-      q.publish "m1"
-      msgs = Channel(AMQP::Client::DeliverMessage).new
-      tag = q.subscribe(no_ack: false) { |m| msgs.send m }
-      msgs.receive.body_io.to_s.should eq "m1"
-      q.unsubscribe(tag)
-      ch.basic_recover(requeue: true)
-      select
-      when m = msgs.receive
-        m.should be_nil
-      when timeout 100.milliseconds
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("q")
+        q.publish "m1"
+        msgs = Channel(AMQP::Client::DeliverMessage).new
+        tag = q.subscribe(no_ack: false) { |m| msgs.send m }
+        msgs.receive.body_io.to_s.should eq "m1"
+        q.unsubscribe(tag)
+        ch.basic_recover(requeue: true)
+        select
+        when m = msgs.receive
+          m.should be_nil
+        when timeout 100.milliseconds
+        end
+        ch.queue_declare(q.name, passive: true)[:message_count].should eq 1
       end
-      ch.queue_declare(q.name, passive: true)[:message_count].should eq 1
     end
   end
 
   it "supports recover for basic get" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm "m1"
-      q.publish_confirm "m2"
-      q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
-      ch.basic_recover(requeue: true)
-      q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm "m1"
+        q.publish_confirm "m2"
+        q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
+        ch.basic_recover(requeue: true)
+        q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
+      end
     end
   end
 
   it "recover(requeue=false) for basic get actually requeues" do
-    with_channel do |ch|
-      q = ch.queue
-      q.publish_confirm "m1"
-      q.publish_confirm "m2"
-      q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
-      ch.basic_recover(requeue: false)
-      q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        q.publish_confirm "m1"
+        q.publish_confirm "m2"
+        q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
+        ch.basic_recover(requeue: false)
+        q.get(no_ack: false).not_nil!.body_io.to_s.should eq "m1"
+      end
     end
   end
 
   it "supports delivery-limit" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-delivery-limit"] = 2
-      q = ch.queue("delivery_limit", args: args)
-      q.publish "m1"
-      msg = q.get(no_ack: false).not_nil!
-      msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
-      msg.reject(requeue: true)
-      msg = q.get(no_ack: false).not_nil!
-      msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 2
-      msg.reject(requeue: true)
-      Fiber.yield
-      q.get(no_ack: false).should be_nil
-      Server.vhosts["/"].queues["delivery_limit"].empty?.should be_true
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-delivery-limit"] = 2
+        q = ch.queue("delivery_limit", args: args)
+        q.publish "m1"
+        msg = q.get(no_ack: false).not_nil!
+        msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
+        msg.reject(requeue: true)
+        msg = q.get(no_ack: false).not_nil!
+        msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 2
+        msg.reject(requeue: true)
+        Fiber.yield
+        q.get(no_ack: false).should be_nil
+        s.vhosts["/"].queues["delivery_limit"].empty?.should be_true
+      end
     end
   end
 
   it "supports sends nack if all queues reject" do
-    with_channel do |ch|
-      args = AMQP::Client::Arguments.new
-      args["x-max-length"] = 0_i64
-      args["x-overflow"] = "reject-publish"
-      q = ch.queue("", args: args)
-      q.publish_confirm("m1").should be_false
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 0_i64
+        args["x-overflow"] = "reject-publish"
+        q = ch.queue("", args: args)
+        q.publish_confirm("m1").should be_false
+      end
     end
   end
 
   it "binding to empty queue name binds last queue" do
-    with_channel do |ch|
-      q = ch.queue
-      ch.queue_bind("", "amq.direct", "foo")
-      ch.basic_publish_confirm("bar", "amq.direct", "foo")
-      msg = q.get
-      msg.should_not be_nil
-      msg.not_nil!.body_io.to_s.should eq "bar"
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        ch.queue_bind("", "amq.direct", "foo")
+        ch.basic_publish_confirm("bar", "amq.direct", "foo")
+        msg = q.get
+        msg.should_not be_nil
+        msg.not_nil!.body_io.to_s.should eq "bar"
+      end
     end
   end
 
   it "refuses binding to amq.default" do
-    with_channel do |ch|
-      q = ch.queue
-      expect_raises(AMQP::Client::Channel::ClosedException, "ACCESS_REFUSED") do
-        q.bind("", "foo")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        expect_raises(AMQP::Client::Channel::ClosedException, "ACCESS_REFUSED") do
+          q.bind("", "foo")
+        end
       end
     end
   end
 
   it "refuses unbinding from amq.default" do
-    with_channel do |ch|
-      q = ch.queue
-      expect_raises(AMQP::Client::Channel::ClosedException, "ACCESS_REFUSED") do
-        q.unbind("", q.name)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        expect_raises(AMQP::Client::Channel::ClosedException, "ACCESS_REFUSED") do
+          q.unbind("", q.name)
+        end
       end
     end
   end
 
   it "requeues unacked msg from basic_ack on disconnect" do
-    with_channel do |ch|
-      q = ch.queue("ba", durable: true)
-      q.publish "m1"
-      msg = ch.basic_get(q.name, no_ack: false)
-      msg.should_not be_nil
-    end
-    with_channel do |ch|
-      q = ch.queue("ba", durable: true)
-      msg = ch.basic_get(q.name, no_ack: true)
-      msg.should_not be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("ba", durable: true)
+        q.publish "m1"
+        msg = ch.basic_get(q.name, no_ack: false)
+        msg.should_not be_nil
+      end
+      with_channel(s) do |ch|
+        q = ch.queue("ba", durable: true)
+        msg = ch.basic_get(q.name, no_ack: true)
+        msg.should_not be_nil
+      end
     end
   end
 
   it "will close channel on unknown delivery tag" do
-    with_channel do |ch|
-      ch.basic_ack(1)
-      sleep 0.1
-      expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED - unknown delivery tag 1/) do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
         ch.basic_ack(1)
+        sleep 0.1
+        expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED - unknown delivery tag 1/) do
+          ch.basic_ack(1)
+        end
       end
     end
   end
 
   it "will close channel on double ack" do
-    with_channel do |ch|
-      q = ch.queue("")
-      q.publish "1"
-      q.publish "2"
-      q.publish "3"
-      msg1 = ch.basic_get(q.name, no_ack: false)
-      msg2 = ch.basic_get(q.name, no_ack: false)
-      _msg3 = ch.basic_get(q.name, no_ack: false)
-      msg2.not_nil!.ack
-      msg2.not_nil!.ack # this will trigger the error
-      sleep 0.1
-      expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED - unknown delivery tag 2/) do
-        msg1.not_nil!.ack
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("")
+        q.publish "1"
+        q.publish "2"
+        q.publish "3"
+        msg1 = ch.basic_get(q.name, no_ack: false)
+        msg2 = ch.basic_get(q.name, no_ack: false)
+        _msg3 = ch.basic_get(q.name, no_ack: false)
+        msg2.not_nil!.ack
+        msg2.not_nil!.ack # this will trigger the error
+        sleep 0.1
+        expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED - unknown delivery tag 2/) do
+          msg1.not_nil!.ack
+        end
       end
     end
   end
 
   it "will close channel on double ack with multiple" do
-    with_channel do |ch|
-      q = ch.queue("")
-      q.publish "1"
-      q.publish "2"
-      q.publish "3"
-      _msg1 = ch.basic_get(q.name, no_ack: false)
-      msg2 = ch.basic_get(q.name, no_ack: false)
-      msg3 = ch.basic_get(q.name, no_ack: false)
-      msg2.not_nil!.ack
-      msg2.not_nil!.ack(multiple: true) # this should tigger a precondition fail
-      sleep 0.1
-      expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED - unknown delivery tag 2/) do
-        msg3.not_nil!.ack
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("")
+        q.publish "1"
+        q.publish "2"
+        q.publish "3"
+        _msg1 = ch.basic_get(q.name, no_ack: false)
+        msg2 = ch.basic_get(q.name, no_ack: false)
+        msg3 = ch.basic_get(q.name, no_ack: false)
+        msg2.not_nil!.ack
+        msg2.not_nil!.ack(multiple: true) # this should tigger a precondition fail
+        sleep 0.1
+        expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION_FAILED - unknown delivery tag 2/) do
+          msg3.not_nil!.ack
+        end
       end
     end
   end
 
   it "will requeue messages that can't be delivered" do
-    qname = "requeue-failed-delivery"
-    count = 0
-    with_channel do |ch|
-      ch.@connection.@io.as(TCPSocket).linger = 0
-      q = ch.queue(qname)
-      q.subscribe(no_ack: false) do |_msg|
-        count += 1
-      end
-      q.publish "1"
-      ch.@connection.@io.as(TCPSocket).close
-      sleep 0.05
-      count.should eq 0
+    with_amqp_server do |s|
+      qname = "requeue-failed-delivery"
+      count = 0
+      with_channel(s) do |ch|
+        ch.@connection.@io.as(TCPSocket).linger = 0
+        q = ch.queue(qname)
+        q.subscribe(no_ack: false) do |_msg|
+          count += 1
+        end
+        q.publish "1"
+        ch.@connection.@io.as(TCPSocket).close
+        sleep 0.05
+        count.should eq 0
 
-      Fiber.yield
-      Server.vhosts["/"].queues[qname].message_count.should eq 1
-      Server.vhosts["/"].queues[qname].unacked_count.should eq 0
+        Fiber.yield
+        s.vhosts["/"].queues[qname].message_count.should eq 1
+        s.vhosts["/"].queues[qname].unacked_count.should eq 0
+      end
     end
   end
 
   it "will limit message size" do
     LavinMQ::Config.instance.max_message_size = 128
-    with_channel do |ch|
-      expect_raises(AMQP::Client::Channel::ClosedException, /message size/) do
-        ch.basic_publish_confirm("a" * 129, "amq.direct", "none")
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        expect_raises(AMQP::Client::Channel::ClosedException, /message size/) do
+          ch.basic_publish_confirm("a" * 129, "amq.direct", "none")
+        end
       end
     end
   ensure
@@ -996,152 +1126,164 @@ describe LavinMQ::Server do
   it "should measure time it takes to collect metrics in stats_loop" do
     stats_interval = LavinMQ::Config.instance.stats_interval
     LavinMQ::Config.instance.stats_interval = 100
-    server = LavinMQ::Server.new("/tmp/lavinmq-spec")
-    should_eventually(be_true, 1.seconds) { server.stats_collection_duration_seconds_total > Time::Span.zero }
-    server.stats_rates_collection_duration_seconds.should_not eq Time::Span.zero
-    server.stats_system_collection_duration_seconds.should_not eq Time::Span.zero
+    with_amqp_server do |s|
+      should_eventually(be_true, 1.seconds) { s.stats_collection_duration_seconds_total > Time::Span.zero }
+      s.stats_rates_collection_duration_seconds.should_not eq Time::Span.zero
+      s.stats_system_collection_duration_seconds.should_not eq Time::Span.zero
+    end
   ensure
     LavinMQ::Config.instance.stats_interval = stats_interval if stats_interval
-    server.try &.close
   end
 
   it "should requeue messages correctly on channel close" do
-    qname = "requeue-on-close"
-    with_channel do |ch|
-      q = ch.queue(qname)
+    with_amqp_server do |s|
+      qname = "requeue-on-close"
+      with_channel(s) do |ch|
+        q = ch.queue(qname)
 
-      10.times { q.publish_confirm "" }
+        10.times { q.publish_confirm "" }
 
-      q.get(no_ack: true)
-      q.get(no_ack: false)
-      q.get(no_ack: false)
+        q.get(no_ack: true)
+        q.get(no_ack: false)
+        q.get(no_ack: false)
 
-      count = 0
-      q.subscribe(no_ack: false) do |_msg|
-        count += 1
+        count = 0
+        q.subscribe(no_ack: false) do |_msg|
+          count += 1
+        end
+        wait_for { count == 7 }
       end
-      wait_for { count == 7 }
-    end
-    with_channel do |ch|
-      q = ch.queue(qname)
-      q.message_count.should eq 9
+      with_channel(s) do |ch|
+        q = ch.queue(qname)
+        q.message_count.should eq 9
+      end
     end
   end
 
   it "supports single active consumer" do
-    with_channel do |ch|
-      ch.prefetch 1
-      q = ch.queue("sac", args: AMQ::Protocol::Table.new({"x-single-active-consumer": true}))
-      begin
-        msgs = Channel(Tuple(String, AMQP::Client::DeliverMessage)).new
-        q.subscribe(no_ack: false, tag: "1") do |msg|
-          msgs.send({"1", msg})
-        end
-        q.subscribe(no_ack: false, tag: "2") do |msg|
-          msgs.send({"2", msg})
-        end
-        4.times { q.publish "" }
-        2.times do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.prefetch 1
+        q = ch.queue("sac", args: AMQ::Protocol::Table.new({"x-single-active-consumer": true}))
+        begin
+          msgs = Channel(Tuple(String, AMQP::Client::DeliverMessage)).new
+          q.subscribe(no_ack: false, tag: "1") do |msg|
+            msgs.send({"1", msg})
+          end
+          q.subscribe(no_ack: false, tag: "2") do |msg|
+            msgs.send({"2", msg})
+          end
+          4.times { q.publish "" }
+          2.times do
+            tag, msg = msgs.receive
+            tag.should eq "1"
+            msg.ack
+          end
           tag, msg = msgs.receive
           tag.should eq "1"
+          q.unsubscribe "1"
           msg.ack
+          tag, msg = msgs.receive
+          tag.should eq "2"
+          msg.ack
+        ensure
+          q.delete
         end
-        tag, msg = msgs.receive
-        tag.should eq "1"
-        q.unsubscribe "1"
-        msg.ack
-        tag, msg = msgs.receive
-        tag.should eq "2"
-        msg.ack
-      ensure
-        q.delete
       end
     end
   end
 
   it "can publish large messages to multiple queues" do
-    with_channel do |ch|
-      q1 = ch.queue
-      q2 = ch.queue
-      q1.bind("amq.fanout", "")
-      q2.bind("amq.fanout", "")
-      2.times do |i|
-        ch.basic_publish_confirm(i.to_s * 200_000, "amq.fanout", "")
-      end
-      2.times do |i|
-        if msg = q1.get
-          msg.body_io.to_s.should eq i.to_s * 200_000
-        else
-          msg.should_not be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q1 = ch.queue
+        q2 = ch.queue
+        q1.bind("amq.fanout", "")
+        q2.bind("amq.fanout", "")
+        2.times do |i|
+          ch.basic_publish_confirm(i.to_s * 200_000, "amq.fanout", "")
         end
-        if msg = q2.get
-          msg.body_io.to_s.should eq i.to_s * 200_000
-        else
-          msg.should_not be_nil
+        2.times do |i|
+          if msg = q1.get
+            msg.body_io.to_s.should eq i.to_s * 200_000
+          else
+            msg.should_not be_nil
+          end
+          if msg = q2.get
+            msg.body_io.to_s.should eq i.to_s * 200_000
+          else
+            msg.should_not be_nil
+          end
         end
       end
     end
   end
 
   it "can publish small messages to multiple queues" do
-    with_channel do |ch|
-      q1 = ch.queue
-      q2 = ch.queue
-      q1.bind("amq.fanout", "")
-      q2.bind("amq.fanout", "")
-      2.times do |i|
-        ch.basic_publish_confirm(i.to_s * 200, "amq.fanout", "")
-      end
-      2.times do |i|
-        if msg = q1.get
-          msg.body_io.to_s.should eq i.to_s * 200
-        else
-          msg.should_not be_nil
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q1 = ch.queue
+        q2 = ch.queue
+        q1.bind("amq.fanout", "")
+        q2.bind("amq.fanout", "")
+        2.times do |i|
+          ch.basic_publish_confirm(i.to_s * 200, "amq.fanout", "")
         end
-        if msg = q2.get
-          msg.body_io.to_s.should eq i.to_s * 200
-        else
-          msg.should_not be_nil
+        2.times do |i|
+          if msg = q1.get
+            msg.body_io.to_s.should eq i.to_s * 200
+          else
+            msg.should_not be_nil
+          end
+          if msg = q2.get
+            msg.body_io.to_s.should eq i.to_s * 200
+          else
+            msg.should_not be_nil
+          end
         end
       end
     end
   end
 
   it "supports consumer timeouts" do
-    with_channel do |ch|
-      q = ch.queue("", exclusive: true, args: AMQP::Client::Arguments.new({"x-consumer-timeout": 100}))
-      q.publish_confirm("a")
-      expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION/) do
-        q.subscribe(no_ack: false, tag: "c", block: true) { }
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("", exclusive: true, args: AMQP::Client::Arguments.new({"x-consumer-timeout": 100}))
+        q.publish_confirm("a")
+        expect_raises(AMQP::Client::Channel::ClosedException, /PRECONDITION/) do
+          q.subscribe(no_ack: false, tag: "c", block: true) { }
+        end
       end
     end
   end
 
   it "restarts fast even with large messages" do
-    data = Bytes.new 128 * 1024**2
-    with_channel do |ch|
-      q = ch.queue("large-messages")
-      10.times do |i|
-        q.publish_confirm(data)
+    with_amqp_server do |s|
+      data = Bytes.new 128 * 1024**2
+      with_channel(s) do |ch|
+        q = ch.queue("large-messages")
+        10.times do
+          q.publish_confirm(data)
+        end
       end
-    end
-    restart_time = Benchmark.realtime do
-      restart_memory = Benchmark.memory do
-        Server.restart
+      restart_time = Benchmark.realtime do
+        restart_memory = Benchmark.memory do
+          s.restart
+        end
+        restart_memory.should be < 1 * 1024**2
       end
-      restart_memory.should be < 1 * 1024**2
-    end
-    restart_time.should be < 3.seconds # Some CI environments are slow
-    with_channel do |ch|
-      ch.prefetch 1
-      q = ch.queue("large-messages")
-      done = Channel(Nil).new
-      q.subscribe(no_ack: false) do |msg|
-        msg.body_io.bytesize.should eq 128 * 1024**2
-        msg.ack
-        done.send nil
+      restart_time.should be < 3.seconds # Some CI environments are slow
+      with_channel(s) do |ch|
+        ch.prefetch 1
+        q = ch.queue("large-messages")
+        done = Channel(Nil).new
+        q.subscribe(no_ack: false) do |msg|
+          msg.body_io.bytesize.should eq 128 * 1024**2
+          msg.ack
+          done.send nil
+        end
+        10.times { done.receive }
       end
-      10.times { done.receive }
     end
   end
 end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -13,508 +13,551 @@ end
 
 describe LavinMQ::Shovel do
   describe "AMQP" do
-    vhost = Server.vhosts.create("x")
-
     it "should shovel and stop when queue length is met" do
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "ql_q1",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "ql_q2",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
-      with_channel do |ch|
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "ql_"
-        x.publish_confirm "shovel me 1", "ql_q1"
-        x.publish_confirm "shovel me 2", "ql_q1"
-        shovel.run
-        x.publish_confirm "shovel me 3", "ql_q1"
-        q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
-        q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
-        q2.get(no_ack: true).try(&.body_io.to_s).should be_nil
-        Server.vhosts["/"].shovels.empty?.should be_true
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "ql_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "ql_q2",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
+        with_channel(s) do |ch|
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "ql_"
+          x.publish_confirm "shovel me 1", "ql_q1"
+          x.publish_confirm "shovel me 2", "ql_q1"
+          shovel.run
+          x.publish_confirm "shovel me 3", "ql_q1"
+          q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
+          q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
+          q2.get(no_ack: true).try(&.body_io.to_s).should be_nil
+          s.vhosts["/"].shovels.empty?.should be_true
+        end
       end
     end
 
     it "should shovel large messages" do
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "lm_q1",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(SpecHelper.amqp_base_url), "lm_q2", direct_user: Server.users.direct_user)
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "lm_shovel", vhost)
-      with_channel do |ch|
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "lm_"
-        x.publish_confirm "a" * 200_000, "lm_q1"
-        shovel.run
-        sleep 10.milliseconds
-        q2.get(no_ack: true).not_nil!.body_io.to_s.bytesize.should eq 200_000
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "lm_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(s.amqp_url), "lm_q2", direct_user: s.users.direct_user)
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "lm_shovel", vhost)
+        with_channel(s) do |ch|
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "lm_"
+          x.publish_confirm "a" * 200_000, "lm_q1"
+          shovel.run
+          sleep 10.milliseconds
+          q2.get(no_ack: true).not_nil!.body_io.to_s.bytesize.should eq 200_000
+        end
       end
     end
 
     it "should shovel forever" do
-      source = LavinMQ::Shovel::AMQPSource.new("spec", [URI.parse(SpecHelper.amqp_base_url)], "sf_q1", direct_user: Server.users.direct_user)
-      dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(SpecHelper.amqp_base_url), "sf_q2", direct_user: Server.users.direct_user)
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "sf_shovel", vhost)
-      with_channel do |ch|
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "sf_"
-        x.publish_confirm "shovel me 1", "sf_q1"
-        x.publish_confirm "shovel me 2", "sf_q1"
-        spawn shovel.run
-        msgs = Channel(String).new
-        q2.subscribe(no_ack: true) do |msg|
-          msgs.send(msg.body_io.to_s)
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new("spec", [URI.parse(s.amqp_url)], "sf_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::AMQPDestination.new("spec", URI.parse(s.amqp_url), "sf_q2", direct_user: s.users.direct_user)
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "sf_shovel", vhost)
+        with_channel(s) do |ch|
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "sf_"
+          x.publish_confirm "shovel me 1", "sf_q1"
+          x.publish_confirm "shovel me 2", "sf_q1"
+          spawn shovel.run
+          msgs = Channel(String).new
+          q2.subscribe(no_ack: true) do |msg|
+            msgs.send(msg.body_io.to_s)
+          end
+          wait_for { shovel.running? }
+          x.publish_confirm "shovel me 3", "sf_q1"
+          3.times do |i|
+            msgs.receive.should eq "shovel me #{i + 1}"
+          end
+          shovel.running?.should be_true
         end
-        wait_for { shovel.running? }
-        x.publish_confirm "shovel me 3", "sf_q1"
-        3.times do |i|
-          msgs.receive.should eq "shovel me #{i + 1}"
-        end
-        shovel.running?.should be_true
       end
     end
 
     it "should shovel with ack mode on-publish" do
-      ack_mode = LavinMQ::Shovel::AckMode::OnPublish
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "ap_q1",
-        prefetch: 1_u16,
-        ack_mode: ack_mode,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "ap_q2",
-        ack_mode: ack_mode,
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ap_shovel", vhost)
-      with_channel do |ch|
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "ap_"
-        x.publish_confirm "shovel me", "ap_q1"
-        spawn shovel.run
-        wait_for { shovel.running? }
-        sleep 0.1 # Give time for message to be shoveled
-        Server.vhosts["/"].queues["ap_q1"].message_count.should eq 0
-        q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        ack_mode = LavinMQ::Shovel::AckMode::OnPublish
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "ap_q1",
+          prefetch: 1_u16,
+          ack_mode: ack_mode,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "ap_q2",
+          ack_mode: ack_mode,
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ap_shovel", vhost)
+        with_channel(s) do |ch|
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "ap_"
+          x.publish_confirm "shovel me", "ap_q1"
+          spawn shovel.run
+          wait_for { shovel.running? }
+          sleep 0.1 # Give time for message to be shoveled
+          s.vhosts["/"].queues["ap_q1"].message_count.should eq 0
+          q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
+        end
       end
     end
 
     it "should shovel with ack mode no-ack" do
-      ack_mode = LavinMQ::Shovel::AckMode::NoAck
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "na_q1",
-        ack_mode: ack_mode,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "na_q2",
-        ack_mode: ack_mode,
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "na_shovel", vhost)
-      with_channel do |ch|
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "na_"
-        x.publish_confirm "shovel me", "na_q1"
-        spawn { shovel.run }
-        wait_for { shovel.running? }
-        sleep 0.1 # Give time for message to be shoveled
-        Server.vhosts["/"].queues["na_q1"].message_count.should eq 0
-        q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        ack_mode = LavinMQ::Shovel::AckMode::NoAck
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "na_q1",
+          ack_mode: ack_mode,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "na_q2",
+          ack_mode: ack_mode,
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "na_shovel", vhost)
+        with_channel(s) do |ch|
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "na_"
+          x.publish_confirm "shovel me", "na_q1"
+          spawn { shovel.run }
+          wait_for { shovel.running? }
+          sleep 0.1 # Give time for message to be shoveled
+          s.vhosts["/"].queues["na_q1"].message_count.should eq 0
+          q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
+        end
       end
     end
 
     it "should shovel past prefetch" do
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "prefetch_q1",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        prefetch: 21_u16,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "prefetch_q2",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        prefetch: 21_u16,
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch_shovel", vhost)
-      with_channel do |ch|
-        x = ShovelSpecHelpers.setup_qs(ch, "prefetch_").first
-        100.times do
-          x.publish_confirm "shovel me", "prefetch_q1"
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "prefetch_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          prefetch: 21_u16,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "prefetch_q2",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          prefetch: 21_u16,
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ShovelSpecHelpers.setup_qs(ch, "prefetch_").first
+          100.times do
+            x.publish_confirm "shovel me", "prefetch_q1"
+          end
+          wait_for { s.vhosts["/"].queues["prefetch_q1"].message_count == 100 }
+          shovel.run
+          wait_for { shovel.terminated? }
+          s.vhosts["/"].queues["prefetch_q1"].message_count.should eq 0
+          s.vhosts["/"].queues["prefetch_q2"].message_count.should eq 100
         end
-        wait_for { Server.vhosts["/"].queues["prefetch_q1"].message_count == 100 }
-        shovel.run
-        wait_for { shovel.terminated? }
-        Server.vhosts["/"].queues["prefetch_q1"].message_count.should eq 0
-        Server.vhosts["/"].queues["prefetch_q2"].message_count.should eq 100
       end
     end
 
     it "should shovel once qs are declared" do
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "od_q1",
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "od_q2",
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "od_shovel", vhost)
-      with_channel do |ch|
-        spawn { shovel.run }
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "od_"
-        x.publish_confirm "shovel me", "od_q1"
-        rmsg = nil
-        wait_for { rmsg = q2.get(no_ack: true) }
-        rmsg.not_nil!.body_io.to_s.should eq "shovel me"
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "od_q1",
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "od_q2",
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "od_shovel", vhost)
+        with_channel(s) do |ch|
+          spawn { shovel.run }
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "od_"
+          x.publish_confirm "shovel me", "od_q1"
+          rmsg = nil
+          wait_for { rmsg = q2.get(no_ack: true) }
+          rmsg.not_nil!.body_io.to_s.should eq "shovel me"
+        end
       end
     end
 
     it "should reconnect and continue" do
-      with_channel do |ch|
-        q1 = ch.queue("rc_q1")
-        _q2 = ch.queue("rc_q2")
-        q1.publish_confirm "shovel me 1", props: AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
-      end
-      config = %({
-        "src-uri": "#{SpecHelper.amqp_base_url}",
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q1 = ch.queue("rc_q1")
+          _q2 = ch.queue("rc_q2")
+          q1.publish_confirm "shovel me 1", props: AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
+        end
+        config = %({
+        "src-uri": "#{s.amqp_url}",
         "src-queue": "rc_q1",
-        "dest-uri": "#{SpecHelper.amqp_base_url}",
+        "dest-uri": "#{s.amqp_url}",
         "dest-queue": "rc_q2",
         "src-prefetch-count": 2})
-      p = LavinMQ::Parameter.new("shovel", "rc_shovel", JSON.parse(config))
-      Server.vhosts["/"].add_parameter(p)
-      Server.restart
-      wait_for { Server.vhosts["/"].shovels.size > 0 }
-      shovel = Server.vhosts["/"].shovels["rc_shovel"]
-      wait_for { shovel.running? }
-      with_channel do |ch|
-        q1 = ch.queue("rc_q1", durable: true)
-        q2 = ch.queue("rc_q2", durable: true)
-        msgs = Channel(String).new
-        q2.subscribe(no_ack: true) do |msg|
-          msgs.send(msg.body_io.to_s)
+        p = LavinMQ::Parameter.new("shovel", "rc_shovel", JSON.parse(config))
+        s.vhosts["/"].add_parameter(p)
+        s.restart
+        wait_for { s.vhosts["/"].shovels.size > 0 }
+        shovel = s.vhosts["/"].shovels["rc_shovel"]
+        wait_for { shovel.running? }
+        with_channel(s) do |ch|
+          q1 = ch.queue("rc_q1", durable: true)
+          q2 = ch.queue("rc_q2", durable: true)
+          msgs = Channel(String).new
+          q2.subscribe(no_ack: true) do |msg|
+            msgs.send(msg.body_io.to_s)
+          end
+          props = AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
+          spawn do
+            q1.publish_confirm "shovel me 2", props: props
+            q1.publish_confirm "shovel me 3", props: props
+            q1.publish_confirm "shovel me 4", props: props
+          end
+          4.times do |i|
+            msgs.receive.should eq "shovel me #{i + 1}"
+          end
+          ch.queue_declare("rc_q1", passive: true)[:message_count].should eq 0
         end
-        props = AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
-        spawn do
-          q1.publish_confirm "shovel me 2", props: props
-          q1.publish_confirm "shovel me 3", props: props
-          q1.publish_confirm "shovel me 4", props: props
-        end
-        4.times do |i|
-          msgs.receive.should eq "shovel me #{i + 1}"
-        end
-        ch.queue_declare("rc_q1", passive: true)[:message_count].should eq 0
       end
     end
 
     it "should shovel over amqps" do
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse("#{SpecHelper.amqps_base_url}?verify=none")],
-        "ssl_q1",
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse("#{SpecHelper.amqps_base_url}?verify=none"),
-        "ssl_q2",
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ssl_shovel", vhost)
-      with_channel do |ch|
-        x, q2 = ShovelSpecHelpers.setup_qs ch, "ssl_"
-        spawn { shovel.run }
-        x.publish_confirm "shovel me", "ssl_q1"
-        msgs = Channel(AMQP::Client::DeliverMessage).new
-        q2.subscribe { |m| msgs.send m }
-        msg = msgs.receive
-        msg.body_io.to_s.should eq "shovel me"
+      with_amqp_server(tls: true) do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse("#{s.amqp_url.sub("amqp://", "amqps://")}?verify=none")],
+          "ssl_q1",
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse("#{s.amqp_url.sub("amqp://", "amqps://")}?verify=none"),
+          "ssl_q2",
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ssl_shovel", vhost)
+        with_channel(s, tls: true, verify_mode: OpenSSL::SSL::VerifyMode::NONE) do |ch|
+          x, q2 = ShovelSpecHelpers.setup_qs ch, "ssl_"
+          spawn { shovel.run }
+          x.publish_confirm "shovel me", "ssl_q1"
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q2.subscribe { |m| msgs.send m }
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "shovel me"
+        end
       end
     end
 
     it "should ack all messages that has been moved" do
-      prefetch = 9_u16
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "prefetch2_q1",
-        prefetch: prefetch,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "prefetch2_q2",
-        prefetch: prefetch,
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch2_shovel", vhost)
-      with_channel do |ch|
-        x = ShovelSpecHelpers.setup_qs(ch, "prefetch2_").first
-        spawn { shovel.run }
-        x.publish_confirm "shovel me 1", "prefetch2_q1"
-        x.publish_confirm "shovel me 2", "prefetch2_q1"
-        x.publish_confirm "shovel me 2", "prefetch2_q1"
-        x.publish_confirm "shovel me 2", "prefetch2_q1"
-        wait_for { Server.vhosts["/"].queues["prefetch2_q2"].message_count == 4 }
-        sleep 0.1
-        shovel.terminate
-        Server.vhosts["/"].queues["prefetch2_q2"].message_count.should eq 4
-        Server.vhosts["/"].queues["prefetch2_q1"].message_count.should eq 0
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        prefetch = 9_u16
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "prefetch2_q1",
+          prefetch: prefetch,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "prefetch2_q2",
+          prefetch: prefetch,
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch2_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ShovelSpecHelpers.setup_qs(ch, "prefetch2_").first
+          spawn { shovel.run }
+          x.publish_confirm "shovel me 1", "prefetch2_q1"
+          x.publish_confirm "shovel me 2", "prefetch2_q1"
+          x.publish_confirm "shovel me 2", "prefetch2_q1"
+          x.publish_confirm "shovel me 2", "prefetch2_q1"
+          wait_for { s.vhosts["/"].queues["prefetch2_q2"].message_count == 4 }
+          sleep 0.1
+          shovel.terminate
+          s.vhosts["/"].queues["prefetch2_q2"].message_count.should eq 4
+          s.vhosts["/"].queues["prefetch2_q1"].message_count.should eq 0
+        end
       end
     end
 
     describe "authentication error" do
       it "should be stopped" do
-        uri = URI.parse(SpecHelper.amqp_base_url)
-        uri.user = "foo"
-        uri.password = "bar"
-        source = LavinMQ::Shovel::AMQPSource.new(
-          "spec",
-          [uri],
-          "q1",
-          direct_user: Server.users.direct_user
-        )
-        dest = LavinMQ::Shovel::AMQPDestination.new(
-          "spec",
-          uri,
-          "q2",
-          direct_user: Server.users.direct_user
-        )
-        shovel = LavinMQ::Shovel::Runner.new(source, dest, "auth_fail", vhost)
-        spawn { shovel.run }
-        wait_for { shovel.details_tuple[:error] }
-        shovel.details_tuple[:error].not_nil!.should contain "ACCESS_REFUSED"
-        shovel.terminate
-        shovel.state.should eq "Terminated"
+        with_amqp_server do |s|
+          vhost = s.vhosts.create("x")
+          uri = URI.parse(s.amqp_url)
+          uri.user = "foo"
+          uri.password = "bar"
+          source = LavinMQ::Shovel::AMQPSource.new(
+            "spec",
+            [uri],
+            "q1",
+            direct_user: s.users.direct_user
+          )
+          dest = LavinMQ::Shovel::AMQPDestination.new(
+            "spec",
+            uri,
+            "q2",
+            direct_user: s.users.direct_user
+          )
+          shovel = LavinMQ::Shovel::Runner.new(source, dest, "auth_fail", vhost)
+          spawn { shovel.run }
+          wait_for { shovel.details_tuple[:error] }
+          shovel.details_tuple[:error].not_nil!.should contain "ACCESS_REFUSED"
+          shovel.terminate
+          shovel.state.should eq "Terminated"
+        end
       end
     end
 
     it "should count messages shoveled" do
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "c_q1",
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        "c_q2",
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "c_shovel", vhost)
-      with_channel do |ch|
-        x, _ = ShovelSpecHelpers.setup_qs ch, "c_"
-        spawn { shovel.run }
-        10.times do
-          x.publish_confirm "shovel me", "c_q1"
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "c_q1",
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "c_q2",
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "c_shovel", vhost)
+        with_channel(s) do |ch|
+          x, _ = ShovelSpecHelpers.setup_qs ch, "c_"
+          spawn { shovel.run }
+          10.times do
+            x.publish_confirm "shovel me", "c_q1"
+          end
+          wait_for { s.vhosts["/"].queues["c_q2"].message_count == 10 }
+          shovel.details_tuple[:message_count].should eq 10
         end
-        wait_for { Server.vhosts["/"].queues["c_q2"].message_count == 10 }
-        shovel.details_tuple[:message_count].should eq 10
+        shovel.state.should eq "Running"
       end
-      shovel.state.should eq "Running"
     end
 
     it "should shovel stream queues" do
-      q1_name = "stream_q1"
-      q2_name = "stream_q2"
-      consumer_args = {"x-stream-offset" => JSON::Any.new("first")}
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        q1_name,
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user,
-        consumer_args: consumer_args
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "spec",
-        URI.parse(SpecHelper.amqp_base_url),
-        q2_name,
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user,
-        consumer_args: consumer_args
-      )
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        q1_name = "stream_q1"
+        q2_name = "stream_q2"
+        consumer_args = {"x-stream-offset" => JSON::Any.new("first")}
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          q1_name,
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user,
+          consumer_args: consumer_args
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          q2_name,
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user,
+          consumer_args: consumer_args
+        )
 
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
-      with_channel do |ch|
-        x = ch.exchange("", "direct", passive: true)
-        ch.prefetch 1
-        args = AMQP::Client::Arguments.new({"x-queue-type" => "stream"})
-        q1 = ch.queue(q1_name, args: args)
-        q2 = ch.queue(q2_name, args: args)
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.prefetch 1
+          args = AMQP::Client::Arguments.new({"x-queue-type" => "stream"})
+          q1 = ch.queue(q1_name, args: args)
+          q2 = ch.queue(q2_name, args: args)
 
-        10.times do
-          x.publish_confirm "shovel me", q1_name
+          10.times do
+            x.publish_confirm "shovel me", q1_name
+          end
+          shovel.run
+
+          q1_msg_count = 0
+          q2_msg_count = 0
+          q1.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "first"})) do |msg|
+            msg.ack
+            q1_msg_count += 1
+          end
+          q2.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "first"})) do |msg|
+            msg.ack
+            q2_msg_count += 1
+          end
+
+          should_eventually(be_true) { q1_msg_count == 10 }
+          should_eventually(be_true) { q2_msg_count == 10 }
+          s.vhosts["/"].shovels.empty?.should be_true
         end
-        shovel.run
-
-        q1_msg_count = 0
-        q2_msg_count = 0
-        q1.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "first"})) do |msg|
-          msg.ack
-          q1_msg_count += 1
-        end
-        q2.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "first"})) do |msg|
-          msg.ack
-          q2_msg_count += 1
-        end
-
-        should_eventually(be_true) { q1_msg_count == 10 }
-        should_eventually(be_true) { q2_msg_count == 10 }
-        Server.vhosts["/"].shovels.empty?.should be_true
       end
     end
 
     it "should move messages between queues with long names" do
-      long_prefix = "a" * 250
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "#{long_prefix}q1",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "#{long_prefix}q1",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::AMQPDestination.new(
-        "#{long_prefix}q2",
-        URI.parse(SpecHelper.amqp_base_url),
-        "#{long_prefix}q2",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
-      with_channel do |ch|
-        q1, q2 = ShovelSpecHelpers.setup_qs ch, long_prefix
-        q1.publish_confirm "shovel me 1", "#{long_prefix}q1"
-        q1.publish_confirm "shovel me 2", "#{long_prefix}q1"
-        shovel.run
-        q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
-        q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
-        Server.vhosts["/"].shovels.empty?.should be_true
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("x")
+        long_prefix = "a" * 250
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "#{long_prefix}q1",
+          [URI.parse(s.amqp_url)],
+          "#{long_prefix}q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "#{long_prefix}q2",
+          URI.parse(s.amqp_url),
+          "#{long_prefix}q2",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
+        with_channel(s) do |ch|
+          q1, q2 = ShovelSpecHelpers.setup_qs ch, long_prefix
+          q1.publish_confirm "shovel me 1", "#{long_prefix}q1"
+          q1.publish_confirm "shovel me 2", "#{long_prefix}q1"
+          shovel.run
+          q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
+          q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
+          s.vhosts["/"].shovels.empty?.should be_true
+        end
       end
     end
   end
 
   describe "HTTP" do
     it "should shovel" do
-      # # Setup HTTP server
-      h = Hash(String, String).new
-      body = "<no body>"
-      path = "<no path>"
-      server = HTTP::Server.new do |context|
-        context.request.headers.each do |k, v|
-          h[k] = v.first
+      with_amqp_server do |s|
+        # # Setup HTTP server
+        h = Hash(String, String).new
+        body = "<no body>"
+        path = "<no path>"
+        server = HTTP::Server.new do |context|
+          context.request.headers.each do |k, v|
+            h[k] = v.first
+          end
+          body = context.request.body.try &.gets
+          path = context.request.path
+          context.response.content_type = "text/plain"
+          context.response.print "ok"
+          context
         end
-        body = context.request.body.try &.gets
-        path = context.request.path
-        context.response.content_type = "text/plain"
-        context.response.print "ok"
-        context
-      end
-      addr = server.bind_unused_port
-      spawn server.listen
+        addr = server.bind_unused_port
+        spawn server.listen
 
-      vhost = Server.vhosts.create("x")
-      # # Setup shovel source and destination
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "ql_q1",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::HTTPDestination.new(
-        "spec",
-        URI.parse("http://a:b@#{addr}/pp")
-      )
+        vhost = s.vhosts.create("x")
+        # # Setup shovel source and destination
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "ql_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::HTTPDestination.new(
+          "spec",
+          URI.parse("http://a:b@#{addr}/pp")
+        )
 
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
-      with_channel do |ch|
-        x, _ = ShovelSpecHelpers.setup_qs ch, "ql_"
-        headers = AMQP::Client::Arguments.new
-        headers["a"] = "b"
-        props = AMQP::Client::Properties.new("text/plain", nil, headers)
-        x.publish_confirm "shovel me", "ql_q1", props: props
-        shovel.run
-        sleep 0.01
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
+        with_channel(s) do |ch|
+          x, _ = ShovelSpecHelpers.setup_qs ch, "ql_"
+          headers = AMQP::Client::Arguments.new
+          headers["a"] = "b"
+          props = AMQP::Client::Properties.new("text/plain", nil, headers)
+          x.publish_confirm "shovel me", "ql_q1", props: props
+          shovel.run
+          sleep 0.01
 
-        # Check that we have sent one message successfully
-        path.should eq "/pp"
-        h["User-Agent"].should eq "LavinMQ"
-        h["Content-Type"].should eq "text/plain"
-        h["Authorization"].should eq "Basic YTpi" # base64 encoded "a:b"
-        h["X-a"].should eq "b"
-        body.should eq "shovel me"
+          # Check that we have sent one message successfully
+          path.should eq "/pp"
+          h["User-Agent"].should eq "LavinMQ"
+          h["Content-Type"].should eq "text/plain"
+          h["Authorization"].should eq "Basic YTpi" # base64 encoded "a:b"
+          h["X-a"].should eq "b"
+          body.should eq "shovel me"
 
-        Server.vhosts["/"].shovels.empty?.should be_true
+          s.vhosts["/"].shovels.empty?.should be_true
+        end
       end
     end
 
     it "should set path for URI from headers" do
-      # # Setup HTTP server
-      path = "<no path>"
-      server = HTTP::Server.new do |context|
-        path = context.request.path
-        context.response.content_type = "text/plain"
-        context.response.print "ok"
-        context
-      end
-      addr = server.bind_unused_port
-      spawn server.listen
+      with_amqp_server do |s|
+        # # Setup HTTP server
+        path = "<no path>"
+        server = HTTP::Server.new do |context|
+          path = context.request.path
+          context.response.content_type = "text/plain"
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
 
-      vhost = Server.vhosts.create("x")
-      # # Setup shovel source and destination
-      source = LavinMQ::Shovel::AMQPSource.new(
-        "spec",
-        [URI.parse(SpecHelper.amqp_base_url)],
-        "ql_q1",
-        delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-        direct_user: Server.users.direct_user
-      )
-      dest = LavinMQ::Shovel::HTTPDestination.new(
-        "spec",
-        URI.parse("http://a:b@#{addr}")
-      )
+        vhost = s.vhosts.create("x")
+        # # Setup shovel source and destination
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "ql_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::HTTPDestination.new(
+          "spec",
+          URI.parse("http://a:b@#{addr}")
+        )
 
-      shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
-      with_channel do |ch|
-        x, _ = ShovelSpecHelpers.setup_qs ch, "ql_"
-        headers = AMQP::Client::Arguments.new
-        headers["uri_path"] = "/some_path"
-        props = AMQP::Client::Properties.new("text/plain", nil, headers)
-        x.publish_confirm "shovel me", "ql_q1", props: props
-        shovel.run
-        sleep 10.milliseconds # better when than sleep?
-        path.should eq "/some_path"
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
+        with_channel(s) do |ch|
+          x, _ = ShovelSpecHelpers.setup_qs ch, "ql_"
+          headers = AMQP::Client::Arguments.new
+          headers["uri_path"] = "/some_path"
+          props = AMQP::Client::Properties.new("text/plain", nil, headers)
+          x.publish_confirm "shovel me", "ql_q1", props: props
+          shovel.run
+          sleep 10.milliseconds # better when than sleep?
+          path.should eq "/some_path"
+        end
       end
     end
   end

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -26,8 +26,9 @@ describe LavinMQ::DurableQueue do
   context "with corrupt segments" do
     context "when consumed" do
       it "should be closed" do
-        with_vhost("corrupt_vhost") do |vhost|
-          with_channel(vhost: vhost.name) do |ch|
+        with_amqp_server do |s|
+          vhost = s.vhosts.create("corrupt_vhost")
+          with_channel(s, vhost: vhost.name) do |ch|
             q = ch.queue("corrupt_q")
             queue = vhost.queues["corrupt_q"].as(LavinMQ::DurableQueue)
             q.publish_confirm "test message"
@@ -50,9 +51,10 @@ describe LavinMQ::DurableQueue do
     end
 
     it "should ignore corrupt endings" do
-      with_vhost("corrupt_vhost") do |vhost|
+      with_amqp_server do |s|
+        vhost = s.vhosts.create("corrupt_vhost")
         enq_path = ""
-        with_channel(vhost: vhost.name) do |ch|
+        with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("corrupt_q2")
           queue = vhost.queues["corrupt_q2"].as(LavinMQ::DurableQueue)
           enq_path = queue.@msg_store.@segments.last_value.path
@@ -60,10 +62,10 @@ describe LavinMQ::DurableQueue do
             q.publish_confirm "test message #{i}"
           end
         end
-        Server.stop
+        s.stop
         File.open(enq_path, "r+") { |f| f.truncate(f.size - 3) }
-        Server.restart
-        with_channel(vhost: vhost.name) do |ch|
+        s.restart
+        with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue_declare("corrupt_q2", passive: true)
           q[:message_count].should eq 1
         end
@@ -74,55 +76,59 @@ describe LavinMQ::DurableQueue do
   # Index corruption bug
   # https://github.com/cloudamqp/lavinmq/pull/384
   it "must find messages written after a uncompacted hole" do
-    enq_path = ""
-    with_channel do |ch|
-      q = ch.queue("corruption_test", durable: true)
-      q.publish_confirm "Hello world"
-      queue = Server.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
-      enq_path = queue.@msg_store.@segments.last_value.path
+    with_amqp_server do |s|
+      enq_path = ""
+      with_channel(s) do |ch|
+        q = ch.queue("corruption_test", durable: true)
+        q.publish_confirm "Hello world"
+        queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
+        enq_path = queue.@msg_store.@segments.last_value.path
+      end
+      s.stop
+      # Emulate the file was preallocated after server crash
+      File.open(enq_path, "r+") { |f| f.truncate(f.size + 24 * 1024**2) }
+      s.restart
+      # Write another message after the prealloced space
+      with_channel(s) do |ch|
+        q = ch.queue("corruption_test", durable: true)
+        q.publish_confirm "Hello world"
+      end
+      s.restart
+      queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
+      queue.message_count.should eq 2
     end
-    Server.stop
-    # Emulate the file was preallocated after server crash
-    File.open(enq_path, "r+") { |f| f.truncate(f.size + 24 * 1024**2) }
-    Server.restart
-    # Write another message after the prealloced space
-    with_channel do |ch|
-      q = ch.queue("corruption_test", durable: true)
-      q.publish_confirm "Hello world"
-    end
-    Server.restart
-    queue = Server.vhosts["/"].queues["corruption_test"].as(LavinMQ::DurableQueue)
-    queue.message_count.should eq 2
   end
 end
 
 describe LavinMQ::VHost do
   pending "GC segments" do
-    vhost = Server.vhosts["/"]
-    vhost.queues.each_value &.delete
-    vhost.queues.clear
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      vhost.queues.each_value &.delete
+      vhost.queues.clear
 
-    msg_size = 5120
-    overhead = 21
-    body = Bytes.new(msg_size)
+      msg_size = 5120
+      overhead = 21
+      body = Bytes.new(msg_size)
 
-    segments = ->{ Dir.new(vhost.data_dir).children.select!(/^msgs\./) }
+      segments = ->{ Dir.new(vhost.data_dir).children.select!(/^msgs\./) }
 
-    size_of_current_segment = File.size(File.join(vhost.data_dir, segments.call.last))
+      size_of_current_segment = File.size(File.join(vhost.data_dir, segments.call.last))
 
-    msgs_to_fill_2_segments = ((LavinMQ::Config.instance.segment_size * 2 - size_of_current_segment) / (msg_size + overhead)).ceil.to_i
+      msgs_to_fill_2_segments = ((LavinMQ::Config.instance.segment_size * 2 - size_of_current_segment) / (msg_size + overhead)).ceil.to_i
 
-    with_channel do |ch|
-      ch.confirm_select
-      msgid = 0_u64
-      q = ch.queue("dd", durable: true)
-      msgs_to_fill_2_segments.times do
-        msgid = q.publish body
+      with_channel(s) do |ch|
+        ch.confirm_select
+        msgid = 0_u64
+        q = ch.queue("dd", durable: true)
+        msgs_to_fill_2_segments.times do
+          msgid = q.publish body
+        end
+        ch.wait_for_confirm(msgid)
+        segments.call.size.should eq 2
+        q.purge
+        segments.call.size.should eq 1
       end
-      ch.wait_for_confirm(msgid)
-      segments.call.size.should eq 2
-      q.purge
-      segments.call.size.should eq 1
     end
   end
 end

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -6,176 +6,201 @@ describe LavinMQ::StreamQueue do
 
   describe "Consume" do
     it "should get message with offset 2" do
-      with_channel do |ch|
-        q = ch.queue("pub_and_consume", args: stream_queue_args)
-        10.times { |i| q.publish "m#{i}" }
-        ch.prefetch 1
-        msgs = Channel(AMQP::Client::DeliverMessage).new
-        q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": 2})) do |msg|
-          msgs.send msg
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("pub_and_consume", args: stream_queue_args)
+          10.times { |i| q.publish "m#{i}" }
+          ch.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": 2})) do |msg|
+            msgs.send msg
+          end
+          msg = msgs.receive
+          msg.properties.headers.should eq LavinMQ::AMQP::Table.new({"x-stream-offset": 2})
+          msg.body_io.to_s.should eq "m1"
         end
-        msg = msgs.receive
-        msg.properties.headers.should eq LavinMQ::AMQP::Table.new({"x-stream-offset": 2})
-        msg.body_io.to_s.should eq "m1"
       end
     end
 
     it "should get same nr of messages as published" do
-      with_channel do |ch2|
-        q = ch2.queue("pub_and_consume_2", args: stream_queue_args)
-        10.times { |i| q.publish "m#{i}" }
-        ch2.prefetch 1
-        msgs = Channel(AMQP::Client::DeliverMessage).new
-        q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": 0})) do |msg|
-          msgs.send(msg)
-          msg.ack
-        end
-        10.times do
-          msgs.receive
+      with_amqp_server do |s|
+        with_channel(s) do |ch2|
+          q = ch2.queue("pub_and_consume_2", args: stream_queue_args)
+          10.times { |i| q.publish "m#{i}" }
+          ch2.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": 0})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          10.times do
+            msgs.receive
+          end
         end
       end
     end
 
     it "should be able to consume multiple times" do
-      with_channel do |ch|
-        q = ch.queue("pub_and_consume_3", args: stream_queue_args)
-        10.times { |i| q.publish "m#{i}" }
-
-        msgs = Channel(AMQP::Client::DeliverMessage).new(20)
-        ch.prefetch 1
-        2.times do
-          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": 0})) do |msg|
-            msgs.send(msg)
-            msg.ack
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("pub_and_consume_3", args: stream_queue_args)
+          10.times { |i| q.publish "m#{i}" }
+          msgs = Channel(AMQP::Client::DeliverMessage).new(20)
+          ch.prefetch 1
+          2.times do
+            q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": 0})) do |msg|
+              msgs.send(msg)
+              msg.ack
+            end
           end
-        end
-        20.times do
-          msgs.receive
+          20.times do
+            msgs.receive
+          end
         end
       end
     end
 
     it "consumer gets new messages as they arrive" do
-      with_channel do |ch|
-        ch.prefetch 1
-        args = {"x-queue-type": "stream"}
-        q = ch.queue("stream-consume", args: AMQP::Client::Arguments.new(args))
-        q.publish "1"
-        msgs = Channel(AMQP::Client::DeliverMessage).new
-        q.subscribe(no_ack: false) do |msg|
-          msg.ack
-          msgs.send(msg)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 1
+          args = {"x-queue-type": "stream"}
+          q = ch.queue("stream-consume", args: AMQP::Client::Arguments.new(args))
+          q.publish "1"
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false) do |msg|
+            msg.ack
+            msgs.send(msg)
+          end
+          msgs.receive.body_io.to_s.should eq "1"
+          q.publish "2"
+          msgs.receive.body_io.to_s.should eq "2"
         end
-        msgs.receive.body_io.to_s.should eq "1"
-        q.publish "2"
-        msgs.receive.body_io.to_s.should eq "2"
       end
     end
   end
 
   describe "Expiration" do
     it "segments should be removed if max-length set" do
-      with_channel do |ch|
-        args = {"x-queue-type": "stream", "x-max-length": 1}
-        q = ch.queue("stream-max-length", args: AMQP::Client::Arguments.new(args))
-        data = Bytes.new(LavinMQ::Config.instance.segment_size)
-        3.times { q.publish_confirm data }
-        q.message_count.should eq 1
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-length": 1}
+          q = ch.queue("stream-max-length", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          3.times { q.publish_confirm data }
+          q.message_count.should eq 1
+        end
       end
     end
 
     it "segments should be removed if max-length-bytes set" do
-      with_channel do |ch|
-        args = {"x-queue-type": "stream", "x-max-length-bytes": 1}
-        q = ch.queue("stream-max-length-bytes", args: AMQP::Client::Arguments.new(args))
-        data = Bytes.new(LavinMQ::Config.instance.segment_size)
-        3.times { q.publish_confirm data }
-        q.message_count.should eq 1
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-length-bytes": 1}
+          q = ch.queue("stream-max-length-bytes", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          3.times { q.publish_confirm data }
+          q.message_count.should eq 1
+        end
       end
     end
 
     it "segments should be removed if max-age set" do
-      with_channel do |ch|
-        args = {"x-queue-type": "stream", "x-max-age": "1s"}
-        q = ch.queue("stream-max-age", args: AMQP::Client::Arguments.new(args))
-        data = Bytes.new(LavinMQ::Config.instance.segment_size)
-        2.times { q.publish_confirm data }
-        sleep 1.1
-        q.publish_confirm data
-        q.message_count.should eq 1
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-age": "1s"}
+          q = ch.queue("stream-max-age", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          2.times { q.publish_confirm data }
+          sleep 1.1
+          q.publish_confirm data
+          q.message_count.should eq 1
+        end
       end
     end
 
     it "removes segments on publish if max-age policy is set" do
-      Server.vhosts["/"].add_policy("max", "stream-max-age-policy", "queues", {"max-age" => JSON::Any.new("1s")}, 0i8)
-      with_channel do |ch|
-        args = {"x-queue-type": "stream", "x-max-age": "1M"}
-        q = ch.queue("stream-max-age-policy", args: AMQP::Client::Arguments.new(args))
-        data = Bytes.new(LavinMQ::Config.instance.segment_size)
-        2.times { q.publish_confirm data }
-        sleep 1.1
-        q.publish_confirm data
-        q.message_count.should eq 1
+      with_amqp_server do |s|
+        s.vhosts["/"].add_policy("max", "stream-max-age-policy", "queues", {"max-age" => JSON::Any.new("1s")}, 0i8)
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-age": "1M"}
+          q = ch.queue("stream-max-age-policy", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          2.times { q.publish_confirm data }
+          sleep 1.1
+          q.publish_confirm data
+          q.message_count.should eq 1
+        end
       end
     end
 
     it "removes segments when max-age policy is applied" do
-      with_channel do |ch|
-        args = {"x-queue-type": "stream", "x-max-age": "1M"}
-        q = ch.queue("stream-max-age-policy", args: AMQP::Client::Arguments.new(args))
-        data = Bytes.new(LavinMQ::Config.instance.segment_size)
-        2.times { q.publish_confirm data }
-        q.message_count.should eq 2
-        sleep 1.1
-        Server.vhosts["/"].add_policy("max", "stream-max-age-policy", "queues", {"max-age" => JSON::Any.new("1s")}, 0i8)
-        q.message_count.should eq 1
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-age": "1M"}
+          q = ch.queue("stream-max-age-policy", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          2.times { q.publish_confirm data }
+          q.message_count.should eq 2
+          sleep 1.1
+          s.vhosts["/"].add_policy("max", "stream-max-age-policy", "queues", {"max-age" => JSON::Any.new("1s")}, 0i8)
+          q.message_count.should eq 1
+        end
       end
     end
   end
 
   it "doesn't support basic_get" do
-    with_channel do |ch|
-      q = ch.queue("stream_basic_get", args: stream_queue_args)
-      q.publish_confirm "foobar"
-      expect_raises(AMQP::Client::Channel::ClosedException, /NOT_IMPLEMENTED.*basic_get/) do
-        ch.basic_get(q.name, no_ack: false)
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("stream_basic_get", args: stream_queue_args)
+        q.publish_confirm "foobar"
+        expect_raises(AMQP::Client::Channel::ClosedException, /NOT_IMPLEMENTED.*basic_get/) do
+          ch.basic_get(q.name, no_ack: false)
+        end
       end
     end
   end
 
   it "can requeue msgs per consumer" do
-    with_channel do |ch|
-      q = ch.queue("stream-requeue", args: stream_queue_args)
-      q.publish_confirm "foobar"
-      msgs = Channel(AMQP::Client::DeliverMessage).new
-      ch.prefetch 1
-      q.subscribe(no_ack: false) do |msg|
-        msgs.send msg
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("stream-requeue", args: stream_queue_args)
+        q.publish_confirm "foobar"
+        msgs = Channel(AMQP::Client::DeliverMessage).new
+        ch.prefetch 1
+        q.subscribe(no_ack: false) do |msg|
+          msgs.send msg
+        end
+        msg1 = msgs.receive
+        msg1.body_io.to_s.should eq "foobar"
+        msg1.reject(requeue: true)
+        msg2 = msgs.receive
+        msg2.body_io.to_s.should eq "foobar"
       end
-      msg1 = msgs.receive
-      msg1.body_io.to_s.should eq "foobar"
-      msg1.reject(requeue: true)
-      msg2 = msgs.receive
-      msg2.body_io.to_s.should eq "foobar"
     end
   end
 
   it "can start consume from last segment even is queue is empty" do
-    with_channel do |ch|
-      q = ch.queue("empty-stream", args: stream_queue_args)
-      ch.prefetch 1
-      q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "last"})) do |msg|
-        msg.ack
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("empty-stream", args: stream_queue_args)
+        ch.prefetch 1
+        q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "last"})) do |msg|
+          msg.ack
+        end
       end
     end
   end
 
   it "can be purged" do
-    with_channel do |ch|
-      q = ch.queue("purge-stream", args: stream_queue_args)
-      data = Bytes.new(LavinMQ::Config.instance.segment_size)
-      3.times { q.publish_confirm data }
-      q.purge[:message_count].should eq 2 # never deletes the last segment
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("purge-stream", args: stream_queue_args)
+        data = Bytes.new(LavinMQ::Config.instance.segment_size)
+        3.times { q.publish_confirm data }
+        q.purge[:message_count].should eq 2 # never deletes the last segment
+      end
     end
   end
 end

--- a/spec/tx_spec.cr
+++ b/spec/tx_spec.cr
@@ -3,99 +3,109 @@ require "./spec_helper"
 describe "Transactions" do
   describe "publishes" do
     it "can be commited" do
-      with_channel do |ch|
-        ch.tx_select
-        q = ch.queue
-        2.times do |i|
-          q.publish "#{i}" * 200_000
-        end
-        q.get.should be_nil
-        ch.tx_commit
-        2.times do |i|
-          msg = q.get
-          if msg
-            msg.body_io.to_s.should eq "#{i}" * 200_000
-          else
-            msg.should_not be_nil
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.tx_select
+          q = ch.queue
+          2.times do |i|
+            q.publish "#{i}" * 200_000
+          end
+          q.get.should be_nil
+          ch.tx_commit
+          2.times do |i|
+            msg = q.get
+            if msg
+              msg.body_io.to_s.should eq "#{i}" * 200_000
+            else
+              msg.should_not be_nil
+            end
           end
         end
       end
     end
 
     it "can be commited to multiple queues" do
-      with_channel do |ch|
-        ch.tx_select
-        q1 = ch.queue
-        q2 = ch.queue
-        q1.bind("amq.fanout", "")
-        q2.bind("amq.fanout", "")
-        x = ch.exchange("amq.fanout", "fanout")
-        2.times do |i|
-          x.publish i.to_s * 200_000, ""
-          ch.basic_publish("", "", "")
-        end
-        q1.get.should be_nil
-        ch.tx_commit
-        2.times do |i|
-          if msg = q1.get
-            msg.body_io.to_s.should eq i.to_s * 200_000
-          else
-            msg.should_not be_nil
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.tx_select
+          q1 = ch.queue
+          q2 = ch.queue
+          q1.bind("amq.fanout", "")
+          q2.bind("amq.fanout", "")
+          x = ch.exchange("amq.fanout", "fanout")
+          2.times do |i|
+            x.publish i.to_s * 200_000, ""
+            ch.basic_publish("", "", "")
           end
-          if msg = q2.get
-            msg.body_io.to_s.should eq i.to_s * 200_000
-          else
-            msg.should_not be_nil
+          q1.get.should be_nil
+          ch.tx_commit
+          2.times do |i|
+            if msg = q1.get
+              msg.body_io.to_s.should eq i.to_s * 200_000
+            else
+              msg.should_not be_nil
+            end
+            if msg = q2.get
+              msg.body_io.to_s.should eq i.to_s * 200_000
+            else
+              msg.should_not be_nil
+            end
           end
         end
       end
     end
 
     it "can be rollbacked" do
-      with_channel do |ch|
-        ch.tx_select
-        q = ch.queue
-        q.publish ""
-        q.get.should be_nil
-        ch.tx_rollback
-        q.get.should be_nil
-        q.message_count.should eq 0
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.tx_select
+          q = ch.queue
+          q.publish ""
+          q.get.should be_nil
+          ch.tx_rollback
+          q.get.should be_nil
+          q.message_count.should eq 0
+        end
       end
     end
   end
 
   describe "acks" do
     it "can be commited" do
-      with_channel do |ch|
-        ch.tx_select
-        q = ch.queue
-        2.times { |i| q.publish "#{i}" }
-        ch.tx_commit
-        2.times do |i|
-          msg = q.get(no_ack: false).not_nil!
-          msg.body_io.to_s.should eq "#{i}"
-          msg.ack
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.tx_select
+          q = ch.queue
+          2.times { |i| q.publish "#{i}" }
+          ch.tx_commit
+          2.times do |i|
+            msg = q.get(no_ack: false).not_nil!
+            msg.body_io.to_s.should eq "#{i}"
+            msg.ack
+          end
+          ch.tx_commit
+          ch.basic_recover(requeue: true)
+          q.message_count.should eq 0
         end
-        ch.tx_commit
-        ch.basic_recover(requeue: true)
-        q.message_count.should eq 0
       end
     end
 
     it "can be rollbacked" do
-      with_channel do |ch|
-        ch.tx_select
-        q = ch.queue
-        2.times { |i| q.publish "#{i}" }
-        ch.tx_commit
-        2.times do |i|
-          msg = q.get(no_ack: false).not_nil!
-          msg.body_io.to_s.should eq "#{i}"
-          msg.ack
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.tx_select
+          q = ch.queue
+          2.times { |i| q.publish "#{i}" }
+          ch.tx_commit
+          2.times do |i|
+            msg = q.get(no_ack: false).not_nil!
+            msg.body_io.to_s.should eq "#{i}"
+            msg.ack
+          end
+          ch.tx_rollback
+          ch.basic_recover(requeue: true)
+          q.message_count.should eq 2
         end
-        ch.tx_rollback
-        ch.basic_recover(requeue: true)
-        q.message_count.should eq 2
       end
     end
   end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -9,20 +9,13 @@ module UpstreamSpecHelpers
     {x, q2}
   end
 
-  def self.cleanup(upstream)
-    links = upstream.links
-    Server.vhosts["/"].delete_queue("federation_q1")
-    Server.vhosts["/"].delete_queue("federation_q2")
-    wait_for { links.all?(&.state.terminated?) }
-  end
-
-  def self.setup_federation(upstream_name, exchange = nil, queue = nil, prefetch = 1000_u16)
-    self.cleanup_vhosts
-    upstream_vhost = Server.vhosts.create("upstream")
-    downstream_vhost = Server.vhosts.create("downstream")
+  def self.setup_federation(s, upstream_name, exchange = nil, queue = nil, prefetch = 1000_u16)
+    self.cleanup_vhosts(s)
+    upstream_vhost = s.vhosts.create("upstream")
+    downstream_vhost = s.vhosts.create("downstream")
     upstream = LavinMQ::Federation::Upstream.new(
       downstream_vhost, upstream_name,
-      "#{SpecHelper.amqp_base_url}/upstream", exchange, queue,
+      "#{s.amqp_url}/upstream", exchange, queue,
       LavinMQ::Federation::AckMode::OnConfirm, nil, 1_i64, nil, prefetch
     )
     downstream_vhost.upstreams.not_nil!.add(upstream)
@@ -34,372 +27,395 @@ module UpstreamSpecHelpers
     upstream.vhost.add_policy("FE", pattern, applies_to, definitions, 12_i8)
   end
 
-  def self.cleanup_vhost(vhost_name)
-    v = Server.vhosts[vhost_name]
-    Server.vhosts.delete(vhost_name)
+  def self.cleanup_vhost(s, vhost_name)
+    v = s.vhosts[vhost_name]
+    s.vhosts.delete(vhost_name)
     wait_for { !(Dir.exists?(v.data_dir)) }
   rescue KeyError
   end
 
-  def self.cleanup_vhosts
-    cleanup_vhost("upstream")
-    cleanup_vhost("downstream")
+  def self.cleanup_vhosts(s)
+    cleanup_vhost(s, "upstream")
+    cleanup_vhost(s, "downstream")
   end
 end
 
 describe LavinMQ::Federation::Upstream do
   it "should use federated queue's name if @queue is empty" do
-    vhost_downstream = Server.vhosts.create("/")
-    vhost_upstream = Server.vhosts.create("upstream")
-    upstream = LavinMQ::Federation::Upstream.new(vhost_downstream, "qf test upstream", "#{SpecHelper.amqp_base_url}/upstream", nil, "")
+    with_amqp_server do |s|
+      vhost_downstream = s.vhosts.create("/")
+      vhost_upstream = s.vhosts.create("upstream")
+      upstream = LavinMQ::Federation::Upstream.new(vhost_downstream, "qf test upstream", "#{s.amqp_url}/upstream", nil, "")
 
-    with_channel do |ch|
-      ch.queue("federated_q")
-      link = upstream.link(vhost_downstream.queues["federated_q"])
-      wait_for { link.state.running? }
-      vhost_upstream.queues.has_key?("federated_q").should be_true
+      with_channel(s) do |ch|
+        ch.queue("federated_q")
+        link = upstream.link(vhost_downstream.queues["federated_q"])
+        wait_for { link.state.running? }
+        vhost_upstream.queues.has_key?("federated_q").should be_true
+      end
     end
   end
 
   it "should federate queue" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", SpecHelper.amqp_base_url, nil, "federation_q1")
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream", s.amqp_url, nil, "federation_q1")
 
-    with_channel do |ch|
-      x, q2 = UpstreamSpecHelpers.setup_qs ch
-      x.publish "federate me", "federation_q1"
-      upstream.link(vhost.queues["federation_q2"])
-      msgs = [] of AMQP::Client::DeliverMessage
-      q2.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
-      vhost.queues["federation_q1"].message_count.should eq 0
+      with_channel(s) do |ch|
+        x, q2 = UpstreamSpecHelpers.setup_qs ch
+        x.publish "federate me", "federation_q1"
+        upstream.link(vhost.queues["federation_q2"])
+        msgs = [] of AMQP::Client::DeliverMessage
+        q2.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+        vhost.queues["federation_q1"].message_count.should eq 0
+      end
     end
   end
 
   it "should not federate queue if no downstream consumer" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream wo downstream", SpecHelper.amqp_base_url, nil, "federation_q1")
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream wo downstream", s.amqp_url, nil, "federation_q1")
 
-    with_channel do |ch|
-      x = UpstreamSpecHelpers.setup_qs(ch).first
-      x.publish "federate me", "federation_q1"
-      link = upstream.link(vhost.queues["federation_q2"])
-      wait_for { link.state.running? }
-      vhost.queues["federation_q1"].message_count.should eq 1
-      vhost.queues["federation_q2"].message_count.should eq 0
+      with_channel(s) do |ch|
+        x = UpstreamSpecHelpers.setup_qs(ch).first
+        x.publish "federate me", "federation_q1"
+        link = upstream.link(vhost.queues["federation_q2"])
+        wait_for { link.state.running? }
+        vhost.queues["federation_q1"].message_count.should eq 1
+        vhost.queues["federation_q2"].message_count.should eq 0
+      end
     end
   end
 
   it "should federate queue with ack mode no-ack" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream no-ack", SpecHelper.amqp_base_url, nil, "federation_q1",
-      ack_mode: LavinMQ::Federation::AckMode::NoAck)
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream no-ack", s.amqp_url, nil, "federation_q1",
+        ack_mode: LavinMQ::Federation::AckMode::NoAck)
 
-    with_channel do |ch|
-      x, q2 = UpstreamSpecHelpers.setup_qs ch
-      x.publish "federate me", "federation_q1"
-      upstream.link(vhost.queues["federation_q2"])
-      msgs = [] of AMQP::Client::DeliverMessage
-      q2.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
-      vhost.queues["federation_q1"].message_count.should eq 0
+      with_channel(s) do |ch|
+        x, q2 = UpstreamSpecHelpers.setup_qs ch
+        x.publish "federate me", "federation_q1"
+        upstream.link(vhost.queues["federation_q2"])
+        msgs = [] of AMQP::Client::DeliverMessage
+        q2.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+        vhost.queues["federation_q1"].message_count.should eq 0
+      end
     end
   end
 
   it "should federate queue with ack mode on-publish" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream on-publish", SpecHelper.amqp_base_url, nil, "federation_q1",
-      ack_mode: LavinMQ::Federation::AckMode::OnPublish)
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream on-publish", s.amqp_url, nil, "federation_q1",
+        ack_mode: LavinMQ::Federation::AckMode::OnPublish)
 
-    with_channel do |ch|
-      x, q2 = UpstreamSpecHelpers.setup_qs ch
-      x.publish "federate me", "federation_q1"
-      upstream.link(vhost.queues["federation_q2"])
-      msgs = [] of AMQP::Client::DeliverMessage
-      q2.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
-      vhost.queues["federation_q1"].message_count.should eq 0
+      with_channel(s) do |ch|
+        x, q2 = UpstreamSpecHelpers.setup_qs ch
+        x.publish "federate me", "federation_q1"
+        upstream.link(vhost.queues["federation_q2"])
+        msgs = [] of AMQP::Client::DeliverMessage
+        q2.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+        vhost.queues["federation_q1"].message_count.should eq 0
+      end
     end
   end
 
   it "should resume federation after downstream reconnects" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream reconnect", SpecHelper.amqp_base_url, nil, "federation_q1")
-    msgs = [] of AMQP::Client::DeliverMessage
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream reconnect", s.amqp_url, nil, "federation_q1")
+      msgs = [] of AMQP::Client::DeliverMessage
 
-    with_channel do |ch|
-      x, q2 = UpstreamSpecHelpers.setup_qs ch
-      x.publish "federate me", "federation_q1"
-      upstream.link(vhost.queues["federation_q2"])
-      q2.subscribe do |msg|
-        msgs << msg
+      with_channel(s) do |ch|
+        x, q2 = UpstreamSpecHelpers.setup_qs ch
+        x.publish "federate me", "federation_q1"
+        upstream.link(vhost.queues["federation_q2"])
+        q2.subscribe do |msg|
+          msgs << msg
+        end
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
       end
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
-    end
 
-    with_channel do |ch|
-      x, q2 = UpstreamSpecHelpers.setup_qs ch
-      x.publish "federate me", "federation_q1"
-      q2.subscribe do |msg|
-        msgs << msg
+      with_channel(s) do |ch|
+        x, q2 = UpstreamSpecHelpers.setup_qs ch
+        x.publish "federate me", "federation_q1"
+        q2.subscribe do |msg|
+          msgs << msg
+        end
+        wait_for { msgs.size == 2 }
+        msgs.size.should eq 2
+        wait_for { vhost.queues["federation_q1"].message_count == 0 }
       end
-      wait_for { msgs.size == 2 }
-      msgs.size.should eq 2
-      wait_for { vhost.queues["federation_q1"].message_count == 0 }
     end
   end
 
   it "should federate exchange" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "ef test upstream", SpecHelper.amqp_base_url, "upstream_ex")
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "ef test upstream", s.amqp_url, "upstream_ex")
 
-    with_channel do |ch|
-      downstream_ex = ch.exchange("downstream_ex", "topic")
-      downstream_q = ch.queue("downstream_q")
-      downstream_q.bind(downstream_ex.name, "#")
-      link = upstream.link(vhost.exchanges[downstream_ex.name])
-      wait_for { link.state.running? }
-      upstream_ex = ch.exchange("upstream_ex", "topic", passive: true)
-      upstream_ex.publish "federate me", "rk"
-      msgs = [] of AMQP::Client::DeliverMessage
-      downstream_q.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.size.should eq 1
+      with_channel(s) do |ch|
+        downstream_ex = ch.exchange("downstream_ex", "topic")
+        downstream_q = ch.queue("downstream_q")
+        downstream_q.bind(downstream_ex.name, "#")
+        link = upstream.link(vhost.exchanges[downstream_ex.name])
+        wait_for { link.state.running? }
+        upstream_ex = ch.exchange("upstream_ex", "topic", passive: true)
+        upstream_ex.publish "federate me", "rk"
+        msgs = [] of AMQP::Client::DeliverMessage
+        downstream_q.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.size.should eq 1
+      end
     end
   end
 
   it "should keep message properties" do
-    vhost = Server.vhosts["/"]
-    upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream props", SpecHelper.amqp_base_url, nil, "federation_q1")
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      upstream = LavinMQ::Federation::Upstream.new(vhost, "qf test upstream props", s.amqp_url, nil, "federation_q1")
 
-    with_channel do |ch|
-      x, q2 = UpstreamSpecHelpers.setup_qs ch
-      x.publish "federate me", "federation_q1", props: AMQP::Client::Properties.new(content_type: "application/json")
-      upstream.link(vhost.queues["federation_q2"])
-      msgs = [] of AMQP::Client::DeliverMessage
-      q2.subscribe { |msg| msgs << msg }
-      wait_for { msgs.size == 1 }
-      msgs.first.properties.content_type.should eq "application/json"
+      with_channel(s) do |ch|
+        x, q2 = UpstreamSpecHelpers.setup_qs ch
+        x.publish "federate me", "federation_q1", props: AMQP::Client::Properties.new(content_type: "application/json")
+        upstream.link(vhost.queues["federation_q2"])
+        msgs = [] of AMQP::Client::DeliverMessage
+        q2.subscribe { |msg| msgs << msg }
+        wait_for { msgs.size == 1 }
+        msgs.first.properties.content_type.should eq "application/json"
+      end
     end
   end
 
   it "should federate exchange even with no downstream consumer" do
-    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation("ef test upstream wo downstream", "upstream_ex")
-    UpstreamSpecHelpers.start_link(upstream)
-    Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
-    Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
-    with_channel(vhost: "upstream") do |upstream_ch|
-      with_channel(vhost: "downstream") do |downstream_ch|
-        upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
-        downstream_ch.exchange("downstream_ex", "topic")
-        wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
-        # Assert setup is correct
-        wait_for { upstream.links.first?.try &.state.running? }
-        downstream_q = downstream_ch.queue("downstream_q")
-        downstream_q.bind("downstream_ex", "#")
-        upstream_ex.publish_confirm "federate me", "rk"
-        wait_for { downstream_q.get }
-        msgs = [] of AMQP::Client::DeliverMessage
-        downstream_q.subscribe { |msg| msgs << msg }
-        upstream_ex.publish_confirm "federate me", "rk"
-        wait_for { msgs.size == 1 }
-        msgs.first.not_nil!.body_io.to_s.should eq("federate me")
+    with_amqp_server do |s|
+      upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation(s, "ef test upstream wo downstream", "upstream_ex")
+      UpstreamSpecHelpers.start_link(upstream)
+      s.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
+      s.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
+      with_channel(s, vhost: "upstream") do |upstream_ch|
+        with_channel(s, vhost: "downstream") do |downstream_ch|
+          upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
+          downstream_ch.exchange("downstream_ex", "topic")
+          wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
+          # Assert setup is correct
+          wait_for { upstream.links.first?.try &.state.running? }
+          downstream_q = downstream_ch.queue("downstream_q")
+          downstream_q.bind("downstream_ex", "#")
+          upstream_ex.publish_confirm "federate me", "rk"
+          wait_for { downstream_q.get }
+          msgs = [] of AMQP::Client::DeliverMessage
+          downstream_q.subscribe { |msg| msgs << msg }
+          upstream_ex.publish_confirm "federate me", "rk"
+          wait_for { msgs.size == 1 }
+          msgs.first.not_nil!.body_io.to_s.should eq("federate me")
+        end
       end
+      upstream_vhost.queues.each_value.all?(&.empty?).should be_true
     end
-    upstream_vhost.queues.each_value.all?(&.empty?).should be_true
   end
 
   it "should continue after upstream restart" do
-    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation("ef test upstream restart", "upstream_ex")
-    UpstreamSpecHelpers.start_link(upstream)
-    Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
-    Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
+    with_amqp_server do |s|
+      upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_federation(s, "ef test upstream restart", "upstream_ex")
+      UpstreamSpecHelpers.start_link(upstream)
+      s.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
+      s.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
 
-    with_channel(vhost: "upstream") do |upstream_ch|
-      with_channel(vhost: "downstream") do |downstream_ch|
-        upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
-        downstream_ch.exchange("downstream_ex", "topic")
-        wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
-        # Assert setup is correct
+      with_channel(s, vhost: "upstream") do |upstream_ch|
+        with_channel(s, vhost: "downstream") do |downstream_ch|
+          upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
+          downstream_ch.exchange("downstream_ex", "topic")
+          wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
+          # Assert setup is correct
+          wait_for { upstream.links.first?.try &.state.running? }
+          downstream_q = downstream_ch.queue("downstream_q")
+          downstream_q.bind("downstream_ex", "#")
+          msgs = Channel(String).new
+          downstream_q.subscribe do |msg|
+            msgs.send msg.body_io.to_s
+          end
+          upstream_ex.publish_confirm "msg1", "rk1"
+          msgs.receive.should eq "msg1"
+          sleep 0.01 # allow the downstream federation to ack the msg
+          upstream_vhost.connections.each do |conn|
+            next unless conn.client_name.starts_with?("Federation link")
+            conn.close
+          end
+          wait_for { upstream.links.first?.try { |l| l.state.stopped? || l.state.starting? } }
+          upstream_ex.publish "msg2", "rk2"
+          # Should reconnect
+          wait_for { upstream.links.first?.try(&.state.running?) }
+          upstream_ex.publish "msg3", "rk3"
+          msgs.receive.should eq "msg2"
+          msgs.receive.should eq "msg3"
+        end
+      end
+      upstream_vhost.queues.each_value.all?(&.empty?).should be_true
+    end
+  end
+
+  it "should only transfer messages when downstream has consumer" do
+    with_amqp_server do |s|
+      ds_queue_name = Random::Secure.hex(10)
+      us_queue_name = Random::Secure.hex(10)
+      upstream, us_vhost, ds_vhost = UpstreamSpecHelpers.setup_federation(s, Random::Secure.hex(10), nil, us_queue_name)
+
+      UpstreamSpecHelpers.start_link(upstream, ds_queue_name, "queues")
+      s.users.add_permission("guest", us_vhost.name, /.*/, /.*/, /.*/)
+      s.users.add_permission("guest", ds_vhost.name, /.*/, /.*/, /.*/)
+
+      # publish 1 message
+      with_channel(s, vhost: us_vhost.name) do |upstream_ch|
+        upstream_q = upstream_ch.queue(us_queue_name)
+        upstream_q.publish "msg1"
+      end
+
+      # consume 1 message
+      with_channel(s, vhost: ds_vhost.name) do |downstream_ch|
+        downstream_q = downstream_ch.queue(ds_queue_name)
+        wait_for { ds_vhost.queues[ds_queue_name].policy.try(&.name) == "FE" }
         wait_for { upstream.links.first?.try &.state.running? }
-        downstream_q = downstream_ch.queue("downstream_q")
-        downstream_q.bind("downstream_ex", "#")
+
         msgs = Channel(String).new
         downstream_q.subscribe do |msg|
           msgs.send msg.body_io.to_s
         end
-        upstream_ex.publish_confirm "msg1", "rk1"
         msgs.receive.should eq "msg1"
-        sleep 0.01 # allow the downstream federation to ack the msg
-        upstream_vhost.connections.each do |conn|
-          next unless conn.client_name.starts_with?("Federation link")
-          conn.close
+        wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
+      end
+
+      wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].consumers.empty? }
+
+      # publish another message
+      with_channel(s, vhost: us_vhost.name) do |upstream_ch|
+        upstream_q = upstream_ch.queue(us_queue_name)
+        upstream_q.publish "msg2"
+      end
+
+      # resume consuming on downstream, should get 1 message
+      with_channel(s, vhost: ds_vhost.name) do |downstream_ch|
+        msgs = Channel(String).new
+        downstream_ch.queue(ds_queue_name).subscribe do |msg|
+          msgs.send msg.body_io.to_s
         end
-        wait_for { upstream.links.first?.try { |l| l.state.stopped? || l.state.starting? } }
-        upstream_ex.publish "msg2", "rk2"
-        # Should reconnect
-        wait_for { upstream.links.first?.try(&.state.running?) }
-        upstream_ex.publish "msg3", "rk3"
         msgs.receive.should eq "msg2"
-        msgs.receive.should eq "msg3"
       end
     end
-    upstream_vhost.queues.each_value.all?(&.empty?).should be_true
-    UpstreamSpecHelpers.cleanup_vhosts
-  end
-
-  it "should only transfer messages when downstream has consumer" do
-    ds_queue_name = Random::Secure.hex(10)
-    us_queue_name = Random::Secure.hex(10)
-    upstream, us_vhost, ds_vhost = UpstreamSpecHelpers.setup_federation(Random::Secure.hex(10), nil, us_queue_name)
-
-    UpstreamSpecHelpers.start_link(upstream, ds_queue_name, "queues")
-    Server.users.add_permission("guest", us_vhost.name, /.*/, /.*/, /.*/)
-    Server.users.add_permission("guest", ds_vhost.name, /.*/, /.*/, /.*/)
-
-    # publish 1 message
-    with_channel(vhost: us_vhost.name) do |upstream_ch|
-      upstream_q = upstream_ch.queue(us_queue_name)
-      upstream_q.publish "msg1"
-    end
-
-    # consume 1 message
-    with_channel(vhost: ds_vhost.name) do |downstream_ch|
-      downstream_q = downstream_ch.queue(ds_queue_name)
-      wait_for { ds_vhost.queues[ds_queue_name].policy.try(&.name) == "FE" }
-      wait_for { upstream.links.first?.try &.state.running? }
-
-      msgs = Channel(String).new
-      downstream_q.subscribe do |msg|
-        msgs.send msg.body_io.to_s
-      end
-      msgs.receive.should eq "msg1"
-      wait_for { Server.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
-    end
-
-    wait_for { Server.vhosts[ds_vhost.name].queues[ds_queue_name].consumers.empty? }
-
-    # publish another message
-    with_channel(vhost: us_vhost.name) do |upstream_ch|
-      upstream_q = upstream_ch.queue(us_queue_name)
-      upstream_q.publish "msg2"
-    end
-
-    # resume consuming on downstream, should get 1 message
-    with_channel(vhost: ds_vhost.name) do |downstream_ch|
-      msgs = Channel(String).new
-      downstream_ch.queue(ds_queue_name).subscribe do |msg|
-        msgs.send msg.body_io.to_s
-      end
-      msgs.receive.should eq "msg2"
-    end
-  ensure
-    UpstreamSpecHelpers.cleanup_vhosts
   end
 
   it "should stop transfering messages if downstream consumer disconnects" do
-    ds_queue_name = Random::Secure.hex(10)
-    us_queue_name = Random::Secure.hex(10)
-    upstream, us_vhost, ds_vhost = UpstreamSpecHelpers.setup_federation(Random::Secure.hex(10), nil, us_queue_name, 1_u16)
-    UpstreamSpecHelpers.start_link(upstream, ds_queue_name, "queues")
-    Server.users.add_permission("guest", us_vhost.name, /.*/, /.*/, /.*/)
-    Server.users.add_permission("guest", ds_vhost.name, /.*/, /.*/, /.*/)
-    message_count = 2
+    with_amqp_server do |s|
+      ds_queue_name = Random::Secure.hex(10)
+      us_queue_name = Random::Secure.hex(10)
+      upstream, us_vhost, ds_vhost = UpstreamSpecHelpers.setup_federation(s, Random::Secure.hex(10), nil, us_queue_name, 1_u16)
+      UpstreamSpecHelpers.start_link(upstream, ds_queue_name, "queues")
+      s.users.add_permission("guest", us_vhost.name, /.*/, /.*/, /.*/)
+      s.users.add_permission("guest", ds_vhost.name, /.*/, /.*/, /.*/)
+      message_count = 2
 
-    # publish 2 messages to upstream queue
-    with_channel(vhost: us_vhost.name) do |upstream_ch|
-      upstream_q = upstream_ch.queue(us_queue_name)
-      message_count.times do |i|
-        upstream_q.publish "msg#{i}"
+      # publish 2 messages to upstream queue
+      with_channel(s, vhost: us_vhost.name) do |upstream_ch|
+        upstream_q = upstream_ch.queue(us_queue_name)
+        message_count.times do |i|
+          upstream_q.publish "msg#{i}"
+        end
+      end
+
+      # consume 1 message from downstream queue
+      with_channel(s, vhost: ds_vhost.name) do |downstream_ch|
+        downstream_q = downstream_ch.queue(ds_queue_name)
+
+        # make sure FE policy is set and link is running
+        wait_for { ds_vhost.queues[ds_queue_name].policy.try(&.name) == "FE" }
+        wait_for { upstream.links.first?.try &.state.running? }
+
+        messages_consumed = 0
+        downstream_q.subscribe(tag: "c") do |_msg|
+          messages_consumed += 1
+          downstream_q.unsubscribe("c")
+        end
+        wait_for { messages_consumed == 1 }
+        wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
+        wait_for { s.vhosts[us_vhost.name].queues[us_queue_name].message_count == 1 }
+      end
+
+      # make sure consumer is disconnected
+      wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].consumers.empty? }
+
+      # resume consuming on downstream, should get 1 message
+      with_channel(s, vhost: ds_vhost.name) do |downstream_ch|
+        messages_consumed = 0
+        downstream_ch.queue(ds_queue_name).subscribe(tag: "c2") do |_msg|
+          messages_consumed += 1
+        end
+        wait_for { s.vhosts[us_vhost.name].queues[us_queue_name].message_count == 0 }
+        wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
+        wait_for { messages_consumed == 1 }
       end
     end
-
-    # consume 1 message from downstream queue
-    with_channel(vhost: ds_vhost.name) do |downstream_ch|
-      downstream_q = downstream_ch.queue(ds_queue_name)
-
-      # make sure FE policy is set and link is running
-      wait_for { ds_vhost.queues[ds_queue_name].policy.try(&.name) == "FE" }
-      wait_for { upstream.links.first?.try &.state.running? }
-
-      messages_consumed = 0
-      downstream_q.subscribe(tag: "c") do |_msg|
-        messages_consumed += 1
-        downstream_q.unsubscribe("c")
-      end
-      wait_for { messages_consumed == 1 }
-      wait_for { Server.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
-      wait_for { Server.vhosts[us_vhost.name].queues[us_queue_name].message_count == 1 }
-    end
-
-    # make sure consumer is disconnected
-    wait_for { Server.vhosts[ds_vhost.name].queues[ds_queue_name].consumers.empty? }
-
-    # resume consuming on downstream, should get 1 message
-    with_channel(vhost: ds_vhost.name) do |downstream_ch|
-      messages_consumed = 0
-      downstream_ch.queue(ds_queue_name).subscribe(tag: "c2") do |_msg|
-        messages_consumed += 1
-      end
-      wait_for { Server.vhosts[us_vhost.name].queues[us_queue_name].message_count == 0 }
-      wait_for { Server.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
-      wait_for { messages_consumed == 1 }
-    end
-  ensure
-    UpstreamSpecHelpers.cleanup_vhosts
   end
 
   it "should reflect all bindings to upstream q" do
-    upstream, upstream_vhost, _ = UpstreamSpecHelpers.setup_federation("ef test bindings", "upstream_ex")
-    Server.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
-    Server.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
+    with_amqp_server do |s|
+      upstream, upstream_vhost, _ = UpstreamSpecHelpers.setup_federation(s, "ef test bindings", "upstream_ex")
+      s.users.add_permission("guest", "upstream", /.*/, /.*/, /.*/)
+      s.users.add_permission("guest", "downstream", /.*/, /.*/, /.*/)
 
-    with_channel(vhost: "downstream") do |downstream_ch|
-      downstream_ch.exchange("downstream_ex", "topic")
-      queues = [] of AMQP::Client::Queue
-      10.times do |i|
-        downstream_q = downstream_ch.queue("")
-        downstream_q.bind("downstream_ex", "before.link.#{i}")
-        queues << downstream_q
+      with_channel(s, vhost: "downstream") do |downstream_ch|
+        downstream_ch.exchange("downstream_ex", "topic")
+        queues = [] of AMQP::Client::Queue
+        10.times do |i|
+          downstream_q = downstream_ch.queue("")
+          downstream_q.bind("downstream_ex", "before.link.#{i}")
+          queues << downstream_q
+        end
+
+        UpstreamSpecHelpers.start_link(upstream)
+        wait_for { upstream.links.first?.try &.state.running? }
+
+        upstream_q = upstream_vhost.queues.values.first
+        upstream_q.bindings.size.should eq queues.size
+        # Assert setup is correct
+        10.times do |i|
+          downstream_q = downstream_ch.queue("")
+          downstream_q.bind("downstream_ex", "after.link.#{i}")
+          queues << downstream_q
+        end
+        sleep 0.1
+        upstream_q.bindings.size.should eq queues.size
+        queues.each &.delete
+        sleep 0.01
+        upstream_q.bindings.size.should eq 0
       end
-
-      UpstreamSpecHelpers.start_link(upstream)
-      wait_for { upstream.links.first?.try &.state.running? }
-
-      upstream_q = upstream_vhost.queues.values.first
-      upstream_q.bindings.size.should eq queues.size
-      # Assert setup is correct
-      10.times do |i|
-        downstream_q = downstream_ch.queue("")
-        downstream_q.bind("downstream_ex", "after.link.#{i}")
-        queues << downstream_q
-      end
-      sleep 0.1
-      upstream_q.bindings.size.should eq queues.size
-      queues.each &.delete
-      sleep 0.01
-      upstream_q.bindings.size.should eq 0
     end
   end
 
   describe "when @queue is nil" do
     describe "#link(Queue)" do
       it "should create link that consumes upstream queue with same name as downstream queue" do
-        vhost = Server.vhosts["/"]
+        with_amqp_server do |s|
+          vhost = s.vhosts["/"]
 
-        vhost.declare_queue("q1", true, false)
-        vhost.declare_queue("q2", true, false)
+          vhost.declare_queue("q1", true, false)
+          vhost.declare_queue("q2", true, false)
 
-        upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", nil, nil)
-        link1 = upstream.link(vhost.queues["q1"])
-        link2 = upstream.link(vhost.queues["q2"])
+          upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", nil, nil)
+          link1 = upstream.link(vhost.queues["q1"])
+          link2 = upstream.link(vhost.queues["q2"])
 
-        link1.@upstream_q.should eq "q1"
-        link2.@upstream_q.should eq "q2"
+          link1.@upstream_q.should eq "q1"
+          link2.@upstream_q.should eq "q2"
+        end
       end
     end
   end

--- a/spec/users_spec.cr
+++ b/spec/users_spec.cr
@@ -32,208 +32,240 @@ describe LavinMQ::Server do
   end
 
   it "disallow users who dont have vhost access" do
-    Server.vhosts.create("v1")
-    Server.users.rm_permission("guest", "v1")
-    Fiber.yield
-    expect_raises(AMQP::Client::Connection::ClosedException) do
-      with_channel(vhost: "v1", user: "guest", password: "guest") { }
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.rm_permission("guest", "v1")
+      Fiber.yield
+      expect_raises(AMQP::Client::Connection::ClosedException) do
+        with_channel(s, vhost: "v1", user: "guest", password: "guest") { }
+      end
     end
   end
 
   it "allows users with access to vhost" do
-    Server.vhosts.create("v1")
-    Server.users.create("u1", "p1")
-    Server.users.add_permission("u1", "v1", /.*/, /.*/, /.*/)
-    with_channel(vhost: "v1", user: "u1", password: "p1") { }
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.create("u1", "p1")
+      s.users.add_permission("u1", "v1", /.*/, /.*/, /.*/)
+      with_channel(s, vhost: "v1", user: "u1", password: "p1") { }
+    end
   end
 
   it "prohibits declaring exchanges if don't have access" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        ch.exchange("x1", "direct")
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          ch.exchange("x1", "direct")
+        end
       end
     end
   end
 
   it "prohibits declaring queues if don't have access" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
-    Fiber.yield
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        ch.queue("q1")
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
+      Fiber.yield
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          ch.queue("q1")
+        end
       end
     end
   end
 
   it "prohibits publish if user doesn't have access" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /.*/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        q = ch.queue("")
-        q.publish_confirm "msg"
-        q.get
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /.*/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          q = ch.queue("")
+          q.publish_confirm "msg"
+          q.get
+        end
       end
     end
   end
 
   it "prohibits consuming if user doesn't have access" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /.*/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        q = ch.queue("")
-        q.subscribe(no_ack: true) { }
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /.*/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          q = ch.queue("")
+          q.subscribe(no_ack: true) { }
+        end
       end
     end
   end
 
   it "prohibits getting from queue if user doesn't have access" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /.*/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        q = ch.queue("")
-        q.get(no_ack: true)
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /.*/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          q = ch.queue("")
+          q.get(no_ack: true)
+        end
       end
     end
   end
 
   it "prohibits purging queue if user doesn't have write access" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /^$/, /.*/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        q = ch.queue("")
-        q.purge
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /^$/, /.*/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          q = ch.queue("")
+          q.purge
+        end
       end
     end
   end
 
   it "allows declaring exchanges passivly even without config perms" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
-    with_channel(vhost: "v1") do |ch|
-      x = ch.exchange("amq.topic", "topic", passive: true)
-      x.is_a?(AMQP::Client::Exchange).should be_true
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
+      with_channel(s, vhost: "v1") do |ch|
+        x = ch.exchange("amq.topic", "topic", passive: true)
+        x.is_a?(AMQP::Client::Exchange).should be_true
+      end
     end
   end
 
   it "allows declaring queues passivly even without config perms" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
-    with_channel(vhost: "v1") do |ch|
-      ch.queue("q1cp", durable: false, auto_delete: true)
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
-    with_channel(vhost: "v1") do |ch|
-      q1 = ch.queue("q1cp", passive: true)
-      q1.is_a?(AMQP::Client::Queue).should be_true
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
+      with_channel(s, vhost: "v1") do |ch|
+        ch.queue("q1cp", durable: false, auto_delete: true)
+      end
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
+      with_channel(s, vhost: "v1") do |ch|
+        q1 = ch.queue("q1cp", passive: true)
+        q1.is_a?(AMQP::Client::Queue).should be_true
+      end
     end
   end
 
   it "disallows deleting queues without config perms" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
-    Fiber.yield
-    with_channel(vhost: "v1") do |ch|
-      ch.queue("q1", durable: false, auto_delete: true)
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        q1 = ch.queue("q1", passive: true)
-        q1.delete
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
+      Fiber.yield
+      with_channel(s, vhost: "v1") do |ch|
+        ch.queue("q1", durable: false, auto_delete: true)
+      end
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          q1 = ch.queue("q1", passive: true)
+          q1.delete
+        end
       end
     end
   end
 
   it "disallows deleting exchanges without config perms" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
-    with_channel(vhost: "v1") do |ch|
-      ch.exchange("x1", "direct", durable: false)
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        x1 = ch.exchange("x1", "direct", passive: true)
-        x1.delete
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
+      with_channel(s, vhost: "v1") do |ch|
+        ch.exchange("x1", "direct", durable: false)
+      end
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          x1 = ch.exchange("x1", "direct", passive: true)
+          x1.delete
+        end
       end
     end
   end
 
   it "binding queue required write perm on queue" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
-    Fiber.yield
-    with_channel(vhost: "v1") do |ch|
-      ch.exchange("x1", "direct", durable: false)
-      ch.queue("q1", durable: false)
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /.*/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        ch.exchange("x1", "direct", passive: true)
-        q1 = ch.queue("q1", passive: true)
-        q1.bind("x1", "")
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
+      Fiber.yield
+      with_channel(s, vhost: "v1") do |ch|
+        ch.exchange("x1", "direct", durable: false)
+        ch.queue("q1", durable: false)
+      end
+      s.users.add_permission("guest", "v1", /^$/, /.*/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          ch.exchange("x1", "direct", passive: true)
+          q1 = ch.queue("q1", passive: true)
+          q1.bind("x1", "")
+        end
       end
     end
   end
 
   it "binding queue required read perm on exchange" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
-    with_channel(vhost: "v1") do |ch|
-      ch.exchange("x1", "direct", durable: false)
-      ch.queue("q1", durable: false)
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /.*/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        x1 = ch.exchange("x1", "direct", passive: true)
-        q1 = ch.queue("q1", passive: true)
-        q1.bind(x1.name, "")
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /^$/, /^$/)
+      with_channel(s, vhost: "v1") do |ch|
+        ch.exchange("x1", "direct", durable: false)
+        ch.queue("q1", durable: false)
+      end
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /.*/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          x1 = ch.exchange("x1", "direct", passive: true)
+          q1 = ch.queue("q1", passive: true)
+          q1.bind(x1.name, "")
+        end
       end
     end
   end
 
   it "unbinding queue required write perm on queue" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /.*/, /.*/)
-    Fiber.yield
-    with_channel(vhost: "v1") do |ch|
-      x1 = ch.exchange("x1", "direct", durable: false)
-      q1 = ch.queue("q1", durable: false)
-      q1.bind(x1.name, "")
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /.*/, /^$/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        x1 = ch.exchange("x1", "direct", passive: true)
-        q1 = ch.queue("q1", passive: true)
-        q1.unbind(x1.name, "")
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /.*/, /.*/)
+      Fiber.yield
+      with_channel(s, vhost: "v1") do |ch|
+        x1 = ch.exchange("x1", "direct", durable: false)
+        q1 = ch.queue("q1", durable: false)
+        q1.bind(x1.name, "")
+      end
+      s.users.add_permission("guest", "v1", /^$/, /.*/, /^$/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          x1 = ch.exchange("x1", "direct", passive: true)
+          q1 = ch.queue("q1", passive: true)
+          q1.unbind(x1.name, "")
+        end
       end
     end
   end
 
   it "unbinding queue required read perm on exchange" do
-    Server.vhosts.create("v1")
-    Server.users.add_permission("guest", "v1", /.*/, /.*/, /.*/)
-    with_channel(vhost: "v1") do |ch|
-      x1 = ch.exchange("x1", "direct", durable: false)
-      q1 = ch.queue("q1", durable: false)
-      q1.bind(x1.name, "")
-    end
-    Server.users.add_permission("guest", "v1", /^$/, /^$/, /.*/)
-    expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
-      with_channel(vhost: "v1") do |ch|
-        x1 = ch.exchange("x1", "direct", passive: true)
-        q1 = ch.queue("q1", passive: true)
-        q1.unbind(x1.name, "")
+    with_amqp_server do |s|
+      s.vhosts.create("v1")
+      s.users.add_permission("guest", "v1", /.*/, /.*/, /.*/)
+      with_channel(s, vhost: "v1") do |ch|
+        x1 = ch.exchange("x1", "direct", durable: false)
+        q1 = ch.queue("q1", durable: false)
+        q1.bind(x1.name, "")
+      end
+      s.users.add_permission("guest", "v1", /^$/, /^$/, /.*/)
+      expect_raises(AMQP::Client::Channel::ClosedException, /403/) do
+        with_channel(s, vhost: "v1") do |ch|
+          x1 = ch.exchange("x1", "direct", passive: true)
+          q1 = ch.queue("q1", passive: true)
+          q1.unbind(x1.name, "")
+        end
       end
     end
   end

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -2,190 +2,220 @@ require "./spec_helper"
 
 describe LavinMQ::VHost do
   it "should be able to create vhosts" do
-    Server.vhosts.create("test")
-    Server.vhosts["test"]?.should_not be_nil
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      s.vhosts["test"]?.should_not be_nil
+    end
   end
 
   it "should be able to delete vhosts" do
-    Server.vhosts.create("test")
-    Server.vhosts.delete("test")
-    Server.vhosts["test"]?.should be_nil
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      s.vhosts.delete("test")
+      s.vhosts["test"]?.should be_nil
+    end
   end
 
   it "should be able to persist vhosts" do
-    Server.vhosts.create("test")
-    Server.restart
-    Server.vhosts["test"]?.should_not be_nil
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      s.restart
+      s.vhosts["test"]?.should_not be_nil
+    end
   end
 
   it "should be able to persist durable exchanges" do
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    v.declare_exchange("e", "direct", true, false)
-    Server.restart
-    Server.vhosts["test"].exchanges["e"].should_not be_nil
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      v = s.vhosts["test"].not_nil!
+      v.declare_exchange("e", "direct", true, false)
+      s.restart
+      s.vhosts["test"].exchanges["e"].should_not be_nil
+    end
   end
 
   it "should be able to persist durable delayed exchanges when type = x-delayed-message" do
-    # This spec is to verify a fix where a server couldn't start again after a crash if
-    # an delayed exchange had been declared by specifiying the type as "x-delayed-message".
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    arguments = AMQ::Protocol::Table.new({"x-delayed-type": "direct"})
-    v.declare_exchange("e", "x-delayed-message", true, false, arguments: arguments)
+    with_amqp_server do |s|
+      # This spec is to verify a fix where a server couldn't start again after a crash if
+      # an delayed exchange had been declared by specifiying the type as "x-delayed-message".
+      s.vhosts.create("test")
+      v = s.vhosts["test"].not_nil!
+      arguments = AMQ::Protocol::Table.new({"x-delayed-type": "direct"})
+      v.declare_exchange("e", "x-delayed-message", true, false, arguments: arguments)
 
-    # Start a new server with the same data dir as `Server` without stopping
-    # `Server` first, because stopping would compact definitions and therefore "rewrite"
+      # Start a new server with the same data dir as `Server` without stopping
+      # `Server` first, because stopping would compact definitions and therefore "rewrite"
+    end
     # the definitions file. This is to simulate a start after a "crash".
     # If this succeeds we assume it worked...?
     LavinMQ::Server.new(DATA_DIR)
   end
 
   it "should be able to persist durable queues" do
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    v.declare_queue("q", true, false)
-    Server.restart
-    Server.vhosts["test"].queues["q"].should_not be_nil
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      v = s.vhosts["test"].not_nil!
+      v.declare_queue("q", true, false)
+      s.restart
+      s.vhosts["test"].queues["q"].should_not be_nil
+    end
   end
 
   it "should be able to persist bindings" do
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    v.declare_exchange("e", "direct", true, false)
-    v.declare_queue("q", true, false)
-    Server.vhosts["test"].bind_queue("q", "e", "q")
-    Server.restart
-    Server.vhosts["test"].exchanges["e"].queue_bindings[{"q", nil}].size.should eq 1
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      v = s.vhosts["test"].not_nil!
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      s.vhosts["test"].bind_queue("q", "e", "q")
+      s.restart
+      s.vhosts["test"].exchanges["e"].queue_bindings[{"q", nil}].size.should eq 1
+    end
   end
 
   it "should not write bind frame to definition file for existing binding" do
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    v.declare_exchange("e", "direct", true, false)
-    v.declare_queue("q", true, false)
-    Server.vhosts["test"].bind_queue("q", "e", "q")
-    pos = v.@definitions_file.pos
-    Server.vhosts["test"].bind_queue("q", "e", "q")
-    v.@definitions_file.pos.should eq pos
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      v = s.vhosts["test"].not_nil!
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      s.vhosts["test"].bind_queue("q", "e", "q")
+      pos = v.@definitions_file.pos
+      s.vhosts["test"].bind_queue("q", "e", "q")
+      v.@definitions_file.pos.should eq pos
+    end
   end
 
   it "should not write unbind frame to definition file for non-existing binding" do
-    Server.vhosts.create("test")
-    v = Server.vhosts["test"].not_nil!
-    v.declare_exchange("e", "direct", true, false)
-    v.declare_queue("q", true, false)
-    Server.vhosts["test"].bind_queue("q", "e", "q")
-    Server.vhosts["test"].unbind_queue("q", "e", "q")
-    pos = v.@definitions_file.pos
-    Server.vhosts["test"].unbind_queue("q", "e", "q")
-    v.@definitions_file.pos.should eq pos
+    with_amqp_server do |s|
+      s.vhosts.create("test")
+      v = s.vhosts["test"].not_nil!
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      s.vhosts["test"].bind_queue("q", "e", "q")
+      s.vhosts["test"].unbind_queue("q", "e", "q")
+      pos = v.@definitions_file.pos
+      s.vhosts["test"].unbind_queue("q", "e", "q")
+      v.@definitions_file.pos.should eq pos
+    end
   end
 
   it "should compact definitions during runtime" do
-    v = Server.vhosts.create("test")
-    (LavinMQ::Config.instance.max_deleted_definitions - 1).times do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      (LavinMQ::Config.instance.max_deleted_definitions - 1).times do
+        v.declare_queue("q", true, false)
+        v.delete_queue("q")
+      end
+      file_size = v.@definitions_file.size
       v.declare_queue("q", true, false)
       v.delete_queue("q")
+      v.@definitions_file.size.should be < file_size
     end
-    file_size = v.@definitions_file.size
-    v.declare_queue("q", true, false)
-    v.delete_queue("q")
-    v.@definitions_file.size.should be < file_size
   end
-
   describe "auto add permissions" do
     it "should add permission to the user creating the vhost" do
-      username = "test-user"
-      user = Server.users.create(username, "password", [LavinMQ::Tag::Administrator])
-      vhost = "test-vhost"
-      Server.vhosts.create(vhost, user)
-      p = user.permissions[vhost]
-      p[:config].should eq /.*/
-      p[:read].should eq /.*/
-      p[:write].should eq /.*/
+      with_amqp_server do |s|
+        username = "test-user"
+        user = s.users.create(username, "password", [LavinMQ::Tag::Administrator])
+        vhost = "test-vhost"
+        s.vhosts.create(vhost, user)
+        p = user.permissions[vhost]
+        p[:config].should eq /.*/
+        p[:read].should eq /.*/
+        p[:write].should eq /.*/
+      end
     end
 
     it "should auto add permission to the default user" do
-      vhost = "test-vhost"
-      Server.vhosts.create(vhost)
-      user = Server.users.default_user
-      p = user.permissions[vhost]
-      p[:config].should eq /.*/
-      p[:read].should eq /.*/
-      p[:write].should eq /.*/
+      with_amqp_server do |s|
+        vhost = "test-vhost"
+        s.vhosts.create(vhost)
+        user = s.users.default_user
+        p = user.permissions[vhost]
+        p[:config].should eq /.*/
+        p[:read].should eq /.*/
+        p[:write].should eq /.*/
+      end
     end
   end
-
   describe "Purge vhost" do
     it "should purge all queues in the vhost" do
-      with_channel do |ch|
-        x = ch.exchange("purge", "direct")
-        q1 = ch.queue("purge_1", durable: true)
-        q2 = ch.queue("purge_1", durable: true)
-        q1.bind(x.name, q1.name)
-        q2.bind(x.name, q2.name)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x = ch.exchange("purge", "direct")
+          q1 = ch.queue("purge_1", durable: true)
+          q2 = ch.queue("purge_1", durable: true)
+          q1.bind(x.name, q1.name)
+          q2.bind(x.name, q2.name)
 
-        x.publish_confirm "test message 1.1", q1.name
-        x.publish_confirm "test message 2.1", q1.name
-        x.publish_confirm "test message 2.1", q2.name
-        x.publish_confirm "test message 2.2", q2.name
+          x.publish_confirm "test message 1.1", q1.name
+          x.publish_confirm "test message 2.1", q1.name
+          x.publish_confirm "test message 2.1", q2.name
+          x.publish_confirm "test message 2.2", q2.name
 
-        vhost = Server.vhosts["/"]
-        vhost.message_details[:messages].should eq 4
+          vhost = s.vhosts["/"]
+          vhost.message_details[:messages].should eq 4
 
-        vhost.purge_queues_and_close_consumers(false, "")
-        vhost.message_details[:messages].should eq 0
+          vhost.purge_queues_and_close_consumers(false, "")
+          vhost.message_details[:messages].should eq 0
+        end
       end
     end
 
     it "should backup the folder on reset" do
-      with_channel do |ch|
-        x = ch.exchange("purge", "direct")
-        q1 = ch.queue("purge_1", durable: true)
-        q2 = ch.queue("purge_1", durable: true)
-        q1.bind(x.name, q1.name)
-        q2.bind(x.name, q2.name)
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          x = ch.exchange("purge", "direct")
+          q1 = ch.queue("purge_1", durable: true)
+          q2 = ch.queue("purge_1", durable: true)
+          q1.bind(x.name, q1.name)
+          q2.bind(x.name, q2.name)
 
-        x.publish_confirm "test message 1.1", q1.name
-        x.publish_confirm "test message 2.1", q1.name
-        x.publish_confirm "test message 2.1", q2.name
-        x.publish_confirm "test message 2.2", q2.name
+          x.publish_confirm "test message 1.1", q1.name
+          x.publish_confirm "test message 2.1", q1.name
+          x.publish_confirm "test message 2.1", q2.name
+          x.publish_confirm "test message 2.2", q2.name
 
-        vhost = Server.vhosts["/"]
-        vhost.purge_queues_and_close_consumers(true, "reset_spec")
+          vhost = s.vhosts["/"]
+          vhost.purge_queues_and_close_consumers(true, "reset_spec")
 
-        backup_dir = Path.new(vhost.data_dir, "..", "#{vhost.dir}_reset_spec").normalize
-        Dir.exists?(backup_dir).should be_true
+          backup_dir = Path.new(vhost.data_dir, "..", "#{vhost.dir}_reset_spec").normalize
+          Dir.exists?(backup_dir).should be_true
+        end
       end
     end
   end
 
   it "can limit queues" do
-    vhost = Server.vhosts["/"]
-    vhost.max_queues = 1
-    with_channel do |ch|
-      ch.queue
-      expect_raises(AMQP::Client::Channel::ClosedException, /queue limit/) do
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      vhost.max_queues = 1
+      with_channel(s) do |ch|
+        ch.queue
+        expect_raises(AMQP::Client::Channel::ClosedException, /queue limit/) do
+          ch.queue
+        end
+      end
+      vhost.max_queues = -1
+      with_channel(s) do |ch|
         ch.queue
       end
-    end
-    vhost.max_queues = -1
-    with_channel do |ch|
-      ch.queue
     end
   end
 
   it "can limit connections" do
-    vhost = Server.vhosts["/"]
-    vhost.max_connections = 1
-    with_channel do |_ch|
-      expect_raises(AMQP::Client::Connection::ClosedException, /connection limit/) do
-        with_channel do |_ch2|
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      vhost.max_connections = 1
+      with_channel(s) do |_ch|
+        expect_raises(AMQP::Client::Connection::ClosedException, /connection limit/) do
+          with_channel(s) do |_ch2|
+          end
         end
-      end
-      vhost.max_connections = -1
-      with_channel do |_ch3|
+        vhost.max_connections = -1
+        with_channel(s) do |_ch3|
+        end
       end
     end
   end

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -4,60 +4,66 @@ require "../src/lavinmq/config"
 describe LavinMQ::VHost do
   describe "Stats" do
     it "should update queue data" do
-      vhost = Server.vhosts["/"]
-      Server.update_stats_rates
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        s.update_stats_rates
 
-      initial_declared_queues = vhost.queue_declared_count
-      initial_deleted_queues = vhost.queue_deleted_count
-      Server.vhosts["/"].declare_queue("this_queue_should_not_exist", false, false)
-      Server.update_stats_rates
+        initial_declared_queues = vhost.queue_declared_count
+        initial_deleted_queues = vhost.queue_deleted_count
+        s.vhosts["/"].declare_queue("this_queue_should_not_exist", false, false)
+        s.update_stats_rates
 
-      vhost.queue_declared_count.should eq(initial_declared_queues + 1)
-      vhost.queue_deleted_count.should eq initial_deleted_queues
-      Server.vhosts["/"].delete_queue("this_queue_should_not_exist")
-      Server.update_stats_rates
+        vhost.queue_declared_count.should eq(initial_declared_queues + 1)
+        vhost.queue_deleted_count.should eq initial_deleted_queues
+        s.vhosts["/"].delete_queue("this_queue_should_not_exist")
+        s.update_stats_rates
 
-      vhost.queue_declared_count.should eq(initial_declared_queues + 1)
-      vhost.queue_deleted_count.should eq(initial_deleted_queues + 1)
+        vhost.queue_declared_count.should eq(initial_declared_queues + 1)
+        vhost.queue_deleted_count.should eq(initial_deleted_queues + 1)
+      end
     end
 
     it "should not delete stats when connection is closed" do
-      vhost = Server.vhosts["/"]
-      wait_for { Server.connections.sum(&.channels.size).zero? }
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        wait_for { s.connections.sum(&.channels.size).zero? }
 
-      Server.update_stats_rates
-      initial_channels_created = vhost.channel_created_count
-      initial_channels_closed = vhost.channel_closed_count
+        s.update_stats_rates
+        initial_channels_created = vhost.channel_created_count
+        initial_channels_closed = vhost.channel_closed_count
 
-      with_channel do |ch|
-        Server.update_stats_rates
+        with_channel(s) do |ch|
+          s.update_stats_rates
 
+          vhost.channel_created_count.should eq(initial_channels_created + 1)
+          vhost.channel_closed_count.should eq(initial_channels_closed)
+          ch.close
+        end
+
+        s.update_stats_rates
         vhost.channel_created_count.should eq(initial_channels_created + 1)
-        vhost.channel_closed_count.should eq(initial_channels_closed)
-        ch.close
+        vhost.channel_closed_count.should eq(initial_channels_closed + 1)
       end
-
-      Server.update_stats_rates
-      vhost.channel_created_count.should eq(initial_channels_created + 1)
-      vhost.channel_closed_count.should eq(initial_channels_closed + 1)
     end
 
     it "should count connections open / closed once" do
-      vhost = Server.vhosts["/"]
-      initial_connections_created = vhost.connection_created_count
-      initial_connections_closed = vhost.connection_closed_count
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        initial_connections_created = vhost.connection_created_count
+        initial_connections_closed = vhost.connection_closed_count
 
-      with_channel do
-        Server.update_stats_rates
+        with_channel(s) do
+          s.update_stats_rates
+          vhost.connection_created_count.should eq(initial_connections_created + 1)
+          vhost.connection_closed_count.should eq(initial_connections_closed)
+        end
+
+        wait_for { vhost.@connections.empty? }
+
+        s.update_stats_rates
         vhost.connection_created_count.should eq(initial_connections_created + 1)
-        vhost.connection_closed_count.should eq(initial_connections_closed)
+        vhost.connection_closed_count.should eq(initial_connections_closed + 1)
       end
-
-      wait_for { vhost.@connections.empty? }
-
-      Server.update_stats_rates
-      vhost.connection_created_count.should eq(initial_connections_created + 1)
-      vhost.connection_closed_count.should eq(initial_connections_closed + 1)
     end
   end
 end

--- a/spec/websocket_spec.cr
+++ b/spec/websocket_spec.cr
@@ -2,21 +2,25 @@ require "./spec_helper"
 
 describe "Websocket support" do
   it "should connect over websocket" do
-    c = AMQP::Client.new(SpecHelper.ws_base_url)
-    conn = c.connect
-    conn.should_not be_nil
-    conn.close
+    with_http_server do |http, _|
+      c = AMQP::Client.new("ws://#{http.addr}")
+      conn = c.connect
+      conn.should_not be_nil
+      conn.close
+    end
   end
 
   it "can publish large messages" do
-    c = AMQP::Client.new(SpecHelper.ws_base_url)
-    conn = c.connect
-    ch = conn.channel
-    q = ch.queue
-    q.publish "b" * 150_000
-    msg = q.get(no_ack: true)
-    msg.should_not be_nil
-    msg.body_io.to_s.should eq "b" * 150_000 if msg
-    conn.close
+    with_http_server do |http, _|
+      c = AMQP::Client.new("ws://#{http.addr}")
+      conn = c.connect
+      ch = conn.channel
+      q = ch.queue
+      q.publish "b" * 150_000
+      msg = q.get(no_ack: true)
+      msg.should_not be_nil
+      msg.body_io.to_s.should eq "b" * 150_000 if msg
+      conn.close
+    end
   end
 end

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -45,10 +45,8 @@ module LavinMQ
                      @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
         @tag = "Shovel"
-        cfg = Config.instance
         raise ArgumentError.new("At least one source uri is required") if @uris.empty?
         @uris.each do |uri|
-          uri.host ||= "#{cfg.amqp_bind}:#{cfg.amqp_port}"
           unless uri.user
             if direct_user
               uri.user = direct_user.name
@@ -204,8 +202,6 @@ module LavinMQ
                      @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
                      @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
                      direct_user : User? = nil)
-        cfg = Config.instance
-        @uri.host ||= "#{cfg.amqp_bind}:#{cfg.amqp_port}"
         unless @uri.user
           if direct_user
             @uri.user = direct_user.name


### PR DESCRIPTION
### WHAT is this pull request doing?

Instead of having a global `Server` (`LavinMQ::Server`) in the specs all specs that needs a amqp server will get a new fresh one with `with_amqp_server`, and `with_http_server` when that's needed.

### HOW can this pull request be tested?

Specs
