### PR TITLE
Cleanup upstream exchange

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -375,11 +375,11 @@ describe LavinMQ::Federation::Upstream do
         downstream_ex = ch.exchange("downstream_ex", "topic")
         link = upstream.link(vhost.exchanges[downstream_ex.name])
         wait_for { link.state.running? }
-        upstream_vhost.queues[federation_name]
-        upstream_vhost.exchanges[federation_name]
+        upstream_vhost.queues.has_key?(federation_name).should eq true
+        upstream_vhost.exchanges.has_key?(federation_name).should eq true
         link.terminate
-        upstream_vhost.queues.should_not contain(federation_name)
-        upstream_vhost.exchanges.should_not contain(federation_name)
+        upstream_vhost.queues.has_key?(federation_name).should eq false
+        upstream_vhost.exchanges.has_key?(federation_name).should eq false
       end
     end
   end

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -324,7 +324,6 @@ module LavinMQ
             ch = c.channel
             ch.queue_delete(@upstream_q)
             ch.exchange_delete(@upstream_q)
-            ch.exchange_delete(@upstream_exchange)
           end
         rescue e
           @log.warn(e) { "cleanup interrupted " }

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -324,6 +324,7 @@ module LavinMQ
             ch = c.channel
             ch.queue_delete(@upstream_q)
             ch.exchange_delete(@upstream_q)
+            ch.exchange_delete(@upstream_exchange)
           end
         rescue e
           @log.warn(e) { "cleanup interrupted " }

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -323,6 +323,7 @@ module LavinMQ
           ::AMQP::Client.start(upstream_uri) do |c|
             ch = c.channel
             ch.queue_delete(@upstream_q)
+            ch.exchange_delete(@upstream_q)
           end
         rescue e
           @log.warn(e) { "cleanup interrupted " }


### PR DESCRIPTION
### WHAT is this pull request doing?
If a federation gets deleted, we do a cleanup process where we are supposed to delete the internal queue that the federation created on the upstream server. 
this PR adds that we also delete the internal exchange. 

### HOW can this pull request be tested?
specs coming
