### PR TITLE
Cluster proxy unix

### DIFF
--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -54,7 +54,7 @@ module LavinMQ
           spawn http_proxy.forward_to(host, @config.http_port), name: "HTTP proxy"
         end
         if unix_amqp_proxy = @unix_amqp_proxy
-          spawn unix_amqp_proxy.forward_to(host, @config.amqp_port, true), name: "AMQP proxy"
+          spawn unix_amqp_proxy.forward_to(host, @config.amqp_port), name: "AMQP proxy"
         end
         if unix_http_proxy = @unix_http_proxy
           spawn unix_http_proxy.forward_to(host, @config.http_port), name: "HTTP proxy"

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -11,6 +11,8 @@ module LavinMQ
       @closed = false
       @amqp_proxy : Proxy?
       @http_proxy : Proxy?
+      @unix_amqp_proxy : Proxy?
+      @unix_http_proxy : Proxy?
       @socket : TCPSocket?
 
       def initialize(@config : Config, @id : Int32, @password : String, proxy = true)
@@ -28,6 +30,8 @@ module LavinMQ
         if proxy
           @amqp_proxy = Proxy.new(@config.amqp_bind, @config.amqp_port)
           @http_proxy = Proxy.new(@config.http_bind, @config.http_port)
+          @unix_amqp_proxy = Proxy.new(@config.unix_path) unless @config.unix_path.empty?
+          @unix_http_proxy = Proxy.new(@config.http_unix_path) unless @config.http_unix_path.empty?
         end
       end
 
@@ -48,6 +52,12 @@ module LavinMQ
         end
         if http_proxy = @http_proxy
           spawn http_proxy.forward_to(host, @config.http_port), name: "HTTP proxy"
+        end
+        if unix_amqp_proxy = @unix_amqp_proxy
+          spawn unix_amqp_proxy.forward_to(host, @config.amqp_port, true), name: "AMQP proxy"
+        end
+        if unix_http_proxy = @unix_http_proxy
+          spawn unix_http_proxy.forward_to(host, @config.http_port), name: "HTTP proxy"
         end
         loop do
           @socket = socket = TCPSocket.new(host, port)
@@ -238,6 +248,8 @@ module LavinMQ
         @closed = true
         @amqp_proxy.try &.close
         @http_proxy.try &.close
+        @unix_amqp_proxy.try &.close
+        @unix_http_proxy.try &.close
         @files.each_value &.close
         @data_dir_lock.release
         @socket.try &.close

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -203,7 +203,7 @@ module LavinMQ
         end
       end
 
-      private Signature = StaticArray[13u8, 10u8, 13u8, 10u8, 0u8, 13u8, 10u8, 81u8, 85u8, 73u8, 84u8, 10u8]
+      Signature = StaticArray[13u8, 10u8, 13u8, 10u8, 0u8, 13u8, 10u8, 81u8, 85u8, 73u8, 84u8, 10u8]
 
       private enum SSLCLIENT : UInt8
         SSL       = 0x01

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -90,6 +90,10 @@ module LavinMQ
                  followers.any? { |f| f.remote_address.address == remote_address.address }
                 # Expect PROXY protocol header if remote address is a follower
                 ProxyProtocol::V1.parse(client)
+              elsif client.peek[0, 12] == ProxyProtocol::V2::Signature.to_slice &&
+                    followers.any? { |f| f.remote_address.address == remote_address.address }
+                # Expect PROXY protocol header if remote address is a follower
+                ProxyProtocol::V2.parse(client)
               else
                 ConnectionInfo.new(remote_address, client.local_address)
               end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -81,23 +81,7 @@ module LavinMQ
           remote_address = client.remote_address
           set_socket_options(client)
           set_buffer_size(client)
-          conn_info =
-            case Config.instance.tcp_proxy_protocol
-            when 1 then ProxyProtocol::V1.parse(client)
-            when 2 then ProxyProtocol::V2.parse(client)
-            else
-              if client.peek[0, 5] == "PROXY".to_slice &&
-                 followers.any? { |f| f.remote_address.address == remote_address.address }
-                # Expect PROXY protocol header if remote address is a follower
-                ProxyProtocol::V1.parse(client)
-              elsif client.peek[0, 12] == ProxyProtocol::V2::Signature.to_slice &&
-                    followers.any? { |f| f.remote_address.address == remote_address.address }
-                # Expect PROXY protocol header if remote address is a follower
-                ProxyProtocol::V2.parse(client)
-              else
-                ConnectionInfo.new(remote_address, client.local_address)
-              end
-            end
+          conn_info = extract_conn_info(client)
           handle_connection(client, conn_info)
         rescue ex
           Log.warn(exception: ex) { "Error accepting connection from #{remote_address}" }
@@ -108,6 +92,26 @@ module LavinMQ
       abort "Unrecoverable error in listener: #{ex.inspect_with_backtrace}"
     ensure
       @listeners.delete(s)
+    end
+
+    private def extract_conn_info(client) : ConnectionInfo
+      remote_address = client.remote_address
+      case Config.instance.tcp_proxy_protocol
+      when 1 then ProxyProtocol::V1.parse(client)
+      when 2 then ProxyProtocol::V2.parse(client)
+      else
+        if client.peek[0, 5] == "PROXY".to_slice &&
+           followers.any? { |f| f.remote_address.address == remote_address.address }
+          # Expect PROXY protocol header if remote address is a follower
+          ProxyProtocol::V1.parse(client)
+        elsif client.peek[0, 8] == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
+              followers.any? { |f| f.remote_address.address == remote_address.address }
+          # Expect PROXY protocol header if remote address is a follower
+          ProxyProtocol::V2.parse(client)
+        else
+          ConnectionInfo.new(remote_address, client.local_address)
+        end
+      end
     end
 
     def listen(s : UNIXServer)


### PR DESCRIPTION
### WHAT is this pull request doing?

Clustering follower can forward AMQP/HTTP from UNIX socket if configured.  

### HOW can this pull request be tested?

```
bin/lavinmq --clustering --data-dir=/tmp/amqp2 --clustering-advertised-uri=tcp://127.2 --clustering-bind=127.2 --bind=127.2 --amqp-unix-path=/tmp/amqp --
http-unix-path=/tmp/http
```
