### PR TITLE
Improve broker initiated client disconnects

### DIFF
--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -417,7 +417,7 @@ module LavinMQ
         @log.debug { "#{ex.inspect} when closing socket" }
       end
 
-      def close(reason = nil, timeout force_close_timeout : Time::Span = 60.seconds)
+      def close(reason = nil, timeout : Time::Span = 60.seconds)
         reason ||= "Connection closed"
         @log.info { "Closing: #{reason}" }
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -417,7 +417,7 @@ module LavinMQ
         @log.debug { "#{ex.inspect} when closing socket" }
       end
 
-      def close(reason = nil, timeout : Time::Span = 60.seconds)
+      def close(reason = nil, timeout : Time::Span = 5.seconds)
         reason ||= "Connection closed"
         @log.info { "Closing: #{reason}" }
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -421,13 +421,14 @@ module LavinMQ
         reason ||= "Connection closed"
         @log.info { "Closing: #{reason}" }
 
-        send AMQP::Frame::Connection::Close.new(320_u16, "CONNECTION_FORCED - #{reason}", 0_u16, 0_u16)
-        @running = false
-
         socket = @socket
         if socket.responds_to?(:"write_timeout=")
           socket.write_timeout = timeout
+          socket.read_timeout = timeout
         end
+
+        send AMQP::Frame::Connection::Close.new(320_u16, "CONNECTION_FORCED - #{reason}", 0_u16, 0_u16)
+        @running = false
 
         socket.close
       end

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -410,57 +410,27 @@ module LavinMQ
         @vhost.rm_connection(self)
       end
 
-      private def close_socket(force : Bool = false)
+      private def close_socket
         @running = false
-        return @socket.close unless force
-
-        case @socket
-        when Socket
-          @socket.close_write
-        when OpenSSL::Socket
-          @socket.@bio.io.close_write
-        end
-
         @socket.close
       rescue ex
         @log.debug { "#{ex.inspect} when closing socket" }
       end
 
-      def close(reason = nil, timeout force_close_timeout : Time::Span = 10.seconds)
+      def close(reason = nil, timeout force_close_timeout : Time::Span = 60.seconds)
         reason ||= "Connection closed"
         @log.info { "Closing: #{reason}" }
 
-        # We spawn fibers to make #close non-blocking. Required for e.g. http API calls.
-        # It's probably good for VHost#close too which will close all it's connections.
-        # If we run into problems with too many fibers we can probably make one timeout fiber
-        # handling all fibers we're about to close.
-
-        ch = ::Channel(Nil).new
-        # send may be block by @write_lock, therefore we spawn to send
-        spawn(name: "Client send Close") do
-          send AMQP::Frame::Connection::Close.new(320_u16, "CONNECTION_FORCED - #{reason}", 0_u16, 0_u16)
-          @running = false
-          ch.send nil rescue ::Channel::ClosedError
-        rescue IO::Error
+        socket = @socket
+        if socket.responds_to?(:"write_timeout=")
+          socket.write_timeout = force_close_timeout
         end
 
-        # The @write_lock may be locked "forever" (consumer not consuming and buffers filled up),
-        # so we may never be able to send Close. We therefore spawn this timeout fiber
-        spawn(name: "Client send Close tiemout") do
-          select
-          when ch.receive
-            @log.info { "Close frame sent, now force closing socket" }
-          when timeout force_close_timeout
-            @log.info { "Timeout sending close, force closing socket" }
-          end
-          ch.close
-          # We always force close... Maybe wrong?
-          force_close
-        end
+        socket.close
       end
 
       def force_close
-        close_socket(force: true)
+        close_socket
       end
 
       def closed?

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -423,7 +423,7 @@ module LavinMQ
 
         socket = @socket
         if socket.responds_to?(:"write_timeout=")
-          socket.write_timeout = force_close_timeout
+          socket.write_timeout = timeout
         end
 
         socket.close

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -421,6 +421,9 @@ module LavinMQ
         reason ||= "Connection closed"
         @log.info { "Closing: #{reason}" }
 
+        send AMQP::Frame::Connection::Close.new(320_u16, "CONNECTION_FORCED - #{reason}", 0_u16, 0_u16)
+        @running = false
+
         socket = @socket
         if socket.responds_to?(:"write_timeout=")
           socket.write_timeout = timeout

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -429,8 +429,6 @@ module LavinMQ
 
         send AMQP::Frame::Connection::Close.new(320_u16, "CONNECTION_FORCED - #{reason}", 0_u16, 0_u16)
         @running = false
-
-        socket.close
       end
 
       def force_close

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -412,16 +412,16 @@ module LavinMQ
 
       private def close_socket(force : Bool = false)
         @running = false
-        if force && (socket = @socket.as?(Socket))
-          # Socket#close_write will close on "kernel level" which will ensure
-          # we abort any blocking writes. Socket#close tries to flush the socket
-          # etc, meaning that we may block for a long time (or forever for broken
-          # clients)
-          socket.close_write
-          socket.close
-        else
-          @socket.close
+        return @socket.close unless force
+
+        case @socket
+        when Socket
+          @socket.close_write
+        when OpenSSL::Socket
+          @socket.@bio.io.close_write
         end
+
+        @socket.close
       rescue ex
         @log.debug { "#{ex.inspect} when closing socket" }
       end

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -38,7 +38,7 @@ module LavinMQ
         delete "/api/connections/:name" do |context, params|
           with_connection(context, params) do |c|
             reason = context.request.headers["X-Reason"]? || "Closed via management plugin"
-            c.close(reason, timeout: 3.seconds)
+            c.close(reason)
             context.response.status_code = 204
           end
         end

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -58,7 +58,7 @@ module LavinMQ
           connections = get_connections_by_username(context, params["username"])
           reason = context.request.headers["X-Reason"]? || "Closed via management plugin"
           connections.each do |c|
-            c.close(reason, timeout: 3.seconds)
+            c.close(reason)
           end
           context.response.status_code = 204
           context

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -38,7 +38,7 @@ module LavinMQ
         delete "/api/connections/:name" do |context, params|
           with_connection(context, params) do |c|
             reason = context.request.headers["X-Reason"]? || "Closed via management plugin"
-            c.close(reason)
+            c.close(reason, timeout: 3.seconds)
             context.response.status_code = 204
           end
         end
@@ -58,7 +58,7 @@ module LavinMQ
           connections = get_connections_by_username(context, params["username"])
           reason = context.request.headers["X-Reason"]? || "Closed via management plugin"
           connections.each do |c|
-            c.close(reason)
+            c.close(reason, timeout: 3.seconds)
           end
           context.response.status_code = 204
           context

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -410,11 +410,10 @@ module LavinMQ
       select
       when close_done.receive?
         @log.info { "All connections closed gracefully" }
-      when timeout 5.seconds
-        @log.warn { "Timeout waiting for connections to close. #{@connections.size} left." }
+      when timeout 15.seconds
+        @log.warn { "Timeout waiting for connections to close. #{@connections.size} left that will be forced closed." }
       end
       close_done.close
-
       # then force close the remaining (close tcp socket)
       @connections.each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -419,14 +419,14 @@ module LavinMQ
       stop_shovels
       stop_upstream_links
 
-      @log.debug { "Closing connections" }
+      @log.info { "Closing connections" }
       close_done = Channel(Nil).new
       close_connections reason, close_done
       @log.debug { "Close sent to all connections" }
 
       select
       when close_done.receive?
-        @log.debug { "All connections closed gracefully" }
+        @log.info { "All connections closed gracefully" }
       when timeout 10.seconds
         @log.warn { "Timeout waiting for connections to close. #{@connections.size} left." }
       end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -415,8 +415,11 @@ module LavinMQ
 
       @log.info { "Closing connections" }
       close_done = Channel(Nil).new
-      close_connections reason, close_done
-      @log.debug { "Close sent to all connections" }
+
+      spawn do
+        close_connections reason, close_done
+        @log.debug { "Close sent to all connections" }
+      end
 
       select
       when close_done.receive?

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -379,15 +379,7 @@ module LavinMQ
         @log.trace { "Spawn close fiber #{fiber_id}" }
         wg.add
         spawn(name: "vhost close connection #{fiber_id}") do
-          loop do
-            select
-            when client = ch.receive
-              client.close(reason)
-            when timeout 50.milliseconds
-              break
-            end
-          rescue
-          end
+          loop { client.close ch.receive? }
           wg.done
           @log.trace { "Exit close fiber #{fiber_id}" }
         end
@@ -409,8 +401,8 @@ module LavinMQ
         end
       end
 
-      wg.wait
       ch.close
+      wg.wait
       close_done.try &.close
     end
 

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -379,7 +379,9 @@ module LavinMQ
         @log.trace { "Spawn close fiber #{fiber_id}" }
         wg.add
         spawn(name: "vhost close connection #{fiber_id}") do
-          loop { client.close ch.receive? }
+          while client = ch.receive?
+            client.close(reason)
+          end
           wg.done
           @log.trace { "Exit close fiber #{fiber_id}" }
         end

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -43,7 +43,11 @@ module LavinMQ
     end
 
     def close
-      @vhosts.each_value &.close
+      WaitGroup.wait do |wg|
+        @vhosts.each_value do |vhost|
+          wg.spawn &->vhost.close
+        end
+      end
     end
 
     def to_json(json : JSON::Builder)


### PR DESCRIPTION
### WHAT is this pull request doing?
Writing to client sockets may block a fiber because the buffers are full. When this happens this fiber will hold the write lock in `Client` until it manage to write the data. Because if this it's not possible to force close a connection from the management UI, and the http request will timeout. It will also affect lavinmq shutdown because `VHost#close` will be blocked from closing all connections effectively.

This PR will: 
- add a timeout argument to `#close` that will set a `write_timeout` on the socket.
- spawn fibers to perform "async" disconnects in parallel on shutdown

### HOW can this pull request be tested?
Manually with a "bad" client, e.g. unlimited prefetch and no acking. Let it consume until LavinMQ stops because of tcp back pressue. Try kill the connection.
