### PR TITLE
add deliver_get to message stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added cluster_status to lavinmqctl [#787](https://github.com/cloudamqp/lavinmq/pull/787)
+- Added deliver_get to message_stats [#793](https://github.com/cloudamqp/lavinmq/pull/793)
 
 ## [2.0.0-rc.4] - 2024-08-21
 

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -91,6 +91,7 @@ describe LavinMQ::HTTP::Server do
         response = http.get("/api/overview")
         before_ack_count = JSON.parse(response.body).dig("message_stats", "ack")
         before_deliver_count = JSON.parse(response.body).dig("message_stats", "deliver")
+        before_deliver_get_count = JSON.parse(response.body).dig("message_stats", "deliver_get")
 
         with_channel(s) do |ch|
           q1 = ch.queue("stats_q1", exclusive: true)
@@ -111,7 +112,7 @@ describe LavinMQ::HTTP::Server do
         count = JSON.parse(response.body).dig("message_stats", "deliver")
         count.should eq(before_deliver_count.as_i + 5)
         count = JSON.parse(response.body).dig("message_stats", "deliver_get")
-        count.should eq(before_deliver_count.as_i + 5)
+        count.should eq(before_deliver_get_count.as_i + 5)
       end
     end
 

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -180,7 +180,6 @@ describe LavinMQ::HTTP::Server do
         5.times do
           q1.get.not_nil!
         end
-        c = 0
       end
 
       response = http.get("/api/overview")

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -44,7 +44,7 @@ describe LavinMQ::HTTP::QueuesController do
       end
     end
 
-    it "should return message stats " do
+    it "should return message stats" do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("stats_q")

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -37,7 +37,7 @@ module LavinMQ
       @tx = false
       @next_msg_body_tmp = IO::Memory.new
 
-      rate_stats({"ack", "get", "publish", "deliver", "redeliver", "reject", "confirm", "return_unroutable"})
+      rate_stats({"ack", "get", "publish", "deliver", "deliver_get", "redeliver", "reject", "confirm", "return_unroutable"})
 
       Log = ::Log.for "AMQP.channel"
 
@@ -330,6 +330,7 @@ module LavinMQ
           @client.vhost.event_tick(EventType::ClientRedeliver)
         else
           @deliver_count += 1
+          @deliver_get_count += 1
           @client.vhost.event_tick(EventType::ClientDeliver)
         end
       end
@@ -384,6 +385,7 @@ module LavinMQ
             @client.send_not_implemented(frame, "Stream queues does not support basic_get")
           else
             @get_count += 1
+            @deliver_get_count += 1
             @client.vhost.event_tick(EventType::ClientGet)
             ok = q.basic_get(frame.no_ack) do |env|
               delivery_tag = next_delivery_tag(q, env.segment_position, frame.no_ack, nil)

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -25,7 +25,7 @@ module LavinMQ
     class MainController < Controller
       include StatsHelpers
 
-      OVERVIEW_STATS = {"ack", "deliver", "get", "publish", "confirm", "redeliver", "reject"}
+      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject"}
       EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers", "x-federation-upstream", "x-consistent-hash"}
       CHURN_STATS    = {"connection_created", "connection_closed", "channel_created", "channel_closed",
                         "queue_declared", "queue_deleted"}

--- a/src/lavinmq/queue/stream_queue.cr
+++ b/src/lavinmq/queue/stream_queue.cr
@@ -70,7 +70,12 @@ module LavinMQ
     def consume_get(consumer : AMQP::StreamConsumer, & : Envelope -> Nil) : Bool
       get(consumer) do |env|
         yield env
-        env.redelivered ? (@redeliver_count += 1) : (@deliver_count += 1)
+        if env.redelivered
+          @redeliver_count += 1
+        else
+          @deliver_count += 1
+          @deliver_get_count += 1
+        end
       end
     end
 

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -726,11 +726,9 @@ module LavinMQ
       in EventType::ClientReject         then @reject_count += 1
       in EventType::ConsumerAdded        then @consumer_added_count += 1
       in EventType::ConsumerRemoved      then @consumer_removed_count += 1
+      in EventType::ClientGet            then @get_count += 1
       in EventType::ClientDeliver
         @deliver_count += 1
-        @deliver_get_count += 1
-      in EventType::ClientGet
-        @get_count += 1
         @deliver_get_count += 1
       end
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds `deliver_get` to `message_stats` as a total of all messages sent (`get + deliver`). 

### HOW can this pull request be tested?
Run specs