### PR TITLE
Add both script and Makefile target for building rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ test: lib
 format:
 	crystal tool format --check
 
+rpm: clean
+	rpmdev-setuptree
+	cp lavinmq.spec ${HOME}/rpmbuild/SPECS
+	tar czvf ${HOME}/rpmbuild/SOURCES/lavinmq.tar.gz -C .. $(notdir $(shell pwd))
+	rpmbuild -ba lavinmq.spec
+
 DESTDIR :=
 PREFIX := /usr
 BINDIR := $(PREFIX)/bin

--- a/extras/build_rpm.sh
+++ b/extras/build_rpm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Install rpmdevtools if not already installed
+# so we can get rpmdev-setuptree to setup the rpmbuild tree, just in case
+if which rpmdev-setuptree > /dev/null; then
+    :
+else
+    sudo dnf install -y rpmdevtools
+fi
+
+rpmdev-setuptree
+
+if [[ "$(basename $(pwd))" == "extras" ]]; then
+    cd ..
+fi
+
+(
+    make clean
+)
+tar czvf $HOME/rpmbuild/SOURCES/lavinmq.tar.gz -C .. $(basename $(pwd))
+cp -f lavinmq.spec $HOME/rpmbuild/SPECS
+rpmbuild -ba lavinmq.spec

--- a/lavinmq.spec
+++ b/lavinmq.spec
@@ -1,6 +1,6 @@
 Name:    lavinmq
 Summary: Message queue server that implements the AMQP 0-9-1 protocol
-Version: 1.0.0
+Version: 2.0.0
 Release: 1%{?dist}
 
 License: ASL 2.0


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR adds a Makefile target for building rpms using the spec file, and adds a script that builds and also installs rpmdevtools to setup the rpmbuild tree. The Makefile target assumes rpmdevtools is already installed.
This also edits lavinmq.spec to reflect the current version.

### HOW can this pull request be tested?
The Makefile target can be tested just by running `make rpm`.
The script can be tested by running it. It works from either inside the extras directory, or in the base dir. The script is build_rpm.sh, so from either lavinmq directory: `./extras/build_rpm.sh`, or from the extras directory as `./build_rpm.sh`


