### PR TITLE
Store non-durable queues in separate transient dir

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -272,7 +272,7 @@ describe LavinMQ::AMQP::Queue do
   it "should delete transient queues segments on creation" do
     with_amqp_server do |s|
       with_channel(s) do |ch|
-        q = ch.queue "transient", durable: false
+        ch.queue "transient", durable: false
       end
       data_dir = s.vhosts["/"].queues["transient"].as(LavinMQ::AMQP::Queue).@msg_store.@queue_data_dir
       Dir.exists?(data_dir).should be_true

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -269,6 +269,17 @@ describe LavinMQ::AMQP::Queue do
     end
   end
 
+  it "should delete transient queues segments on creation" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue "transient", durable: false
+      end
+      data_dir = s.vhosts["/"].queues["transient"].as(LavinMQ::AMQP::Queue).@msg_store.@queue_data_dir
+      Dir.exists?(data_dir).should be_true
+      File.exists?("#{data_dir}/msgs.0000000001").should be_false
+    end
+  end
+
   it "should delete left over transient queue data on Server start" do
     with_amqp_server do |s|
       data_dir = ""

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -276,10 +276,11 @@ describe LavinMQ::AMQP::Queue do
         q = ch.queue "transient", durable: false
         q.publish_confirm "foobar"
         data_dir = s.vhosts["/"].queues["transient"].as(LavinMQ::AMQP::Queue).@msg_store.@queue_data_dir
-        FileUtils.cp_r data_dir, "#{data_dir}.copy"
+        FileUtils.cp_r data_dir, "#{s.vhosts["/"].data_dir}.copy"
       end
       s.stop
-      FileUtils.cp_r "#{data_dir}.copy", data_dir
+      Dir.mkdir_p data_dir
+      FileUtils.cp_r "#{s.vhosts["/"].data_dir}.copy", data_dir
       s.restart
       with_channel(s) do |ch|
         q = ch.queue_declare "transient", durable: false

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -13,7 +13,7 @@ module LavinMQ::AMQP
 
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
-      DelayedMessageStore.new(data_dir, replicator, metadata: @metadata)
+      DelayedMessageStore.new(data_dir, replicator, durable?, metadata: @metadata)
     end
 
     private def expire_at(msg : BytesMessage) : Int64?

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -154,9 +154,10 @@ module LavinMQ::AMQP
     end
 
     private def make_data_dir : String
-      data_dir = File.join(@vhost.data_dir, Digest::SHA1.hexdigest @name)
-      unless durable?
-        data_dir = File.join(@vhost.data_dir, "transient", Digest::SHA1.hexdigest @name)
+      data_dir = if durable?
+        File.join(@vhost.data_dir, Digest::SHA1.hexdigest @name)
+      else
+        File.join(@vhost.data_dir, "transient", Digest::SHA1.hexdigest @name)
       end
       if Dir.exists? data_dir
         # delete left over files from transient queues

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -155,10 +155,10 @@ module LavinMQ::AMQP
 
     private def make_data_dir : String
       data_dir = if durable?
-        File.join(@vhost.data_dir, Digest::SHA1.hexdigest @name)
-      else
-        File.join(@vhost.data_dir, "transient", Digest::SHA1.hexdigest @name)
-      end
+                   File.join(@vhost.data_dir, Digest::SHA1.hexdigest @name)
+                 else
+                   File.join(@vhost.data_dir, "transient", Digest::SHA1.hexdigest @name)
+                 end
       if Dir.exists? data_dir
         # delete left over files from transient queues
         unless durable?

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -155,6 +155,9 @@ module LavinMQ::AMQP
 
     private def make_data_dir : String
       data_dir = File.join(@vhost.data_dir, Digest::SHA1.hexdigest @name)
+      unless durable?
+        data_dir = File.join(@vhost.data_dir, "transient", Digest::SHA1.hexdigest @name)
+      end
       if Dir.exists? data_dir
         # delete left over files from transient queues
         unless durable?

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -150,7 +150,7 @@ module LavinMQ::AMQP
     # own method so that it can be overriden in other queue implementations
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
-      MessageStore.new(data_dir, replicator, metadata: @metadata)
+      MessageStore.new(data_dir, replicator, durable?, metadata: @metadata)
     end
 
     private def make_data_dir : String

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -48,6 +48,7 @@ module LavinMQ
       @dir = Digest::SHA1.hexdigest(@name)
       @data_dir = File.join(@server_data_dir, @dir)
       Dir.mkdir_p File.join(@data_dir)
+      FileUtils.rm_rf File.join(@data_dir, "transient")
       @definitions_file_path = File.join(@data_dir, "definitions.amqp")
       @definitions_file = File.open(@definitions_file_path, "a+")
       @replicator.register_file(@definitions_file)
@@ -421,6 +422,7 @@ module LavinMQ
       @queues.each_value &.close
       Fiber.yield
       @definitions_file.close
+      FileUtils.rm_rf File.join(@data_dir, "transient")
     end
 
     def delete


### PR DESCRIPTION
### WHAT is this pull request doing?
Stores data directory for non-durable queues in a separate directory: `transient`. The transient dir is removed on both `VHost#init` and `VHost#close` to make sure we don't store unnecessary data. 

Also deletes files for non-durable queues on creation, meaning they will be automatically deleted once they are unmapped. This makes sure no segments are kept, even if lavinmq is shut down non-gracefully. 

Fixes #796 

### HOW can this pull request be tested?
Run specs