### PR TITLE
lavinmqperf queue-count test scenario

### DIFF
--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -19,6 +19,7 @@ module LavinMQPerf
   when "channel-churn"    then ChannelChurn.new.run
   when "consumer-churn"   then ConsumerChurn.new.run
   when "connection-count" then ConnectionCount.new.run
+  when "queue-count"      then QueueCount.new.run
   when /^.+$/             then Perf.new.run([mode.not_nil!])
   else                         abort Perf.new.banner
   end

--- a/src/lavinmqperf/connection_count.cr
+++ b/src/lavinmqperf/connection_count.cr
@@ -78,15 +78,5 @@ module LavinMQPerf
       client.host = "127.0.#{Random.rand(UInt8)}.#{Random.rand(UInt8)}" if @random_localhost
       client
     end
-
-    private def rss
-      File.read("/proc/self/statm").split[1].to_i64 * 4096
-    rescue File::NotFoundError
-      if ps_rss = `ps -o rss= -p $PPID`.to_i64?
-        ps_rss * 1024
-      else
-        0
-      end
-    end
   end
 end

--- a/src/lavinmqperf/perf.cr
+++ b/src/lavinmqperf/perf.cr
@@ -35,6 +35,16 @@ module LavinMQPerf
       {{flags.join(" ")}}
     end
 
+    def rss
+      File.read("/proc/self/statm").split[1].to_i64 * 4096
+    rescue File::NotFoundError
+      if ps_rss = `ps -o rss= -p $PPID`.to_i64?
+        ps_rss * 1024
+      else
+        0
+      end
+    end
+
     BUILD_INFO = <<-INFO
     LavinMQPerf #{LavinMQ::VERSION}
     #{Crystal::DESCRIPTION.lines.reject(&.empty?).join("\n")}

--- a/src/lavinmqperf/perf.cr
+++ b/src/lavinmqperf/perf.cr
@@ -8,7 +8,7 @@ module LavinMQPerf
 
     def initialize
       @parser = OptionParser.new
-      @banner = "Usage: #{PROGRAM_NAME} [throughput | bind-churn | queue-churn | connection-churn | connection-count] [arguments]"
+      @banner = "Usage: #{PROGRAM_NAME} [throughput | bind-churn | queue-churn | connection-churn | connection-count | queue-count] [arguments]"
       @parser.banner = @banner
       @parser.on("-h", "--help", "Show this help") { puts @parser; exit 0 }
       @parser.on("-v", "--version", "Show version") { puts LavinMQ::VERSION; exit 0 }

--- a/src/lavinmqperf/queue_count.cr
+++ b/src/lavinmqperf/queue_count.cr
@@ -34,15 +34,5 @@ module LavinMQPerf
     private def client : AMQP::Client
       @client ||= AMQP::Client.new(@uri)
     end
-
-    private def rss
-      File.read("/proc/self/statm").split[1].to_i64 * 4096
-    rescue File::NotFoundError
-      if ps_rss = `ps -o rss= -p $PPID`.to_i64?
-        ps_rss * 1024
-      else
-        0
-      end
-    end
   end
 end

--- a/src/lavinmqperf/queue_count.cr
+++ b/src/lavinmqperf/queue_count.cr
@@ -13,11 +13,11 @@ module LavinMQPerf
     end
 
     def run
-     super
-     count = 0
-     c = client.connect
-     ch = c.channel
-     loop do
+      super
+      count = 0
+      c = client.connect
+      ch = c.channel
+      loop do
         @queues.times.each_slice(100) do |slice|
           slice.each do
             ch.queue("lavinmqperf-queue-#{Random::DEFAULT.hex(8)}", durable: false, auto_delete: true, exclusive: true)

--- a/src/lavinmqperf/queue_count.cr
+++ b/src/lavinmqperf/queue_count.cr
@@ -13,14 +13,14 @@ module LavinMQPerf
     end
 
     def run
-     super 
+     super
      count = 0
      c = client.connect
      ch = c.channel
-     loop do   
+     loop do
         @queues.times.each_slice(100) do |slice|
-          slice.each do |i| 
-            queue = ch.queue("lavinmqperf-queue-#{Random::DEFAULT.hex(8)}", durable: false, auto_delete: true, exclusive: true)
+          slice.each do
+            ch.queue("lavinmqperf-queue-#{Random::DEFAULT.hex(8)}", durable: false, auto_delete: true, exclusive: true)
           end
         end
         puts
@@ -32,7 +32,7 @@ module LavinMQPerf
     end
 
     private def client : AMQP::Client
-      client = @client ||= AMQP::Client.new(@uri)
+      @client ||= AMQP::Client.new(@uri)
     end
 
     private def rss

--- a/src/lavinmqperf/queue_count.cr
+++ b/src/lavinmqperf/queue_count.cr
@@ -1,0 +1,48 @@
+require "amqp-client"
+require "./perf"
+
+module LavinMQPerf
+  class QueueCount < Perf
+    @queues = 100
+
+    def initialize
+      super
+      @parser.on("-q queues", "--queues=number", "Number of queues (default 100)") do |v|
+        @queues = v.to_i
+      end
+    end
+
+    def run
+     super 
+     count = 0
+     c = client.connect
+     ch = c.channel
+     loop do   
+        @queues.times.each_slice(100) do |slice|
+          slice.each do |i| 
+            queue = ch.queue("lavinmqperf-queue-#{Random::DEFAULT.hex(8)}", durable: false, auto_delete: true, exclusive: true)
+          end
+        end
+        puts
+        print "#{count += @queues} queues "
+        puts "Using #{rss.humanize_bytes} memory."
+        puts "Press enter to do add #{@queues} queues or ctrl-c to abort"
+        gets
+      end
+    end
+
+    private def client : AMQP::Client
+      client = @client ||= AMQP::Client.new(@uri)
+    end
+
+    private def rss
+      File.read("/proc/self/statm").split[1].to_i64 * 4096
+    rescue File::NotFoundError
+      if ps_rss = `ps -o rss= -p $PPID`.to_i64?
+        ps_rss * 1024
+      else
+        0
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?
Adding a queue-count test scenario to lavinmqperf (similar to the connection-count) that will create x number of queues, using 1 connection and 1 channel. How many queues it will create can be set with -q flag. 

It's really simple now, but we can extend with more arguments if we find it useful. 

### HOW can this pull request be tested?
run `lavinmqperf queue-count`
