### PR TITLE
Publish to exchange

### DIFF
--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -65,7 +65,7 @@ describe LavinMQ::HTTP::BindingsController do
         response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
         response.status_code.should eq 201
         response.headers["Location"].should eq "bindings_q1/rk"
-        s.vhosts["/"].exchanges["be1"].queue_bindings.last_key.first.should eq "rk"
+        s.vhosts["/"].exchanges["be1"].bindings_details.first.routing_key.should eq "rk"
       end
     end
 
@@ -127,7 +127,7 @@ describe LavinMQ::HTTP::BindingsController do
         props = binding[0]["properties_key"].as_s
         response = http.delete("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
         response.status_code.should eq 204
-        s.vhosts["/"].exchanges["be1"].queue_bindings.empty?.should be_true
+        s.vhosts["/"].exchanges["be1"].bindings_details.empty?.should be_true
       end
     end
   end

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -106,13 +106,20 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        matches = [] of String
         ex = s.vhosts["/"].exchanges["import_x1"]
-        ex.do_exchange_matches("r.k2", nil) { |e| matches << e.name }
-        matches.includes?("import_x2").should be_true
-        matches.clear
-        ex.do_queue_matches("rk", nil) { |e| matches << e.name }
-        matches.includes?("import_q1").should be_true
+        qs = Set(LavinMQ::Queue).new
+        es = Set(LavinMQ::Exchange).new
+        ex.find_queues("r.k2", nil, qs, es)
+        res = Set(LavinMQ::Exchange).new
+        res << s.vhosts["/"].exchanges["import_x1"]
+        res << s.vhosts["/"].exchanges["import_x2"]
+        es.should eq res
+        qs = Set(LavinMQ::Queue).new
+        es = Set(LavinMQ::Exchange).new
+        ex.find_queues("rk", nil, qs, es)
+        res = Set(LavinMQ::Queue).new
+        res << s.vhosts["/"].queues["import_q1"]
+        qs.should eq res
       end
     end
 
@@ -470,13 +477,20 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        matches = [] of String
         ex = s.vhosts["/"].exchanges["import_x1"]
-        ex.do_exchange_matches("r.k2", nil) { |e| matches << e.name }
-        matches.includes?("import_x2").should be_true
-        matches.clear
-        ex.do_queue_matches("rk", nil) { |e| matches << e.name }
-        matches.includes?("import_q1").should be_true
+        qs = Set(LavinMQ::Queue).new
+        es = Set(LavinMQ::Exchange).new
+        ex.find_queues("r.k2", nil, qs, es)
+        res = Set(LavinMQ::Exchange).new
+        res << s.vhosts["/"].exchanges["import_x1"]
+        res << s.vhosts["/"].exchanges["import_x2"]
+        es.should eq res
+        qs = Set(LavinMQ::Queue).new
+        es = Set(LavinMQ::Exchange).new
+        ex.find_queues("rk", nil, qs, es)
+        res = Set(LavinMQ::Queue).new
+        res << s.vhosts["/"].queues["import_q1"]
+        qs.should eq res
       end
     end
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -59,7 +59,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq = s.vhosts["/"].queues[q.name]
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -93,7 +93,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq = s.vhosts["/"].queues[q.name]
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -126,7 +126,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq = s.vhosts["/"].queues[q.name]
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -187,7 +187,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message 3", q.name
           x.publish_confirm "test message 4", q.name
 
-          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue = s.vhosts["/"].queues[q.name]
           internal_queue.message_count.should eq 4
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents")
@@ -209,7 +209,7 @@ describe LavinMQ::Queue do
           end
 
           vhost = s.vhosts["/"]
-          internal_queue = vhost.exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue = vhost.queues[q.name]
           internal_queue.message_count.should eq 10
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents?count=5")
@@ -235,8 +235,7 @@ describe LavinMQ::Queue do
             x.publish_confirm "test message #{i}", q.name
           end
 
-          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
-
+          internal_queue = s.vhosts["/"].queues[q.name]
           internal_queue.message_count.should eq 10
 
           channel = Channel(String).new(1)

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -432,7 +432,7 @@ describe LavinMQ::Federation::Upstream do
         wait_for { upstream.links.first?.try &.state.running? }
 
         upstream_q = upstream_vhost.queues.values.first
-        upstream_q.bindings.size.should eq queues.size
+        upstream_q.bindings.size.should eq queues.size + 1 # +1 for the default exchange
         # Assert setup is correct
         10.times do |i|
           downstream_q = downstream_ch.queue("")
@@ -440,10 +440,10 @@ describe LavinMQ::Federation::Upstream do
           queues << downstream_q
         end
         sleep 0.1.seconds
-        upstream_q.bindings.size.should eq queues.size
+        upstream_q.bindings.size.should eq queues.size + 1
         queues.each &.delete
         sleep 10.milliseconds
-        upstream_q.bindings.size.should eq 0
+        upstream_q.bindings.size.should eq 1
       end
     end
   end

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -71,7 +71,7 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.restart
-      s.vhosts["test"].exchanges["e"].queue_bindings[{"q", nil}].size.should eq 1
+      s.vhosts["test"].exchanges["e"].bindings_details.first.destination.name.should eq "q"
     end
   end
 

--- a/src/lavinmq/exchange/default.cr
+++ b/src/lavinmq/exchange/default.cr
@@ -6,22 +6,24 @@ module LavinMQ
       "direct"
     end
 
-    def bind(destination, routing_key, headers = nil)
-      raise "Access refused"
+    def bindings_details : Iterator(BindingDetails)
+      Iterator(BindingDetails).empty
     end
 
-    def unbind(destination, routing_key, headers = nil)
-      raise "Access refused"
-    end
-
-    def do_queue_matches(routing_key, headers = nil, & : Queue -> _)
+    protected def bindings(routing_key, headers) : Iterator(Destination)
       if q = @vhost.queues[routing_key]?
-        yield q
+        Tuple(Destination).new(q).each
+      else
+        Iterator(Destination).empty
       end
     end
 
-    def do_exchange_matches(routing_key, headers = nil, & : Exchange -> _)
-      # noop
+    def bind(destination, routing_key, headers = nil)
+      raise LavinMQ::Exchange::AccessRefused.new(self)
+    end
+
+    def unbind(destination, routing_key, headers = nil)
+      raise LavinMQ::Exchange::AccessRefused.new(self)
     end
   end
 end

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -110,7 +110,7 @@ module LavinMQ
     def in_use?
       return true unless bindings_details.empty?
       @vhost.exchanges.any? do |_, x|
-        x.bindings_details.each.any? { |bd| bd.destination == self }
+        x.bindings_details.any? { |bd| bd.destination == self }
       end
     end
 

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -190,9 +190,9 @@ module LavinMQ
       return unless exchanges.add? self
       bindings(routing_key, headers).each do |d|
         case d
-        when Queue
+        in Queue
           queues.add(d)
-        when Exchange
+        in Exchange
           d.find_queues(routing_key, headers, queues, exchanges)
         end
       end

--- a/src/lavinmq/exchange/exchange.cr
+++ b/src/lavinmq/exchange/exchange.cr
@@ -191,7 +191,7 @@ module LavinMQ
       bindings(routing_key, headers).each do |d|
         case d
         when Queue
-          queues.add(d) unless d.closed?
+          queues.add(d)
         when Exchange
           d.find_queues(routing_key, headers, queues, exchanges)
         end

--- a/src/lavinmq/exchange/fanout.cr
+++ b/src/lavinmq/exchange/fanout.cr
@@ -2,40 +2,38 @@ require "./exchange"
 
 module LavinMQ
   class FanoutExchange < Exchange
+    @bindings = Set(Destination).new
+
     def type : String
       "fanout"
     end
 
-    def bind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].add? destination
-      after_bind(destination, routing_key, headers)
-      ret
+    def bindings_details : Iterator(BindingDetails)
+      @bindings.each.map do |d|
+        binding_key = BindingKey.new("")
+        BindingDetails.new(name, vhost.name, binding_key, d)
+      end
     end
 
-    def bind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].add? destination
-      after_bind(destination, routing_key, headers)
-      ret
+    def bind(destination : Destination, routing_key, headers = nil)
+      return false unless @bindings.add? destination
+      binding_key = BindingKey.new("")
+      data = BindingDetails.new(name, vhost.name, binding_key, destination)
+      notify_observers(ExchangeEvent::Bind, data)
+      true
     end
 
-    def unbind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].delete destination
-      after_unbind(destination, routing_key, headers)
-      ret
+    def unbind(destination : Destination, routing_key, headers = nil)
+      return false unless @bindings.delete destination
+      binding_key = BindingKey.new("")
+      data = BindingDetails.new(name, vhost.name, binding_key, destination)
+      notify_observers(ExchangeEvent::Unbind, data)
+      delete if @auto_delete && @bindings.empty?
+      true
     end
 
-    def unbind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].delete destination
-      after_unbind(destination, routing_key, headers)
-      ret
-    end
-
-    def do_queue_matches(routing_key, headers = nil, & : Queue -> _)
-      @queue_bindings.each_value { |s| s.each { |q| yield q } }
-    end
-
-    def do_exchange_matches(routing_key, headers = nil, & : Exchange -> _)
-      @exchange_bindings.each_value { |s| s.each { |q| yield q } }
+    protected def bindings(routing_key, headers) : Iterator(Destination)
+      @bindings.each
     end
   end
 end

--- a/src/lavinmq/http/binding_helpers.cr
+++ b/src/lavinmq/http/binding_helpers.cr
@@ -10,19 +10,9 @@ module LavinMQ
         end
       end
 
-      private def binding_for_props(context, source, destination : Queue, props)
-        binding = source.queue_bindings.find do |k, v|
-          v.includes?(destination) && BindingDetails.hash_key(k) == props
-        end
-        unless binding
-          not_found(context, "Binding '#{props}' on exchange '#{source.name}' -> queue '#{destination.name}' does not exist")
-        end
-        binding
-      end
-
-      private def binding_for_props(context, source, destination : Exchange, props)
-        binding = source.exchange_bindings.find do |k, v|
-          v.includes?(destination) && BindingDetails.hash_key(k) == props
+      private def binding_for_props(context, source, destination : Destination, props)
+        binding = source.bindings_details.find do |bd|
+          bd.destination == destination && bd.binding_key.properties_key == props
         end
         unless binding
           not_found(context, "Binding '#{props}' on exchange '#{source.name}' -> exchange '#{destination.name}' does not exist")

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -134,9 +134,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
             queue = queue(context, params, vhost)
-            itr = queue.bindings.map { |exchange, args| BindingDetails.new(exchange.name, vhost, args, queue) }
-            default_binding = BindingDetails.new("", queue.vhost.name, {queue.name, nil}, queue)
-            page(context, {default_binding}.each.chain(itr))
+            page(context, queue.bindings)
           end
         end
 

--- a/src/stdlib/iterator.cr
+++ b/src/stdlib/iterator.cr
@@ -1,0 +1,13 @@
+module Iterator(T)
+  def self.empty
+    EmptyIterator(T).new
+  end
+
+  private struct EmptyIterator(T)
+    include Iterator(T)
+
+    def next
+      stop
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?

Move the logic of publishing a message to an exchange from Vhost to the exchange. 

The idea came because of the need for the exchange to handle the messages differently for MQTT support 
but it has additional benefits like `@queue_bindings` and `@exchange_bindings` can have different types and as you may see I've used only one "bindings" for both queue and exchange. for example for FanoutExchange it's just a `@bindings : Set(Destination)` 

There is probably some more things that should move down to each subclass to make the code clearer and to support the different types that `@bindings` has now. 

### HOW can this pull request be tested?

specs