### PR TITLE
Stop log streamed bytes loop

### DIFF
--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -254,6 +254,7 @@ module LavinMQ
       private def log_streamed_bytes_loop
         loop do
           sleep 30.seconds
+          break if @closed
           Log.info { "Total streamed bytes: #{@streamed_bytes}" }
         end
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
The log streamed bytes loop was never stopped, making it continue to log even after the node has been elected leader.

This change will make sure it will stop when the clustering client is stopped. I didn't bother adding a channel to stop it instantly since its only sleeping.

### HOW can this pull request be tested?
Manual test
