### PR TITLE
use correct data-sort-key for consumers

### DIFF
--- a/views/consumers.ecr
+++ b/views/consumers.ecr
@@ -17,10 +17,10 @@
                 <th data-sort-key="vhost">Virtual host</th>
                 <th data-sort-key="queue">Queue</th>
                 <th data-sort-key="channel">Channel</th>
-                <th data-sort-key="consumer-tag" class="left">Consumer tag</th>
+                <th data-sort-key="consumer_tag" class="left">Consumer tag</th>
                 <th>Ack required</th>
                 <th>Exclusive</th>
-                <th data-sort-key="prefetch" class="right">Prefetch count</th>
+                <th data-sort-key="prefetch_count" class="right">Prefetch count</th>
                 <th></th>
               </tr>
             </thead>


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR fixes so we use the correct data-sort-keys of prefetch_count and consumer_tag 
Fixes #756 

### HOW can this pull request be tested?
connect a couple of consumers with different consumer tags and prefetch counts and try to sort them. 