### PR TITLE
Fix .deb build workflow (install failed on 24.04)  (backport #772)

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -12,7 +12,6 @@ COPY src/ src/
 RUN sed -i -E "s/(VERSION =) .*/\1 \"$version\"/" src/lavinmq/version.cr
 RUN tar -czf ../lavinmq_${version}.orig.tar.gz -C /usr/src lavinmq_${version}
 COPY debian/ debian/
-COPY extras/lavinmq.service debian/
 RUN sed -i -E "s/^(lavinmq) \(.*\)/\1 \(${version}-1\)/" debian/changelog
 ARG DEB_BUILD_OPTIONS="parallel=2"
 RUN debuild -us -uc


### PR DESCRIPTION
Backport #772