### PR TITLE
Fix .deb build workflow

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -12,7 +12,6 @@ COPY src/ src/
 RUN sed -i -E "s/(VERSION =) .*/\1 \"$version\"/" src/lavinmq/version.cr
 RUN tar -czf ../lavinmq_${version}.orig.tar.gz -C /usr/src lavinmq_${version}
 COPY debian/ debian/
-COPY extras/lavinmq.service debian/
 RUN sed -i -E "s/^(lavinmq) \(.*\)/\1 \(${version}-1\)/" debian/changelog
 ARG DEB_BUILD_OPTIONS="parallel=2"
 RUN debuild -us -uc


### PR DESCRIPTION
### WHAT is this pull request doing?
When preparing to build the deb packet we explicit `COPY extras/lavinmq.service debian/`. Then when `debuild` runs it will exec `make install` which will copy `lavinmq.service` to `debian/lavinmq/lib/systemd/system/lavinmq.service`.
For some reason this results in an error when trying to install to deb packet in ubuntu 24.04:

```
dpkg: error processing archive /var/cache/apt/archives/lavinmq_2.0.0-rc.3-1_amd64.deb (--unpack):
 unable to open '/usr/lib/systemd/system/lavinmq.service.dpkg-new': No such file or directory
No apport report written because the error message indicates an issue on the local system
```

### HOW can this pull request be tested?
Check GH actions?
