### PR TITLE
log nr of streamed bytes every 30 seconds in follower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Queues will no longer be closed if file size is incorrect. Fixes [#669](https://github.com/cloudamqp/lavinmq/issues/669)
 - Dont redeclare exchange in java client test [#860](https://github.com/cloudamqp/lavinmq/pull/860)
 
+### Added
+
+- Added some logging for followers [#885](https://github.com/cloudamqp/lavinmq/pull/885)
+
 ## [2.0.2] - 2024-11-25
 
 ### Fixed


### PR DESCRIPTION
### WHAT is this pull request doing?
Nothing happens in logs on followers when streaming changes now. This logs a message in followers every 30 seconds with total amount of streamed bytes to make it clear that something is happening. 

### HOW can this pull request be tested?
run follower, check log
