### PR TITLE
make sure etcd lease does not expire during slow startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- etcd lease will no longer expire during slow startup [#834](https://github.com/cloudamqp/lavinmq/pull/834)
+
 ### Changed
 
 - Remove the 'reset vhost' feature [#822](https://github.com/cloudamqp/lavinmq/pull/822/files)

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -296,6 +296,7 @@ module LavinMQ
           end
           @log.debug { "Loaded #{count}/#{ack_files} ack files" } if (count += 1) % 128 == 0
           @deleted[seg] = acked.sort! unless acked.empty?
+          Fiber.yield
         end
         @log.debug { "Loaded #{count} ack files" }
       end
@@ -344,6 +345,7 @@ module LavinMQ
           end
           file.pos = 4
           @segments[seg] = file
+          Fiber.yield
         end
       end
 
@@ -378,6 +380,7 @@ module LavinMQ
           else
             @log.debug { "Loaded #{counter}/#{@segments.size} segments" } if (counter &+= 1) % 128 == 0
           end
+          Fiber.yield
           @segment_msg_count[seg] = count
         end
         @log.info { "Loaded #{counter} segments" }
@@ -405,6 +408,7 @@ module LavinMQ
             @replicator.try &.delete_file(mfile.path)
             true
           end
+          Fiber.yield
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds Fiber.yield to `load_deleted_from_disk`, `load_segments_from_disk`, `load_stats_from_segments`, and `delete_unused_segments`. 

When LavinMQ starts as a leader it creates an etcd lease with a TTL of 5s. If LavinMQ takes more than 5s to startup that lease can expire before LavinMQ starts because lease_keepalive can not run during startup because the fiber reading data from disk does not yield. This fixes that by adding yield to all functions reading data from disk during startup, allowing the lease_keepalive function to refresh the etcd lease. 

Solves #829 

### HOW can this pull request be tested?
Create a lot data, start LavinMQ with clustering enabled. 
