### PR TITLE
Add http authenticator

### DIFF
--- a/spec/auth_spec.cr
+++ b/spec/auth_spec.cr
@@ -32,7 +32,7 @@ describe LavinMQ::Auth::Chain do
       file.print <<-CONFIG
         [main]
         auth_backends = http,basic
-        auth_http_user_path = localhost:8081/auth/user
+        rabbit_backend_url = localhost:8081
         [mgmt]
         [amqp]
       CONFIG
@@ -45,6 +45,57 @@ describe LavinMQ::Auth::Chain do
       chain = LavinMQ::Auth::Chain.create(config, s.@users)
       chain.@backends.should be_a Array(LavinMQ::Auth::Authenticator)
       chain.@backends.size.should eq 2
+    end
+  end
+end
+
+describe AuthBackend do
+  it "respond allow with guest credential" do
+    ab = AuthBackend.new
+    spawn(name: "test auth backend") { ab.listen }
+    payload = {
+      "username" => "guest",
+      "password" => "http_secret",
+    }.to_json
+
+    response = ::HTTP::Client.post("localhost:8081/auth/user",
+      headers: ::HTTP::Headers{"Content-Type" => "application/json"},
+      body: payload)
+    response.body.should eq "allow"
+    ab.close
+  end
+end
+
+describe LavinMQ::Auth::RabbitBackendAuthenticator do
+  it "Successfully authenticates guest user and return a basic user" do
+    config_file = File.tempfile do |file|
+      file.print <<-CONFIG
+        [main]
+        auth_backends = http,basic
+        rabbit_backend_url = localhost:8081
+        [mgmt]
+        [amqp]
+      CONFIG
+    end
+
+    config = LavinMQ::Config.new
+    config.config_file = config_file.path
+    config.parse
+    with_amqp_server do |s|
+      with_http_auth_backend do |_|
+        chain = LavinMQ::Auth::Chain.create(config, s.@users)
+        user = chain.authenticate("guest", "http_secret")
+        user.should_not be_nil
+      end
+    end
+  end
+end
+
+describe LavinMQ::Auth::RabbitBackendClient do
+  it "Successfully authenticate with guest credential" do
+    with_http_auth_backend do |_|
+      client = LavinMQ::Auth::RabbitBackendClient.new("localhost:8081")
+      client.authenticate?("guest", "http_secret").should be_true
     end
   end
 end

--- a/spec/auth_spec.cr
+++ b/spec/auth_spec.cr
@@ -26,4 +26,25 @@ describe LavinMQ::Auth::Chain do
       user.should be_nil
     end
   end
+
+  it "Creates a authentication chain with basic and rabbit" do
+    config_file = File.tempfile do |file|
+      file.print <<-CONFIG
+        [main]
+        auth_backends = http,basic
+        auth_http_user_path = localhost:8888
+        [mgmt]
+        [amqp]
+      CONFIG
+    end
+
+    config = LavinMQ::Config.new
+    config.config_file = config_file.path
+    config.parse
+    with_amqp_server do |s|
+      chain = LavinMQ::Auth::Chain.create(config, s.@users)
+      chain.@backends.should be_a Array(LavinMQ::Auth::Authenticator)
+      chain.@backends.size.should eq 2
+    end
+  end
 end

--- a/spec/auth_spec.cr
+++ b/spec/auth_spec.cr
@@ -32,7 +32,7 @@ describe LavinMQ::Auth::Chain do
       file.print <<-CONFIG
         [main]
         auth_backends = http,basic
-        auth_http_user_path = localhost:8888
+        auth_http_user_path = localhost:8081/auth/user
         [mgmt]
         [amqp]
       CONFIG

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -147,15 +147,14 @@ end
 class AuthBackend
   getter? running : Bool
 
-  # Structure pour représenter une requête d'authentification
   struct AuthRequest
     include JSON::Serializable
     property username : String
     property password : String
   end
 
-  # Simule une base de données d'utilisateurs
   USERS = {
+    "guest" => "http_secret",
     "admin" => "secret",
     "user1" => "password123",
   }

--- a/src/lavinmq/auth/authenticators/rabbit_http_auth.cr
+++ b/src/lavinmq/auth/authenticators/rabbit_http_auth.cr
@@ -1,0 +1,29 @@
+require "../authenticator"
+require "../../server"
+
+module LavinMQ
+  module Auth
+    class RabbitHttpAuthenticator < Authenticator
+      def initialize(@users : UserStore)
+      end
+
+      def authenticate(username : String, password : Bytes) : User?
+        user = @users[username]
+        return user if user && rabbit_http_authenticate?(username, password)
+      rescue ex : Exception
+        Log.error { "Rabbit Http authentication failed: #{ex.message}" }
+      end
+
+      private def rabbit_http_authenticate?(username : String, password : Bytes) : Bool
+        payload = {
+          "username" => username,
+          "password" => password.to_s,
+        }.to_json
+
+        ::HTTP::Client.post(Config.instance.auth_http_user_path,
+          headers: ::HTTP::Headers{"Content-Type" => "application/json"},
+          body: payload).success?
+      end
+    end
+  end
+end

--- a/src/lavinmq/auth/authenticators/rabbit_http_auth.cr
+++ b/src/lavinmq/auth/authenticators/rabbit_http_auth.cr
@@ -3,26 +3,38 @@ require "../../server"
 
 module LavinMQ
   module Auth
-    class RabbitHttpAuthenticator < Authenticator
+    class RabbitBackendAuthenticator < Authenticator
       def initialize(@users : UserStore)
       end
 
       def authenticate(username : String, password : Bytes) : User?
         user = @users[username]
-        return user if user && rabbit_http_authenticate?(username, password)
+        return user if user && rabbit_backend_authenticate?(username, String.new(slice: password))
       rescue ex : Exception
         Log.error { "Rabbit Http authentication failed: #{ex.message}" }
       end
 
-      private def rabbit_http_authenticate?(username : String, password : Bytes) : Bool
-        payload = {
-          "username" => username,
-          "password" => password.to_s,
-        }.to_json
+      def rabbit_backend_authenticate?(username : String, password : String) : Bool
+        client = RabbitBackendClient.new()
+        client.authenticate?(username, password)
+      end
+    end
 
-        ::HTTP::Client.post(Config.instance.auth_http_user_path,
+    class RabbitBackendClient
+      def initialize(@endpoint : String = Config.instance.rabbit_backend_url)
+      end
+
+      def authenticate?(username : String, password : String) : Bool
+        ::HTTP::Client.post("#{@endpoint}#{Config.instance.rabbit_backend_user_path}",
           headers: ::HTTP::Headers{"Content-Type" => "application/json"},
-          body: payload).success?
+          body: payload(username, password)).success?
+      end
+
+      def payload(username : String, password : String)
+        {
+          "username" => username,
+          "password" => password,
+        }.to_json
       end
     end
   end

--- a/src/lavinmq/auth/chain.cr
+++ b/src/lavinmq/auth/chain.cr
@@ -22,7 +22,7 @@ module LavinMQ
             when "basic"
               authenticators << BasicAuthenticator.new(users)
             when "http"
-              authenticators << RabbitHttpAuthenticator.new(users)
+              authenticators << RabbitBackendAuthenticator.new(users)
             else
               raise "Unsupported authentication backend: #{backend}"
             end

--- a/src/lavinmq/auth/chain.cr
+++ b/src/lavinmq/auth/chain.cr
@@ -1,5 +1,6 @@
 require "./authenticator"
 require "./authenticators/basic"
+require "./authenticators/rabbit_http_auth"
 
 module LavinMQ
   module Auth
@@ -20,6 +21,8 @@ module LavinMQ
             case backend
             when "basic"
               authenticators << BasicAuthenticator.new(users)
+            when "http"
+              authenticators << RabbitHttpAuthenticator.new(users)
             else
               raise "Unsupported authentication backend: #{backend}"
             end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -69,6 +69,7 @@ module LavinMQ
     property yield_each_received_bytes = 131_072    # max number of bytes to read from a client connection without letting other tasks in the server do any work
     property yield_each_delivered_bytes = 1_048_576 # max number of bytes sent to a client without tending to other tasks in the server
     property auth_backends : Array(String) = ["basic"]
+    property auth_http_user_path : String = "localhost:8080/users"
     @@instance : Config = self.new
 
     def self.instance : LavinMQ::Config
@@ -251,6 +252,8 @@ module LavinMQ
         when "max_deleted_definitions"   then @max_deleted_definitions = v.to_i
         when "consumer_timeout"          then @consumer_timeout = v.to_u64
         when "default_consumer_prefetch" then @default_consumer_prefetch = v.to_u16
+        when "auth_backends"             then @auth_backends = v.split(',')
+        when "auth_http_user_path"       then @auth_http_user_path = v
         else
           STDERR.puts "WARNING: Unrecognized configuration 'main/#{config}'"
         end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -69,7 +69,8 @@ module LavinMQ
     property yield_each_received_bytes = 131_072    # max number of bytes to read from a client connection without letting other tasks in the server do any work
     property yield_each_delivered_bytes = 1_048_576 # max number of bytes sent to a client without tending to other tasks in the server
     property auth_backends : Array(String) = ["basic"]
-    property auth_http_user_path : String = "localhost:8080/users"
+    property rabbit_backend_url : String = "localhost:8081"
+    property rabbit_backend_user_path : String = "/auth/user"
     @@instance : Config = self.new
 
     def self.instance : LavinMQ::Config
@@ -253,7 +254,8 @@ module LavinMQ
         when "consumer_timeout"          then @consumer_timeout = v.to_u64
         when "default_consumer_prefetch" then @default_consumer_prefetch = v.to_u16
         when "auth_backends"             then @auth_backends = v.split(',')
-        when "auth_http_user_path"       then @auth_http_user_path = v
+        when "rabbit_backend_url"        then @rabbit_backend_url = v
+        when "rabbit_backend_user_path"  then @rabbit_backend_user_path = v
         else
           STDERR.puts "WARNING: Unrecognized configuration 'main/#{config}'"
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR adds the ability to configure a "rabbit auth backend" in addition to the basic one.

To work, the user must exist in the AMQP server UserStore.

This PR also adds a client for the "Rabbit Auth Backend" because it provides other services than authentication. It also manages authorization on elements such as vhosts.

This PR does not fully cover issue 246 but meets the need of feature 952

### HOW can this pull request be tested?
For testing, `crystal spec` is enough.
The PR adds, in the `spec_helper`, a stubbed `Rabbit Auth Backend`