### PR TITLE
Dont log handled exception as error with backtrace

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   amqp-client:
     git: https://github.com/cloudamqp/amqp-client.cr.git
-    version: 1.2.6
+    version: 1.2.7
 
   lz4:
     git: https://github.com/84codes/lz4.cr.git

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -410,13 +410,13 @@ module LavinMQ
           if ex.message.to_s.starts_with?("404")
             break
           end
-          Log.error(exception: ex) { ex.message }
+          Log.warn { ex.message }
           @error = ex.message
           exponential_reconnect_delay
         rescue ex
           break if terminated?
           @state = State::Error
-          Log.error(exception: ex) { ex.message }
+          Log.warn { ex.message }
           @error = ex.message
           exponential_reconnect_delay
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
This will change log level and remove backtrace when we log errors in the shovel. Since the errors are handled and the shovel should reconnect warn should be enough.

This PR needs cloudamqp/amqp-client.cr#47 to get rid of all scary logging.

### HOW can this pull request be tested?
Run a shovel and close the connection from mgmt ui.
