### PR TITLE
Streams filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
 - Support for message deduplication on exchanges and queues [854](https://github.com/cloudamqp/lavinmq/pull/854)
+- Added filtering for streams [#893](https://github.com/cloudamqp/lavinmq/pull/893)
 
 ## [2.1.0] - 2025-01-16
 

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -216,7 +216,7 @@ describe LavinMQ::AMQP::StreamQueue do
           q.publish("msg without filter")
 
           msgs = Channel(AMQP::Client::DeliverMessage).new
-          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-filter-value": "foo"})) do |msg|
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-filter": "foo"})) do |msg|
             msgs.send msg
             msg.ack
           end
@@ -239,7 +239,7 @@ describe LavinMQ::AMQP::StreamQueue do
           q.publish("msg without filter")
 
           msgs = Channel(AMQP::Client::DeliverMessage).new
-          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-filter-value": "bar"})) do |msg|
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-filter": "bar"})) do |msg|
             msgs.send msg
             msg.ack
           end
@@ -266,7 +266,7 @@ describe LavinMQ::AMQP::StreamQueue do
           msgs = Channel(AMQP::Client::DeliverMessage).new
           filters = "foo,bar"
           q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new(
-            {"x-stream-filter-value": filters}
+            {"x-stream-filter": filters}
           )) do |msg|
             msgs.send msg
             msg.ack
@@ -293,7 +293,7 @@ describe LavinMQ::AMQP::StreamQueue do
           msgs = Channel(AMQP::Client::DeliverMessage).new
           q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new(
             {
-              "x-stream-filter-value":     "foo",
+              "x-stream-filter":           "foo",
               "x-stream-match-unfiltered": true,
             }
           )) do |msg|
@@ -319,7 +319,7 @@ describe LavinMQ::AMQP::StreamQueue do
           q.publish("msg without filter")
 
           msgs = Channel(AMQP::Client::DeliverMessage).new
-          args = AMQP::Client::Arguments.new({"x-stream-filter-value": "foo", "x-stream-offset": 2})
+          args = AMQP::Client::Arguments.new({"x-stream-filter": "foo", "x-stream-offset": 2})
           q.subscribe(no_ack: false, args: args) do |msg|
             msgs.send msg
             msg.ack

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -203,4 +203,109 @@ describe LavinMQ::AMQP::StreamQueue do
       end
     end
   end
+
+  describe "Filters" do
+    it "should only get message matching filter" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 1
+          q = ch.queue("stream_filter_1", args: stream_queue_args)
+          q.publish("msg without filter")
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "foo"})
+          q.publish("msg with filter", props: AMQP::Client::Properties.new(headers: hdrs))
+          q.publish("msg without filter")
+
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-filter-value": "foo"})) do |msg|
+            msgs.send msg
+            msg.ack
+          end
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg with filter"
+        end
+      end
+    end
+
+    it "should ignore messages with non-matching filters" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 1
+          q = ch.queue("stream_filter_2", args: stream_queue_args)
+          q.publish("msg without filter")
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "foo"})
+          q.publish("msg with filter", props: AMQP::Client::Properties.new(headers: hdrs))
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "bar"})
+          q.publish("msg with filter: bar", props: AMQP::Client::Properties.new(headers: hdrs))
+          q.publish("msg without filter")
+
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-filter-value": "bar"})) do |msg|
+            msgs.send msg
+            msg.ack
+          end
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg with filter: bar"
+        end
+      end
+    end
+
+    it "should support multiple filters" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 1
+          q = ch.queue("stream_filter_3", args: stream_queue_args)
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "foo"})
+          q.publish("msg without filter")
+          q.publish("msg with filter: foo", props: AMQP::Client::Properties.new(headers: hdrs))
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "xyz"})
+          q.publish("msg with filter: xyz", props: AMQP::Client::Properties.new(headers: hdrs))
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "bar"})
+          q.publish("msg with filter: bar", props: AMQP::Client::Properties.new(headers: hdrs))
+          q.publish("msg without filter")
+
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          filters = "foo,bar"
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new(
+            {"x-stream-filter-value": filters}
+          )) do |msg|
+            msgs.send msg
+            msg.ack
+          end
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg with filter: foo"
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg with filter: bar"
+        end
+      end
+    end
+
+    it "should get messages without filter when x-stream-match-unfiltered set" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.prefetch 1
+          q = ch.queue("stream_filter_4", args: stream_queue_args)
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "foo"})
+          q.publish("msg with filter: foo", props: AMQP::Client::Properties.new(headers: hdrs))
+          hdrs = AMQP::Client::Arguments.new({"x-stream-filter-value" => "bar"})
+          q.publish("msg with filter: bar", props: AMQP::Client::Properties.new(headers: hdrs))
+          q.publish("msg without filter")
+
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new(
+            {
+              "x-stream-filter-value":     "foo",
+              "x-stream-match-unfiltered": true,
+            }
+          )) do |msg|
+            msgs.send msg
+            msg.ack
+          end
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg with filter: foo"
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg without filter"
+        end
+      end
+    end
+  end
 end

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -329,6 +329,5 @@ describe LavinMQ::AMQP::StreamQueue do
         end
       end
     end
-
   end
 end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -136,8 +136,8 @@ module LavinMQ::AMQP
       end
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
-        if msg_filter = filter_value_from_headers(msg_headers)
-          return consumer_filter.includes? msg_filter
+        if filter_value = filter_value_from_headers(msg_headers)
+          return consumer_filter.bsearch { |f| f >= filter_value } == filter_value
         else
           return match_unfiltered
         end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -137,9 +137,9 @@ module LavinMQ::AMQP
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
         if filter_value = filter_value_from_headers(msg_headers)
-          return consumer_filter.bsearch { |f| f >= filter_value } == filter_value
+          consumer_filter.bsearch { |f| f >= filter_value } == filter_value
         else
-          return match_unfiltered
+          match_unfiltered
         end
       end
 

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -136,12 +136,12 @@ module LavinMQ::AMQP
       end
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
-        if msg_filters = filter_values_from_headers(msg_headers)
+        if msg_filter = filter_value_from_headers(msg_headers)
           consumer_filter.split(",").each do |filter|
-            return true if msg_filters == filter
+            return true if msg_filter == filter
           end
         else
-          return true if match_unfiltered
+          return match_unfiltered
         end
         false
       end
@@ -250,9 +250,9 @@ module LavinMQ::AMQP
         headers.not_nil!("Message lacks headers")["x-stream-offset"].as(Int64)
       end
 
-      private def filter_values_from_headers(headers) : String?
-        if filters = headers.not_nil!("Message lacks headers")["x-stream-filter-value"]?
-          filters.to_s
+      private def filter_value_from_headers(headers) : String?
+        if filter = headers.not_nil!("Message lacks headers")["x-stream-filter-value"]?
+          filter.to_s
         else
           nil
         end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -137,7 +137,7 @@ module LavinMQ::AMQP
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
         if msg_filter = filter_value_from_headers(msg_headers)
-          consumer_filter.split(",").each do |filter|
+          consumer_filter.each do |filter|
             return true if msg_filter == filter
           end
         else

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -137,7 +137,7 @@ module LavinMQ::AMQP
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
         if msg_filter = filter_value_from_headers(msg_headers)
-            return consumer_filter.includes? msg_filter
+          return consumer_filter.includes? msg_filter
         else
           return match_unfiltered
         end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -126,7 +126,7 @@ module LavinMQ::AMQP
           sp = SegmentPosition.new(consumer.segment, consumer.pos, msg.bytesize.to_u32)
           consumer.pos += sp.bytesize
           consumer.offset += 1
-          if consumer_filter = consumer.filter # can be a string or an array of comma-separated strings
+          if consumer_filter = consumer.filter
             return unless matching?(msg.properties.headers, consumer_filter, consumer.match_unfiltered?)
           end
           Envelope.new(sp, msg, redelivered: false)

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -108,7 +108,7 @@ module LavinMQ::AMQP
         seg
       end
 
-      def shift?(consumer : AMQP::StreamConsumer) : Envelope?
+      def shift?(consumer : AMQP::StreamConsumer) : Envelope? # ameba:disable Metrics/CyclomaticComplexity
         raise ClosedError.new if @closed
 
         if env = shift_requeued(consumer.requeued)
@@ -127,7 +127,7 @@ module LavinMQ::AMQP
           consumer.pos += sp.bytesize
           consumer.offset += 1
           if consumer_filter = consumer.filter # can be a string or an array of comma-separated strings
-            return unless matching?(msg.properties.headers, consumer_filter, consumer.match_unfiltered)
+            return unless matching?(msg.properties.headers, consumer_filter, consumer.match_unfiltered?)
           end
           Envelope.new(sp, msg, redelivered: false)
         rescue ex
@@ -136,7 +136,7 @@ module LavinMQ::AMQP
       end
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
-        if (msg_filters = filter_values_from_headers(msg_headers))
+        if msg_filters = filter_values_from_headers(msg_headers)
           consumer_filter.split(",").each do |filter|
             return true if msg_filters == filter
           end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -251,7 +251,7 @@ module LavinMQ::AMQP
       end
 
       private def filter_value_from_headers(headers) : String?
-        if filter = headers.not_nil!("Message lacks headers")["x-stream-filter-value"]?
+        if filter = headers.try &.["x-stream-filter-value"]?
           filter.to_s
         else
           nil

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -141,7 +141,6 @@ module LavinMQ::AMQP
         else
           return match_unfiltered
         end
-        false
       end
 
       private def shift_requeued(requeued) : Envelope?

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -137,9 +137,7 @@ module LavinMQ::AMQP
 
       private def matching?(msg_headers, consumer_filter, match_unfiltered) : Bool
         if msg_filter = filter_value_from_headers(msg_headers)
-          consumer_filter.each do |filter|
-            return true if msg_filter == filter
-          end
+            return consumer_filter.includes? msg_filter
         else
           return match_unfiltered
         end

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -43,12 +43,14 @@ module LavinMQ
         when String
           @filter = frame.arguments["x-stream-filter-value"].to_s.split(",")
         when Nil
+          # noop
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")
         end
         case frame.arguments["x-stream-match-unfiltered"]?
         when Bool
           @match_unfiltered = frame.arguments["x-stream-match-unfiltered"].as(Bool)
         when Nil
+          # noop
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-match-unfiltered must be a boolean")
         end
       end

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -39,7 +39,7 @@ module LavinMQ
         when Nil, Int, Time, "first", "next", "last"
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-offset must be an integer, a timestamp, 'first', 'next' or 'last'")
         end
-        case filter = frame.arguments["x-stream-filter-value"]?
+        case filter = frame.arguments["x-stream-filter"]?
         when String
           @filter = filter.split(',').sort!
         when Nil

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -9,7 +9,7 @@ module LavinMQ
       property segment : UInt32
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
-      @filter : Array(String)? = nil
+      @filter : Array(String) = Array(String).new
       @match_unfiltered : Bool = false
 
       def initialize(@channel : Client::Channel, @queue : StreamQueue, frame : AMQP::Frame::Basic::Consume)
@@ -107,14 +107,11 @@ module LavinMQ
       end
 
       def filter_match?(msg_headers) : Bool
-        if filter = @filter
-          if filter_value = filter_value_from_msg_headers(msg_headers)
-            filter.bsearch { |f| f >= filter_value } == filter_value
-          else
-            @match_unfiltered
-          end
+        return true if @filter.empty?
+        if filter_value = filter_value_from_msg_headers(msg_headers)
+          @filter.bsearch { |f| f >= filter_value } == filter_value
         else
-          true
+          @match_unfiltered
         end
       end
 

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -9,8 +9,8 @@ module LavinMQ
       property segment : UInt32
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
-      @filter : Array(String) = Array(String).new
-      @match_unfiltered : Bool = false
+      @filter = Array(String).new
+      @match_unfiltered = false
 
       def initialize(@channel : Client::Channel, @queue : StreamQueue, frame : AMQP::Frame::Basic::Consume)
         validate_preconditions(frame)

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -9,7 +9,7 @@ module LavinMQ
       property segment : UInt32
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
-      getter filter : String?
+      getter filter : Array(String)? = nil
       getter? match_unfiltered : Bool = false
 
       def initialize(@channel : Client::Channel, @queue : StreamQueue, frame : AMQP::Frame::Basic::Consume)
@@ -41,7 +41,7 @@ module LavinMQ
         end
         case frame.arguments["x-stream-filter-value"]?
         when String
-          @filter = frame.arguments["x-stream-filter-value"].to_s
+          @filter = frame.arguments["x-stream-filter-value"].to_s.split(",")
         when Nil
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")
         end

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -10,7 +10,7 @@ module LavinMQ
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
       getter filter : String?
-      getter match_unfiltered : Bool = false
+      getter? match_unfiltered : Bool = false
 
       def initialize(@channel : Client::Channel, @queue : StreamQueue, frame : AMQP::Frame::Basic::Consume)
         validate_preconditions(frame)

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -10,6 +10,7 @@ module LavinMQ
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
       getter filter : String?
+      getter match_unfiltered : Bool = false
 
       def initialize(@channel : Client::Channel, @queue : StreamQueue, frame : AMQP::Frame::Basic::Consume)
         validate_preconditions(frame)
@@ -43,6 +44,12 @@ module LavinMQ
           @filter = frame.arguments["x-stream-filter-value"].to_s
         when Nil
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")
+        end
+        case frame.arguments["x-stream-match-unfiltered"]?
+        when Bool
+          @match_unfiltered = frame.arguments["x-stream-match-unfiltered"].as(Bool)
+        when Nil
+        else raise LavinMQ::Error::PreconditionFailed.new("x-stream-match-unfiltered must be a boolean")
         end
       end
 

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -39,9 +39,9 @@ module LavinMQ
         when Nil, Int, Time, "first", "next", "last"
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-offset must be an integer, a timestamp, 'first', 'next' or 'last'")
         end
-        case frame.arguments["x-stream-filter-value"]?
+        case filter = frame.arguments["x-stream-filter-value"]?
         when String
-          @filter = frame.arguments["x-stream-filter-value"].to_s.split(",")
+          @filter = filter.split(',').sort!
         when Nil
           # noop
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -46,9 +46,9 @@ module LavinMQ
           # noop
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")
         end
-        case frame.arguments["x-stream-match-unfiltered"]?
+        case match_unfiltered = frame.arguments["x-stream-match-unfiltered"]?
         when Bool
-          @match_unfiltered = frame.arguments["x-stream-match-unfiltered"].as(Bool)
+          @match_unfiltered = match_unfiltered
         when Nil
           # noop
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-match-unfiltered must be a boolean")

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -9,6 +9,7 @@ module LavinMQ
       property segment : UInt32
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
+      getter filter : String?
 
       def initialize(@channel : Client::Channel, @queue : StreamQueue, frame : AMQP::Frame::Basic::Consume)
         validate_preconditions(frame)
@@ -36,6 +37,12 @@ module LavinMQ
         case frame.arguments["x-stream-offset"]?
         when Nil, Int, Time, "first", "next", "last"
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-offset must be an integer, a timestamp, 'first', 'next' or 'last'")
+        end
+        case frame.arguments["x-stream-filter-value"]?
+        when String
+          @filter = frame.arguments["x-stream-filter-value"].to_s
+        when Nil
+        else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds support for filtering in streams. 

Filters can be set on messages by providing `x-stream-filter-value` when publishing messages to a stream. 
When a consumer tries to consume with `x-stream-filter` set, only messages matching the filter value will be returned. `x-stream-filter` on consumers can be a single value as a string, or a set of values separated by commas. Any message matching any of the filters on the consumer will be returned. 

You can also choose to return all messages without a filter by providing `x-stream-match-unfiltered` as an argument on the consumer. 
If you do not provide `x-stream-filter` when consuming, all messages in the stream will be returned as if no filters existed. 


### HOW can this pull request be tested?
Run specs
