### PR TITLE
Add metadata for which queue in which vhost thats loading

### DIFF
--- a/src/lavinmq/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/queue/delayed_exchange_queue.cr
@@ -1,4 +1,4 @@
-require "./queue"
+"./queue"
 require "./durable_queue"
 
 module LavinMQ
@@ -14,7 +14,7 @@ module LavinMQ
 
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
-      DelayedMessageStore.new(data_dir, replicator)
+      DelayedMessageStore.new(data_dir, @metadata, replicator)
     end
 
     private def expire_at(msg : BytesMessage) : Int64?
@@ -57,7 +57,7 @@ module LavinMQ
     end
 
     class DelayedMessageStore < MessageStore
-      def initialize(@data_dir : String, @replicator : Clustering::Replicator?)
+      def initialize(@data_dir : String, metadata : ::Log::Metadata, @replicator : Clustering::Replicator?)
         super
         order_messages
       end

--- a/src/lavinmq/queue/priority_queue.cr
+++ b/src/lavinmq/queue/priority_queue.cr
@@ -4,11 +4,11 @@ module LavinMQ
   class PriorityQueue < Queue
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
-      PriorityMessageStore.new(data_dir, replicator)
+      PriorityMessageStore.new(data_dir, @metadata, replicator)
     end
 
     class PriorityMessageStore < MessageStore
-      def initialize(@data_dir : String, @replicator : Clustering::Replicator?)
+      def initialize(@data_dir : String, metadata : ::Log::Metadata, @replicator : Clustering::Replicator?)
         super
         order_messages
       end

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -146,7 +146,7 @@ module LavinMQ
     # own method so that it can be overriden in other queue implementations
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
-      MessageStore.new(data_dir, replicator)
+      MessageStore.new(data_dir, @metadata, replicator)
     end
 
     private def make_data_dir : String

--- a/src/lavinmq/queue/stream_queue.cr
+++ b/src/lavinmq/queue/stream_queue.cr
@@ -41,7 +41,7 @@ module LavinMQ
 
     private def init_msg_store(data_dir)
       replicator = @vhost.@replicator
-      @msg_store = StreamQueueMessageStore.new(data_dir, replicator)
+      @msg_store = StreamQueueMessageStore.new(data_dir, @metadata, replicator)
     end
 
     private def stream_queue_msg_store : StreamQueueMessageStore

--- a/src/lavinmq/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/queue/stream_queue_message_store.cr
@@ -10,7 +10,7 @@ module LavinMQ
       getter last_offset : Int64
       @segment_last_ts = Hash(UInt32, Int64).new(0i64) # used for max-age
 
-      def initialize(@queue_data_dir : String, @replicator : Clustering::Replicator?)
+      def initialize(@queue_data_dir : String, metadata : ::Log::Metadata, @replicator : Clustering::Replicator?)
         super
         @last_offset = get_last_offset
         drop_overflow


### PR DESCRIPTION
### WHAT is this pull request doing?
The logging when a message store is loading acks and segments isn't very clear. This PR adds metadata to the logging so one knows which queue in which vhost that's loading.

### HOW can this pull request be tested?
Publish a lot of messages to a queue and restart lavinmq. Observe logs.
