### PR TITLE
Separate process to keepalive etcd lease

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ./src ./src
 
 # Run specs on build platform
 FROM base AS spec
-RUN apt-get install -y etcd-server
+RUN apt-get install -y etcd-server etcd-client
 COPY ./spec ./spec
 ARG spec_args="--order random"
 RUN crystal spec ${spec_args}

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Maintainer: CloudAMQP <contact@cloudamqp.com>
 Package: lavinmq
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, adduser
-Suggests: etcd-server (>= 3.4.0)
+Suggests: etcd-server (>= 3.4.0), etcd-client
 Description: message queue server that implements the AMQP 0-9-1 protocol
  Aims to be very fast, have low RAM requirements,
  handle very long queues, many connections and


### PR DESCRIPTION
During high load lavinmq can struggle to get renew the etcd lease because the fiber is not run often enough. By putting it in a subprocess we can ensure that it gets more resources. When proper MT is added to LavinMQ we can revert this patch.

It introduces a dependency on `etcdctl`, thus for example in Ubuntu/Debian the etcd-client package has to be installed.

Fixes #935 


