### PR TITLE
Bugfix: follower must keep its lease alive

### DIFF
--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -2,6 +2,7 @@ require "socket"
 require "wait_group"
 require "json"
 require "./logger"
+require "./etcd/leadership"
 
 module LavinMQ
   class Etcd
@@ -91,44 +92,6 @@ module LavinMQ
       lease_id, _ttl = lease_grant(ttl)
       election_campaign(name, value, lease_id)
       Leadership.new(self, lease_id)
-    end
-
-    # Represents holding a Leadership
-    # Can be revoked or wait until lost
-    class Leadership
-      def initialize(@etcd : Etcd, @lease_id : Int64)
-        @lost_leadership = Channel(Nil).new
-        spawn(keepalive_loop, name: "Etcd lease keepalive #{@lease_id}")
-      end
-
-      # Force release leadership
-      def release
-        @etcd.lease_revoke(@lease_id)
-        @lost_leadership.close
-      end
-
-      # Wait until looses leadership
-      # Returns true when lost leadership, false when timeout occured
-      def wait(timeout : Time::Span) : Bool
-        select
-        when @lost_leadership.receive?
-          true
-        when timeout(timeout)
-          false
-        end
-      end
-
-      private def keepalive_loop
-        ttl = @etcd.lease_ttl(@lease_id)
-        loop do
-          sleep (ttl * 0.7).seconds
-          ttl = @etcd.lease_keepalive(@lease_id)
-        end
-      rescue ex
-        Log.error(exception: ex) { "Lost leadership" } unless @lost_leadership.closed?
-      ensure
-        @lost_leadership.close
-      end
     end
 
     def elect_listen(name, &)

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -90,8 +90,9 @@ module LavinMQ
     # Returns a `Leadership` instance
     def elect(name, value, ttl = 10) : Leadership
       lease_id, _ttl = lease_grant(ttl)
+      leadership = Leadership.new(self, lease_id)
       election_campaign(name, value, lease_id)
-      Leadership.new(self, lease_id)
+      leadership
     end
 
     def elect_listen(name, &)

--- a/src/lavinmq/etcd/leadership.cr
+++ b/src/lavinmq/etcd/leadership.cr
@@ -1,0 +1,41 @@
+module LavinMQ
+  class Etcd
+    # Represents holding a Leadership
+    # Can be revoked or wait until lost
+    class Leadership
+      def initialize(@etcd : Etcd, @lease_id : Int64)
+        @lost_leadership = Channel(Nil).new
+        spawn(keepalive_loop, name: "Etcd lease keepalive #{@lease_id}")
+      end
+
+      # Force release leadership
+      def release
+        @etcd.lease_revoke(@lease_id)
+        @lost_leadership.close
+      end
+
+      # Wait until looses leadership
+      # Returns true when lost leadership, false when timeout occured
+      def wait(timeout : Time::Span) : Bool
+        select
+        when @lost_leadership.receive?
+          true
+        when timeout(timeout)
+          false
+        end
+      end
+
+      private def keepalive_loop
+        ttl = @etcd.lease_ttl(@lease_id)
+        loop do
+          sleep (ttl * 0.7).seconds
+          ttl = @etcd.lease_keepalive(@lease_id)
+        end
+      rescue ex
+        Log.error(exception: ex) { "Lost leadership" } unless @lost_leadership.closed?
+      ensure
+        @lost_leadership.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?
Before this change a follower may use an expired lease when it's elected leader, making it losing its leadership instantly.

By creating the `Leadership` before the election campaign the lease will be kept alive.

### HOW can this pull request be tested?
Currently manually by running two instances and stopping the leader after the follower has been running for at least lease ttl seconds. Before this change the follower would restart as a leader but losing its leadership instantly.
