### PR TITLE
make keyColumns look for unique combinations on bindings tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Build with Crystal 1.13.1
 - Yield at end of while loop in Queue#drop_overflow to avoid holding the fiber for too long [#725](https://github.com/cloudamqp/lavinmq/pull/725)
-  
+
 ### Fixed
 
 - Make proxied UNIX sockets in followers RW for all
 - SystemD notify ready in cluster mode when lader is found
+- Make keyColumns look for unique combinations on bindings tables [#726](https://github.com/cloudamqp/lavinmq/pull/726)
 
 ## [2.0.0-rc.2] - 2024-07-05
 

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -49,7 +49,7 @@ updateExchange()
 const tableOptions = {
   dataSource: new UrlDataSource(exchangeUrl + '/bindings/source', { useQueryState: false }),
   pagination: true,
-  keyColumns: ['properties_key']
+  keyColumns: ['properties_key', 'destination', 'routing_key']
 }
 const bindingsTable = Table.renderTable('bindings-table', tableOptions, function (tr, item, all) {
   if (!all) return

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -49,7 +49,7 @@ updateExchange()
 const tableOptions = {
   dataSource: new UrlDataSource(exchangeUrl + '/bindings/source', { useQueryState: false }),
   pagination: true,
-  keyColumns: ['properties_key', 'destination', 'routing_key']
+  keyColumns: ['destination', 'properties_key']
 }
 const bindingsTable = Table.renderTable('bindings-table', tableOptions, function (tr, item, all) {
   if (!all) return

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -144,7 +144,7 @@ setInterval(updateQueue, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(queueUrl + '/bindings', { useQueryState: false }),
-  keyColumns: ['properties_key', 'source', 'routing_key'],
+  keyColumns: ['source', 'properties_key'],
   countId: 'bindings-count'
 }
 const bindingsTable = Table.renderTable('bindings-table', tableOptions, function (tr, item, all) {

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -144,7 +144,7 @@ setInterval(updateQueue, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(queueUrl + '/bindings', { useQueryState: false }),
-  keyColumns: ['properties_key'],
+  keyColumns: ['properties_key', 'source', 'routing_key'],
   countId: 'bindings-count'
 }
 const bindingsTable = Table.renderTable('bindings-table', tableOptions, function (tr, item, all) {

--- a/views/exchange.ecr
+++ b/views/exchange.ecr
@@ -43,7 +43,7 @@
           <table id="bindings-table" class="table">
             <thead>
               <tr>
-                <th>Type</th>
+                <th class="left">Type</th>
                 <th class="left">To</th>
                 <th class="left">Routing key</th>
                 <th class="left">Arguments</th>

--- a/views/queue.ecr
+++ b/views/queue.ecr
@@ -84,7 +84,7 @@
           <table id="table" class="table">
             <thead>
               <tr>
-                <th>Channel</th>
+                <th class="left">Channel</th>
                 <th class="left">Consumer tag</th>
                 <th>Ack required</th>
                 <th>Exclusive</th>
@@ -107,7 +107,7 @@
           <table id="bindings-table" class="table">
             <thead>
               <tr>
-                <th>From</th>
+                <th class="left">From</th>
                 <th class="left">Routing key</th>
                 <th class="left">Arguments</th>
                 <th></th>


### PR DESCRIPTION
### WHAT is this pull request doing?
bindings tables were rendering in random because it did not have a unique column combination for keeping track of rows. 
this adds a unique combination of columns keys so they don't re-render out of order each update. 

fixes #568 

### HOW can this pull request be tested?
create queues exchanges and bindings, and look at UI to see that the bindings don't jump around in the table. 
