### PR TITLE
Bugfix. federation binds to default exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wait for followers to synchronize on shutdown of leader
 - Shovel the exact number of messages available on start if `delete-after=queue-length`, not more
 - Prevet a queue that's overflowing to consume too much resources
+- Exchange federation tried to bind to upstream's default exchange
 
 ### Changed
 

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -400,6 +400,22 @@ describe LavinMQ::Federation::Upstream do
     end
   end
 
+  {% for descr, v in {nil: nil, empty: ""} %}
+    describe "when @exchange is {{descr}}" do
+      it "should use downstream exchange name as upstream exchange" do
+        with_amqp_server do |s|
+          vhost = s.vhosts["/"]
+
+          vhost.declare_exchange("ex1", "topic", true, false)
+
+          upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", {{v}})
+          link1 = upstream.link(vhost.exchanges["ex1"])
+
+          link1.@upstream_exchange.should eq "ex1"
+        end
+      end
+    end
+  {% end %}
   describe "when @queue is nil" do
     describe "#link(Queue)" do
       it "should create link that consumes upstream queue with same name as downstream queue" do

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -63,7 +63,10 @@ module LavinMQ
         if link = @ex_links[federated_exchange.name]?
           return link
         end
-        upstream_exchange = @exchange ||= federated_exchange.name
+        upstream_exchange = @exchange || federated_exchange.name
+        if upstream_exchange.nil? || upstream_exchange.empty?
+          upstream_exchange = federated_exchange.name
+        end
         upstream_q = "federation: #{upstream_exchange} -> #{System.hostname}:#{vhost.name}:#{federated_exchange.name}"
         link = ExchangeLink.new(self, federated_exchange, upstream_q, upstream_exchange)
         @ex_links[federated_exchange.name] = link

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -63,7 +63,7 @@ module LavinMQ
         if link = @ex_links[federated_exchange.name]?
           return link
         end
-        upstream_exchange = @exchange || federated_exchange.name
+        upstream_exchange = @exchange
         if upstream_exchange.nil? || upstream_exchange.empty?
           upstream_exchange = federated_exchange.name
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
If the upstream configuration is created without an exchange it's stored as an empty string. Currently only a nil check is done if the downstream exchange should be used, meaning that the empty string is used and the link tries to bind to the upstream default exchange.

This will add a check for empty string.

### HOW can this pull request be tested?
Run specs
