### PR TITLE
UI: Remove reset vhost button (feature gone)

### DIFF
--- a/views/vhost.ecr
+++ b/views/vhost.ecr
@@ -100,12 +100,6 @@
       </form>
       <section class="card cols-4">
         <h3>Danger zone</h3>
-        <form method="post" id="resetVhost" class="form">
-          <label>
-            <button title="Will purge all queues and close the consumers" type="submit" class="btn btn-red">Reset vhost</button>
-          </label>
-        </form>
-        <br />
         <form method="delete" id="deleteVhost" class="form">
           <label>
             <button type="submit" class="btn btn-red">Delete vhost</button>


### PR DESCRIPTION
### WHAT is this pull request doing?

Remove reset vhost button (feature gone) as "reset vhost" was removed in 33147bf59d4fe4db33001923282209d1789db434 #822

### HOW can this pull request be tested?

Before:

<img width="1552" alt="Screenshot 2025-01-02 at 21 10 58" src="https://github.com/user-attachments/assets/d093efe1-0461-4677-8590-afb313d747ca" />

After:

<img width="1552" alt="Screenshot 2025-01-02 at 21 11 01" src="https://github.com/user-attachments/assets/cc20b07d-1c16-401c-bde2-3987b7984a85" />
