### PR TITLE
Remove some tuple usage

### DIFF
--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -65,7 +65,7 @@ describe LavinMQ::HTTP::BindingsController do
         response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
         response.status_code.should eq 201
         response.headers["Location"].should eq "bindings_q1/rk"
-        s.vhosts["/"].exchanges["be1"].queue_bindings.last_key.first.should eq "rk"
+        s.vhosts["/"].exchanges["be1"].queue_bindings.last_key.routing_key.should eq "rk"
       end
     end
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -59,7 +59,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[LavinMQ::BindingKey.new(q.name, nil)].first
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -93,7 +93,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[LavinMQ::BindingKey.new(q.name, nil)].first
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -126,7 +126,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          iq = s.vhosts["/"].exchanges[x_name].queue_bindings[LavinMQ::BindingKey.new(q.name, nil)].first
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -187,7 +187,7 @@ describe LavinMQ::Queue do
           x.publish_confirm "test message 3", q.name
           x.publish_confirm "test message 4", q.name
 
-          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[LavinMQ::BindingKey.new(q.name, nil)].first
           internal_queue.message_count.should eq 4
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents")
@@ -209,7 +209,7 @@ describe LavinMQ::Queue do
           end
 
           vhost = s.vhosts["/"]
-          internal_queue = vhost.exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue = vhost.exchanges[x_name].queue_bindings[LavinMQ::BindingKey.new(q.name, nil)].first
           internal_queue.message_count.should eq 10
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents?count=5")
@@ -235,7 +235,7 @@ describe LavinMQ::Queue do
             x.publish_confirm "test message #{i}", q.name
           end
 
-          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+          internal_queue = s.vhosts["/"].exchanges[x_name].queue_bindings[LavinMQ::BindingKey.new(q.name, nil)].first
 
           internal_queue.message_count.should eq 10
 

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -71,7 +71,7 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.restart
-      s.vhosts["test"].exchanges["e"].queue_bindings[{"q", nil}].size.should eq 1
+      s.vhosts["test"].exchanges["e"].queue_bindings[LavinMQ::BindingKey.new("q", nil)].size.should eq 1
     end
   end
 

--- a/src/lavinmq/exchange/consistent_hash.cr
+++ b/src/lavinmq/exchange/consistent_hash.cr
@@ -29,9 +29,9 @@ module LavinMQ
       @hasher.add(destination.name, w, destination)
       ret = case destination
             when Queue
-              @queue_bindings[{routing_key, headers}].add? destination
+              @queue_bindings[BindingKey.new(routing_key, headers)].add? destination
             when Exchange
-              @exchange_bindings[{routing_key, headers}].add? destination
+              @exchange_bindings[BindingKey.new(routing_key, headers)].add? destination
             end
       after_bind(destination, routing_key, headers)
       ret
@@ -41,9 +41,9 @@ module LavinMQ
       w = weight(routing_key)
       ret = case destination
             when Queue
-              @queue_bindings[{routing_key, headers}].delete destination
+              @queue_bindings[BindingKey.new(routing_key, headers)].delete destination
             when Exchange
-              @exchange_bindings[{routing_key, headers}].delete destination
+              @exchange_bindings[BindingKey.new(routing_key, headers)].delete destination
             end
       @hasher.remove(destination.name, w)
       ret

--- a/src/lavinmq/exchange/direct.cr
+++ b/src/lavinmq/exchange/direct.cr
@@ -7,35 +7,35 @@ module LavinMQ
     end
 
     def bind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].add? destination
+      ret = @queue_bindings[BindingKey.new(routing_key, nil)].add? destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def bind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].add? destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, nil)].add? destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].delete destination
+      ret = @queue_bindings[BindingKey.new(routing_key, nil)].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].delete destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, nil)].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end
 
     def do_queue_matches(routing_key, headers = nil, & : Queue -> _)
-      @queue_bindings[{routing_key, nil}].each { |q| yield q }
+      @queue_bindings[BindingKey.new(routing_key, nil)].each { |q| yield q }
     end
 
     def do_exchange_matches(routing_key, headers = nil, & : Exchange -> _)
-      @exchange_bindings[{routing_key, nil}].each { |x| yield x }
+      @exchange_bindings[BindingKey.new(routing_key, nil)].each { |x| yield x }
     end
   end
 end

--- a/src/lavinmq/exchange/fanout.cr
+++ b/src/lavinmq/exchange/fanout.cr
@@ -7,25 +7,25 @@ module LavinMQ
     end
 
     def bind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].add? destination
+      ret = @queue_bindings[BindingKey.new(routing_key, nil)].add? destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def bind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].add? destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, nil)].add? destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].delete destination
+      ret = @queue_bindings[BindingKey.new(routing_key, nil)].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].delete destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, nil)].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end

--- a/src/lavinmq/exchange/headers.cr
+++ b/src/lavinmq/exchange/headers.cr
@@ -16,7 +16,7 @@ module LavinMQ
     def bind(destination : Queue, routing_key, headers)
       validate!(headers)
       args = headers ? @arguments.clone.merge!(headers) : @arguments
-      ret = @queue_bindings[{routing_key, args}].add? destination
+      ret = @queue_bindings[BindingKey.new(routing_key, args)].add? destination
       after_bind(destination, routing_key, headers)
       ret
     end
@@ -24,21 +24,21 @@ module LavinMQ
     def bind(destination : Exchange, routing_key, headers)
       validate!(headers)
       args = headers ? @arguments.clone.merge!(headers) : @arguments
-      ret = @exchange_bindings[{routing_key, args}].add? destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, args)].add? destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Queue, routing_key, headers)
       args = headers ? @arguments.clone.merge!(headers) : @arguments
-      ret = @queue_bindings[{routing_key, args}].delete destination
+      ret = @queue_bindings[BindingKey.new(routing_key, args)].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Exchange, routing_key, headers)
       args = headers ? @arguments.clone.merge!(headers) : @arguments
-      ret = @exchange_bindings[{routing_key, args}].delete destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, args)].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end
@@ -66,7 +66,7 @@ module LavinMQ
     # ameba:disable Metrics/CyclomaticComplexity
     private def matches(bindings, routing_key, headers, & : Queue | Exchange ->)
       bindings.each do |bt, dst|
-        args = bt[1] || next
+        args = bt.arguments || next
         if headers.nil? || headers.empty?
           if args.empty?
             dst.each { |d| yield d }

--- a/src/lavinmq/exchange/topic.cr
+++ b/src/lavinmq/exchange/topic.cr
@@ -17,28 +17,28 @@ module LavinMQ
     end
 
     def bind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].add? destination
+      ret = @queue_bindings[BindingKey.new(routing_key, nil)].add? destination
       @queue_binding_keys[routing_key.split(".")] << destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def bind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].add? destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, nil)].add? destination
       @exchange_binding_keys[routing_key.split(".")] << destination
       after_bind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Queue, routing_key, headers = nil)
-      ret = @queue_bindings[{routing_key, nil}].delete destination
+      ret = @queue_bindings[BindingKey.new(routing_key, nil)].delete destination
       @queue_binding_keys[routing_key.split(".")].delete destination
       after_unbind(destination, routing_key, headers)
       ret
     end
 
     def unbind(destination : Exchange, routing_key, headers = nil)
-      ret = @exchange_bindings[{routing_key, nil}].delete destination
+      ret = @exchange_bindings[BindingKey.new(routing_key, nil)].delete destination
       @exchange_binding_keys[routing_key.split(".")].delete destination
       after_unbind(destination, routing_key, headers)
       ret

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -134,7 +134,9 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
             queue = queue(context, params, vhost)
-            itr = queue.bindings.map { |exchange, args| BindingDetails.new(exchange.name, vhost, args, queue) }
+            itr = queue.bindings.map do |binding|
+              BindingDetails.new(binding.exchange.name, vhost, binding.binding_key, queue)
+            end
             default_binding = BindingDetails.new("", queue.vhost.name, BindingKey.new(queue.name, nil), queue)
             page(context, {default_binding}.each.chain(itr))
           end

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -135,7 +135,7 @@ module LavinMQ
             refuse_unless_management(context, user(context), vhost)
             queue = queue(context, params, vhost)
             itr = queue.bindings.map { |exchange, args| BindingDetails.new(exchange.name, vhost, args, queue) }
-            default_binding = BindingDetails.new("", queue.vhost.name, {queue.name, nil}, queue)
+            default_binding = BindingDetails.new("", queue.vhost.name, BindingKey.new(queue.name, nil), queue)
             page(context, {default_binding}.each.chain(itr))
           end
         end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -360,13 +360,13 @@ module LavinMQ
       end
     end
 
-    alias QueueBinding = Tuple(BindingKey, Exchange)
+    record QueueBinding, binding_key : BindingKey, exchange : Exchange
 
     def queue_bindings(queue : Queue)
       iterators = @exchanges.each_value.map do |ex|
         ex.queue_bindings.each.select do |(_binding_args, destinations)|
           destinations.includes?(queue)
-        end.map { |(binding_args, _destinations)| {ex, binding_args} }
+        end.map { |(binding_key, _destinations)| QueueBinding.new(binding_key, ex) }
       end
       Iterator(QueueBinding).chain(iterators)
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
It's very annoying when tuples are nested in tuples and you need to do `value[0][1]`. This will change `BindingKey` and `QueueBinding` from `Tuple` to `struct`.

Interesting is that

```crystal
alias QueueBinding = Tuple(BindingKey, Exchange)
```
didn't force the order of the values based on type, see

https://github.com/cloudamqp/lavinmq/blob/0603aa921a37e5bb41ba803b78a77082f4375602/src/lavinmq/vhost.cr#L365-L372

where the orders in line 369 are swapped compared to `QueueBinding`

One problem with this refactoring is that `Hash#[](key)` isn't type, which means we don't get any compile time error when we access our binding hashes with the old value, so there's a risk i've missed change the type in one place or two.

### HOW can this pull request be tested?
Run specs
