### PR TITLE
`Server#stop` should close vhosts with `VHostStore#close`

### DIFF
--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -53,7 +53,7 @@ module LavinMQ
     def stop
       return if @closed
       @closed = true
-      @vhosts.each_value &.close
+      @vhosts.close
       @replicator.clear
       Fiber.yield
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
This was missed in #816

We must close all vhosts with `VHostStore#close` to make sure we're closing all vhosts concurrently.

### HOW can this pull request be tested?
Run specs
