### PR TITLE
Retain store bugfixes

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -81,7 +81,7 @@ describe LavinMQ::Clustering::Client do
   end
 
   it "replicates and streams retained messages to followers" do
-    replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new, 0)
+    replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379"), 0)
     tcp_server = TCPServer.new("localhost", 0)
 
     spawn(replicator.listen(tcp_server), name: "repli server spec")

--- a/spec/mqtt/integrations/retain_store_spec.cr
+++ b/spec/mqtt/integrations/retain_store_spec.cr
@@ -42,6 +42,21 @@ module MqttSpecs
     end
 
     describe "each" do
+      it "can be called multiple times" do
+        index = IndexTree.new
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        props = LavinMQ::AMQP::Properties.new
+        msg = LavinMQ::Message.new(100, "test", "rk", props, 10, IO::Memory.new("body"))
+        store.retain("a", msg.body_io, msg.bodysize)
+        10.times do
+          store.each("a") do |_topic, body_io, body_bytesize|
+            body = Bytes.new(body_bytesize)
+            body_io.read(body)
+            body.should eq "body".to_slice
+          end
+        end
+      end
+
       it "calls block with correct arguments" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)

--- a/src/lavinmq/mqtt/retain_store.cr
+++ b/src/lavinmq/mqtt/retain_store.cr
@@ -14,7 +14,7 @@ module LavinMQ
       def initialize(@dir : String, @replicator : Clustering::Replicator, @index = IndexTree.new)
         Dir.mkdir_p @dir
         @files = Hash(String, File).new do |files, file_name|
-          files[file_name] = File.open(File.join(@dir, file_name), "W").tap &.sync = true
+          files[file_name] = File.open(File.join(@dir, file_name), "r+").tap &.sync = true
         end
         @index_file_name = File.join(@dir, INDEX_FILE_NAME)
         @index_file = File.new(@index_file_name, "a+")

--- a/src/lavinmq/mqtt/retain_store.cr
+++ b/src/lavinmq/mqtt/retain_store.cr
@@ -135,6 +135,7 @@ module LavinMQ
         f = @files[file_name]
         body = Bytes.new(f.size)
         f.read_fully(body)
+        f.rewind
         body
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixed the flaky retain store clustering spec. It wasn't really flaky in itself, but worked if you had a running etcd.

When etcd connection string was fixed another bug was exposed: messages files got truncated. It turned out files was opened with wrong mode.

Also, `#read` only worked once since IO wasn't rewinded.

### HOW can this pull request be tested?
Run specs
