### PR TITLE
Be more reslient when identifying PROXY protocol connections

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -1288,4 +1288,15 @@ describe LavinMQ::Server do
       end
     end
   end
+
+  it "can handle non valid protocol starts" do
+    LavinMQ::Config.instance.clustering = true
+    with_amqp_server do |s|
+      t = TCPSocket.new("localhost", amqp_port(s))
+      t.print "HTTP"
+      buf = Bytes.new 8
+      t.read(buf)
+      buf.should eq Bytes['A'.ord, 'M'.ord, 'Q'.ord, 'P'.ord, 0, 0, 9, 1]
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -29,13 +29,16 @@ end
 
 def with_channel(s : LavinMQ::Server, file = __FILE__, line = __LINE__, **args, &)
   name = "lavinmq-spec-#{file}:#{line}"
-  port = s.@listeners.keys.select(TCPServer).first.local_address.port
-  args = {port: port, name: name}.merge(args)
+  args = {port: amqp_port(s), name: name}.merge(args)
   conn = AMQP::Client.new(**args).connect
   ch = conn.channel
   yield ch
 ensure
   conn.try &.close(no_wait: false)
+end
+
+def amqp_port(s)
+  s.@listeners.keys.select(TCPServer).first.local_address.port
 end
 
 def should_eventually(expectation, timeout = 5.seconds, file = __FILE__, line = __LINE__, &)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -103,11 +103,14 @@ module LavinMQ
       when 1 then ProxyProtocol::V1.parse(client)
       when 2 then ProxyProtocol::V2.parse(client)
       else
-        if client.peek[0, 5] == "PROXY".to_slice &&
+        # Allow proxy connection from followers
+        if Config.instance.clustering? &&
+           client.peek[0, 5]? == "PROXY".to_slice &&
            followers.any? { |f| f.remote_address.address == remote_address.address }
           # Expect PROXY protocol header if remote address is a follower
           ProxyProtocol::V1.parse(client)
-        elsif client.peek[0, 8] == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
+        elsif Config.instance.clustering? &&
+              client.peek[0, 8]? == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
               followers.any? { |f| f.remote_address.address == remote_address.address }
           # Expect PROXY protocol header if remote address is a follower
           ProxyProtocol::V2.parse(client)


### PR DESCRIPTION
PROXY protocol connections are sniffed in clustering mode, so that followers can forward traffic to the leader. A IndexError was raised when a client opened a connections but didn't send a full 5 or 8 bytes (eg. opening and closing the connection for healtcheck). This patch fixes that bug, and also only check for PROXY protocol connections if clustering is enabled at all.

Fixes #803 