### PR TITLE
Exit 1 if loosing leadership lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase default etcd lease TTL to 10s and run keepalive earlier [#847](https://github.com/cloudamqp/lavinmq/pull/847)
 
 
+### Changed
+
+- Exit with status 1 if lost leadership so that LavinMQ is restarted by systemd [#846](https://github.com/cloudamqp/lavinmq/pull/846)
+
 ## [2.0.1] - 2024-11-13
 
 ### Fixed

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -45,8 +45,10 @@ module LavinMQ
         if lease = @lease
           select
           when lease.receive?
+            break unless @running
             Log.warn { "Lost leadership lease" }
-            break
+            stop
+            exit 1
           when timeout(30.seconds)
             @data_dir_lock.try &.poll
             GC.collect
@@ -57,7 +59,6 @@ module LavinMQ
           GC.collect
         end
       end
-      stop
     end
 
     def stop


### PR DESCRIPTION
So that systemd with "restart on failure" restarts it.

### WHAT is this pull request doing?

Exit with status 1 if lost leadership without previous graceful shutdown. 


### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
