### PR TITLE
automatically rerun failed jobs in debian workflow

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -108,3 +108,13 @@ jobs:
               https://packagecloud.io/api/v1/repos/${{ github.repository }}-head/packages.json
           done
         if: github.event_name != 'pull_request'
+  rerun_on_failure:
+    needs: build_deb
+    if: failure() && github.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rerun workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run rerun.yml -f run_id=${{ github.run_id }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,19 @@
+# .github/workflows/rerun.yml
+
+name: Rerun Failed Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
### WHAT is this pull request doing?
We've been dealing with random workflow failures on ubuntu-24.04 for linux/arm64, which usually get fixed when we manually rerun them. To cut down on these hiccups and the need for manual restarts, this pull request adds an automatic retry feature for any jobs that fail.

### HOW can this pull request be tested?
observe deb workflow
