### PR TITLE
Log: strip logged user input for cleaner logs

### DIFF
--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -47,7 +47,10 @@ module LavinMQ
         elsif proto != AMQP::PROTOCOL_START_0_9_1 && proto != AMQP::PROTOCOL_START_0_9
           socket.write AMQP::PROTOCOL_START_0_9_1.to_slice
           socket.flush
-          log.warn { "Unexpected protocol '#{String.new(proto.to_slice)}', closing socket" }
+          log.warn {
+            bad_protocol = String.new(proto.to_slice).gsub(/\n/, "\\n")
+            "Unexpected protocol '#{bad_protocol}', closing socket"
+            }
           false
         else
           true

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -47,10 +47,7 @@ module LavinMQ
         elsif proto != AMQP::PROTOCOL_START_0_9_1 && proto != AMQP::PROTOCOL_START_0_9
           socket.write AMQP::PROTOCOL_START_0_9_1.to_slice
           socket.flush
-          log.warn {
-            bad_protocol = String.new(proto.to_slice).gsub(/\n/, "\\n")
-            "Unexpected protocol '#{bad_protocol}', closing socket"
-            }
+          log.warn { "Unexpected protocol #{String.new(proto.to_unsafe, count).inspect}, closing socket" }
           false
         else
           true


### PR DESCRIPTION
### WHAT is this pull request doing?

It strip the protocol string from newlines, so we get cleaner logs if users send in bad input. 

EX: 

> Dec 19 06:07:33Z lmq.amqp.connection_factory: "Unexpected protocol '# 003
Dec 19 06:07:33Z  *%�
Dec 19 06:07:33Z  ', closing socket

### HOW can this pull request be tested?
send in a header with a bad protocol, with newlines, and see that the log is not devided. 