### PR TITLE
Use perf-tools for allocations/fiber tracking

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -20,6 +20,10 @@ shards:
     git: https://github.com/84codes/mqtt-protocol.cr.git
     version: 0.2.0+git.commit.3f82ee85d029e6d0505cbe261b108e156df4e598
 
+  perf_tools:
+    git: https://github.com/crystal-lang/perf-tools.git
+    version: 0.1.0+git.commit.bf884bc85431f8b446ae3b50e250d9a5cca262ac
+
   systemd:
     git: https://github.com/84codes/systemd.cr.git
     version: 2.0.0

--- a/shard.yml
+++ b/shard.yml
@@ -38,6 +38,8 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+  perf_tools:
+    github: crystal-lang/perf-tools
 
 crystal: 1.15.0
 

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -1,3 +1,7 @@
+{% unless flag?(:release) %}
+  require "perf_tools/mem_prof"
+  require "perf_tools/fiber_trace"
+{% end %}
 require "log"
 require "file"
 require "systemd"
@@ -202,9 +206,19 @@ module LavinMQ
       puts "  marker threads: #{ps.markers_m1}"
       puts "  reclaimed bytes during last GC: #{ps.bytes_reclaimed_since_gc.humanize_bytes}"
       puts "  reclaimed bytes before last GC: #{ps.reclaimed_bytes_before_gc.humanize_bytes}"
-      puts "Fibers:"
-      Fiber.list { |f| puts f.inspect }
-      LavinMQ::Reporter.report(@amqp_server)
+      # puts "Fibers:"
+      # Fiber.list { |f| puts f.inspect }
+      # LavinMQ::Reporter.report(@amqp_server)
+      {% unless flag?(:release) %}
+        puts "Object counts:"
+        PerfTools::MemProf.log_object_counts(STDOUT)
+        puts "Object sizes:"
+        PerfTools::MemProf.log_object_sizes(STDOUT)
+        puts "Allocations:"
+        PerfTools::MemProf.log_allocations(STDOUT)
+        puts "Fibers:"
+        PerfTools::FiberTrace.log_fibers(STDOUT)
+      {% end %}
       STDOUT.flush
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Uses https://github.com/crystal-lang/perf-tools to get various allocations and fiber reports 

### HOW can this pull request be tested?

`pkill -USR1 lavinmq`
