### PR TITLE
Catch exits in spec_helper and raise an exception that can be handled in other specs

### DIFF
--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -2,6 +2,7 @@ require "spec"
 require "../src/lavinmq/etcd"
 require "file_utils"
 require "http/client"
+require "./spec_helper"
 
 describe LavinMQ::Etcd do
   it "can put and get" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -140,6 +140,13 @@ def create_ttl_and_dl_queues(channel, queue_ttl = 1)
   {q, dlq}
 end
 
+def exit(reason = nil)
+  raise SpecExit.new("LavinMQ exited with reason: #{reason.to_s}")
+end
+
+class SpecExit < Exception
+end
+
 module LavinMQ
   # Allow creating new Config object without using the singleton
   class Config

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -140,11 +140,16 @@ def create_ttl_and_dl_queues(channel, queue_ttl = 1)
   {q, dlq}
 end
 
-def exit(reason = nil)
-  raise SpecExit.new("LavinMQ exited with reason: #{reason.to_s}")
+def exit(code = 0)
+  raise SpecExit.new(code)
 end
 
 class SpecExit < Exception
+  getter code : Int32
+
+  def initialize(@code)
+    super "Exiting with code #{@code}"
+  end
 end
 
 module LavinMQ


### PR DESCRIPTION
### WHAT is this pull request doing?
Defines exit in spec_helper so we can catch any program exits and instead raise an exception that we can handle in other specs. 

### HOW can this pull request be tested?
Run specs.
