### PR TITLE
Bugfix: make sure AMQPSource reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevet a queue that's overflowing to consume too much resources
 - Dead-lettering loop when publishing to a delayed exchange's internal queue [#748](https://github.com/cloudamqp/lavinmq/pull/748)
 - Exchange federation tried to bind to upstream's default exchange
+- Shovel AMQP source didn't reconnect on network failures
 
 ### Changed
 

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -155,10 +155,11 @@ module LavinMQ
           end
         rescue e : FailedDeliveryError
           msg.reject
-        rescue e
-          stop
-          raise e
         end
+      rescue e
+        Log.warn { "name=#{@name} #{e.message}" }
+        stop
+        raise e
       end
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
The shovel Runner will restart Source and Destionation when an exception occurs in any of them. The Source was however not restarted because it was in a "started" state because it didn't change state on all exceptions because exception was rescued in the wrong place.

This PR will rescue all exceptions and stop the source before re-raising the exception to the Runner.

### HOW can this pull request be tested?
Specs
