### PR TITLE
Add GC metrics to prometheus endpoints

### DIFF
--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -334,7 +334,7 @@ module LavinMQ
         writer.write({name: "gc_since_last_collection_explicitly_freed_bytes", value: gc_stats.expl_freed_bytes_since_gc,
                       type: "counter",
                       help: "Number of bytes freed explicitly since the recent GC"})
-        k
+
         writer.write({name: "gc_from_os_obtained_bytes_total", value: gc_stats.obtained_from_os_bytes,
                       type: "counter",
                       help: "Total amount of memory obtained from OS, in bytes"})

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -39,7 +39,8 @@ module LavinMQ
       def write(m : Metric)
         return if m[:value].nil?
         io = @io
-        name = "#{@prefix}_#{m[:name]}"
+
+        name = name_writer(m)
         if t = m[:type]?
           io << "# TYPE " << name << " " << t << "\n"
         end
@@ -51,6 +52,19 @@ module LavinMQ
           write_labels(io, l)
         end
         io << " " << m[:value] << "\n"
+      end
+
+      struct NameWriter
+        def initialize(@prefix : String, @name : String)
+        end
+
+        def to_s(io : IO) : IO
+          io << @prefix << "_" << @name
+        end
+      end
+
+      private def name_writer(m : Metric)
+        NameWriter.new(@prefix, m[:name])
       end
     end
 

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -319,7 +319,7 @@ module LavinMQ
                       type: "counter",
                       help: "Garbage collection cycle number (value may wrap)"})
 
-        writer.write({name: "gc_marker_threads_total", value: gc_stats.markers_m1,
+        writer.write({name: "gc_marker_threads", value: gc_stats.markers_m1,
                       type: "gauge",
                       help: "Number of marker threads (excluding the initiating one)"})
 

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -323,7 +323,7 @@ module LavinMQ
                       type: "gauge",
                       help: "Number of marker threads (excluding the initiating one)"})
 
-        writer.write({name: "gc_since_last_collection_reclaimed_bytes", value: gc_stats.bytes_reclaimed_since_gc,
+        writer.write({name: "gc_since_recent_collection_reclaimed_bytes", value: gc_stats.bytes_reclaimed_since_gc,
                       type: "gauge",
                       help: "Approximate number of reclaimed bytes after recent GC"})
 
@@ -331,7 +331,7 @@ module LavinMQ
                       type: "counter",
                       help: "Approximate number of bytes reclaimed before the recent GC (value may wrap)"})
 
-        writer.write({name: "gc_since_last_collection_explicitly_freed_bytes", value: gc_stats.expl_freed_bytes_since_gc,
+        writer.write({name: "gc_since_recent_collection_explicitly_freed_bytes", value: gc_stats.expl_freed_bytes_since_gc,
                       type: "counter",
                       help: "Number of bytes freed explicitly since the recent GC"})
 

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -291,40 +291,51 @@ module LavinMQ
       private def gc_metrics(writer)
         gc_stats = @amqp_server.gc_stats
 
-        writer.write({name: "gc_heap_size", value: gc_stats.heap_size,
+        writer.write({name: "gc_heap_size_bytes", value: gc_stats.heap_size,
                       type: "gauge",
                       help: "Heap size in bytes (including the area unmapped to OS)"})
+
         writer.write({name: "gc_free_bytes", value: gc_stats.free_bytes,
                       type: "gauge",
                       help: "Total bytes contained in free and unmapped blocks"})
+
         writer.write({name: "gc_unmapped_bytes", value: gc_stats.unmapped_bytes,
                       type: "gauge",
                       help: "Amount of memory unmapped to OS"})
-        writer.write({name: "gc_bytes_since_gc", value: gc_stats.bytes_since_gc,
-                      type: "counter",
-                      help: "Number of bytes allocated since the recent GC"})
-        writer.write({name: "gc_bytes_before_gc", value: gc_stats.bytes_before_gc,
+
+        writer.write({name: "gc_since_recent_collection_allocated_bytes", value: gc_stats.bytes_since_gc,
                       type: "gauge",
+                      help: "Number of bytes allocated since the recent GC"})
+
+        writer.write({name: "gc_before_recent_collection_allocated_bytes_total", value: gc_stats.bytes_before_gc,
+                      type: "counter",
                       help: "Number of bytes allocated before the recent GC (value may wrap)"})
-        writer.write({name: "gc_non_gc_bytes", value: gc_stats.non_gc_bytes,
+
+        writer.write({name: "gc_non_candidate_bytes", value: gc_stats.non_gc_bytes,
                       type: "gauge",
                       help: "Number of bytes not considered candidates for GC"})
-        writer.write({name: "gc_no", value: gc_stats.gc_no,
+
+        writer.write({name: "gc_cycles_total", value: gc_stats.gc_no,
                       type: "counter",
                       help: "Garbage collection cycle number (value may wrap)"})
-        writer.write({name: "gc_markers_m1", value: gc_stats.markers_m1,
+
+        writer.write({name: "gc_marker_threads_total", value: gc_stats.markers_m1,
                       type: "gauge",
                       help: "Number of marker threads (excluding the initiating one)"})
-        writer.write({name: "gc_bytes_reclaimed_since_gc", value: gc_stats.bytes_reclaimed_since_gc,
+
+        writer.write({name: "gc_since_last_collection_reclaimed_bytes", value: gc_stats.bytes_reclaimed_since_gc,
                       type: "gauge",
                       help: "Approximate number of reclaimed bytes after recent GC"})
-        writer.write({name: "gc_reclaimed_bytes_before_gc", value: gc_stats.reclaimed_bytes_before_gc,
+
+        writer.write({name: "gc_before_recent_collection_reclaimed_bytes_total", value: gc_stats.reclaimed_bytes_before_gc,
                       type: "counter",
                       help: "Approximate number of bytes reclaimed before the recent GC (value may wrap)"})
-        writer.write({name: "gc_expl_freed_bytes_since_gc", value: gc_stats.expl_freed_bytes_since_gc,
+
+        writer.write({name: "gc_since_last_collection_explicitly_freed_bytes", value: gc_stats.expl_freed_bytes_since_gc,
                       type: "counter",
                       help: "Number of bytes freed explicitly since the recent GC"})
-        writer.write({name: "gc_obtained_from_os_bytes", value: gc_stats.obtained_from_os_bytes,
+        k
+        writer.write({name: "gc_from_os_obtained_bytes_total", value: gc_stats.obtained_from_os_bytes,
                       type: "counter",
                       help: "Total amount of memory obtained from OS, in bytes"})
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -373,6 +373,7 @@ module LavinMQ
             update_system_metrics(statm)
           end
         end
+        @gc_stats = GC.prof_stats
 
         control_flow!
         sleep @config.stats_interval.milliseconds
@@ -441,6 +442,7 @@ module LavinMQ
     getter stats_collection_duration_seconds_total = Time::Span.new
     getter stats_rates_collection_duration_seconds = Time::Span.new
     getter stats_system_collection_duration_seconds = Time::Span.new
+    getter gc_stats = GC.prof_stats
 
     private def control_flow!
       if disk_full?


### PR DESCRIPTION
### WHAT is this pull request doing?
This will make stats loop save GC.prof_stats which is then added to prometheus `metrics`

Metrics exported is what's in https://github.com/ivmai/bdwgc/blob/47e0ef445d1aa48b8c48ef166b117386e4e0100c/include/gc/gc.h#L795

Fixes #936

### HOW can this pull request be tested?
Spin up lavinmq, then `curl -u guest:guest http://localhost:15672/metrics | grep gc_`
