### PR TITLE
exit 5 instead of raising error if no etcd endpoint responds

### DIFF
--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -27,7 +27,7 @@ describe LavinMQ::Etcd do
         etcd.watch("foo") do |val|
           w.send val
         end
-      rescue LavinMQ::Etcd::Error
+      rescue SpecExit
         # expect this when etcd nodes are terminated
       end
       w.receive # sync
@@ -51,7 +51,7 @@ describe LavinMQ::Etcd do
         etcd.elect_listen(key) do |value|
           leader.send value
         end
-      rescue LavinMQ::Etcd::Error
+      rescue SpecExit
         # expect this when etcd nodes are terminated
       end
       lease = etcd.elect(key, "bar", 1)
@@ -59,7 +59,7 @@ describe LavinMQ::Etcd do
       spawn(name: "elect other leader spec") do
         begin
           etcd.elect(key, "bar2", 1)
-        rescue LavinMQ::Etcd::Error
+        rescue SpecExit
           # expect this when etcd nodes are terminated
         end
       end

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -261,7 +261,8 @@ module LavinMQ
         Log.debug { "Could not connect to #{address}: #{ex}" }
         next
       end
-      raise Error.new("No endpoint responded")
+      Log.fatal { "No etcd endpoint responded" }
+      exit 5 # 5th character in the alphabet is E(etcd)
     end
 
     private def update_endpoints(tcp, address)

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -244,8 +244,6 @@ module LavinMQ
       end
     end
 
-    class NoEtcdEndpoint < Exception; end
-
     private def connect : Tuple(TCPSocket, String)
       @endpoints.shuffle!.each do |address|
         host, port = address.split(':', 2)
@@ -264,7 +262,7 @@ module LavinMQ
         next
       end
       Log.fatal { "No etcd endpoint responded" }
-      raise NoEtcdEndpoint.new
+      exit 5 # 5th character in the alphabet is E(etcd)
     end
 
     private def update_endpoints(tcp, address)

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -244,6 +244,8 @@ module LavinMQ
       end
     end
 
+    class NoEtcdEndpoint < Exception; end
+
     private def connect : Tuple(TCPSocket, String)
       @endpoints.shuffle!.each do |address|
         host, port = address.split(':', 2)
@@ -262,7 +264,7 @@ module LavinMQ
         next
       end
       Log.fatal { "No etcd endpoint responded" }
-      exit 5 # 5th character in the alphabet is E(etcd)
+      raise NoEtcdEndpoint.new
     end
 
     private def update_endpoints(tcp, address)


### PR DESCRIPTION
### WHAT is this pull request doing?
Exit 5 (5th letter, E, for etcd) instead of raising error when no etcd endpoint responds. 

fixes #872 

### HOW can this pull request be tested?
Try starting LavinMQ with clustering enabled and no etcd running. 