### PR TITLE
Add WaitGroup to ensure consumer has sent all before removing itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't raise FileNotFound when deleting already deleted file [#849](https://github.com/cloudamqp/lavinmq/pull/849)
 - Increase default etcd lease TTL to 10s and run keepalive earlier [#847](https://github.com/cloudamqp/lavinmq/pull/847)
-
+- Don't remove consumers from queue before all data is sent to client. It may cause a segmentation fault because a unmapped message segment is accessed. [#850](https://github.com/cloudamqp/lavinmq/pull/850)
 
 ## [2.0.1] - 2024-11-13
 


### PR DESCRIPTION
### WHAT is this pull request doing?
I'm not sure we've run into this potential bug, but this is a solution to make sure the consumer has written all to socket before it's removing itself from a queue. The bug may trigger if it's the last consumer because then the queue will unmap its segments, but the consumer may still have references to a mapped segment that it tries to write to socket, resulting in a crash.

### HOW can this pull request be tested?
Uhm... yolo? Should try to add specs for this.
