### PR TITLE
MFile#read should not raise IO::EOFError

### DIFF
--- a/spec/mfile_spec.cr
+++ b/spec/mfile_spec.cr
@@ -12,4 +12,21 @@ describe MFile do
       file.delete
     end
   end
+
+  it "can be read" do
+    file = File.tempfile "mfile_spec"
+    file.print "hello world"
+    file.flush
+    begin
+      MFile.open(file.path) do |mfile|
+        buf = Bytes.new(6)
+        cnt = mfile.read(buf)
+        String.new(buf[0, cnt]).should eq "hello "
+        cnt = mfile.read(buf)
+        String.new(buf[0, cnt]).should eq "world"
+      end
+    ensure
+      file.delete
+    end
+  end
 end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -185,11 +185,10 @@ class MFile < IO
 
   def read(slice : Bytes)
     pos = @pos
-    new_pos = pos + slice.size
-    raise IO::EOFError.new if new_pos > @size
-    slice.copy_from(buffer + pos, slice.size)
-    @pos = new_pos
-    slice.size
+    len = Math.min(slice.size, @size - pos)
+    slice.copy_from(buffer + pos, len)
+    @pos = pos + len
+    len
   end
 
   def rewind


### PR DESCRIPTION
### WHAT is this pull request doing?

IO#read reads at most slice.size bytes from the IO into slice. Returns the number of bytes read, which is 0 if and only if there is no more data to read.

### HOW can this pull request be tested?
Spec
