### PR TITLE
Adds cleanup_datadir to lavinmqctl

### DIFF
--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -717,10 +717,10 @@ class LavinMQCtl
       rescue e : File::NotFoundError
       end
 
-      queues = get("/api/queues/#{URI.encode_www_form(current_vhost)}","name")
+      queues = get("/api/queues/#{URI.encode_www_form(current_vhost)}", "name")
 
       Dir.glob("#{vhost_data_dir}/*/.queue").each do |dir|
-        queues.delete({ "name"=> File.read(dir) })
+        queues.delete({"name" => File.read(dir)})
         queue_dirs.delete(dir[0..-8])
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a `cleanup_datadir` cmd that removes any queue dirs without a corresponding queue in LavinMQ. Mainly useful for removing any "orphaned" non-durable queues that can have been left because of an earlier non-graceful shutdown of LavinMQ. 

Somewhat related to #900 

### HOW can this pull request be tested?
Add a directory to a vhost data directory, run `lavinmqctl cleanup_datadir <datadir>`, see that your new directory is removed. 
