### PR TITLE
Don't shovel msgs after initial queue length

### DIFF
--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -62,7 +62,6 @@ describe LavinMQ::Shovel do
           "spec",
           URI.parse(s.amqp_url),
           "ql_q2",
-          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
           direct_user: s.users.direct_user
         )
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
@@ -204,17 +203,15 @@ describe LavinMQ::Shovel do
           "spec",
           URI.parse(s.amqp_url),
           "prefetch_q2",
-          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-          prefetch: 21_u16,
           direct_user: s.users.direct_user
         )
-        shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch_shovel", vhost)
         with_channel(s) do |ch|
           x = ShovelSpecHelpers.setup_qs(ch, "prefetch_").first
           100.times do
             x.publish_confirm "shovel me", "prefetch_q1"
           end
           wait_for { s.vhosts["/"].queues["prefetch_q1"].message_count == 100 }
+          shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch_shovel", vhost)
           shovel.run
           wait_for { shovel.terminated? }
           s.vhosts["/"].queues["prefetch_q1"].message_count.should eq 0
@@ -333,7 +330,6 @@ describe LavinMQ::Shovel do
           "spec",
           URI.parse(s.amqp_url),
           "prefetch2_q2",
-          prefetch: prefetch,
           direct_user: s.users.direct_user
         )
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch2_shovel", vhost)
@@ -430,9 +426,7 @@ describe LavinMQ::Shovel do
           "spec",
           URI.parse(s.amqp_url),
           q2_name,
-          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
           direct_user: s.users.direct_user,
-          consumer_args: consumer_args
         )
 
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)
@@ -481,7 +475,6 @@ describe LavinMQ::Shovel do
           "#{long_prefix}q2",
           URI.parse(s.amqp_url),
           "#{long_prefix}q2",
-          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
           direct_user: s.users.direct_user
         )
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "ql_shovel", vhost)

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -207,10 +207,7 @@ module LavinMQ
       @ch : ::AMQP::Client::Channel?
 
       def initialize(@name : String, @uri : URI, @queue : String?, @exchange : String? = nil,
-                     @exchange_key : String? = nil,
-                     @delete_after = DEFAULT_DELETE_AFTER, @prefetch = DEFAULT_PREFETCH,
-                     @ack_mode = DEFAULT_ACK_MODE, consumer_args : Hash(String, JSON::Any)? = nil,
-                     direct_user : User? = nil)
+                     @exchange_key : String? = nil, @ack_mode = DEFAULT_ACK_MODE, direct_user : User? = nil)
         unless @uri.user
           if direct_user
             @uri.user = direct_user.name
@@ -228,10 +225,6 @@ module LavinMQ
         end
         if @exchange.nil?
           raise ArgumentError.new("Shovel destination requires an exchange")
-        end
-        @args = AMQ::Protocol::Table.new
-        consumer_args.try &.each do |k, v|
-          @args[k] = v.as_s?
         end
       end
 

--- a/src/lavinmq/shovel/shovel_store.cr
+++ b/src/lavinmq/shovel/shovel_store.cr
@@ -32,7 +32,7 @@ module LavinMQ
         ack_mode,
         config["src-consumer-args"]?.try &.as_h?,
         direct_user: @vhost.users.direct_user)
-      dest = destination(name, config, ack_mode, delete_after, prefetch)
+      dest = destination(name, config, ack_mode)
       shovel = Shovel::Runner.new(src, dest, name, @vhost, reconnect_delay)
       @shovels[name] = shovel
       spawn(shovel.run, name: "Shovel name=#{name} vhost=#{@vhost.name}")
@@ -48,7 +48,7 @@ module LavinMQ
       end
     end
 
-    private def destination(name, config, ack_mode, delete_after, prefetch)
+    private def destination(name, config, ack_mode)
       uris = parse_uris(config["dest-uri"])
       destinations = uris.map do |uri|
         case uri.scheme
@@ -59,8 +59,7 @@ module LavinMQ
             config["dest-queue"]?.try &.as_s?,
             config["dest-exchange"]?.try &.as_s?,
             config["dest-exchange-key"]?.try &.as_s?,
-            delete_after: delete_after,
-            prefetch: prefetch,
+            ack_mode,
             direct_user: @vhost.users.direct_user)
         end
       end


### PR DESCRIPTION
### WHAT is this pull request doing?

If a shovel was supposed to "delete after queue length", but the queue was receiving a high rate of messages, messages after the initial queue length could also erroneously be sent to the destination. A race condition could then reject the consumed message which wasn't yet confirmed by the destination, causing message duplication.

### HOW can this pull request be tested?


