### PR TITLE
Longer lease TTL and run lease_keepalive earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't raise FileNotFound when deleting already deleted file [#849](https://github.com/cloudamqp/lavinmq/pull/849)
+- Increase default etcd lease TTL to 10s and run keepalive earlier [#847](https://github.com/cloudamqp/lavinmq/pull/847)
 
 
 ## [2.0.1] - 2024-11-13

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -48,7 +48,7 @@ module LavinMQ
     end
 
     # Returns {ID, TTL}
-    def lease_grant(ttl = 5) : Tuple(Int64, Int32)
+    def lease_grant(ttl = 10) : Tuple(Int64, Int32)
       json = post("/v3/lease/grant", body: %({"TTL":"#{ttl}"}))
       ttl = json.dig("TTL").as_s.to_i
       id = json.dig("ID").as_s.to_i64
@@ -80,7 +80,7 @@ module LavinMQ
     # Campaign for an election
     # Returns a Channel when elected leader,
     # when the channel is closed the leadership is lost
-    def elect(name, value, ttl = 5) : Channel(Nil)
+    def elect(name, value, ttl = 10) : Channel(Nil)
       channel = Channel(Nil).new
       lease_id, ttl = lease_grant(ttl)
       wg = WaitGroup.new(1)

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -92,7 +92,7 @@ module LavinMQ
             lease_revoke(lease_id)
             channel.close
             break
-          when timeout((ttl * 0.9).seconds)
+          when timeout((ttl * 0.7).seconds)
             ttl = lease_keepalive(lease_id)
           end
         rescue ex


### PR DESCRIPTION
We've seen the etcd lease expiring without obvious reasons, but probably because LavinMQ was busy doing something else during the pretty short timeframe (0.5s) it has to run `lease_keepalive`. 

### WHAT is this pull request doing?
Increases default lease TTL 5s -> 10s. Also timeouts earlier so `lease_keepalive` has a longer window to run (3s instead of 0.5s), which should make it less likely that unnecessary leader elections happen. 

### HOW can this pull request be tested?
manual/specs