### PR TITLE
remove Rlimit alias and struct that was added in crystal 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          brew update
           brew install crystal etcd
           echo "/opt/homebrew/opt/etcd/bin" >> $GITHUB_PATH
         env:

--- a/src/stdlib/resource.cr
+++ b/src/stdlib/resource.cr
@@ -1,20 +1,4 @@
 lib LibC
-  {% if flag?(:linux) || flag?(:bsd) %}
-    alias RlimT = ULongLong
-
-    struct Rlimit
-      rlim_cur : RlimT
-      rlim_max : RlimT
-    end
-  {% end %}
-
-  {% if flag?(:linux) || flag?(:darwin) %}
-    RLIMIT_NOFILE = 7
-  {% elsif flag?(:bsd) %}
-    RLIMIT_NOFILE = 8
-  {% end %}
-
-  fun getrlimit(Int, Rlimit*) : Int
   fun setrlimit(Int, Rlimit*) : Int
 end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
`Rlimt` alias, `Rlimit` struct and `fun getrlimit` was added to Crystal in 1.15 (for example [here](https://github.com/crystal-lang/crystal/commit/cc30da2d3b8d5d3ee300a65d73268b0ded5638f3#diff-3ea6e5daa196047d646ad75d1749e3928d090e5215381a57171d062a0d3013f6)), so we don't have to do that ourselves. 

Also make sure we run `brew update` before `brew install` to make sure we get the latest versions in CI.


### HOW can this pull request be tested?
Run specs
