### PR TITLE
Message deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support for message deduplication on exchanges and queues [854](https://github.com/cloudamqp/lavinmq/pull/854)
+
 ## [2.1.0] - 2025-01-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ For questions or suggestions:
 - Replication
 - Stream queues
 - Automatic leader election in clusters via etcd
+- Message deduplication
 
 ### Known differences to other AMQP servers
 

--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -1,0 +1,150 @@
+require "./spec_helper"
+require "../src/lavinmq/deduplication.cr"
+
+describe LavinMQ::Deduplication do
+  describe LavinMQ::Deduplication::MemoryCache do
+    it "should have a max size" do
+      cache = LavinMQ::Deduplication::MemoryCache(String).new(2)
+      cache.insert("item1")
+      cache.insert("item2")
+      cache.insert("item3")
+      cache.contains?("item1").should be_false
+      cache.contains?("item2").should be_true
+      cache.contains?("item3").should be_true
+    end
+
+    it "should store item without ttl" do
+      cache = LavinMQ::Deduplication::MemoryCache(String).new(10)
+      cache.insert("item1")
+      cache.contains?("item1").should be_true
+      cache.contains?("item2").should be_false
+    end
+
+    it "should respect ttl" do
+      cache = LavinMQ::Deduplication::MemoryCache(String).new(3)
+      cache.insert("item1", 1)
+      cache.insert("item2", 300)
+      cache.insert("item3")
+      sleep 0.2.seconds
+      cache.contains?("item1").should be_false
+      cache.contains?("item2").should be_true
+      cache.contains?("item3").should be_true
+    end
+  end
+end
+
+class MockCache < LavinMQ::Deduplication::Cache(AMQ::Protocol::Field)
+  @counter = Hash(String, Array({String, UInt32?})).new do |h, k|
+    h[k] = Array({String, UInt32?}).new
+  end
+
+  def contains?(key) : Bool
+    @counter["contains?"] << {key.as(String), nil}
+    false
+  end
+
+  def insert(key, ttl = nil)
+    @counter["insert"] << {key.as(String), ttl}
+  end
+
+  def calls(key : String)
+    @counter[key]
+  end
+end
+
+describe LavinMQ::Deduplication::Deduper do
+  describe "duplicate?" do
+    it "should return false if \"x-deduplication-header\" is missing (no identifier, always unique)" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock)
+      props = LavinMQ::AMQP::Properties.new
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      res = deduper.duplicate?(msg)
+      res.should be_false
+    end
+
+    it "should check cache if entry exists" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock)
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "x-deduplication-header" => "msg1",
+      }))
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.duplicate?(msg)
+      mock.calls("contains?").size.should eq 1
+    end
+
+    it "should only insert into cache if header has a value" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock)
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new)
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.add(msg)
+      mock.calls("insert").size.should eq 0
+    end
+
+    it "should only insert into cache if header has a value" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock)
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "x-deduplication-header" => "msg1",
+      }))
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.add(msg)
+      mock.calls("insert").size.should eq 1
+    end
+
+    it "should respect x-cache-ttl on message" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock)
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "x-deduplication-header" => "msg1",
+        "x-cache-ttl"            => 10,
+      }))
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.add(msg)
+      calls = mock.calls("insert")
+      calls.first[0].should eq "msg1"
+      calls.first[1].should eq 10
+    end
+
+    it "should fallback to default ttl" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock, 12)
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "x-deduplication-header" => "msg1",
+      }))
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.add(msg)
+      calls = mock.calls("insert")
+      calls.first[0].should eq "msg1"
+      calls.first[1].should eq 12
+    end
+
+    it "should prio message ttl over default ttl" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock, 12)
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "x-deduplication-header" => "msg1",
+        "x-cache-ttl"            => 10,
+      }))
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.add(msg)
+      calls = mock.calls("insert")
+      calls.first[0].should eq "msg1"
+      calls.first[1].should eq 10
+    end
+    it "should allow checking any header for dedups" do
+      mock = MockCache.new
+      deduper = LavinMQ::Deduplication::Deduper.new(mock, 10, "custom")
+      props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "custom" => "msg1",
+      }))
+      msg = LavinMQ::Message.new("ex", "rk", "body", props)
+      deduper.add(msg)
+      calls = mock.calls("insert")
+      calls.first[0].should eq "msg1"
+      calls.first[1].should eq 10
+    end
+  end
+end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -13,6 +13,7 @@ require "./state"
 require "./event"
 require "./message_store"
 require "../../unacked_message"
+require "../../deduplication"
 
 module LavinMQ::AMQP
   class Queue < LavinMQ::Queue
@@ -111,8 +112,8 @@ module LavinMQ::AMQP
 
     # Creates @[x]_count and @[x]_rate and @[y]_log
     rate_stats(
-      {"ack", "deliver", "deliver_get", "confirm", "get", "get_no_ack", "publish", "redeliver", "reject", "return_unroutable"},
-      {"message_count", "unacked_count", "dedup"})
+      {"ack", "deliver", "deliver_get", "confirm", "get", "get_no_ack", "publish", "redeliver", "reject", "return_unroutable", "dedup"},
+      {"message_count", "unacked_count"})
 
     getter name, arguments, vhost, consumers, last_get_time
     getter? auto_delete, exclusive

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -112,7 +112,7 @@ module LavinMQ::AMQP
     # Creates @[x]_count and @[x]_rate and @[y]_log
     rate_stats(
       {"ack", "deliver", "deliver_get", "confirm", "get", "get_no_ack", "publish", "redeliver", "reject", "return_unroutable"},
-      {"message_count", "unacked_count"})
+      {"message_count", "unacked_count", "dedup"})
 
     getter name, arguments, vhost, consumers, last_get_time
     getter? auto_delete, exclusive
@@ -127,6 +127,7 @@ module LavinMQ::AMQP
     @data_dir : String
     Log = LavinMQ::Log.for "queue"
     @metadata : ::Log::Metadata
+    @deduper : Deduplication::Deduper?
 
     def initialize(@vhost : VHost, @name : String,
                    @exclusive = false, @auto_delete = false,
@@ -271,6 +272,14 @@ module LavinMQ::AMQP
       @single_active_consumer_queue = parse_header("x-single-active-consumer", Bool) == true
       @consumer_timeout = parse_header("x-consumer-timeout", Int).try &.to_u64
       validate_positive("x-consumer-timeout", @consumer_timeout)
+      if parse_header("x-message-deduplication", Bool)
+        size = parse_header("x-cache-size", Int).try(&.to_u32)
+        raise LavinMQ::Error::PreconditionFailed.new("Invalid x-cache-size for message deduplication") unless size
+        ttl = parse_header("x-cache-ttl", Int).try(&.to_u32)
+        header_key = parse_header("x-deduplication-header", String)
+        cache = Deduplication::MemoryCache(AMQ::Protocol::Field).new(size)
+        @deduper = Deduplication::Deduper.new(cache, ttl, header_key)
+      end
     end
 
     private macro parse_header(header, type)
@@ -421,6 +430,13 @@ module LavinMQ::AMQP
 
     def publish(msg : Message) : Bool
       return false if @deleted || @state.closed?
+      if d = @deduper
+        if d.duplicate?(msg)
+          @dedup_count += 1
+          return false
+        end
+        d.add(msg)
+      end
       reject_on_overflow(msg)
       @msg_store_lock.synchronize do
         @msg_store.push(msg)

--- a/src/lavinmq/deduplication.cr
+++ b/src/lavinmq/deduplication.cr
@@ -1,0 +1,66 @@
+module LavinMQ
+  module Deduplication
+    abstract class Cache(T)
+      abstract def contains?(key : T) : Bool
+      abstract def insert(key : T, ttl : UInt32?)
+    end
+
+    class MemoryCache(T) < Cache(T)
+      def initialize(@size : UInt32)
+        @store = Hash(T, Int64?).new
+      end
+
+      def contains?(key : T) : Bool
+        return false unless @store.has_key?(key)
+        ttd = @store[key]
+        return true unless ttd
+        return true if ttd > RoughTime.unix_ms
+        @store.delete(key)
+        false
+      end
+
+      def insert(key : T, ttl : UInt32? = nil)
+        @store.shift if @store.size >= @size
+        @store[key] = ttl ? RoughTime.unix_ms + ttl : nil
+      end
+    end
+
+    class Deduper
+      DEFAULT_HEADER_KEY = "x-deduplication-header"
+
+      def initialize(@cache : Cache(AMQ::Protocol::Field), @default_ttl : UInt32? = nil,
+                     @header_key : String? = nil)
+      end
+
+      def add(msg : Message)
+        key = dedup_key(msg)
+        return unless key
+        @cache.insert(key, dedup_ttl(msg))
+      end
+
+      def duplicate?(msg : Message) : Bool
+        key = dedup_key(msg)
+        return false unless key
+        @cache.contains?(key)
+      end
+
+      private def dedup_key(msg)
+        headers = msg.properties.headers
+        return unless headers
+        key = @header_key || DEFAULT_HEADER_KEY
+        headers[key]?
+      end
+
+      private def dedup_ttl(msg) : UInt32?
+        headers = msg.properties.headers
+        def_ttl = @default_ttl
+        return def_ttl unless headers
+        value = headers["x-cache-ttl"]?
+        return def_ttl unless value
+        value = value.try(&.as?(Int32))
+        return def_ttl unless value
+        value.to_u32 || def_ttl
+      end
+    end
+  end
+end

--- a/src/lavinmq/deduplication.cr
+++ b/src/lavinmq/deduplication.cr
@@ -7,7 +7,7 @@ module LavinMQ
 
     class MemoryCache(T) < Cache(T)
       def initialize(@size : UInt32)
-        @store = Hash(T, Time::Span?).new
+        @store = Hash(T, Time::Span?).new(initial_capacity: @size)
       end
 
       def contains?(key : T) : Bool
@@ -21,11 +21,7 @@ module LavinMQ
 
       def insert(key : T, ttl : UInt32? = nil)
         @store.shift if @store.size >= @size
-        val = if ttl
-                RoughTime.monotonic + Time::Span.new(nanoseconds: ttl * 1_000_000)
-              else
-                nil
-              end
+        val = ttl.try { |v| RoughTime.monotonic + v.milliseconds }
         @store[key] = val
       end
     end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -63,6 +63,7 @@ module LavinMQ
         vhosts.to_a
       end
 
+      # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/metrics" do |context, _|
           context.response.content_type = "text/plain"

--- a/views/exchanges.ecr
+++ b/views/exchanges.ecr
@@ -85,6 +85,18 @@
             <a class="arg-tooltip" data-tag="x-alternate-exchange">Alternate Exchange
               <span class="tooltiptext">If messages to this exchange cannot otherwise be routed, send them to the alternate exchange named here.</span>
             </a>
+            <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true">Message deduplication
+              <span class="tooltiptext">Enable deduplication for this exchange</span>
+            </a> | 
+            <a class="arg-tooltip" data-tag="x-cache-size" data-value="100">Deduplication cache size
+              <span class="tooltiptext">Deduplication cache size, in number of entries</span>
+            </a> | 
+            <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000">Deduplication cache ttl
+              <span class="tooltiptext">How long an entry lives in the deduplication cache, in milliseconds</span>
+            </a> | 
+            <a class="arg-tooltip" data-tag="x-deduplication-header">Deduplication header
+              <span class="tooltiptext">Which header to check for deduplication, defaults to x-deduplication-header</span>
+            </a>
           </div>
         </label>
         <button type="submit" class="btn btn-green">Add exchange</button>

--- a/views/queues.ecr
+++ b/views/queues.ecr
@@ -115,6 +115,18 @@
                 Valid units are Y(ear), M(onth), D(ays), h(ours), m(inutes), s(seconds).
                 Segments are only deleted when new messages are published to the stream queue.</span>
             </a>
+             <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true">Message deduplication
+              <span class="tooltiptext">Enable deduplication for this exchange</span>
+            </a> | 
+            <a class="arg-tooltip" data-tag="x-cache-size" data-value="100">Deduplication cache size
+              <span class="tooltiptext">Deduplication cache size, in number of entries</span>
+            </a> | 
+            <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000">Deduplication cache ttl
+              <span class="tooltiptext">How long an entry lives in the deduplication cache, in milliseconds</span>
+            </a> | 
+            <a class="arg-tooltip" data-tag="x-deduplication-header">Deduplication header
+              <span class="tooltiptext">Which header to check for deduplication, defaults to x-deduplication-header</span>
+            </a>
           </div>
         </label>
         <button type="submit" class="btn btn-green">Add queue</button>


### PR DESCRIPTION
### WHAT is this pull request doing?

Implementation for message deduplication on exchanges. 
It works for any exchange type and is enabled by setting the argument `x-message-deduplication = true` on any exchange. 

Features
- [X] Deduplication on Exchanges 
- [X] Deduplication cache storage in memory 
- [X] TTL for each message
- [X] Default TTL
- [x] Deduplication on queues 

Fixes #833 
 
### HOW can this pull request be tested?

Specs.
