### PR TITLE
UI: Load svgs from files instead of from data tags

### DIFF
--- a/static/img/arrow-down.svg
+++ b/static/img/arrow-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'><path stroke='#f7f5f2' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/></svg>

--- a/static/img/usermenu-button.svg
+++ b/static/img/usermenu-button.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 21V19C20 17.9391 19.5786 16.9217 18.8284 16.1716C18.0783 15.4214 17.0609 15 16 15H8C6.93913 15 5.92172 15.4214 5.17157 16.1716C4.42143 16.9217 4 17.9391 4 19V21" stroke="#F7F5F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 11C14.2091 11 16 9.20914 16 7C16 4.79086 14.2091 3 12 3C9.79086 3 8 4.79086 8 7C8 9.20914 9.79086 11 12 11Z" stroke="#F7F5F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/main.css
+++ b/static/main.css
@@ -115,7 +115,7 @@ input[type="text"], input[type="number"], input[type="password"] {
 }
 
 select.dropdown {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23f7f5f2' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-image: url(img/arrow-down.svg);
   background-position: right .5rem center;
   background-repeat: no-repeat;
   background-size: 1.5em 1.5em;

--- a/static/main.css
+++ b/static/main.css
@@ -1916,7 +1916,7 @@ pre.arguments > div {
 }
 
 #usermenu-button::before {
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M20 21V19C20 17.9391 19.5786 16.9217 18.8284 16.1716C18.0783 15.4214 17.0609 15 16 15H8C6.93913 15 5.92172 15.4214 5.17157 16.1716C4.42143 16.9217 4 17.9391 4 19V21' stroke='%23F7F5F2' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M12 11C14.2091 11 16 9.20914 16 7C16 4.79086 14.2091 3 12 3C9.79086 3 8 4.79086 8 7C8 9.20914 9.79086 11 12 11Z' stroke='%23F7F5F2' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  content: url(img/usermenu-button.svg);
   color: #f7f5f2;
   font-weight: 600;
   width: 24px;


### PR DESCRIPTION
### WHAT is this pull request doing?
Load svg's from files instead of from data-tag to abide by Content Security Policy.

Fixes console error: 
```
Refused to load the image 'data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23f7f5f2' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e' because it violates the following Content Security Policy directive: "img-src 'self'".
``` 
### HOW can this pull request be tested?
Start LavinMQ, make sure the arrow in the vhost dropdown is shown. And usermenu button in mobile. 

![image](https://github.com/user-attachments/assets/a4706046-d2ed-4f38-9b26-2471a3f8c544)