### PR TITLE
Speed up definitions compaction spec by setting max_deleted_definitions=8

### DIFF
--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -104,6 +104,7 @@ describe LavinMQ::VHost do
 
   it "should compact definitions during runtime" do
     with_amqp_server do |s|
+      LavinMQ::Config.instance.max_deleted_definitions = 8
       v = s.vhosts.create("test")
       (LavinMQ::Config.instance.max_deleted_definitions - 1).times do
         v.declare_queue("q", true, false)


### PR DESCRIPTION
### WHAT is this pull request doing?
Speeds up the `should compact definitions during runtime` spec by setting `max_deleted_definitions=8` instead of the default `8192`. 

### HOW can this pull request be tested?
Run the spec
