### PR TITLE
Dont wait on a disconnected follower

### DIFF
--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -59,7 +59,7 @@ module LavinMQ
         end
       ensure
         begin
-          @lz4.close
+          lz4.close unless lz4.closed?
           @socket.close
         rescue IO::Error
           # ignore connection errors while closing
@@ -186,6 +186,9 @@ module LavinMQ
             Log.warn { "Timeout waiting for follower to be in sync" }
           end
         end
+      ensure
+        @lz4.close unless @lz4.closed?
+        @socket.close
       end
 
       def to_json(json : JSON::Builder)

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -177,6 +177,7 @@ module LavinMQ
       def close(timeout : Time::Span = 30.seconds)
         @closed = true
         @actions.close
+        return if @socket.closed?
         if lag_in_bytes > 0
           Log.info { "Waiting for follower to be in sync" }
           select

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -160,12 +160,16 @@ module LavinMQ
         end
       rescue ex : AuthenticationError
         Log.warn { "Follower negotiation error" }
+        socket.close
       rescue ex : InvalidStartHeaderError
         Log.warn { ex.message }
+        socket.close
       rescue ex : IO::EOFError
         Log.info { "Follower disconnected" }
+        socket.close
       rescue ex : IO::Error
         Log.warn { "Follower disonnected: #{ex.message}" }
+        socket.close
       ensure
         follower.try &.close
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
While testing clustering stuff I noticed that the leader sometimes wait for a disconnected follower to be fully in sync. This PR prevents at least some of these cases.

### HOW can this pull request be tested?
Manually run a cluster and stop follower in different stage. No "Waiting for follower to be in sync" should be logged.