### PR TITLE
add disk space used to /queues

### DIFF
--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -388,7 +388,7 @@ module LavinMQ::AMQP
         consumers:                   @consumers.size,
         vhost:                       @vhost.name,
         messages:                    @msg_store.size + @unacked_count,
-        total_bytes:                  @msg_store.bytesize + @unacked_bytesize,
+        total_bytes:                 @msg_store.bytesize + @unacked_bytesize,
         messages_persistent:         durable? ? @msg_store.size + @unacked_count : 0,
         ready:                       @msg_store.size,
         ready_bytes:                 @msg_store.bytesize,

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -388,6 +388,7 @@ module LavinMQ::AMQP
         consumers:                   @consumers.size,
         vhost:                       @vhost.name,
         messages:                    @msg_store.size + @unacked_count,
+        total_bytes:                  @msg_store.bytesize + @unacked_bytesize,
         messages_persistent:         durable? ? @msg_store.size + @unacked_count : 0,
         ready:                       @msg_store.size,
         ready_bytes:                 @msg_store.bytesize,

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -94,7 +94,7 @@ function updateQueue (all) {
       document.getElementById('q-unacked-bytes').textContent = Helpers.nFormatter(item.unacked_bytes) + 'B'
       document.getElementById('q-unacked-avg-bytes').textContent = Helpers.nFormatter(item.unacked_avg_bytes) + 'B'
       document.getElementById('q-total').textContent = Helpers.formatNumber(item.messages)
-      document.getElementById('q-total-bytes').textContent = Helpers.nFormatter(item.unacked_bytes + item.ready_bytes) + 'B'
+      document.getElementById('q-total-bytes').textContent = Helpers.nFormatter(item.total_bytes) + 'B'
       const totalAvgBytes = item.messages !== 0 ? (item.unacked_bytes + item.ready_bytes) / item.messages : 0
       document.getElementById('q-total-avg-bytes').textContent = Helpers.nFormatter(totalAvgBytes) + 'B'
       document.getElementById('q-ready').textContent = Helpers.formatNumber(item.ready)

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -111,6 +111,7 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
   Table.renderCell(tr, 11, Helpers.formatNumber(item.message_stats.deliver_details.rate), 'right')
   Table.renderCell(tr, 12, Helpers.formatNumber(item.message_stats.redeliver_details.rate), 'right')
   Table.renderCell(tr, 13, Helpers.formatNumber(item.message_stats.ack_details.rate), 'right')
+  Table.renderCell(tr, 14, Helpers.nFormatter(item.total_bytes) + 'B', 'right')
 })
 
 document.querySelector('#declare').addEventListener('submit', function (evt) {

--- a/views/queues.ecr
+++ b/views/queues.ecr
@@ -38,6 +38,7 @@
                 <th data-sort-key="message_stats.deliver_details.rate">Deliver rate</th>
                 <th data-sort-key="message_stats.redeliver_details.rate">Redeliver rate</th>
                 <th data-sort-key="message_stats.ack_details.rate">Ack rate</th>
+                <th data-sort-key="total_bytes">Disk space used</th>
               </tr>
             </thead>
             <tbody></tbody>
@@ -117,13 +118,13 @@
             </a>
              <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true">Message deduplication
               <span class="tooltiptext">Enable deduplication for this exchange</span>
-            </a> | 
+            </a> |
             <a class="arg-tooltip" data-tag="x-cache-size" data-value="100">Deduplication cache size
               <span class="tooltiptext">Deduplication cache size, in number of entries</span>
-            </a> | 
+            </a> |
             <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000">Deduplication cache ttl
               <span class="tooltiptext">How long an entry lives in the deduplication cache, in milliseconds</span>
-            </a> | 
+            </a> |
             <a class="arg-tooltip" data-tag="x-deduplication-header">Deduplication header
               <span class="tooltiptext">Which header to check for deduplication, defaults to x-deduplication-header</span>
             </a>


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds total_bytes as disk usage in the /queues view

### HOW can this pull request be tested?
publish some messages to some queues and see that the total amount of bytes are displayed as "Disk space used"
