### PR TITLE
add clustering_max_lag to /metrics

### DIFF
--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -264,6 +264,10 @@ module LavinMQ
                       value: @amqp_server.followers.size,
                       type:  "gauge",
                       help:  "Amount of follower nodes connected"})
+        writer.write({name:  "clustering_max_lag",
+                      value: Config.instance.clustering_max_lag,
+                      type:  "gauge",
+                      help:  "Max unsynced replicated messages"})
         @amqp_server.followers.each do |f|
           writer.write({name:   "follower_lag",
                         labels: {id: f.id.to_s(36)},

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -267,7 +267,7 @@ module LavinMQ
         writer.write({name:  "clustering_max_lag",
                       value: Config.instance.clustering_max_lag,
                       type:  "gauge",
-                      help:  "Max unsynced replicated messages"})
+                      help:  "Maximum allowed unsynced replicated messages"})
         @amqp_server.followers.each do |f|
           writer.write({name:   "follower_lag",
                         labels: {id: f.id.to_s(36)},


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds `clustering_max_lag` to prometheus metrics 

### HOW can this pull request be tested?
`curl http://guest:guest@localhost:15672/metrics`
