### PR TITLE
don't strip debug symbols in deb packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,9 +1,6 @@
 #!/usr/bin/make -f
 export DH_VERBOSE=1
+export DEB_BUILD_OPTIONS += nostrip
 
 %:
 	dh $@
-
-.PHONY: override_dh_strip
-override_dh_strip:
-	dh_strip --keep-debug


### PR DESCRIPTION
### WHAT is this pull request doing?

With `dh_strip --keep-debug` debug symbols was placed in external files, but for some reason it doesn't seem to work. Now skipping stripping symbols completely. 

### HOW can this pull request be tested?

Install deb, call something that raises an exception. 
