### PR TITLE
Allow other fibers to do work while files are sent to followers

### DIFF
--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -107,6 +107,7 @@ module LavinMQ
           socket.write_bytes path.bytesize.to_i32, IO::ByteFormat::LittleEndian
           socket.write path.to_slice
           socket.write hash
+          Fiber.yield
         end
         socket.write_bytes 0i32
         socket.flush
@@ -120,6 +121,7 @@ module LavinMQ
           filename = socket.read_string(filename_len)
           send_requested_file(filename)
           @lz4.flush
+          Fiber.yield
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
When a follower connects to a leader with a large amount of files/data to send, the leader is unresponsive while sending the files, and eventually the etcd lease times out and leadership is lost if the sync is slow enough. 

This adds yields to `send_file_list` and `send_requested_files` to allow other fibers to do work while a follower is syncing up. 

### HOW can this pull request be tested?
Connect a follower to a leader with a lot of data. 