### PR TITLE
Import definitions with delayed exchange

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -672,7 +672,7 @@ describe LavinMQ::HTTP::Server do
         "auto_delete": false,
         "delayed": true
       })
-      response = http.put("/api/exchanges/%2f/test-delayed", body: body)
+      http.put("/api/exchanges/%2f/test-delayed", body: body)
       response = http.get("/api/definitions")
       body = JSON.parse(response.body)
       http.delete("/api/exchanges/%2f/test-delayed")

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -662,4 +662,26 @@ describe LavinMQ::HTTP::Server do
       vhost.exchanges["test"].match?(*args).should be_true
     end
   end
+
+  it "should be able to import delayed exchanges created in LavinMQ (issue #743)" do
+    with_http_server do |http, s|
+      body = %({
+        "type": "direct",
+        "durable": true,
+        "internal": false,
+        "auto_delete": false,
+        "delayed": true
+      })
+      response = http.put("/api/exchanges/%2f/test-delayed", body: body)
+      wait_for { s.vhosts["/"].exchanges.has_key?("test-delayed") == true }
+      response = http.get("/api/definitions")
+      body = JSON.parse(response.body)
+      http.delete("/api/exchanges/%2f/test-delayed")
+      wait_for { s.vhosts["/"].exchanges.has_key?("test-delayed") == false }
+      LavinMQ::HTTP::DefinitionsController::GlobalDefinitions.new(s).import(body)
+      wait_for { s.vhosts["/"].exchanges.has_key?("test-delayed") == true }
+      response = http.get("/api/exchanges/%2f/test-delayed")
+      response.status_code.should eq 200
+    end
+  end
 end

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -673,13 +673,10 @@ describe LavinMQ::HTTP::Server do
         "delayed": true
       })
       response = http.put("/api/exchanges/%2f/test-delayed", body: body)
-      wait_for { s.vhosts["/"].exchanges.has_key?("test-delayed") == true }
       response = http.get("/api/definitions")
       body = JSON.parse(response.body)
       http.delete("/api/exchanges/%2f/test-delayed")
-      wait_for { s.vhosts["/"].exchanges.has_key?("test-delayed") == false }
       LavinMQ::HTTP::DefinitionsController::GlobalDefinitions.new(s).import(body)
-      wait_for { s.vhosts["/"].exchanges.has_key?("test-delayed") == true }
       response = http.get("/api/exchanges/%2f/test-delayed")
       response.status_code.should eq 200
     end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -675,7 +675,7 @@ module LavinMQ
         TopicExchange.new(vhost, name, durable, auto_delete, internal, arguments)
       when "headers"
         HeadersExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      when "x-delayed-message"
+      when "x-delayed-message", "x-delayed-exchange"
         arguments = arguments.clone
         type = arguments.delete("x-delayed-type")
         raise Error::ExchangeTypeError.new("Missing required argument 'x-delayed-type'") unless type


### PR DESCRIPTION
### WHAT is this pull request doing?
Importing definitions from a LavinMQ instance with delayed exchanges fails because it expects exchange type to be `x-delayed-message`, but it actually is `x-delayed-exchange`. This fix allows the exchange type to be `x-delayed-exchange` as well. See https://github.com/cloudamqp/lavinmq/issues/743

(Exchange type is `x-delayed-message` when exporting from RabbitMQ)

Fixes #743 

### HOW can this pull request be tested?
Run spec
