### PR TITLE
Consumer default prefetch

### DIFF
--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -19,7 +19,7 @@ module LavinMQ
       property? running = true
       getter? flow = true
       getter consumers = Array(Consumer).new
-      getter prefetch_count = 0_u16
+      getter prefetch_count : UInt16 = Config.instance.default_consumer_prefetch
       getter global_prefetch_count = 0_u16
       getter has_capacity = ::Channel(Nil).new
       getter unacked = Deque(Unack).new

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -12,7 +12,7 @@ module LavinMQ
       getter? exclusive : Bool
       getter? no_ack : Bool
       getter channel, queue
-      getter prefetch_count = 0u16
+      getter prefetch_count  : UInt16 = Config.instance.default_consumer_prefetch
       getter unacked = 0_u32
       getter? closed = false
       @flow : Bool

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -12,7 +12,7 @@ module LavinMQ
       getter? exclusive : Bool
       getter? no_ack : Bool
       getter channel, queue
-      getter prefetch_count  : UInt16 = Config.instance.default_consumer_prefetch
+      getter prefetch_count : UInt16 = Config.instance.default_consumer_prefetch
       getter unacked = 0_u32
       getter? closed = false
       @flow : Bool

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -12,7 +12,7 @@ module LavinMQ
       getter? exclusive : Bool
       getter? no_ack : Bool
       getter channel, queue
-      getter prefetch_count : UInt16 = Config.instance.default_consumer_prefetch
+      getter prefetch_count : UInt16
       getter unacked = 0_u32
       getter? closed = false
       @flow : Bool

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -59,6 +59,7 @@ module LavinMQ
     property max_deleted_definitions = 8192 # number of deleted queues, unbinds etc that compacts the definitions file
     property consumer_timeout : UInt64? = nil
     property consumer_timeout_loop_interval = 60 # seconds
+    property default_consumer_prefetch = UInt16::MAX
     @@instance : Config = self.new
 
     def self.instance : LavinMQ::Config
@@ -138,6 +139,9 @@ module LavinMQ
         end
         p.on("--clustering-etcd-endpoints=URIs", "Comma separeted host/port pairs (default: 127.0.0.1:2379)") do |v|
           @clustering_etcd_endpoints = v
+        end
+        p.on("--default-consumer-prefetch=NUMBER", "Default consumer prefetch") do |v|
+          @default_consumer_prefetch = v.to_u16
         end
         p.invalid_option { |arg| abort "Invalid argument: #{arg}" }
       end
@@ -226,6 +230,7 @@ module LavinMQ
         when "free_disk_warn"          then @free_disk_warn = v.to_i64
         when "max_deleted_definitions" then @max_deleted_definitions = v.to_i
         when "consumer_timeout"        then @consumer_timeout = v.to_u64
+        when "default_consumer_prefetch" then @default_consumer_prefetch = v.to_u16
         else
           STDERR.puts "WARNING: Unrecognized configuration 'main/#{config}'"
         end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -140,7 +140,7 @@ module LavinMQ
         p.on("--clustering-etcd-endpoints=URIs", "Comma separeted host/port pairs (default: 127.0.0.1:2379)") do |v|
           @clustering_etcd_endpoints = v
         end
-        p.on("--default-consumer-prefetch=NUMBER", "Default consumer prefetch") do |v|
+        p.on("--default-consumer-prefetch=NUMBER", "Default consumer prefetch (default 65535)") do |v|
           @default_consumer_prefetch = v.to_u16
         end
         p.invalid_option { |arg| abort "Invalid argument: #{arg}" }

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -207,29 +207,29 @@ module LavinMQ
     private def parse_main(settings)
       settings.each do |config, v|
         case config
-        when "data_dir"                then @data_dir = v
-        when "data_dir_lock"           then @data_dir_lock = true?(v)
-        when "log_level"               then @log_level = ::Log::Severity.parse(v)
-        when "log_file"                then @log_file = v
-        when "stats_interval"          then @stats_interval = v.to_i32
-        when "stats_log_size"          then @stats_log_size = v.to_i32
-        when "segment_size"            then @segment_size = v.to_i32
-        when "set_timestamp"           then @set_timestamp = true?(v)
-        when "socket_buffer_size"      then @socket_buffer_size = v.to_i32
-        when "tcp_nodelay"             then @tcp_nodelay = true?(v)
-        when "tcp_keepalive"           then @tcp_keepalive = tcp_keepalive?(v)
-        when "tcp_recv_buffer_size"    then @tcp_recv_buffer_size = v.to_i32?
-        when "tcp_send_buffer_size"    then @tcp_send_buffer_size = v.to_i32?
-        when "tls_cert"                then @tls_cert_path = v
-        when "tls_key"                 then @tls_key_path = v
-        when "tls_ciphers"             then @tls_ciphers = v
-        when "tls_min_version"         then @tls_min_version = v
-        when "guest_only_loopback"     then @guest_only_loopback = true?(v)
-        when "log_exchange"            then @log_exchange = true?(v)
-        when "free_disk_min"           then @free_disk_min = v.to_i64
-        when "free_disk_warn"          then @free_disk_warn = v.to_i64
-        when "max_deleted_definitions" then @max_deleted_definitions = v.to_i
-        when "consumer_timeout"        then @consumer_timeout = v.to_u64
+        when "data_dir"                  then @data_dir = v
+        when "data_dir_lock"             then @data_dir_lock = true?(v)
+        when "log_level"                 then @log_level = ::Log::Severity.parse(v)
+        when "log_file"                  then @log_file = v
+        when "stats_interval"            then @stats_interval = v.to_i32
+        when "stats_log_size"            then @stats_log_size = v.to_i32
+        when "segment_size"              then @segment_size = v.to_i32
+        when "set_timestamp"             then @set_timestamp = true?(v)
+        when "socket_buffer_size"        then @socket_buffer_size = v.to_i32
+        when "tcp_nodelay"               then @tcp_nodelay = true?(v)
+        when "tcp_keepalive"             then @tcp_keepalive = tcp_keepalive?(v)
+        when "tcp_recv_buffer_size"      then @tcp_recv_buffer_size = v.to_i32?
+        when "tcp_send_buffer_size"      then @tcp_send_buffer_size = v.to_i32?
+        when "tls_cert"                  then @tls_cert_path = v
+        when "tls_key"                   then @tls_key_path = v
+        when "tls_ciphers"               then @tls_ciphers = v
+        when "tls_min_version"           then @tls_min_version = v
+        when "guest_only_loopback"       then @guest_only_loopback = true?(v)
+        when "log_exchange"              then @log_exchange = true?(v)
+        when "free_disk_min"             then @free_disk_min = v.to_i64
+        when "free_disk_warn"            then @free_disk_warn = v.to_i64
+        when "max_deleted_definitions"   then @max_deleted_definitions = v.to_i
+        when "consumer_timeout"          then @consumer_timeout = v.to_u64
         when "default_consumer_prefetch" then @default_consumer_prefetch = v.to_u16
         else
           STDERR.puts "WARNING: Unrecognized configuration 'main/#{config}'"

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -103,7 +103,7 @@ class Throughput < Perf
     @parser.on("-p", "--persistent", "Persistent messages (default false)") do
       @persistent = true
     end
-    @parser.on("-P", "--prefetch=number", "Number of messages to prefetch (default 0, unlimited)") do |v|
+    @parser.on("-P", "--prefetch=number", "Number of messages to prefetch (default @prefetch)") do |v|
       @prefetch = v.to_u16
     end
     @parser.on("-g", "--poll", "Poll with basic_get instead of consuming") do

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -44,7 +44,7 @@ class Throughput < Perf
   @consume_rate = 0
   @max_unconfirm = 0
   @persistent = false
-  @prefetch = 0_u32
+  @prefetch = UInt16::MAX
   @quiet = false
   @poll = false
   @json_output = false
@@ -104,7 +104,7 @@ class Throughput < Perf
       @persistent = true
     end
     @parser.on("-P", "--prefetch=number", "Number of messages to prefetch (default 0, unlimited)") do |v|
-      @prefetch = v.to_u32
+      @prefetch = v.to_u16
     end
     @parser.on("-g", "--poll", "Poll with basic_get instead of consuming") do
       @poll = true
@@ -264,7 +264,7 @@ class Throughput < Perf
         ch.queue(@queue, passive: true)
       end
       ch.tx_select if @ack_in_transaction > 0
-      ch.prefetch @prefetch unless @prefetch.zero?
+      ch.prefetch @prefetch unless @prefetch == UInt16::MAX
       q.bind(@exchange, @routing_key) unless @exchange.empty?
       Fiber.yield
       consumes_this_second = 0
@@ -303,7 +303,7 @@ class Throughput < Perf
         ch = a.channel
         ch.queue(@queue, passive: true)
       end
-      ch.prefetch @prefetch unless @prefetch.zero?
+      ch.prefetch @prefetch unless @prefetch == UInt16::MAX
       q.bind(@exchange, @routing_key) unless @exchange.empty?
       Fiber.yield
       consumes_this_second = 0

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -44,7 +44,7 @@ class Throughput < Perf
   @consume_rate = 0
   @max_unconfirm = 0
   @persistent = false
-  @prefetch = UInt16::MAX
+  @prefetch : UInt16? = nil
   @quiet = false
   @poll = false
   @json_output = false
@@ -103,7 +103,7 @@ class Throughput < Perf
     @parser.on("-p", "--persistent", "Persistent messages (default false)") do
       @persistent = true
     end
-    @parser.on("-P", "--prefetch=number", "Number of messages to prefetch (default #{@prefetch})") do |v|
+    @parser.on("-P", "--prefetch=number", "Number of messages to prefetch)") do |v|
       @prefetch = v.to_u16
     end
     @parser.on("-g", "--poll", "Poll with basic_get instead of consuming") do
@@ -264,7 +264,9 @@ class Throughput < Perf
         ch.queue(@queue, passive: true)
       end
       ch.tx_select if @ack_in_transaction > 0
-      ch.prefetch @prefetch unless @prefetch == UInt16::MAX
+      if prefetch = @prefetch
+        ch.prefetch prefetch
+      end
       q.bind(@exchange, @routing_key) unless @exchange.empty?
       Fiber.yield
       consumes_this_second = 0
@@ -303,7 +305,9 @@ class Throughput < Perf
         ch = a.channel
         ch.queue(@queue, passive: true)
       end
-      ch.prefetch @prefetch unless @prefetch == UInt16::MAX
+      if prefetch = @prefetch
+        ch.prefetch prefetch
+      end
       q.bind(@exchange, @routing_key) unless @exchange.empty?
       Fiber.yield
       consumes_this_second = 0

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -103,7 +103,7 @@ class Throughput < Perf
     @parser.on("-p", "--persistent", "Persistent messages (default false)") do
       @persistent = true
     end
-    @parser.on("-P", "--prefetch=number", "Number of messages to prefetch (default @prefetch)") do |v|
+    @parser.on("-P", "--prefetch=number", "Number of messages to prefetch (default #{@prefetch})") do |v|
       @prefetch = v.to_u16
     end
     @parser.on("-g", "--poll", "Poll with basic_get instead of consuming") do


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a configurable `default_consumer_prefetch` for all consumers. Defaults to UInt16::MAX (65535), and can be set either in config (`default_consumer_prefetch`) or cli (`--default-consumer-prefetch=`). 

### HOW can this pull request be tested?
Manual
