### PR TITLE
Dont call stop if already stopping

### DIFF
--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -38,9 +38,9 @@ module LavinMQ
     end
 
     def run
+      @running = true
       listen
       SystemD.notify_ready
-      @running = true
       loop do
         if lease = @lease
           select
@@ -57,10 +57,11 @@ module LavinMQ
           GC.collect
         end
       end
-      stop if @running
+      stop
     end
 
     def stop
+      return unless @running
       @running = false
       Log.warn { "Stopping" }
       SystemD.notify_stopping


### PR DESCRIPTION
### WHAT is this pull request doing?
When stopping the leader it will release its leadership lease, which in turn triggers "lost leadership" which calls stop again. This PR adds a state variable to prevent double stop.

### HOW can this pull request be tested?
Start lavinmq in clustering mode, then stop it. No more double logging of `lmq.launcher Stopping`.
