### PR TITLE
Add metadata when logging connection handshake

### DIFF
--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -1,4 +1,5 @@
 require "../version"
+require "../logger"
 require "./client"
 require "../client/connection_factory"
 
@@ -10,11 +11,13 @@ module LavinMQ
       def start(socket, connection_info, vhosts, users) : Client?
         remote_address = connection_info.src
         socket.read_timeout = 15.seconds
-        if confirm_header(socket)
-          if start_ok = start(socket)
-            if user = authenticate(socket, remote_address, users, start_ok)
-              if tune_ok = tune(socket)
-                if vhost = open(socket, vhosts, user)
+        metadata = ::Log::Metadata.build({address: remote_address.to_s})
+        logger = Logger.new(Log, metadata)
+        if confirm_header(socket, logger)
+          if start_ok = start(socket, logger)
+            if user = authenticate(socket, remote_address, users, start_ok, logger)
+              if tune_ok = tune(socket, logger)
+                if vhost = open(socket, vhosts, user, logger)
                   socket.read_timeout = heartbeat_timeout(tune_ok)
                   return LavinMQ::AMQP::Client.new(socket, connection_info, vhost, user, tune_ok, start_ok)
                 end
@@ -36,7 +39,7 @@ module LavinMQ
         end
       end
 
-      def confirm_header(socket) : Bool
+      def confirm_header(socket, log) : Bool
         proto = uninitialized UInt8[8]
         count = socket.read(proto.to_slice)
         if count.zero? # EOF, socket closed by peer
@@ -44,7 +47,7 @@ module LavinMQ
         elsif proto != AMQP::PROTOCOL_START_0_9_1 && proto != AMQP::PROTOCOL_START_0_9
           socket.write AMQP::PROTOCOL_START_0_9_1.to_slice
           socket.flush
-          Log.warn { "Unexpected protocol '#{String.new(proto.to_slice)}', closing socket" }
+          log.warn { "Unexpected protocol '#{String.new(proto.to_slice)}', closing socket" }
           false
         else
           true
@@ -68,13 +71,13 @@ module LavinMQ
         },
       })
 
-      def start(socket)
+      def start(socket, log)
         start = AMQP::Frame::Connection::Start.new(server_properties: SERVER_PROPERTIES)
         socket.write_bytes start, ::IO::ByteFormat::NetworkEndian
         socket.flush
         start_ok = AMQP::Frame.from_io(socket) { |f| f.as(AMQP::Frame::Connection::StartOk) }
         if start_ok.bytesize > 4096
-          Log.warn { "StartOk frame was #{start_ok.bytesize} bytes, max allowed is 4096 bytes" }
+          log.warn { "StartOk frame was #{start_ok.bytesize} bytes, max allowed is 4096 bytes" }
           return
         end
         start_ok
@@ -97,16 +100,16 @@ module LavinMQ
         end
       end
 
-      def authenticate(socket, remote_address, users, start_ok)
+      def authenticate(socket, remote_address, users, start_ok, log)
         username, password = credentials(start_ok)
         user = users[username]?
         return user if user && user.password && user.password.not_nil!.verify(password) &&
                        guest_only_loopback?(remote_address, user)
 
         if user.nil?
-          Log.warn { "User \"#{username}\" not found" }
+          log.warn { "User \"#{username}\" not found" }
         else
-          Log.warn { "Authentication failure for user \"#{username}\"" }
+          log.warn { "Authentication failure for user \"#{username}\"" }
         end
         props = start_ok.client_properties
         if capabilities = props["capabilities"]?.try &.as?(AMQP::Table)
@@ -120,7 +123,7 @@ module LavinMQ
         nil
       end
 
-      def tune(socket)
+      def tune(socket, log)
         frame_max = socket.is_a?(WebSocketIO) ? 4096_u32 : Config.instance.frame_max
         socket.write_bytes AMQP::Frame::Connection::Tune.new(
           channel_max: Config.instance.channel_max,
@@ -131,29 +134,29 @@ module LavinMQ
           case frame
           when AMQP::Frame::Connection::TuneOk
             if frame.frame_max < 4096
-              Log.warn { "Suggested Frame max (#{frame.frame_max}) too low, closing connection" }
+              log.warn { "Suggested Frame max (#{frame.frame_max}) too low, closing connection" }
               return
             end
             frame
           else
-            Log.warn { "Expected TuneOk Frame got #{frame.inspect}" }
+            log.warn { "Expected TuneOk Frame got #{frame.inspect}" }
             return
           end
         end
         if tune_ok.frame_max < 4096
-          Log.warn { "Suggested Frame max (#{tune_ok.frame_max}) too low, closing connection" }
+          log.warn { "Suggested Frame max (#{tune_ok.frame_max}) too low, closing connection" }
           return
         end
         tune_ok
       end
 
-      def open(socket, vhosts, user)
+      def open(socket, vhosts, user, log)
         open = AMQP::Frame.from_io(socket) { |f| f.as(AMQP::Frame::Connection::Open) }
         vhost_name = open.vhost.empty? ? "/" : open.vhost
         if vhost = vhosts[vhost_name]?
           if user.permissions[vhost_name]?
             if vhost.max_connections.try { |max| vhost.connections.size >= max }
-              Log.warn { "Max connections (#{vhost.max_connections}) reached for vhost #{vhost_name}" }
+              log.warn { "Max connections (#{vhost.max_connections}) reached for vhost #{vhost_name}" }
               reply_text = "NOT_ALLOWED - access to vhost '#{vhost_name}' refused: connection limit (#{vhost.max_connections}) is reached"
               socket.write_bytes AMQP::Frame::Connection::Close.new(530_u16, reply_text,
                 open.class_id, open.method_id), IO::ByteFormat::NetworkEndian
@@ -164,14 +167,14 @@ module LavinMQ
             socket.flush
             return vhost
           else
-            Log.warn { "Access denied for user \"#{user.name}\" to vhost \"#{vhost_name}\"" }
+            log.warn { "Access denied for user \"#{user.name}\" to vhost \"#{vhost_name}\"" }
             reply_text = "NOT_ALLOWED - '#{user.name}' doesn't have access to '#{vhost.name}'"
             socket.write_bytes AMQP::Frame::Connection::Close.new(530_u16, reply_text,
               open.class_id, open.method_id), IO::ByteFormat::NetworkEndian
             socket.flush
           end
         else
-          Log.warn { "VHost \"#{vhost_name}\" not found" }
+          log.warn { "VHost \"#{vhost_name}\" not found" }
           socket.write_bytes AMQP::Frame::Connection::Close.new(530_u16, "NOT_ALLOWED - vhost not found",
             open.class_id, open.method_id), IO::ByteFormat::NetworkEndian
           socket.flush


### PR DESCRIPTION
### WHAT is this pull request doing?
Before this we just log 

```
2024-11-04T09:04:56.964682Z  WARN lmq.amqp.connection_factory Authentication failure for user "guest"
2024-11-04T09:05:04.050882Z  WARN lmq.amqp.connection_factory User "qwerty" not found
```
It's impossible to know where the connection comes from.

This PR will add remote address as log metadata:

```
2024-11-04T08:54:23.557667Z  WARN lmq.amqp.connection_factory[remote_address: "127.0.0.1:51303"] User "qwerty" not found
2024-11-04T08:54:32.224236Z  WARN lmq.amqp.connection_factory[remote_address: "127.0.0.1:51304"] Authentication failure for user "guest"
```

### HOW can this pull request be tested?
Run and test with different invalid credentials.
