### PR TITLE
Don't warn if AMQPS isn't enabled

### DIFF
--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -123,8 +123,6 @@ module LavinMQ
         if ctx = @tls_context
           spawn @amqp_server.listen_tls(@config.amqp_bind, @config.amqps_port, ctx),
             name: "AMQPS listening on #{@config.amqps_port}"
-        else
-          Log.warn { "Certificate for AMQPS not @configured" }
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

I don't know why we would warn for this? AMQPS could be enabled via a TLS terminator for instance.
