### PR TITLE
A deleted queue shouldn't allow publish

### DIFF
--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -413,7 +413,7 @@ module LavinMQ::AMQP
     class Closed < Exception; end
 
     def publish(msg : Message) : Bool
-      return false if @state.closed?
+      return false if @deleted || @state.closed?
       reject_on_overflow(msg)
       @msg_store_lock.synchronize do
         @msg_store.push(msg)


### PR DESCRIPTION
### WHAT is this pull request doing?
Not sure how/if we can end up with this, but maybe we've seen that a message has been published to a queue that's partially deleted (message store deleted, but vhost still references the queue).

This adds a deleted guard to `#publish`

### HOW can this pull request be tested?
No sure how yet.
