### PR TITLE
Make Launcher the starting point in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rescue more exceptions while reading msg store on startup [#865](https://github.com/cloudamqp/lavinmq/pull/865)
 - Crystal 1.15 support [#905](https://github.com/cloudamqp/lavinmq/pull/905)
 - lavinmqctl now handles pagination of large result sets [#904](https://github.com/cloudamqp/lavinmq/pull/904)
-- Make clustering more reliable [#879](https://github.com/cloudamqp/lavinmq/pull/879)
+- Make clustering more reliable [#879](https://github.com/cloudamqp/lavinmq/pull/879), [#909](https://github.com/cloudamqp/lavinmq/pull/909), [#906](https://github.com/cloudamqp/lavinmq/pull/906)
 - Strip newlines from logs [#896](https://github.com/cloudamqp/lavinmq/pull/896)
 
 ### Added

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -134,10 +134,10 @@ describe LavinMQ::Clustering::Client do
     end
     sleep 0.5.seconds
     spawn(name: "failover1") do
-      controller1.run
+      controller1.run { }
     end
     spawn(name: "failover2") do
-      controller2.run
+      controller2.run { }
     end
     sleep 0.1.seconds
     leader = listen.receive

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -168,7 +168,7 @@ describe LavinMQ::Clustering::Client do
     election_done = Channel(Nil).new
     etcd = LavinMQ::Etcd.new(config.clustering_etcd_endpoints)
     spawn do
-      etcd.elect_listen("lavinmq/leader") { |v| election_done.close }
+      etcd.elect_listen("lavinmq/leader") { election_done.close }
     end
 
     spawn { launcher.run }

--- a/src/lavinmq.cr
+++ b/src/lavinmq.cr
@@ -15,10 +15,4 @@ config.parse # both ARGV and config file
 
 # config has to be loaded before we require vhost/queue, byte_format is a constant
 require "./lavinmq/launcher"
-require "./lavinmq/clustering/controller"
-
-if config.clustering?
-  LavinMQ::Clustering::Controller.new(config).run
-else
-  LavinMQ::Launcher.new(config).run
-end
+LavinMQ::Launcher.new(config).run

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -35,15 +35,6 @@ module LavinMQ
           @unix_http_proxy = Proxy.new(@config.http_unix_path) unless @config.http_unix_path.empty?
         end
         HTTP::Server.follower_internal_socket_http_server
-
-        Signal::INT.trap { close_and_exit }
-        Signal::TERM.trap { close_and_exit }
-      end
-
-      private def close_and_exit
-        Log.info { "Received termination signal, shutting down..." }
-        close
-        exit 0
       end
 
       def follow(uri : String)

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -19,6 +19,10 @@ class LavinMQ::Clustering::Controller
                       "tcp://#{System.hostname}:#{@config.clustering_port}"
   end
 
+  # This method is called by the Launcher#run.
+  # The block will be yielded when the controller's prerequisites for a leader
+  # to start are met, i.e when the current node has been elected leader.
+  # The method is blocking.
   def run(&)
     spawn(follow_leader, name: "Follower monitor")
     wait_to_be_insync

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -1,25 +1,31 @@
-require "../launcher"
 require "../etcd"
 require "./client"
 
 class LavinMQ::Clustering::Controller
   Log = LavinMQ::Log.for "clustering.controller"
 
-  @id : Int32
+  getter id : Int32
 
-  def initialize(@config = Config.instance)
-    @etcd = Etcd.new(@config.clustering_etcd_endpoints)
+  @repli_client : Client? = nil
+
+  def self.new(config : Config)
+    etcd = Etcd.new(config.clustering_etcd_endpoints)
+    new(config, etcd)
+  end
+
+  def initialize(@config : Config, @etcd : Etcd)
     @id = clustering_id
     @advertised_uri = @config.clustering_advertised_uri ||
                       "tcp://#{System.hostname}:#{@config.clustering_port}"
   end
 
-  def run
+  def run(&)
     spawn(follow_leader, name: "Follower monitor")
     wait_to_be_insync
     @lease = lease = @etcd.elect("#{@config.clustering_etcd_prefix}/leader", @advertised_uri) # blocks until becoming leader
+    @repli_client.try &.close
     # TODO: make sure we still are in the ISR set
-    @launcher = Launcher.new(@config, @etcd).start
+    yield
     loop do
       if lease.wait(30.seconds)
         break if @stopped
@@ -35,7 +41,7 @@ class LavinMQ::Clustering::Controller
 
   def stop
     @stopped = true
-    @launcher.try &.stop
+    @repli_client.try &.close
     @lease.try &.release
   end
 
@@ -74,7 +80,7 @@ class LavinMQ::Clustering::Controller
           break
         end
       end
-      repli_client = r = Clustering::Client.new(@config, @id, secret)
+      @repli_client = repli_client = r = Clustering::Client.new(@config, @id, secret)
       spawn r.follow(uri), name: "Clustering client #{uri}"
       SystemD.notify_ready
     end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -34,7 +34,7 @@ module LavinMQ
       @id : Int32
       @config : Config
 
-      def initialize(config : Config, @etcd : Etcd, @id = File.read(File.join(config.data_dir, ".clustering_id")).to_i(36))
+      def initialize(config : Config, @etcd : Etcd, @id : Int32)
         Log.info { "ID: #{@id.to_s(36)}" }
         @config = config
         @data_dir = @config.data_dir

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -53,7 +53,7 @@ module LavinMQ
         @replicator = Clustering::Server.new(@config, etcd, controller.id)
       else
         @replicator = Clustering::NoopServer.new
-        @runner = DefaultRunner.new
+        @runner = StandaloneRunner.new
       end
 
       @tls_context = create_tls_context if @config.tls_configured?

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -11,6 +11,9 @@ require "./clustering/controller"
 
 module LavinMQ
   struct StandaloneRunner
+    # The block will be yielded when the runner's prerequisites for a leader
+    # to start are met. For the standalone runner, this is immediately.
+    # The method is blocking.
     def run(&)
       yield
       loop do

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -10,7 +10,7 @@ require "./etcd"
 require "./clustering/controller"
 
 module LavinMQ
-  struct DefaultRunner
+  struct StandaloneRunner
     def run(&)
       yield
       loop do

--- a/src/lavinmq/reporter.cr
+++ b/src/lavinmq/reporter.cr
@@ -1,6 +1,10 @@
 module LavinMQ
   class Reporter
     def self.report(s)
+      if s.nil?
+        puts "No server instance to report"
+        return
+      end
       puts_size_capacity s.@users
       s.users.each do |name, user|
         puts "User #{name}"


### PR DESCRIPTION
### WHAT is this pull request doing?
After other refactoring lavinmq no longer released its leader lease on graceful shutdown. The problem was that `Launcher` handled the signal, but didn't have a reference to `Clustering::Controller` or the `Leadership`, and therefore couldn't release the lease.

When looking into different solutions I realized that we had two ways of starting lavinmq: `Launcher` and `Clustering::Controller`.

This PR will refactor the upstart to make `Launcher` responsible for the upstart. This also makes launcher the signal handler instead of having this in both `Launcher` and `Clustering::Client`. `Launcher` will now have a reference to `Clustering::Controller` instead of the other way around.

### HOW can this pull request be tested?
Specs still passes, but some things needs to be tested manually.
