### PR TITLE
Fix broken etcd and cluster specs (dont reuse socket)

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -16,11 +16,14 @@ describe LavinMQ::Clustering::Client do
     }, output: STDOUT, error: STDERR)
 
     sock : Socket? = nil
+    i = 0
     loop do
       sleep 0.02
       sock = TCPSocket.new "127.0.0.1", 2379
       break
     rescue e : Socket::ConnectError
+      i += 1
+      raise "Cant connect to etcd on port 2379. Giving up after 100 tries. (#{e.message})" if i >= 100
       next
     end
     sock.try &.close

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -15,15 +15,15 @@ describe LavinMQ::Clustering::Client do
       "--force-new-cluster=true",
     }, output: STDOUT, error: STDERR)
 
-    sock = Socket.tcp(Socket::Family::INET)
+    sock : Socket? = nil
     loop do
       sleep 0.02
-      sock.connect "127.0.0.1", 2379
+      sock = TCPSocket.new "127.0.0.1", 2379
       break
-    rescue Socket::ConnectError
+    rescue e : Socket::ConnectError
       next
     end
-    sock.close
+    sock.try &.close
     begin
       spec.run
     ensure

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -29,6 +29,7 @@ describe LavinMQ::Etcd do
         # expect this when etcd nodes are terminated
       end
       w.receive # sync
+      sleep 0.05
       etcd.put "foo", "bar"
       w.receive.should eq "bar"
       etcd.put "foo", "rab"

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -157,16 +157,17 @@ class EtcdCluster
   end
 
   private def wait_until_online
-    sock : Socket? = nil
-    begin
-      @ports.each do |port|
-        loop do
-          sleep 0.02
-          sock = TCPSocket.new "127.0.0.1", 23000 + port
-          break
-        rescue e : Socket::ConnectError
-          next
-        end
+    @ports.each do |port|
+      sock : Socket? = nil
+      i = 0
+      loop do
+        sleep 0.02
+        sock = TCPSocket.new "127.0.0.1", 23000 + port
+        break
+      rescue e : Socket::ConnectError
+        i += 1
+        raise "Cant connect to etcd on port #{23000 + port}. Giving up after 100 tries. (#{e.message})" if i >= 100
+        next
       end
     ensure
       sock.try &.close

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -157,19 +157,19 @@ class EtcdCluster
   end
 
   private def wait_until_online
-    sock = Socket.tcp(Socket::Family::INET)
+    sock : Socket? = nil
     begin
       @ports.each do |port|
         loop do
           sleep 0.02
-          sock.connect "127.0.0.1", 23000 + port
+          sock = TCPSocket.new "127.0.0.1", 23000 + port
           break
-        rescue Socket::ConnectError
+        rescue e : Socket::ConnectError
           next
         end
       end
     ensure
-      sock.close
+      sock.try &.close
     end
   end
 end


### PR DESCRIPTION

### WHAT is this pull request doing?
Trying to fix failing specs in OS X (and probably others).

Calling `connect` on a socket a second time results in ConnectError `connect: Invalid argument`. 

### HOW can this pull request be tested?
Run specs
