### PR TITLE
Always use x-dead-letter-exchange when deliver a delayed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wait for followers to synchronize on shutdown of leader
 - Shovel the exact number of messages available on start if `delete-after=queue-length`, not more
 - Prevet a queue that's overflowing to consume too much resources
+- Dead-lettering loop when publishing to a delayed exchange's internal queue [#748](https://github.com/cloudamqp/lavinmq/pull/748)
 
 ### Changed
 

--- a/src/lavinmq/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/queue/delayed_exchange_queue.cr
@@ -5,6 +5,13 @@ module LavinMQ
   class DelayedExchangeQueue < Queue
     @internal = true
 
+    @exchange_name : String
+
+    def initialize(*args)
+      super(*args)
+      @exchange_name = arguments["x-dead-letter-exchange"]?.try(&.to_s) || raise "Missing x-dead-letter-exchange"
+    end
+
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
       DelayedMessageStore.new(data_dir, replicator)
@@ -44,12 +51,8 @@ module LavinMQ
         headers.delete("x-delay")
         msg.properties.headers = headers
       end
-      if exchange_name = arguments["x-dead-letter-exchange"]?.try &.to_s
-        @vhost.publish Message.new(msg.timestamp, exchange_name, msg.routing_key,
-          msg.properties, msg.bodysize, IO::Memory.new(msg.body))
-      else
-        @log.warn { "Can't publish delayed message #{sp}: missing x-dead-letter-exchange" }
-      end
+      @vhost.publish Message.new(msg.timestamp, @exchange_name, msg.routing_key,
+        msg.properties, msg.bodysize, IO::Memory.new(msg.body))
       delete_message sp
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
When an exchange is delayed it will create a queue and use message expiration and dead lettering for the delay. When a message is published to the exchange it will put the message in the "delay queue", and when the message is expired it will be republished to the message's exchange and the message is routed.

However, it's possible to publish messages to this queue via the default exchange and then the exchange field of the message is an empty string. This caused the message to be republished to the default exchange instead of the delayed exchange, resulting in the message looping between the queue and default exchange causing lavinmq to freeze.

This PR will make sure that the `x-dead-letter-exchange` argument for the queue is used when the messages is republished due to expiration.

### HOW can this pull request be tested?
Run specs
