### PR TITLE
Use MFiles in followers

### DIFF
--- a/spec/mfile_spec.cr
+++ b/spec/mfile_spec.cr
@@ -29,4 +29,26 @@ describe MFile do
       file.delete
     end
   end
+
+  describe "#resize" do
+    it "can increase size" do
+      file = File.tempfile "mfile_spec"
+      file.print "hello world"
+      file.flush
+      data = "foo"
+      initial_size = file.size
+      MFile.open(file.path, initial_size) do |mfile|
+        mfile.capacity.should eq initial_size
+        expect_raises(IO::EOFError) { mfile.write data.to_slice }
+        mfile.resize(mfile.size + data.bytesize)
+        mfile.write data.to_slice
+        mfile.capacity.should eq(initial_size + data.bytesize)
+      end
+      file.size.should eq(initial_size + data.bytesize)
+      data = File.read(file.path)
+      data.should eq "hello worldfoo"
+    ensure
+      file.try &.delete
+    end
+  end
 end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -6,6 +6,8 @@ require "lz4"
 
 module LavinMQ
   module Clustering
+    # Wraps an MFile and keep tracks of access time and adds logic
+    # to resize the file if needed.
     class ReplicatedFile
       getter last_access = Time.monotonic
       getter path : String
@@ -52,39 +54,9 @@ module LavinMQ
       end
     end
 
-    class ReplicatedFiles
-      OPEN_FILES_THRESHOLD = ENV.fetch("LAVINMQ_OPEN_FILES_THRESHOLD", 2048).to_i
-
-      def initialize(@data_dir : String)
-        @files = Hash(String, ReplicatedFile).new do |h, k|
-          path = File.join(@data_dir, k)
-          Dir.mkdir_p File.dirname(path)
-          h[k] = ReplicatedFile.new(path, Config.instance.segment_size)
-          h[k]
-        end
-      end
-
-      def [](path : String) : ReplicatedFile
-        return @files[path] if @files.has_key? path
-        i = @files.size
-        @files.reject! do |_, f|
-          break false if i <= OPEN_FILES_THRESHOLD
-          if f.last_access < (Time.monotonic - 10.seconds)
-            i &-= 1
-            f.close
-            true
-          else
-            false
-          end
-        end
-        @files[path]
-      end
-
-      forward_missing_to @files
-    end
-
     class Client
-      Log = LavinMQ::Log.for "clustering.client"
+      OPEN_FILES_THRESHOLD = ENV.fetch("LAVINMQ_OPEN_FILES_THRESHOLD", 2048).to_i
+      Log                  = LavinMQ::Log.for "clustering.client"
       @data_dir_lock : DataDirLock
       @closed = false
       @amqp_proxy : Proxy?
@@ -100,7 +72,26 @@ module LavinMQ
         Dir.mkdir_p @data_dir
         @data_dir_lock = DataDirLock.new(@data_dir).tap &.acquire
         @backup_dir = File.join(@data_dir, "backups", Time.utc.to_rfc3339)
-        @files = ReplicatedFiles.new(@data_dir)
+        #        @files = ReplicatedFiles.new(@data_dir)
+        @files = Hash(String, ReplicatedFile).new do |h, k|
+          # If a file is to be opened, first close files that haven't been used
+          # for a while but only if we have "too many" open.
+          i = h.size
+          h.reject! do |_, f|
+            break false if i <= OPEN_FILES_THRESHOLD
+            if f.last_access < (Time.monotonic - 10.seconds)
+              i &-= 1
+              f.close
+              true
+            else
+              false
+            end
+          end
+          path = File.join(@data_dir, k)
+          Dir.mkdir_p File.dirname(path)
+          h[k] = ReplicatedFile.new(path, Config.instance.segment_size)
+          h[k]
+        end
 
         if proxy
           @amqp_proxy = Proxy.new(@config.amqp_bind, @config.amqp_port)
@@ -300,6 +291,7 @@ module LavinMQ
           when .positive? # replace file
             Log.debug { "Replacing file #{filename} (#{len} bytes)" }
             f = @files["#{filename}.tmp"]
+            f.resize_to_fit(len)
             IO.copy(lz4, f, len) == len || raise IO::EOFError.new("Full file not received")
             f.rename f.path[0..-5]
             @files.delete("#{filename}.tmp").try &.close


### PR DESCRIPTION
### WHAT is this pull request doing?

This fixes #931

Followers will be using MFiles. It will keep track on last access time for a file and close it when it's been unused for at least 10 seconds (this can be discussed). Files are only closed when a new one is opened, meaning that a lot of files may stay open for a good period of time.

### HOW can this pull request be tested?
Run specs (still passes). Should probably add specs to verify that files are closed and unmapped.
