### PR TITLE
add log for unsupported queue types

### DIFF
--- a/src/lavinmq/queue/queue_factory.cr
+++ b/src/lavinmq/queue/queue_factory.cr
@@ -57,7 +57,7 @@ module LavinMQ
 
     private def self.warn_if_unsupported_queue_type(frame)
       if frame.arguments["x-queue-type"]?
-        Log.warn { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will revert to default" }
+        Log.warn { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will be changed to the default queue type" }
       end
     end
   end

--- a/src/lavinmq/queue/queue_factory.cr
+++ b/src/lavinmq/queue/queue_factory.cr
@@ -26,6 +26,7 @@ module LavinMQ
         end
         StreamQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       else
+        check_unsupported_queue_type frame
         DurableQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       end
     end
@@ -36,6 +37,7 @@ module LavinMQ
       elsif stream_queue? frame
         raise Error::PreconditionFailed.new("A stream queue cannot be non-durable")
       else
+        check_unsupported_queue_type frame
         Queue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       end
     end
@@ -51,6 +53,12 @@ module LavinMQ
 
     private def self.stream_queue?(frame) : Bool
       frame.arguments["x-queue-type"]? == "stream"
+    end
+
+    private def self.check_unsupported_queue_type(frame)
+      if frame.arguments["x-queue-type"]?
+        Log.warn { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will revert to default" }
+      end
     end
   end
 end

--- a/src/lavinmq/queue/queue_factory.cr
+++ b/src/lavinmq/queue/queue_factory.cr
@@ -26,7 +26,7 @@ module LavinMQ
         end
         StreamQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       else
-        check_unsupported_queue_type frame
+        warn_if_unsupported_queue_type frame
         DurableQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       end
     end
@@ -37,7 +37,7 @@ module LavinMQ
       elsif stream_queue? frame
         raise Error::PreconditionFailed.new("A stream queue cannot be non-durable")
       else
-        check_unsupported_queue_type frame
+        warn_if_unsupported_queue_type frame
         Queue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       end
     end
@@ -55,7 +55,7 @@ module LavinMQ
       frame.arguments["x-queue-type"]? == "stream"
     end
 
-    private def self.check_unsupported_queue_type(frame)
+    private def self.warn_if_unsupported_queue_type(frame)
       if frame.arguments["x-queue-type"]?
         Log.warn { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will revert to default" }
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
This pull request adds a private method check_unsupported_queue_type to QueueFactory. 
If an unsupported queue type is sent in the arguments, we now let user know that that queue type will be ignored. 

### HOW can this pull request be tested?
run lavin and try to declare a quorum queue, observe logs
