### PR TITLE
lavinmqctl on follower nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Shovel AMQP source didn't reconnect on network failures (partially fixed in prev release) [#758](https://github.com/cloudamqp/lavinmq/pull/758)
+- Running lavinmqctl commands on a follower node now displays an error and exits with code 2 [#785](https://github.com/cloudamqp/lavinmq/pull/785)
 
 ### Changed
 

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -33,6 +33,8 @@ module LavinMQ
           @unix_amqp_proxy = Proxy.new(@config.unix_path) unless @config.unix_path.empty?
           @unix_http_proxy = Proxy.new(@config.http_unix_path) unless @config.http_unix_path.empty?
         end
+        HTTP::Server.follower_internal_socket_http_server
+
         Signal::INT.trap { close_and_exit }
         Signal::TERM.trap { close_and_exit }
       end

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -86,7 +86,8 @@ module LavinMQ
       def self.follower_internal_socket_http_server
         http_server = ::HTTP::Server.new do |context|
           context.response.status_code = 503
-          context.response.status_message = "This node is a follower and does not handle HTTP requests."
+          context.response.print "This node is a follower and does not handle lavinmqctl commands. \n" \
+                                 "Please connect to the leader node by using the --host option."
         end
 
         File.delete?(INTERNAL_UNIX_SOCKET)

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -15,6 +15,7 @@ module LavinMQ
 
     class Server
       getter http
+
       def initialize(@amqp_server : LavinMQ::Server)
         handlers = [
           StrictTransportSecurity.new,

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -88,7 +88,7 @@ module LavinMQ
           context.response.status_code = 503
           context.response.status_message = "This node is a follower and does not handle HTTP requests."
         end
-        
+
         File.delete?(INTERNAL_UNIX_SOCKET)
         addr = http_server.bind_unix(INTERNAL_UNIX_SOCKET)
         File.chmod(INTERNAL_UNIX_SOCKET, 0o660)

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -146,7 +146,7 @@ module LavinMQ
         @http_server.bind_unix(@config.http_unix_path)
       end
 
-      @http_server.bind_internal_unix
+      HTTP::Server.bind_internal_unix(@http_server.http)
       spawn(name: "HTTP listener") do
         @http_server.not_nil!.listen
       end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -146,7 +146,7 @@ module LavinMQ
         @http_server.bind_unix(@config.http_unix_path)
       end
 
-      HTTP::Server.bind_internal_unix(@http_server.http)
+      @http_server.bind_internal_unix
       spawn(name: "HTTP listener") do
         @http_server.not_nil!.listen
       end

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -250,6 +250,11 @@ class LavinMQCtl
 
   private def handle_response(resp, *ok)
     return if ok.includes? resp.status_code
+    if resp.status_code == 503
+      puts "[ERROR] This node is a follower and does not handle lavinmqctl commands."
+      puts "Please connect to the leader node by using the --host option."
+      exit 2
+    end
     puts "#{resp.status_code} - #{resp.status}"
     puts resp.body if resp.body? && !resp.headers["Content-Type"]?.try(&.starts_with?("text/html"))
     exit 1

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -251,8 +251,7 @@ class LavinMQCtl
   private def handle_response(resp, *ok)
     return if ok.includes? resp.status_code
     if resp.status_code == 503
-      puts "[ERROR] This node is a follower and does not handle lavinmqctl commands."
-      puts "Please connect to the leader node by using the --host option."
+      puts "[ERROR] #{resp.body}"
       exit 2
     end
     puts "#{resp.status_code} - #{resp.status}"


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a HTTP server on followers that bind to `internal_unix_socket` and returns a 503. This 503 is handled by lavinmqctl which will exit with code `2` and show an error message stating that it's a follower. 

### HOW can this pull request be tested?
Start a follower, run lavinmqctl against it. 
