### PR TITLE
Set up specs with before_build.sh for rabbith-hole specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,8 @@ jobs:
           cd rabbit-hole
           bash bin/ci/before_build.sh
           go test -v ./...
+        env:
+          RABBITHOLE_LAVINMQCTL: ../bin/lavinmqctl
 
   release-mode-test:
     name: Test in release mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
 
       - name: Run LavinMQ in background
         run: |
-          chmod +x bin/lavinmq
+          chmod +x bin/*
           bin/lavinmq --data-dir /tmp/amqp &
 
       - name: Install Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,7 @@ jobs:
       - name: Run specs
         run: |
           cd rabbit-hole
+          bash bin/ci/before_build.sh
           go test -v ./...
 
   release-mode-test:


### PR DESCRIPTION
### WHAT is this pull request doing?
LavinMQ needs to run before_build with lavinmqctl to set up spec env in order to have the right users created for tests to run and pass. 

### HOW can this pull request be tested?
run script locally, or look at github actions 
