### PR TITLE
Use crystal-latest when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base layer
-FROM 84codes/crystal:1.13.1-ubuntu-24.04 AS base
+FROM 84codes/crystal:latest-ubuntu-24.04 AS base
 RUN apt-get update && apt-get install -y liblz4-dev
 WORKDIR /tmp
 COPY shard.yml shard.lock .


### PR DESCRIPTION
### WHAT is this pull request doing?
Use crystal-latest instead of crystal-x.y.z (as we do in Dockerifle.deb and Dockerfile.rpm)

### HOW can this pull request be tested?
Look at CI
