### PR TITLE
make rpm

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -49,21 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate version string
-        run: |
-          last_tag=$(git describe --tags --abbrev=0)
-          version=$(cut -d- -f1 <<< ${last_tag:1})
-          pre_release=$(cut -d- -f2 -s <<< $last_tag)
-          if [ -n "$pre_release" ]
-          then version=$version~${pre_release//./}
-          fi
-          git_describe=$(git describe --tags)
-          post_release=${git_describe//$last_tag/}
-          post_release=${post_release:1}
-          post_release=${post_release//-/.}
-          if [ -n "$post_release" ]
-          then version=$version^${post_release}
-          fi
-          echo "version=$version" >> $GITHUB_ENV
+        run: echo "version=$(./rpm-version)" >> $GITHUB_ENV
 
       - uses: depot/setup-action@v1
       - uses: depot/build-push-action@v1

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,13 @@ uninstall:
 	$(RM) $(DESTDIR)$(DOCDIR)/{lavinmq,README.md,CHANGELOG.md,NOTICE}
 	$(RM) $(DESTDIR)$(SHAREDSTATEDIR)/lavinmq
 
+.PHONY: rpm
+rpm:
+	rpmdev-setuptree
+	git archive --prefix lavinmq/ --output ~/rpmbuild/SOURCES/lavinmq.tar.gz HEAD
+	sed -E "s/^(Version:).*/\1 $(shell ./rpm-version)/" lavinmq.spec > ~/rpmbuild/SPECS/lavinmq.spec
+	rpmbuild -bb ~/rpmbuild/SPECS/lavinmq.spec
+
 .PHONY: clean
 clean:
 	$(RM) $(BINS) $(DOCS) $(JS) $(MANPAGES) $(VIEW_TARGETS)

--- a/lavinmq.spec
+++ b/lavinmq.spec
@@ -1,6 +1,6 @@
 Name:    lavinmq
 Summary: Message queue server that implements the AMQP 0-9-1 protocol
-Version: 1.0.0
+Version: 2.0.0
 Release: 1%{?dist}
 
 License: ASL 2.0

--- a/rpm-version
+++ b/rpm-version
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+# Generates a version string from `git describe` in a format that RPM accepts
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/
+last_tag=$(git describe --tags --abbrev=0)
+version=$(cut -d- -f1 <<< ${last_tag:1})
+pre_release=$(cut -d- -f2 -s <<< $last_tag)
+if [ -n "$pre_release" ]
+then version=$version~${pre_release//./}
+fi
+git_describe=$(git describe --tags)
+post_release=${git_describe//$last_tag/}
+post_release=${post_release:1}
+post_release=${post_release//-/.}
+if [ -n "$post_release" ]
+then version=$version^${post_release}
+fi
+echo $version


### PR DESCRIPTION
### WHAT is this pull request doing?
a better `make rpm` experience. A rpm-version script is required to turn the `git describe` output into something RPM can accept. The script was extracted from the RPM GitHub action we had.

### HOW can this pull request be tested?

`make rpm`

Fixes #832
