### PR TITLE
Output formats (json) for lavinmqctl

### DIFF
--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -264,25 +264,15 @@ class LavinMQCtl
       puts data.to_json
     else
       case data
-      when String
-        output_string(data)
       when Hash
-        output_hash(data)
+        data.keys.each do |k|
+          puts "#{k}: #{data[k]}"
+        end
       when Array
         output_array(data, columns)
       else
         puts data
       end
-    end
-  end
-
-  private def output_string(data : String)
-    puts data
-  end
-
-  private def output_hash(data : Hash)
-    data.keys.each do |k|
-      puts "#{k}: #{data[k]}"
     end
   end
 

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -289,7 +289,7 @@ class LavinMQCtl
 
   private def output_array(data : Array, columns : Array(String)?)
     if columns
-      puts columns.join("\t")
+      puts columns.join(STDOUT, "\t")
     else
       if first = data.first?
         first = first.as_h if first.is_a?(JSON::Any)

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -424,23 +424,6 @@ class LavinMQCtl
     end
   end
 
-  private def print_erlang_terms(h : Hash)
-    str = "["
-    last_index = h.size - 1
-    h.each_with_index do |(key, value), i|
-      print "{\"#{key}\","
-      case value.raw
-      when Hash   then str += print_erlang_terms(value.as_h)
-      when String then str += "\"#{value}\""
-      else             str += value.to_s
-      end
-      str += "}"
-      str += "," unless i == last_index
-    end
-    str += "]"
-    return str
-  end
-
   private def close_connection
     name = ARGV.shift?
     abort @banner unless name

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -684,8 +684,8 @@ class LavinMQCtl
         }
       end
       cluster_status_obj = {
-        this_node: body[0].dig("name"),
-        version:   body[0].dig("applications")[0].dig("version"),
+        this_node: body.dig(0, "name"),
+        version:   body.dig(0, "applications", 0, "version"),
         followers: followers,
       }
       output cluster_status_obj

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -251,7 +251,7 @@ class LavinMQCtl
   private def handle_response(resp, *ok)
     return if ok.includes? resp.status_code
     if resp.status_code == 503
-      output "[ERROR] #{resp.body}"
+      output resp.body
       exit 2
     end
     output "#{resp.status_code} - #{resp.status}"
@@ -426,13 +426,7 @@ class LavinMQCtl
     if conns = JSON.parse(resp.body).as_a?
       cc = conns.map do |u|
         next unless conn = u.as_h?
-        {
-          # columns.map { |c| conn[c] }
-          "user"      => conn["user"].to_s,
-          "peer_host" => conn["peer_host"].to_s,
-          "peer_port" => conn["peer_port"].to_s,
-          "state"     => conn["state"].to_s,
-        }
+        conn.select { |k, v| columns.includes? k }
       end
       output cc, columns
     else

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -276,8 +276,8 @@ class LavinMQCtl
     else
       case data
       when Hash, NamedTuple
-        data.keys.each do |k|
-          puts "#{k}: #{data[k]}"
+        data.each do |k, v|
+          STDOUT << k << " " << v << "\n"
         end
       when Array
         output_array(data, columns)

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -429,14 +429,48 @@ class LavinMQCtl
     puts "Listing connections ..." unless quiet?
     handle_response(resp, 200)
     if conns = JSON.parse(resp.body).as_a?
-      cc = conns.map do |u|
-        next unless conn = u.as_h?
-        conn.select { |k, _v| columns.includes? k }
+      if @options["format"]? == "json"
+        cc = conns.map do |u|
+          next unless conn = u.as_h?
+          conn.select { |k, _v| columns.includes? k }
+        end
+        output cc
+      else
+        puts columns.join("\t")
+        conns.each do |u|
+          if conn = u.as_h?
+            columns.each_with_index do |c, i|
+              case c
+              when "client_properties"
+                print_erlang_terms(conn[c].as_h)
+              else
+                print conn[c]
+              end
+              print "\t" unless i == columns.size - 1
+            end
+            puts
+          end
+        end
       end
-      output cc
     else
       abort "invalid data"
     end
+  end
+
+  private def print_erlang_terms(h : Hash)
+    print '['
+    last_index = h.size - 1
+    h.each_with_index do |(key, value), i|
+      print "{\"#{key}\","
+      case value.raw
+      when Hash   then print_erlang_terms(value.as_h)
+      when String then print '"', value, '"'
+      else             print value
+      end
+      print '}'
+      print ',' unless i == last_index
+    end
+    print ']'
   end
 
   private def close_connection

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -436,7 +436,7 @@ class LavinMQCtl
         end
         output cc
       else
-        puts columns.join("\t")
+        puts columns.join(STDOUT, "\t")
         conns.each do |u|
           if conn = u.as_h?
             columns.each_with_index do |c, i|

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -249,7 +249,7 @@ class LavinMQCtl
   end
 
   private def quiet?
-    @options["quiet"]? || @options["silent"]? || @options["format"] == "json"
+    @options["quiet"]? || @options["silent"]? || @options["format"]? == "json"
   end
 
   private def entity_arg

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -277,7 +277,7 @@ class LavinMQCtl
       case data
       when Hash, NamedTuple
         data.each do |k, v|
-          STDOUT << k << " " << v << "\n"
+          STDOUT << k << ": " << v << "\n"
         end
       when Array
         output_array(data, columns)
@@ -291,23 +291,25 @@ class LavinMQCtl
     if columns
       puts columns.join(STDOUT, "\t")
     else
-      if first = data.first?
-        first = first.as_h if first.is_a?(JSON::Any)
-        puts first.keys.join("\t")
+      case first = data.first?
+      when NamedTuple
+        puts first.keys.join(STDOUT, "\t")
+      when JSON::Any
+        puts first.as_h.each_key.join(STDOUT, "\t")
       end
     end
     data.each do |item|
-      values = [] of String
-      if item.is_a?(Hash) || item.is_a?(NamedTuple)
-        values = item.values.map &.to_s
-      elsif item.is_a?(JSON::Any)
-        if hash = item.as_h
-          values = hash.values.map &.to_s
-        end
+      case item
+      when Hash
+        item.each_value.join(STDOUT, "\t")
+      when JSON::Any
+        item.as_h.each_value.join(STDOUT, "\t")
+      when NamedTuple
+        item.values.join(STDOUT, "\t")
       else
-        values << item.to_s
+        item.to_s(STDOUT)
       end
-      puts values.join("\t")
+      puts
     end
   end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds an option to specify output format (json) for lavinmqctl cmds. Also changes all methods to use the same `output` method. 

Example usage: 
```
$ bin/lavinmqctl list_queues -f json
[{"name":"amq.delayed.delay-test","messages":"0"},{"name":"perf-test","messages":"0"},{"name":"delay-q-test","messages":"0"},{"name":"delay2","messages":"0"},{"name":"q1","messages":"0"},{"name":"q2","messages":"0"},{"name":"federation: ex1 -> viktor-lenovo:/:ex1","messages":"0"}]
```

### HOW can this pull request be tested?
Manual 
