### PR TITLE
lavinmqctl - add comment that node option is only used for tests

### DIFF
--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -226,6 +226,9 @@ class LavinMQCtl
     @parser.on("-H host", "--host=host", "Specify host") do |v|
       @options["host"] = v
     end
+    @parser.on("-n node", "--node=node", "Specify node") do |v|
+      @options["node"] = v
+    end
     @parser.on("-q", "--quiet", "suppress informational messages") do
       @options["quiet"] = "yes"
     end

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -227,6 +227,7 @@ class LavinMQCtl
       @options["host"] = v
     end
     @parser.on("-n node", "--node=node", "Specify node") do |v|
+      # Only used by tests in cloudamqp/rabbitmq-java-client
       @options["node"] = v
     end
     @parser.on("-q", "--quiet", "suppress informational messages") do

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -226,9 +226,6 @@ class LavinMQCtl
     @parser.on("-H host", "--host=host", "Specify host") do |v|
       @options["host"] = v
     end
-    @parser.on("-n node", "--node=node", "Specify node") do |v|
-      @options["node"] = v
-    end
     @parser.on("-q", "--quiet", "suppress informational messages") do
       @options["quiet"] = "yes"
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a comment about the `node` option inlavinmqctl that it's only used for tests
