### PR TITLE
Dont raise NotFoundError when deleting file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Don't raise FileNotFound when deleting already deleted file [#849](https://github.com/cloudamqp/lavinmq/pull/849)
+
 
 ## [2.0.1] - 2024-11-13
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -396,6 +396,8 @@ describe LavinMQ::AMQP::Queue do
       store = LavinMQ::Queue::MessageStore.new(tmpdir, nil)
       data = Random::Secure.hex(512)
       io = IO::Memory.new(data.to_slice)
+
+      # Publish enough data to have more than one segment
       until store.@segments.size > 1
         io.rewind
         store.push(LavinMQ::Message.new(0i64, "a", "b", AMQ::Protocol::Properties.new, data.bytesize.to_u64, io))
@@ -405,8 +407,7 @@ describe LavinMQ::AMQP::Queue do
         File.delete(f)
       end
 
-      store.purge # should not raise
-
+      store.purge
     ensure
       FileUtils.rm_rf tmpdir if tmpdir
     end

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -165,11 +165,11 @@ module LavinMQ
             @log.debug { "Deleting segment #{sp.segment}" }
             select_next_read_segment if sp.segment == @rfile_id
             if a = @acks.delete(sp.segment)
-              a.delete!.close
+              a.delete(raise_on_missing: false).close
               @replicator.try &.delete_file(a.path)
             end
             if seg = @segments.delete(sp.segment)
-              seg.delete!.close
+              seg.delete(raise_on_missing: false).close
               @replicator.try &.delete_file(seg.path)
             end
             @segment_msg_count.delete(sp.segment)
@@ -331,7 +331,7 @@ module LavinMQ
             rescue IO::EOFError
               # delete empty file, it will be recreated if it's needed
               @log.warn { "Empty file at #{path}, deleting it" }
-              file.delete!.close
+              file.delete(raise_on_missing: false).close
               @replicator.try &.delete_file(path)
               if idx == 0 # Recreate the file if it's the first segment because we need at least one segment to exist
                 file = MFile.new(path, Config.instance.segment_size)
@@ -401,10 +401,10 @@ module LavinMQ
             @segment_msg_count.delete seg
             @deleted.delete seg
             if ack = @acks.delete(seg)
-              ack.delete!.close
+              ack.delete(raise_on_missing: false).close
               @replicator.try &.delete_file(ack.path)
             end
-            mfile.delete!.close
+            mfile.delete(raise_on_missing: false).close
             @replicator.try &.delete_file(mfile.path)
             true
           end

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -165,11 +165,11 @@ module LavinMQ
             @log.debug { "Deleting segment #{sp.segment}" }
             select_next_read_segment if sp.segment == @rfile_id
             if a = @acks.delete(sp.segment)
-              a.delete.close
+              a.delete.close rescue File::NotFoundError
               @replicator.try &.delete_file(a.path)
             end
             if seg = @segments.delete(sp.segment)
-              seg.delete.close
+              seg.delete.close rescue File::NotFoundError
               @replicator.try &.delete_file(seg.path)
             end
             @segment_msg_count.delete(sp.segment)
@@ -331,7 +331,7 @@ module LavinMQ
             rescue IO::EOFError
               # delete empty file, it will be recreated if it's needed
               @log.warn { "Empty file at #{path}, deleting it" }
-              file.delete.close
+              file.delete.close rescue File::NotFoundError
               @replicator.try &.delete_file(path)
               if idx == 0 # Recreate the file if it's the first segment because we need at least one segment to exist
                 file = MFile.new(path, Config.instance.segment_size)
@@ -401,10 +401,10 @@ module LavinMQ
             @segment_msg_count.delete seg
             @deleted.delete seg
             if ack = @acks.delete(seg)
-              ack.delete.close
+              ack.delete.close rescue File::NotFoundError
               @replicator.try &.delete_file(ack.path)
             end
-            mfile.delete.close
+            mfile.delete.close rescue File::NotFoundError
             @replicator.try &.delete_file(mfile.path)
             true
           end

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -165,11 +165,11 @@ module LavinMQ
             @log.debug { "Deleting segment #{sp.segment}" }
             select_next_read_segment if sp.segment == @rfile_id
             if a = @acks.delete(sp.segment)
-              a.delete.close rescue File::NotFoundError
+              a.delete!.close
               @replicator.try &.delete_file(a.path)
             end
             if seg = @segments.delete(sp.segment)
-              seg.delete.close rescue File::NotFoundError
+              seg.delete!.close
               @replicator.try &.delete_file(seg.path)
             end
             @segment_msg_count.delete(sp.segment)
@@ -331,7 +331,7 @@ module LavinMQ
             rescue IO::EOFError
               # delete empty file, it will be recreated if it's needed
               @log.warn { "Empty file at #{path}, deleting it" }
-              file.delete.close rescue File::NotFoundError
+              file.delete!.close
               @replicator.try &.delete_file(path)
               if idx == 0 # Recreate the file if it's the first segment because we need at least one segment to exist
                 file = MFile.new(path, Config.instance.segment_size)
@@ -401,10 +401,10 @@ module LavinMQ
             @segment_msg_count.delete seg
             @deleted.delete seg
             if ack = @acks.delete(seg)
-              ack.delete.close rescue File::NotFoundError
+              ack.delete!.close
               @replicator.try &.delete_file(ack.path)
             end
-            mfile.delete.close rescue File::NotFoundError
+            mfile.delete!.close
             @replicator.try &.delete_file(mfile.path)
             true
           end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -91,7 +91,11 @@ class MFile < IO
   end
 
   def delete(*, raise_on_missing = true) : self
-    File.delete?(@path)
+    if raise_on_missing
+      File.delete(@path)
+    else
+      File.delete?(@path)
+    end
     @deleted = true
     self
   end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -90,20 +90,8 @@ class MFile < IO
     addr
   end
 
-  def delete : self
-    code = LibC.unlink(@path.check_no_null_byte)
-    raise File::Error.from_errno("Error deleting file", file: @path) if code < 0
-    @deleted = true
-    self
-  end
-
-  # Delete and ignore NotFoundError
-  def delete! : self
-    code = LibC.unlink(@path.check_no_null_byte)
-    if code < 0
-      err = File::Error.from_errno("Error deleting file", file: @path)
-      raise err unless err.is_a?(File::NotFoundError)
-    end
+  def delete(*, raise_on_missing = true) : self
+    Crystal::System::File.delete(@path, raise_on_missing: raise_on_missing)
     @deleted = true
     self
   end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -91,7 +91,7 @@ class MFile < IO
   end
 
   def delete(*, raise_on_missing = true) : self
-    Crystal::System::File.delete(@path, raise_on_missing: raise_on_missing)
+    File.delete?(@path)
     @deleted = true
     self
   end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -97,6 +97,17 @@ class MFile < IO
     self
   end
 
+  # Delete and ignore NotFoundError
+  def delete! : self
+    code = LibC.unlink(@path.check_no_null_byte)
+    if code < 0
+      err = File::Error.from_errno("Error deleting file", file: @path)
+      raise err unless err.is_a?(File::NotFoundError)
+    end
+    @deleted = true
+    self
+  end
+
   # The file will be truncated to the current position unless readonly or deleted
   def close(truncate_to_size = true)
     # unmap occurs on finalize


### PR DESCRIPTION
### WHAT is this pull request doing?
I see no point in raising `FileNotFound` when trying to delete a file.

One way of triggering the exception:
1. Publish a bunch of messages to a queue to get some segment files
2. Start a consumer on that queue
3. Remove some segments while the consumer is running
4. Disconnect the consumer
5. Purge queue

### HOW can this pull request be tested?
See steps above.
