### PR TITLE
Keep Etcd dependencies to `Clustering::Controller`

### DIFF
--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -13,7 +13,6 @@ module LavinMQ
       abstract def close
       abstract def listen(server : TCPServer)
       abstract def clear
-      abstract def password : String
     end
   end
 end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -50,7 +50,7 @@ module LavinMQ
       if @config.clustering?
         etcd = Etcd.new(@config.clustering_etcd_endpoints)
         @runner = controller = Clustering::Controller.new(@config, etcd)
-        @replicator = Clustering::Server.new(@config, etcd, controller.id)
+        @replicator = Clustering::Server.new(@config, controller)
       else
         @replicator = Clustering::NoopServer.new
         @runner = StandaloneRunner.new


### PR DESCRIPTION
### WHAT is this pull request doing?
Tiny refactor to move all `Etcd` actions to `Clustering::Controller`.

### HOW can this pull request be tested?
Specs
