### PR TITLE
Streams - keep track of first offset and timestamp per segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove the 'reset vhost' feature [#822](https://github.com/cloudamqp/lavinmq/pull/822/files)
 
+### Added
+
+- Added some indexing for streams, greatly increasing performance when looking up by offset or timestamp [#817](https://github.com/cloudamqp/lavinmq/pull/817)
+
 ## [2.0.0] - 2024-10-31
 
 With the release of 2.0.0 we introduce High Availablility for LavinMQ in the form of clustering. With clustering, LavinMQ replicates data between nodes with our own replication protocol, and uses etcd for leader election. See [this post](https://lavinmq.com/blog/lavinmq-high-availability) in the LavinMQ blog or the [readme](https://github.com/cloudamqp/lavinmq?tab=readme-ov-file#clustering) for more information about clustering.

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -67,7 +67,6 @@ module LavinMQ::AMQP
         segment = find_segment_by_offset(offset)
         pos = 4u32
         msg_offset = 0i64
-
         loop do
           rfile = @segments[segment]?
           if rfile.nil? || pos == rfile.size

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -101,7 +101,7 @@ module LavinMQ::AMQP
           end
         when Time
           @timestamp_index.each do |seg_id, first_seg_ts|
-            break if Time.unix_ms(first_seg_ts) >= offset
+            break if Time.unix_ms(first_seg_ts) > offset
             seg = seg_id
           end
         end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -10,13 +10,13 @@ module LavinMQ::AMQP
       getter last_offset : Int64
       @segment_last_ts = Hash(UInt32, Int64).new(0i64) # used for max-age
       @offset_index : Hash(UInt32, Int64)              # segment_id => offset of first msg
-      @offset_index_ts : Hash(UInt32, Int64)           # segment_id => ts of first msg
+      @timestamp_index : Hash(UInt32, Int64)           # segment_id => ts of first msg
 
       def initialize(*args, **kwargs)
         super
         @last_offset = get_last_offset
         @offset_index = build_segment_offset_index
-        @offset_index_ts = build_segment_offset_index_ts
+        @timestamp_index = build_segment_offset_index_ts
         drop_overflow
       end
 
@@ -101,7 +101,7 @@ module LavinMQ::AMQP
             seg = seg_id
           end
         when Time
-          @offset_index_ts.each do |seg_id, first_seg_ts|
+          @timestamp_index.each do |seg_id, first_seg_ts|
             break if Time.unix_ms(first_seg_ts) >= offset
             seg = seg_id
           end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -228,6 +228,7 @@ module LavinMQ::AMQP
         @segments.each do |seg_id, mfile|
           msg = BytesMessage.from_bytes(mfile.to_slice + 4u32)
           @first_offset_per_segment[seg_id] = offset_from_headers(msg.properties.headers)
+        rescue IndexError
         end
       end
     end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -167,7 +167,8 @@ module LavinMQ::AMQP
       private def open_new_segment(next_msg_size = 0) : MFile
         super.tap do
           drop_overflow
-          @offset_index[@segments.last_key] = @last_offset
+          @offset_index[@segments.last_key] = @last_offset + 1
+          @timestamp_index[@segments.last_key] = RoughTime.unix_ms
         end
       end
 

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -9,8 +9,8 @@ module LavinMQ::AMQP
       property max_age : Time::Span | Time::MonthSpan | Nil
       getter last_offset : Int64
       @segment_last_ts = Hash(UInt32, Int64).new(0i64) # used for max-age
-      @offset_index : Hash(UInt32, Int64) # segment_id => offset of first msg
-      @offset_index_ts : Hash(UInt32, Int64) # segment_id => ts of first msg
+      @offset_index : Hash(UInt32, Int64)              # segment_id => offset of first msg
+      @offset_index_ts : Hash(UInt32, Int64)           # segment_id => ts of first msg
 
       def initialize(*args, **kwargs)
         super

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -201,6 +201,7 @@ module LavinMQ::AMQP
           @size -= msg_count if msg_count
           @segment_last_ts.delete(seg_id)
           @offset_index.delete(seg_id)
+          @timestamp_index.delete(seg_id)
           @bytesize -= mfile.size - 4
           mfile.delete.close
           @replicator.try &.delete_file(mfile.path)

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -96,7 +96,7 @@ module LavinMQ::AMQP
         case offset
         when Int
           @offset_index.each do |seg_id, first_seg_offset|
-            break if first_seg_offset >= offset
+            break if first_seg_offset > offset
             seg = seg_id
           end
         when Time


### PR DESCRIPTION
### WHAT is this pull request doing?
Saves a hash with the first offset for each segment, greatly reducing the time (and memory used) to find a message by offset.
Does the same for timestamps. 

Tests done by getting a message by a random offset 10 times in a stream with 10M messages. 

main: 
```
Getting 10 messages by random offsets...
Average time: 660.8 milliseconds
Maximum resident set size (kbytes): 824424
```

this branch: 
```
Getting 10 messages by random offsets...
Average time: 52.9 milliseconds
Maximum resident set size (kbytes): 23692
```

### HOW can this pull request be tested?
Existing specs in `stream_queue_spec.cr` should cover this pretty well. 
