### PR TITLE
Bugfix unmap mfiles on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.15] - 2024-07-16
+
+### Fixed
+
+- Files where not being properly unmapped, causing disk space not to be released [#728](https://github.com/cloudamqp/lavinmq/pull/728)
+
+
 ## [1.2.14] - 2024-06-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Files where not being properly unmapped, causing disk space not to be released [#728](https://github.com/cloudamqp/lavinmq/pull/728)
+- Files where not being properly unmapped, causing disk space not to be released [#728](https://github.com/cloudamqp/lavinmq/pull/729)
 
 
 ## [1.2.14] - 2024-06-15

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lavinmq
-version: 1.2.14
+version: 1.2.15
 
 authors:
   - Carl Hörberg <carl@cloudamqp.com>

--- a/spec/mfile_spec.cr
+++ b/spec/mfile_spec.cr
@@ -1,15 +1,63 @@
 require "spec"
 require "../src/lavinmq/mfile"
 
-describe MFile do
-  it "can be double closed" do
+module MFileSpec
+  def self.with_file(&)
     file = File.tempfile "mfile_spec"
-    begin
-      mfile = MFile.new file.path
-      mfile.close
-      mfile.close
-    ensure
-      file.delete
+    yield file
+  ensure
+    file.delete unless file.nil?
+  end
+
+  describe MFile do
+    describe "#write" do
+      it "should raise ClosedError if closed" do
+        with_file do |file|
+          mfile = MFile.new file.path
+          mfile.close
+          expect_raises(MFile::ClosedError) { mfile.write "foo".to_slice }
+        end
+      end
+    end
+    describe "#read" do
+      it "should raise ClosedError if closed" do
+        with_file do |file|
+          mfile = MFile.new file.path
+          mfile.close
+          data = Bytes.new(1)
+          expect_raises(MFile::ClosedError) { mfile.read data }
+        end
+      end
+    end
+    describe "#to_slice" do
+      describe "without position and size" do
+        it "should raise ClosedError if closed" do
+          with_file do |file|
+            mfile = MFile.new file.path
+            mfile.close
+            expect_raises(MFile::ClosedError) { mfile.to_slice }
+          end
+        end
+      end
+      describe "with position and size" do
+        it "should raise ClosedError if closed" do
+          with_file do |file|
+            mfile = MFile.new file.path
+            mfile.close
+            expect_raises(MFile::ClosedError) { mfile.to_slice(1, 1) }
+          end
+        end
+      end
+    end
+    describe "#copy_to" do
+      it "should raise ClosedError if closed" do
+        with_file do |file|
+          mfile = MFile.new file.path
+          mfile.close
+          data = IO::Memory.new
+          expect_raises(MFile::ClosedError) { mfile.copy_to data }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
Reverts a change that delayed closing of MFiles. That change prevented MFiles from being properly unmapped, causing disk space to not be released. 

### HOW can this pull request be tested?
Run specs
