### PR TITLE
add trap to run cleanup static view files after termination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ dev-ui:
 	@trap '$(MAKE) clean-views; trap - EXIT' EXIT INT TERM; \
 	 $(MAKE) livereload & \
 	 livereload_pid=$$!; \
-	 $(MAKE) watch-views; \
+	 $(MAKE) -s watch-views; \
 	 wait $$livereload_pid
 
 static/views/%.html: views/%.ecr $(VIEW_PARTIALS)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,12 @@ watch-views:
 	while true; do $(MAKE) -q -s views || $(MAKE) -j views; sleep 0.5; done
 
 .PHONY: dev-ui
-dev-ui: livereload watch-views
+dev-ui:
+	@trap '$(MAKE) clean-views; trap - EXIT' EXIT INT TERM; \
+	 $(MAKE) livereload & \
+	 livereload_pid=$$!; \
+	 $(MAKE) watch-views; \
+	 wait $$livereload_pid
 
 static/views/%.html: views/%.ecr $(VIEW_PARTIALS)
 	@mkdir -p static/views


### PR DESCRIPTION
### WHAT is this pull request doing?
In the make file we add a `@trap` to `dev-ui` , which will run clean-views when the dev-ui app is terminated 

### HOW can this pull request be tested?
run `make dev-ui` 
terminate 
see that it cleans up the /static/views folder
