### PR TITLE
Bugifx: Index out of bounds in `Server#extract_conn_info`

### DIFF
--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -56,16 +56,13 @@ describe IO::Buffered do
       with_io(initial_data) do |read_io, write_io|
         read_io.read_buffering = true
         read_io.buffer_size = 10
-        wg = WaitGroup.new(1)
-        peeked = nil
-        spawn do
-          peeked = read_io.peek(6)
-          wg.done
-        end
+
         read_io.peek.should eq "foo".to_slice
+
         extra_data = "barbaz".to_slice
         write_io.write extra_data
-        wg.wait
+
+        peeked = read_io.peek(6)
         peeked.should eq "foobar".to_slice
       end
     end
@@ -75,16 +72,13 @@ describe IO::Buffered do
       with_io(initial_data) do |read_io, write_io|
         read_io.read_buffering = true
         read_io.buffer_size = 9
-        wg = WaitGroup.new(1)
-        peeked = nil
-        spawn do
-          peeked = read_io.peek(6)
-          wg.done
-        end
+
         read_io.peek.should eq "foo".to_slice
+
         extra_data = "barbaz".to_slice
         write_io.write extra_data
-        wg.wait
+
+        peeked = read_io.peek(6)
         peeked.should eq "foobar".to_slice
       end
     end

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -34,6 +34,15 @@ describe IO::Buffered do
       end
     end
 
+    it "raises unless size is positive" do
+      with_io do |read_io, _write_io|
+        read_io.read_buffering = true
+        expect_raises(ArgumentError) do
+          read_io.peek(-10)
+        end
+      end
+    end
+
     it "returns slice of requested size" do
       with_io("foo bar".to_slice) do |read_io, _write_io|
         read_io.read_buffering = true

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -101,21 +101,19 @@ describe IO::Buffered do
       end
     end
 
-    it "raises if io is closed" do
-      initial_data = "000foo".to_slice
+    it "returns what's in buffer upto size if io is closed" do
+      initial_data = "foobar".to_slice
       with_io(initial_data) do |read_io, write_io|
         read_io.read_buffering = true
         read_io.buffer_size = 9
 
         data = Bytes.new(3)
         read_io.read data
+        data.should eq "foo".to_slice
 
-        data.should eq "000".to_slice
         write_io.close
 
-        expect_raises(IO::Error) do
-          read_io.peek(6)
-        end
+        read_io.peek(6).should eq "bar".to_slice
       end
     end
   end

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -67,7 +67,7 @@ describe IO::Buffered do
       end
     end
 
-    it "will read up to buffer size" do
+    it "will read up to buffer size if possible" do
       initial_data = "foo".to_slice
       with_io(initial_data) do |read_io, write_io|
         read_io.read_buffering = true

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -1,0 +1,79 @@
+require "random"
+require "spec"
+require "socket"
+require "wait_group"
+require "../../src/stdlib/io_buffered"
+
+def with_io(initial_content = "foo bar baz".to_slice, &)
+  read_io, write_io = UNIXSocket.pair
+  write_io.write initial_content
+  yield read_io, write_io
+ensure
+  read_io.try &.close
+  write_io.try &.close
+end
+
+describe IO::Buffered do
+  describe "#peek" do
+    it "raises if read_buffering is false" do
+      with_io do |read_io, _write_io|
+        read_io.read_buffering = false
+        expect_raises(RuntimeError) do
+          read_io.peek(5)
+        end
+      end
+    end
+
+    it "raises if size is greater than buffer_size" do
+      with_io do |read_io, _write_io|
+        read_io.read_buffering = true
+        read_io.buffer_size = 5
+        expect_raises(ArgumentError) do
+          read_io.peek(10)
+        end
+      end
+    end
+
+    it "will read until buffer contains at least size bytes" do
+      initial_data = Bytes.new(3)
+      Random::Secure.random_bytes(initial_data)
+      with_io(initial_data) do |read_io, write_io|
+        read_io.read_buffering = true
+        read_io.buffer_size = 100
+        wg = WaitGroup.new(1)
+        spawn do
+          read_io.peek(20)
+          wg.done
+        end
+        Fiber.yield
+        read_io.peek.size.should eq initial_data.size
+        extra_data = Bytes.new(17)
+        Random::Secure.random_bytes(extra_data)
+        write_io.write extra_data
+        wg.wait
+        read_io.peek.size.should eq(initial_data.size + extra_data.size)
+      end
+    end
+
+    it "will read up to buffer size" do
+      initial_data = Bytes.new(3)
+      Random::Secure.random_bytes(initial_data)
+      with_io(initial_data) do |read_io, write_io|
+        read_io.read_buffering = true
+        read_io.buffer_size = 200
+        wg = WaitGroup.new(1)
+        spawn do
+          read_io.peek(20)
+          wg.done
+        end
+        Fiber.yield
+        read_io.peek.size.should eq initial_data.size
+        extra_data = Bytes.new(500)
+        Random::Secure.random_bytes(extra_data)
+        write_io.write extra_data
+        wg.wait
+        read_io.peek.size.should eq(read_io.buffer_size)
+      end
+    end
+  end
+end

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -82,5 +82,41 @@ describe IO::Buffered do
         peeked.should eq "foobar".to_slice
       end
     end
+
+    it "will move existing data to beginning of internal buffer " do
+      initial_data = "000foo".to_slice
+      with_io(initial_data) do |read_io, write_io|
+        read_io.read_buffering = true
+        read_io.buffer_size = 9
+
+        data = Bytes.new(3)
+        read_io.read data
+        data.should eq "000".to_slice
+
+        extra_data = "barbaz".to_slice
+        write_io.write extra_data
+
+        peeked = read_io.peek(6)
+        peeked.should eq "foobar".to_slice
+      end
+    end
+
+    it "raises if io is closed" do
+      initial_data = "000foo".to_slice
+      with_io(initial_data) do |read_io, write_io|
+        read_io.read_buffering = true
+        read_io.buffer_size = 9
+
+        data = Bytes.new(3)
+        read_io.read data
+
+        data.should eq "000".to_slice
+        write_io.close
+
+        expect_raises(IO::Error) do
+          read_io.peek(6)
+        end
+      end
+    end
   end
 end

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -52,44 +52,40 @@ describe IO::Buffered do
     end
 
     it "will read until buffer contains at least size bytes" do
-      initial_data = Bytes.new(3)
-      Random::Secure.random_bytes(initial_data)
+      initial_data = "foo".to_slice
       with_io(initial_data) do |read_io, write_io|
         read_io.read_buffering = true
-        read_io.buffer_size = 100
+        read_io.buffer_size = 10
         wg = WaitGroup.new(1)
+        peeked = nil
         spawn do
-          read_io.peek(20)
+          peeked = read_io.peek(6)
           wg.done
         end
-        Fiber.yield
-        read_io.peek.size.should eq initial_data.size
-        extra_data = Bytes.new(17)
-        Random::Secure.random_bytes(extra_data)
+        read_io.peek.should eq "foo".to_slice
+        extra_data = "barbaz".to_slice
         write_io.write extra_data
         wg.wait
-        read_io.peek.size.should eq(initial_data.size + extra_data.size)
+        peeked.should eq "foobar".to_slice
       end
     end
 
     it "will read up to buffer size" do
-      initial_data = Bytes.new(3)
-      Random::Secure.random_bytes(initial_data)
+      initial_data = "foo".to_slice
       with_io(initial_data) do |read_io, write_io|
         read_io.read_buffering = true
-        read_io.buffer_size = 200
+        read_io.buffer_size = 9
         wg = WaitGroup.new(1)
+        peeked = nil
         spawn do
-          read_io.peek(20)
+          peeked = read_io.peek(6)
           wg.done
         end
-        Fiber.yield
-        read_io.peek.size.should eq initial_data.size
-        extra_data = Bytes.new(500)
-        Random::Secure.random_bytes(extra_data)
+        read_io.peek.should eq "foo".to_slice
+        extra_data = "barbaz".to_slice
         write_io.write extra_data
         wg.wait
-        read_io.peek.size.should eq(read_io.buffer_size)
+        peeked.should eq "foobar".to_slice
       end
     end
   end

--- a/spec/stdlib/io_buffered_spec.cr
+++ b/spec/stdlib/io_buffered_spec.cr
@@ -34,6 +34,14 @@ describe IO::Buffered do
       end
     end
 
+    it "returns slice of requested size" do
+      with_io("foo bar".to_slice) do |read_io, _write_io|
+        read_io.read_buffering = true
+        read_io.buffer_size = 5
+        read_io.peek(3).should eq "foo".to_slice
+      end
+    end
+
     it "will read until buffer contains at least size bytes" do
       initial_data = Bytes.new(3)
       Random::Secure.random_bytes(initial_data)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -103,11 +103,12 @@ module LavinMQ
       when 1 then ProxyProtocol::V1.parse(client)
       when 2 then ProxyProtocol::V2.parse(client)
       else
-        if client.peek[0, 5] == "PROXY".to_slice &&
+        peeked = client.peek(8)
+        if peeked[0, 5] == "PROXY".to_slice &&
            followers.any? { |f| f.remote_address.address == remote_address.address }
           # Expect PROXY protocol header if remote address is a follower
           ProxyProtocol::V1.parse(client)
-        elsif client.peek[0, 8] == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
+        elsif peeked[0, 8] == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
               followers.any? { |f| f.remote_address.address == remote_address.address }
           # Expect PROXY protocol header if remote address is a follower
           ProxyProtocol::V2.parse(client)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -104,6 +104,7 @@ module LavinMQ
       when 2 then ProxyProtocol::V2.parse(client)
       else
         peeked = client.peek(8)
+        raise "failed to determine protocol" if peeked.size < 8
         if peeked[0, 5] == "PROXY".to_slice &&
            followers.any? { |f| f.remote_address.address == remote_address.address }
           # Expect PROXY protocol header if remote address is a follower

--- a/src/stdlib/io_buffered.cr
+++ b/src/stdlib/io_buffered.cr
@@ -7,9 +7,9 @@ module IO::Buffered
       raise ArgumentError.new("size (#{size}) can't be greater than buffer_size #{@buffer_size}")
     end
 
-    remaining_capacity = @buffer_size - @in_buffer_rem.size
-    return @in_buffer_rem[0, size] unless remaining_capacity.positive?
+    return @in_buffer_rem[0, size] if size < @in_buffer_rem.size
 
+    remaining_capacity = @buffer_size - @in_buffer_rem.size
     in_buffer = in_buffer()
 
     while @in_buffer_rem.size < size

--- a/src/stdlib/io_buffered.cr
+++ b/src/stdlib/io_buffered.cr
@@ -7,16 +7,16 @@ module IO::Buffered
       raise ArgumentError.new("size (#{size}) can't be greater than buffer_size #{@buffer_size}")
     end
 
-    to_read = @buffer_size - @in_buffer_rem.size
-    return @in_buffer_rem[0, size] unless to_read.positive?
+    remaining_capacity = @buffer_size - @in_buffer_rem.size
+    return @in_buffer_rem[0, size] unless remaining_capacity.positive?
 
     in_buffer = in_buffer()
 
     while @in_buffer_rem.size < size
-      target = Slice.new(in_buffer + @in_buffer_rem.size, to_read)
+      target = Slice.new(in_buffer + @in_buffer_rem.size, remaining_capacity)
       read_size = unbuffered_read(target).to_i
-      @in_buffer_rem = Slice.new(in_buffer, @in_buffer_rem.size + read_size)
-      to_read -= read_size
+      remaining_capacity -= read_size
+      @in_buffer_rem = Slice.new(in_buffer, @buffer_size - remaining_capacity)
     end
 
     @in_buffer_rem[0, size]

--- a/src/stdlib/io_buffered.cr
+++ b/src/stdlib/io_buffered.cr
@@ -1,0 +1,25 @@
+module IO::Buffered
+  def peek(size : Int)
+    raise RuntimeError.new("Can't prefill when read_buffering is #{read_buffering?}") unless read_buffering?
+
+    return unless size.positive?
+
+    if size > @buffer_size
+      raise ArgumentError.new("size (#{size}) can't be greater than buffer_size #{@buffer_size}")
+    end
+
+    to_read = @buffer_size - @in_buffer_rem.size
+    return unless to_read.positive?
+
+    in_buffer = in_buffer()
+
+    while @in_buffer_rem.size < size
+      target = Slice.new(in_buffer + @in_buffer_rem.size, to_read)
+      read_size = unbuffered_read(target).to_i
+      @in_buffer_rem = Slice.new(in_buffer, @in_buffer_rem.size + read_size)
+      to_read -= read_size
+    end
+
+    @in_buffer_rem[0, size]
+  end
+end

--- a/src/stdlib/io_buffered.cr
+++ b/src/stdlib/io_buffered.cr
@@ -2,16 +2,16 @@ module IO::Buffered
   def peek(size : Int)
     raise RuntimeError.new("Can't fill buffer when read_buffering is #{read_buffering?}") unless read_buffering?
     raise ArgumentError.new("size must be positive") unless size.positive?
-
     if size > @buffer_size
       raise ArgumentError.new("size (#{size}) can't be greater than buffer_size #{@buffer_size}")
     end
 
+    # Enough data in buffer already
     return @in_buffer_rem[0, size] if size < @in_buffer_rem.size
 
-    remaining_capacity = @buffer_size - @in_buffer_rem.size
     in_buffer = in_buffer()
 
+    # Move data to beginning of in_buffer if needed
     if @in_buffer_rem.to_unsafe != in_buffer
       @in_buffer_rem.copy_to(in_buffer, @in_buffer_rem.size)
     end
@@ -20,7 +20,6 @@ module IO::Buffered
       target = Slice.new(in_buffer + @in_buffer_rem.size, @buffer_size - @in_buffer_rem.size)
       bytes_read = unbuffered_read(target).to_i
       break if bytes_read.zero?
-      remaining_capacity -= bytes_read
       @in_buffer_rem = Slice.new(in_buffer, @in_buffer_rem.size + bytes_read)
     end
 

--- a/src/stdlib/io_buffered.cr
+++ b/src/stdlib/io_buffered.cr
@@ -1,15 +1,14 @@
 module IO::Buffered
   def peek(size : Int)
-    raise RuntimeError.new("Can't prefill when read_buffering is #{read_buffering?}") unless read_buffering?
-
-    return unless size.positive?
+    raise RuntimeError.new("Can't fill buffer when read_buffering is #{read_buffering?}") unless read_buffering?
+    raise ArgumentError.new("size must be positive") unless size.positive?
 
     if size > @buffer_size
       raise ArgumentError.new("size (#{size}) can't be greater than buffer_size #{@buffer_size}")
     end
 
     to_read = @buffer_size - @in_buffer_rem.size
-    return unless to_read.positive?
+    return @in_buffer_rem[0, size] unless to_read.positive?
 
     in_buffer = in_buffer()
 


### PR DESCRIPTION
### WHAT is this pull request doing?
When we try to autodetect proxy protocol version we sometimes get a `Index ouf of bounds` because there isn't enough data on the socket for `IO::Buffered#peek` to read, so our `peek[x,y]` call raises.

This will add an overload `#peek(size)` to `IO::Buffered` which will ensure the buffer contains at least `size` bytes.

Maybe we'll get something similar in the stdlib in the future: crystal-lang/crystal#15075

### HOW can this pull request be tested?
Run specs to verify `#peek(size)`…
