### PR TITLE
Clustering etcd restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- HTTP API: Regression where an (empty) body was required to PUT a new vhost
+
+### Added
+
+- Can view which messages are unacked in each queue (HTTP and UI)
+- Clustering clients will now listen on the UNIX sockets if configured
+- Clustering server will accept PROXY protocol V2 headers from followers
+
+### Changed
+
+- Deb packages now includes all debug symbols, for useful stacktraces
+
 ## [2.0.0-rc.1] - 2024-06-25
 
 ### Added

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -99,7 +99,7 @@ describe LavinMQ::Etcd do
     end
   end
 
-  it "learns new cluster endpoints" do
+  pending "learns new cluster endpoints" do
     cluster = EtcdCluster.new
     cluster.run do
       etcd = LavinMQ::Etcd.new(cluster.endpoints.split(",").first)

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -46,7 +46,8 @@ module LavinMQ
       end
 
       def follow(host : String, port : Int32)
-        SystemD.notify_ready
+        @host = host
+        @port = port
         if amqp_proxy = @amqp_proxy
           spawn amqp_proxy.forward_to(host, @config.amqp_port, true), name: "AMQP proxy"
         end
@@ -74,6 +75,20 @@ module LavinMQ
           Log.info { "Disconnected from server #{host}:#{port} (#{ex}), retrying..." }
           sleep 1
         end
+      end
+
+      def follows?(uri : String) : Bool
+        follows? URI.parse(uri)
+      end
+
+      def follows?(uri : URI) : Bool
+        host = uri.hostname.not_nil!("Host missing in follow URI")
+        port = uri.port || 5679
+        follows?(host, port)
+      end
+
+      def follows?(host : String, port : Int32) : Bool
+        @host == host && @port == port
       end
 
       private def sync(socket, lz4)

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -46,6 +46,7 @@ class LavinMQ::Clustering::Controller
   private def follow_leader
     repli_client = nil
     @etcd.elect_listen("#{@config.clustering_etcd_prefix}/leader") do |uri|
+      next if repli_client.try &.follows?(uri) # if lost connection to etcd we continue follow the leader as is
       repli_client.try &.close
       if uri == @advertised_uri # if this instance has become leader
         repli_client = nil

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -70,6 +70,7 @@ class LavinMQ::Clustering::Controller
   def wait_to_be_insync
     if isr = @etcd.get("#{@config.clustering_etcd_prefix}/isr")
       unless isr.split(",").map(&.to_i(36)).includes?(@id)
+        Log.info { "ISR: #{isr}" }
         Log.info { "Not in sync, waiting for a leader" }
         @etcd.watch("#{@config.clustering_etcd_prefix}/isr") do |value|
           break if value.try &.split(",").map(&.to_i(36)).includes?(@id)

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -49,9 +49,8 @@ class LavinMQ::Clustering::Controller
       next if repli_client.try &.follows?(uri) # if lost connection to etcd we continue follow the leader as is
       repli_client.try &.close
       if uri == @advertised_uri # if this instance has become leader
-        repli_client = nil
         Log.debug { "Is leader, don't replicate from self" }
-        next
+        return
       end
       Log.info { "Leader: #{uri}" }
 

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -36,7 +36,7 @@ module LavinMQ
       @config : Config
 
       def initialize(config : Config, @etcd : Etcd, @id = File.read(File.join(config.data_dir, ".clustering_id")).to_i(36))
-        Log.info { "ID: #{@id}" }
+        Log.info { "ID: #{@id.to_s(36)}" }
         @config = config
         @data_dir = @config.data_dir
         @password = password

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -240,9 +240,11 @@ module LavinMQ
         socket.tcp_keepalive_idle = 5
         socket.tcp_keepalive_count = 3
         socket.tcp_keepalive_interval = 1
-        update_endpoints(socket, address)
+        # update_endpoints(socket, address)
+        Log.debug { "Connected to #{address}" }
         return {socket, address}
-      rescue IO::Error
+      rescue ex : IO::Error
+        Log.debug { "Could not connect to #{address}: #{ex}" }
         next
       end
       raise Error.new("No endpoint responded")

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -89,7 +89,7 @@ module LavinMQ
             lease_revoke(lease_id)
             channel.close
             break
-          when timeout((ttl / 2.0).seconds)
+          when timeout((ttl * 0.9).seconds)
             ttl = lease_keepalive(lease_id)
           end
         rescue ex

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -64,7 +64,7 @@ module LavinMQ
     end
 
     def lease_revoke(id) : Nil
-      post("/v3/kv/lease/revoke", body: %({"ID":"#{id}"}))
+      post("/v3/lease/revoke", body: %({"ID":"#{id}"}))
       true
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Stop listen for leader changes after a node has become leader. `elect_observe` doesn't handle that a etcd node is restarted, so this is a short term fix for #721  

### HOW can this pull request be tested?

No specs yet. 
