### PR TITLE
Prevent lavinmq from freezing when closing consumers and channels

### DIFF
--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -636,7 +636,10 @@ module LavinMQ
 
       def close
         @running = false
-        @consumers.each &.close
+        @consumers.each_with_index(1) do |consumer, i|
+          consumer.close
+          Fiber.yield if (i % 128) == 0
+        end
         @consumers.clear
         if drc = @direct_reply_consumer
           @client.vhost.direct_reply_consumers.delete(drc)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -410,7 +410,11 @@ module LavinMQ
 
       private def cleanup
         @running = false
-        @channels.each_value &.close
+        i = 0u32
+        @channels.each_value do |ch|
+          ch.close
+          Fiber.yield if (i &+= 1) % 512 == 0
+        end
         @channels.clear
         @exclusive_queues.each(&.close)
         @exclusive_queues.clear


### PR DESCRIPTION
### WHAT is this pull request doing?
When closing a connection with tons of consumers lavinmq will freeze because the fiber closing the connection will be CPU bound for a very long time.

This PR adds yields to the loops closing consumers and channels.

### HOW can this pull request be tested?
Start lavinmq then run `lavinmqperf connection-count -x 1 -c 10000 -C 1`. Close perf and observe that e.g. mgmt ui is responsive while lavinmq is closing the connection.
