### PR TITLE
Federation queue link should reconnect

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -238,16 +238,14 @@ describe LavinMQ::Federation::Upstream do
 
       wait_for { downstream_vhost.queues["downstream_q"].policy.try(&.name) == "FE" }
       wait_for { upstream.links.first?.try &.state.running? }
-
-      sleep 1.seconds
+      sleep 0.1.seconds
 
       # Disconnect the federation link
       upstream_vhost.connections.each do |conn|
         next unless conn.client_name.starts_with?("Federation link")
         conn.close
       end
-
-      sleep 1.seconds
+      sleep 0.1.seconds
 
       # wait for federation link to be reconnected
       wait_for { upstream.links.first?.try &.state.running? }

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -232,7 +232,11 @@ module LavinMQ
             state(State::Running)
             unless @federated_q.immediate_delivery?
               @log.debug { "Waiting for consumers" }
-              @consumer_available.receive?
+              select
+              when @consumer_available.receive?
+              when timeout(1.second)
+                return if @upstream_connection.try &.closed?
+              end
             end
             q_name = q[:queue_name]
             upstream_channel.basic_consume(q_name, no_ack: no_ack, tag: @upstream.consumer_tag, block: true) do |msg|


### PR DESCRIPTION
### WHAT is this pull request doing?
Makes sure federation links reconnects after the upstream restarts

### HOW can this pull request be tested?
Run the spec