### PR TITLE
use the correct data-sort-key for unacknowledged messages

### DIFF
--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -55,7 +55,7 @@ module LavinMQ
           if first_element = sorted_items.first?
             {% begin %}
               case dig(first_element, sort_by)
-                {% for k in {Int32, UInt32, UInt64, Float64} %}
+                {% for k in {Int32, UInt16, UInt32, UInt64, Float64} %}
                 when {{k.id}}
                   sorted_items.sort_by! { |i| dig(i, sort_by).as({{k.id}}) }
                 {% end %}

--- a/views/channels.ecr
+++ b/views/channels.ecr
@@ -20,7 +20,7 @@
                 <th>Mode</th>
                 <th data-sort-key="consumer_count">Consumers</th>
                 <th data-sort-key="prefetch_count">Prefetch limit</th>
-                <th data-sort-key="messages_unacked">Unacked messages</th>
+                <th data-sort-key="messages_unacknowledged">Unacked messages</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/views/connection.ecr
+++ b/views/connection.ecr
@@ -86,7 +86,7 @@
                 <th>Mode</th>
                 <th data-sort-key="consumer_count">Consumers</th>
                 <th data-sort-key="prefetch_count">Prefetch limit</th>
-                <th data-sort-key="messages_unacked">Unacked messages</th>
+                <th data-sort-key="messages_unacknowledged">Unacked messages</th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
### WHAT is this pull request doing?
updates the data-sort-key for unacknowledged messages in the channels, and connections ecr files. 
Fixes: #820 

### HOW can this pull request be tested?
`make clean-views`
`make views `
now look at the channels tab, and sort on unacknowledged messages. 