### PR TITLE
Clustering - Write to tempfile first when getting full file

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -86,7 +86,7 @@ describe LavinMQ::Clustering::Client do
     wait_for { replicator.followers.size == 1 }
     with_amqp_server(replicator: replicator) do |s|
       s.users.create("u1", "p1")
-      sleep 1.seconds
+      wait_for { replicator.followers.first?.try &.lag == 0 }
       repli.close
       done.receive
     end

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -86,7 +86,7 @@ describe LavinMQ::Clustering::Client do
     wait_for { replicator.followers.size == 1 }
     with_amqp_server(replicator: replicator) do |s|
       s.users.create("u1", "p1")
-      wait_for { replicator.followers.first?.try &.lag == 0 }
+      wait_for { replicator.followers.first?.try &.lag_in_bytes == 0 }
       repli.close
       done.receive
     end

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -72,6 +72,33 @@ describe LavinMQ::Clustering::Client do
     end
   end
 
+  it "can stream full file" do
+    replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new, 0)
+    tcp_server = TCPServer.new("localhost", 0)
+    spawn(replicator.listen(tcp_server), name: "repli server spec")
+    config = LavinMQ::Config.new.tap &.data_dir = follower_data_dir
+    repli = LavinMQ::Clustering::Client.new(config, 1, replicator.password, proxy: false)
+    done = Channel(Nil).new
+    spawn(name: "follow spec") do
+      repli.follow("localhost", tcp_server.local_address.port)
+      done.send nil
+    end
+    wait_for { replicator.followers.size == 1 }
+    with_amqp_server(replicator: replicator) do |s|
+      s.users.create("u1", "p1")
+      sleep 1.seconds
+      repli.close
+      done.receive
+    end
+
+    server = LavinMQ::Server.new(follower_data_dir)
+    begin
+      server.users["u1"].should_not be_nil
+    ensure
+      server.close
+    end
+  end
+
   it "will failover" do
     config1 = LavinMQ::Config.new
     config1.data_dir = "/tmp/failover1"

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -228,11 +228,12 @@ module LavinMQ
             else
               File.delete? File.join(@data_dir, filename)
             end
-          when .positive? # full file is coming
-            Log.debug { "Getting full file #{filename} (#{len} bytes)" }
-            f = @files[filename]
-            f.truncate
+          when .positive? # replace file
+            Log.debug { "Replacing file #{filename} (#{len} bytes)" }
+            f = @files["#{filename}.tmp"]
             IO.copy(lz4, f, len) == len || raise IO::EOFError.new("Full file not received")
+            f.rename f.path[0..-5]
+            @files.delete("#{filename}.tmp")
           end
           ack_bytes = len.abs + sizeof(Int64) + filename_len + sizeof(Int32)
           acks.send(ack_bytes)

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -233,7 +233,7 @@ module LavinMQ
             f = @files["#{filename}.tmp"]
             IO.copy(lz4, f, len) == len || raise IO::EOFError.new("Full file not received")
             f.rename f.path[0..-5]
-            @files.delete("#{filename}.tmp")
+            @files.delete("#{filename}.tmp").try &.close
           end
           ack_bytes = len.abs + sizeof(Int64) + filename_len + sizeof(Int32)
           acks.send(ack_bytes)


### PR DESCRIPTION
### WHAT is this pull request doing?
Writes full file to a tempfile first and then renames it to replace the old file when getting full file on followers. This ensures that followers always has a complete file ready. 

The `Clustering::AddAction` is only ever used by `replace_file` as far as I can tell, meaning we shouldn't have to look for existing files. 

Fixes #806 

### HOW can this pull request be tested?
Run spec.