### PR TITLE
extract Tag from User

### DIFF
--- a/src/lavinmq/tag.cr
+++ b/src/lavinmq/tag.cr
@@ -1,0 +1,13 @@
+module LavinMQ
+  enum Tag
+    Administrator
+    Monitoring
+    Management
+    PolicyMaker
+    Impersonator
+
+    def self.parse_list(list : String) : Array(Tag)
+      list.split(",").compact_map { |t| Tag.parse?(t.strip) }
+    end
+  end
+end

--- a/src/lavinmq/user.cr
+++ b/src/lavinmq/user.cr
@@ -1,20 +1,9 @@
 require "json"
 require "./password"
 require "./sortable_json"
+require "./tag"
 
 module LavinMQ
-  enum Tag
-    Administrator
-    Monitoring
-    Management
-    PolicyMaker
-    Impersonator
-
-    def self.parse_list(list : String) : Array(Tag)
-      list.split(",").compact_map { |t| Tag.parse?(t.strip) }
-    end
-  end
-
   class User
     include SortableJSON
     getter name, password, permissions


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR extracts the `Tag` enum from `LavinMQ::User` to its own file. this help us be consistent in our file structure. 
This is also a preparatory move for introducing the authorization chain, and different user types. 

### HOW can this pull request be tested?
run specs, no functionality should be changed. 
