### PR TITLE
remove duplicate metric rss_bytes from PrometheusWriter

### DIFF
--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -244,10 +244,6 @@ module LavinMQ
                       value: @amqp_server.user_time,
                       type:  "gauge",
                       help:  "Total CPU user time"})
-        writer.write({name:  "rss_bytes",
-                      type:  "gauge",
-                      value: @amqp_server.rss,
-                      help:  "Memory RSS in bytes"})
         writer.write({name:  "stats_collection_duration_seconds_total",
                       value: @amqp_server.stats_collection_duration_seconds_total.to_f,
                       type:  "gauge",


### PR DESCRIPTION
### WHAT is this pull request doing?
The value `@amqp_server.rss` was exported both as `rss_bytes` and `process_resident_memory_bytes` for `[compatibility with RabbitMQ](https://github.com/deadtrickster/prometheus_rabbitmq_exporter#:~:text=process_resident_memory_bytes)`. With this PR we remove the `rss_bytes`(not needed for compatibility) value to not have duplicate metrics. 

### HOW can this pull request be tested?
`http://localhost:15672/metrics`