### PR TITLE
rescue if lavinmq starts with faulty msg_store

### DIFF
--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -22,6 +22,7 @@ module LavinMQ
       @segment_msg_count = Hash(UInt32, UInt32).new(0u32)
       @requeued = Deque(SegmentPosition).new
       @closed = false
+      getter closed
       getter bytesize = 0u64
       getter size = 0u32
       getter empty_change = Channel(Bool).new

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -348,7 +348,7 @@ module LavinMQ
                 next
               end
             rescue ex
-              @log.error { "Closing message store: invalid SchemaVersion in #{path}" }
+              @log.error { "Could not initialize segment, closing message store: #{ex.message}" }
               close
             end
           end
@@ -380,7 +380,7 @@ module LavinMQ
           rescue ex : IO::EOFError
             break
           rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
-            @log.error { "Closing message store: Failed to read segment #{seg} at pos #{mfile.pos}, #{ex}" }
+            @log.error { "Could not initialize segment, closing message store: Failed to read segment #{seg} at pos #{mfile.pos}. #{ex}" }
             close
           end
           mfile.pos = 4

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -348,7 +348,7 @@ module LavinMQ
                 next
               end
             rescue ex
-              Log.error { "Closing message store: invalid SchemaVersion in #{path}" }
+              @log.error { "Closing message store: invalid SchemaVersion in #{path}" }
               close
             end
           end

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -380,7 +380,7 @@ module LavinMQ
           rescue ex : IO::EOFError
             break
           rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
-            Log.error { "Closing message store: Failed to read segment #{seg} at pos #{mfile.pos}, #{ex}" }
+            @log.error { "Closing message store: Failed to read segment #{seg} at pos #{mfile.pos}, #{ex}" }
             close
           end
           mfile.pos = 4

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -347,6 +347,9 @@ module LavinMQ
                 @segments.delete seg
                 next
               end
+            rescue ex
+              Log.error { "Closing message store: invalid SchemaVersion in #{path}" }
+              close
             end
           end
           file.pos = 4
@@ -377,7 +380,8 @@ module LavinMQ
           rescue ex : IO::EOFError
             break
           rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
-            raise Error.new(mfile, cause: ex)
+            Log.error { "Closing message store: Failed to read segment #{seg} at pos #{mfile.pos}, #{ex}" }
+            close
           end
           mfile.pos = 4
           mfile.unmap # will be mmap on demand

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -138,6 +138,9 @@ module LavinMQ::AMQP
       File.open(File.join(@data_dir, ".queue"), "w") { |f| f.sync = true; f.print @name }
       @state = QueueState::Paused if File.exists?(File.join(@data_dir, ".paused"))
       @msg_store = init_msg_store(@data_dir)
+      if @msg_store.closed
+        close
+      end
       @empty_change = @msg_store.empty_change
       handle_arguments
       spawn queue_expire_loop, name: "Queue#queue_expire_loop #{@vhost.name}/#{@name}" if @expires

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -802,6 +802,7 @@ module LavinMQ::AMQP
         expire_msg(sp, :rejected)
       end
     rescue ex : MessageStore::Error
+      @log.error(ex) { "Queue closed due to error" }
       close
       raise ex
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
today if we get an error when initialising the message store in `load_segments_from_disk` and `load_stats_from_segments` we will raise an exception and LavinMQ will not be able to start. With these changes we will instead just close the queue and let LavinMQ start up with closed queues. 

### HOW can this pull request be tested?
try to start up with a faulty msg_store. 
