### PR TITLE
remove reset vhost feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the 'reset vhost' feature [#822](https://github.com/cloudamqp/lavinmq/pull/822/files)
+
 ## [2.0.0-rc.5] - 2024-10-28
 
 ### Fixed

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -221,49 +221,6 @@ describe LavinMQ::Queue do
     end
   end
 
-  describe "#purge_and_close_consumers" do
-    x_name = "purge_and_close"
-    q_name = "purge_and_close"
-    it "should cancel all consumers on the queue" do
-      with_amqp_server do |s|
-        with_channel(s) do |ch|
-          ch.prefetch 5
-          x = ch.exchange(x_name, "direct")
-          q = ch.queue(q_name, durable: true)
-          q.bind(x.name, q.name)
-          10.times do |i|
-            x.publish_confirm "test message #{i}", q.name
-          end
-
-          internal_queue = s.vhosts["/"].queues[q.name]
-          internal_queue.message_count.should eq 10
-
-          channel = Channel(String).new(1)
-          # Get one message of the queue
-          q.subscribe(no_ack: false) do |msg|
-            channel.send msg.body_io.to_s
-            ch.basic_ack(msg.delivery_tag)
-          end
-
-          # 10 messages in total, 5 unacked and 5 ready
-          internal_queue.message_count.should eq 5
-
-          # Here we have one active consumer with 5 unacked messages.
-          internal_queue.consumers.first.unacked.should eq 5
-
-          # Purge should remove all of those
-          internal_queue.purge_and_close_consumers
-
-          # No messages left in the queue
-          internal_queue.message_count.should eq 0
-
-          # No consumers lest on the queue and therefore no unacked
-          internal_queue.consumers.empty?.should be_true
-        end
-      end
-    end
-  end
-
   it "should keep track of unacked basic_get messages" do
     with_amqp_server do |s|
       with_channel(s) do |ch|

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -141,53 +141,6 @@ describe LavinMQ::VHost do
       end
     end
   end
-  describe "Purge vhost" do
-    it "should purge all queues in the vhost" do
-      with_amqp_server do |s|
-        with_channel(s) do |ch|
-          x = ch.exchange("purge", "direct")
-          q1 = ch.queue("purge_1", durable: true)
-          q2 = ch.queue("purge_1", durable: true)
-          q1.bind(x.name, q1.name)
-          q2.bind(x.name, q2.name)
-
-          x.publish_confirm "test message 1.1", q1.name
-          x.publish_confirm "test message 2.1", q1.name
-          x.publish_confirm "test message 2.1", q2.name
-          x.publish_confirm "test message 2.2", q2.name
-
-          vhost = s.vhosts["/"]
-          vhost.message_details[:messages].should eq 4
-
-          vhost.purge_queues_and_close_consumers(false, "")
-          vhost.message_details[:messages].should eq 0
-        end
-      end
-    end
-
-    it "should backup the folder on reset" do
-      with_amqp_server do |s|
-        with_channel(s) do |ch|
-          x = ch.exchange("purge", "direct")
-          q1 = ch.queue("purge_1", durable: true)
-          q2 = ch.queue("purge_1", durable: true)
-          q1.bind(x.name, q1.name)
-          q2.bind(x.name, q2.name)
-
-          x.publish_confirm "test message 1.1", q1.name
-          x.publish_confirm "test message 2.1", q1.name
-          x.publish_confirm "test message 2.1", q2.name
-          x.publish_confirm "test message 2.2", q2.name
-
-          vhost = s.vhosts["/"]
-          vhost.purge_queues_and_close_consumers(true, "reset_spec")
-
-          backup_dir = Path.new(vhost.data_dir, "..", "#{vhost.dir}_reset_spec").normalize
-          Dir.exists?(backup_dir).should be_true
-        end
-      end
-    end
-  end
 
   it "can limit queues" do
     with_amqp_server do |s|

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -67,23 +67,6 @@ module LavinMQ
             end.to_json(context.response)
           end
         end
-
-        post "/api/vhosts/:name/purge_and_close_consumers" do |context, params|
-          refuse_unless_administrator(context, user(context))
-          with_vhost(context, params, "name") do |vhost|
-            v = @amqp_server.vhosts[vhost]?
-            not_found(context) unless v
-            body = parse_body(context)
-            backup = true == body["backup"]?
-            dir_name = body["backup_dir_name"]?.to_s
-            dir_name = Time.utc.to_unix.to_s if dir_name.empty?
-            unless dir_name.match(/^[a-z0-9]+$/)
-              bad_request(context, "Bad backup dir name, use only lower case letters and numbers")
-            end
-            v.purge_queues_and_close_consumers(backup, dir_name)
-            context.response.status_code = 204
-          end
-        end
       end
     end
   end

--- a/src/lavinmq/queue/queue.cr
+++ b/src/lavinmq/queue/queue.cr
@@ -861,16 +861,6 @@ module LavinMQ
       end
     end
 
-    def purge_and_close_consumers : UInt32
-      # closing all channels will move all unacked back into ready queue
-      # so we are purging all messages from the queue, not only ready
-      consumers = @consumers_lock.synchronize { @consumers.dup }
-      consumers.each(&.channel.close)
-      count = purge
-      notify_consumers_empty(true)
-      count.to_u32
-    end
-
     def purge(max_count : Int = UInt32::MAX) : UInt32
       delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
       @log.info { "Purged #{delete_count} messages" }

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -619,18 +619,6 @@ module LavinMQ
       @shovels.not_nil!
     end
 
-    def purge_queues_and_close_consumers(backup_data : Bool, suffix : String)
-      if backup_data
-        backup_dir = File.join(@server_data_dir, "#{@dir}_#{suffix}")
-        @log.info { "vhost=#{@name} reset backup=#{backup_dir}" }
-        FileUtils.cp_r data_dir, backup_dir
-      end
-      @queues.each_value do |queue|
-        purged_msgs = queue.purge_and_close_consumers
-        @log.info { "vhost=#{@name} queue=#{queue.name} action=purge_and_close_consumers purged_messages=#{purged_msgs}" }
-      end
-    end
-
     def event_tick(event_type)
       case event_type
       in EventType::ChannelClosed        then @channel_closed_count += 1

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -532,22 +532,6 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
-  private def reset_vhost
-    name = ARGV.shift?
-    abort @banner unless name
-    body = if @options.has_key? "backup"
-             dir_name = @options["backup-dir-name"]?.to_s
-             dir_name = Time.utc.to_unix.to_s if dir_name.empty?
-             {
-               "backup":          true,
-               "backup_dir_name": dir_name,
-             }
-           end
-    body ||= {} of String => String
-    resp = http.post "/api/vhosts/#{URI.encode_www_form(name)}/purge_and_close_consumers", @headers, body.to_json
-    handle_response(resp, 204)
-  end
-
   private def clear_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?

--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -124,16 +124,6 @@ class LavinMQCtl
         @args["x-persist-ms"] = JSON::Any.new(v.to_i64)
       end
     end
-    @parser.on("reset_vhost", "Purges all messages in all queues in the vhost and close all consumers, optionally back up the data") do
-      @cmd = "reset_vhost"
-      self.banner = "Usage: #{PROGRAM_NAME} reset_vhost <vhost>"
-      @parser.on("--backup-data", "Backup the vhost data folder") do
-        @options["backup"] = "true"
-      end
-      @parser.on("--backup-dir-name=", "Name of the backup folder, defaults to current unix timestamp") do |v|
-        @options["backup-dir-name"] = v
-      end
-    end
     @parser.on("status", "Display server status") do
       @cmd = "status"
     end
@@ -174,7 +164,6 @@ class LavinMQCtl
     when "list_vhosts"           then list_vhosts
     when "add_vhost"             then add_vhost
     when "delete_vhost"          then delete_vhost
-    when "reset_vhost"           then reset_vhost
     when "clear_policy"          then clear_policy
     when "list_policies"         then list_policies
     when "set_policy"            then set_policy

--- a/static/js/vhost.js
+++ b/static/js/vhost.js
@@ -115,11 +115,3 @@ document.querySelector('#deleteVhost').addEventListener('submit', function (evt)
       .then(() => { window.location = 'vhosts' })
   }
 })
-document.querySelector('#resetVhost').addEventListener('submit', function (evt) {
-  evt.preventDefault()
-  const url = 'api/vhosts/' + urlEncodedVhost + '/purge_and_close_consumers'
-  if (window.confirm('This will purge all queues and close the consumers on this vhost\nAre you sure?')) {
-    HTTP.request('POST', url)
-      .then(() => { window.location = 'vhost#name=' + urlEncodedVhost })
-  }
-})


### PR DESCRIPTION
### WHAT is this pull request doing?
Removes the reset vhost feature from LavinMQ. We have decided to remove this feature becuase it couples Queue and Channel, and freeing that up a bit is going to be beneficial for other current projects we are working on.

With multi-threading on the horizon in crystal we need to work on thread safety, and we made the observation that the code was not thread safe, and you are still able to make connections while the queues and connections are being purged.  

We might re-implement this in a thread safe and more de-coupled way in the future. 

### HOW can this pull request be tested?
specs
