### PR TITLE
Add timeout for shovels batch ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Shovels' batching of acks caused a lot of unacked messages in source broker [#777](https://github.com/cloudamqp/lavinmq/pull/777)
 - Shovel AMQP source didn't reconnect on network failures (partially fixed in prev release) [#758](https://github.com/cloudamqp/lavinmq/pull/758)
 
 ## [2.0.0-rc.4] - 2024-08-21

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -140,7 +140,7 @@ module LavinMQ
         end
         ch.prefetch @prefetch
 
-        # We only need if we're actually batching
+        # We only start timeout loop if we're actually batching
         if ack_batch_size > 1
           spawn(name: "Shovel #{@name} ack timeout loop") { ack_timeout_loop(ch) }
         end

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -162,7 +162,7 @@ module LavinMQ
           # there is nothing to ack
           next if @last_unacked.nil?
 
-          # Our memory is the same is the current @last_unacked which means
+          # Our memory is the same as the current @last_unacked which means
           # that nothing has happend, lets ack!
           if last_unacked == @last_unacked
             ack(last_unacked, batch: false)


### PR DESCRIPTION
### WHAT is this pull request doing?
To increase performance of shovels ack is done in "batches", i.e. the shovel will ack for every half prefetch message. This may however cause a lot of unacked messages in the source queue because the queue is drained and the number of messages consumed isn't a multiple of half prefetch.

This PR will introduce a timeout for when we'll ack even though the batch threshold isn't reached.

### HOW can this pull request be tested?
Run specs
