### PR TITLE
Bugfix: revoke leadership on graceful shutdown

### DIFF
--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -45,7 +45,10 @@ module LavinMQ
         if lease = @lease
           select
           when lease.receive?
-            break unless @running
+            unless @running
+              Fiber.yield
+              break
+            end
             Log.warn { "Lost leadership lease" }
             stop
             exit 1


### PR DESCRIPTION
### WHAT is this pull request doing?
On a graceful shutdown lavin exits before the etcd keepalive fiber has had a chance to revoke the leadership. This will yield after the lease has been closed to give the keepalive fiber a chance to revoke the lease.

### HOW can this pull request be tested?
No specs, yet. Needs to be tested manually.
