### PR TITLE
Log original exception if vhost definition load fails

### DIFF
--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -553,7 +553,8 @@ module LavinMQ
     protected def load_apply(frame : AMQP::Frame)
       apply frame, loading: true
     rescue ex : LavinMQ::Error
-      raise Error::InvalidDefinitions.new("Invalid frame: #{frame.inspect}")
+      @log.error(exception: ex) { "Failed to apply frame #{frame.inspect}" }
+      raise Error::InvalidDefinitions.new("Invalid frame: in definitions file")
     end
 
     private def load_default_definitions


### PR DESCRIPTION
### WHAT is this pull request doing?
If an invalid frame is written to `definitions.amqp` lavinmq can't start. However, the log message wasn't clear on what the failure was.

This PR will make sure to log the original error before raising the `Error::InvalidDefinitions`.

### HOW can this pull request be tested?
Manual testing
