### PR TITLE
close amqp connection on error

### DIFF
--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -141,12 +141,14 @@ module LavinMQ
         rescue ex : AMQP::Error::FrameDecode
           @log.error { ex.inspect_with_backtrace }
           send_frame_error(ex.message)
+          break
         rescue ex : IO::Error | OpenSSL::SSL::Error
           @log.debug { "Lost connection, while reading (#{ex.inspect})" } unless closed?
           break
         rescue ex : Exception
           @log.error { "Unexpected error, while reading: #{ex.inspect_with_backtrace}" }
           send_internal_error(ex.message)
+          break
         end
       ensure
         cleanup


### PR DESCRIPTION
Don't try to continue to read from a client socket in the case of FrameDecode or general exceptions. Chance is that a CloseOk never will be receivied and instead new FrameDecode error will be raised again and again.