### PR TITLE
wait for follower to ack all actions before gracefully shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - etcd lease will no longer expire during slow startup [#834](https://github.com/cloudamqp/lavinmq/pull/834)
 - leader node is no longer unresponsive while sending file_list/files to new followers [#838](https://github.com/cloudamqp/lavinmq/pull/838)
+- leader node now waits for all data to be acked to all followers before shutting down on graceful shutdown [#835](https://github.com/cloudamqp/lavinmq/pull/835)
 
 ### Changed
 

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -154,4 +154,38 @@ module FollowerSpec
       end
     end
   end
+
+  describe "#stream changes" do
+    it "should fully sync on graceful shutdown" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        lz4_writer = Compress::LZ4::Writer.new(follower_socket, Compress::LZ4::CompressOptions.new(auto_flush: false, block_mode_linked: true))
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+        wg = WaitGroup.new(1)
+        10.times do
+          follower.append("#{data_dir}/file", "hello world".to_slice)
+        end
+        spawn do
+          follower.action_loop lz4_writer
+        end
+
+        closed = false
+        spawn do
+          wg.done
+          follower.close
+          closed = true
+          wg.done
+        end
+
+        wg.wait
+        closed.should be_false
+        wg.add(1)
+        client_socket.write_bytes follower.lag_in_bytes.to_i64, IO::ByteFormat::LittleEndian
+        client_socket.flush
+        wg.wait
+        closed.should be_true
+      end
+    end
+  end
 end

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -184,6 +184,7 @@ module FollowerSpec
         client_socket.write_bytes follower.lag_in_bytes.to_i64, IO::ByteFormat::LittleEndian
         client_socket.flush
         wg.wait
+        follower.lag_in_bytes.should eq 0
         closed.should be_true
       end
     end

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -75,7 +75,7 @@ module LavinMQ
       private def read_ack(socket = @socket) : Int64
         len = socket.read_bytes(Int64, IO::ByteFormat::LittleEndian)
         @acked_bytes += len
-        if @closed && lag_in_bytes == 0
+        if @closed && lag_in_bytes.zero?
           @closed_change.close
         end
         len

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -76,7 +76,7 @@ module LavinMQ
         len = socket.read_bytes(Int64, IO::ByteFormat::LittleEndian)
         @acked_bytes += len
         if @closed && lag_in_bytes.zero?
-          @closed_change.close
+          @closed_and_in_sync.close
         end
         len
       end
@@ -169,12 +169,12 @@ module LavinMQ
         lag_size
       end
 
-      @closed_change = Channel(Nil).new
+      @closed_and_in_sync = Channel(Nil).new
 
       def close
         @closed = true
         @actions.close
-        @closed_change.receive? if lag_in_bytes > 0
+        @closed_and_in_sync.receive? if lag_in_bytes > 0
       end
 
       def to_json(json : JSON::Builder)

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -174,9 +174,7 @@ module LavinMQ
       def close
         @closed = true
         @actions.close
-        if lag_in_bytes > 0
-          @closed_change.receive?
-        end
+        @closed_change.receive? if lag_in_bytes > 0
       end
 
       def to_json(json : JSON::Builder)


### PR DESCRIPTION
### WHAT is this pull request doing?
Before this change a leader would just wait for all actions to be sent before gracefully shutting down, meaning there's a risk that a few actions could be waiting to be processed by a follower. This changes that so a leader will now wait for followers to ack all actions before gracefully shutting down. 

Fixes #827 

### HOW can this pull request be tested?
Run spec
