### PR TITLE
GUI: Merge headers field and properties.headers instead of overwriting

### DIFF
--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -107,7 +107,7 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
   const url = 'api/exchanges/' + urlEncodedVhost + '/' + urlEncodedExchange + '/publish'
   const properties = DOM.parseJSON(data.get('properties'))
   properties.delivery_mode = parseInt(data.get('delivery_mode'))
-  properties.headers = DOM.parseJSON(data.get('headers'))
+  properties.headers = { ...properties.headers, ...DOM.parseJSON(data.get('headers')) }
   const body = {
     payload: data.get('payload'),
     payload_encoding: data.get('payload_encoding'),

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -199,7 +199,7 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
   const url = 'api/exchanges/' + urlEncodedVhost + '/amq.default/publish'
   const properties = DOM.parseJSON(data.get('properties'))
   properties.delivery_mode = parseInt(data.get('delivery_mode'))
-  properties.headers = DOM.parseJSON(data.get('headers'))
+  properties.headers = { ...properties.headers, ...DOM.parseJSON(data.get('headers')) }
   const body = {
     payload: data.get('payload'),
     payload_encoding: data.get('payload_encoding'),


### PR DESCRIPTION
### WHAT is this pull request doing?
Merges the content of the  `headers` field and `properties.headers` from the `properties` field instead of overwriting `properties.headers` when publishing a message from the GUI. 

Makes it possible to for example just copy message properties to the properties field, even if they include headers. 
I think it can be a little confusing that headers provided in the properties field will be overwritten, even if no headers are provided in the headers field. 

### HOW can this pull request be tested?
Manual
