### PR TITLE
Auto rerun failed deb workflows

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -28,6 +28,7 @@ on:
       - views/**
       - openapi/**
       - debian/**
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -117,6 +117,10 @@ jobs:
     if: failure() && github.run_attempt < 3
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Trigger rerun workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -48,6 +48,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: try to fail
+        run: |
+          invalid_command_to_fail_step
+
       - name: Generate version string
         run: |
           git_describe=$(git describe --tags)

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -28,7 +28,7 @@ on:
       - views/**
       - openapi/**
       - debian/**
-  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -48,6 +48,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: try to fail
+        run: |
+          invalid_command_to_fail_step
+          echo github.run_id
 
       - name: Generate version string
         run: |

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -121,4 +121,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run rerun.yml -f run_id=${{ github.run_id }}
+          gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -117,8 +117,8 @@ jobs:
     if: failure() && github.run_attempt < 3
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger rerun workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run rerun.yml -f run_id=${{ github.run_id }}
+      # - name: Trigger rerun workflow
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh workflow run rerun.yml -f run_id=${{ github.run_id }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -121,4 +121,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
+          gh workflow run rerun.yml -r ${{ github.head_ref || github.ref_name }} -F run_id=${{ github.run_id }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -117,8 +117,8 @@ jobs:
     if: failure() && github.run_attempt < 3
     runs-on: ubuntu-latest
     steps:
-      # - name: Trigger rerun workflow
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     gh workflow run rerun.yml -f run_id=${{ github.run_id }}
+      - name: Trigger rerun workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run rerun.yml -f run_id=${{ github.run_id }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: try to fail
+        run: |
+          invalid_command_to_fail_step
+          echo github.run_id
+
       - name: Generate version string
         run: |
           git_describe=$(git describe --tags)

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -49,10 +49,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: try to fail
-        run: |
-          invalid_command_to_fail_step
-
       - name: Generate version string
         run: |
           git_describe=$(git describe --tags)

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -127,4 +127,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run rerun.yml -F run_id=${{ github.run_id }}
+          gh workflow run rerun.yml -r ${{ github.head_ref || github.ref_name }} -F run_id=${{ github.run_id }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -108,3 +108,13 @@ jobs:
               https://packagecloud.io/api/v1/repos/${{ github.repository }}-head/packages.json
           done
         if: github.event_name != 'pull_request'
+  rerun_on_failure:
+    needs: build_deb
+    if: failure() && github.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rerun workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run rerun.yml -f run_id=${{ github.run_id }}

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: try to fail
-        run: |
-          invalid_command_to_fail_step
-          echo github.run_id
-
       - name: Generate version string
         run: |
           git_describe=$(git describe --tags)

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -28,7 +28,6 @@ on:
       - views/**
       - openapi/**
       - debian/**
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: try to fail
-        run: |
-          invalid_command_to_fail_step
-          echo github.run_id
-
       - name: Generate version string
         run: |
           git_describe=$(git describe --tags)
@@ -127,4 +122,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run rerun.yml -r ${{ github.head_ref || github.ref_name }} -F run_id=${{ github.run_id }}
+          gh workflow run rerun.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -16,6 +16,6 @@ jobs:
           fetch-depth: 0  # Ensure full clone
 
       - name: Rerun workflow
-        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
+        run: gh workflow run deb.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -15,12 +15,7 @@ jobs:
         with:
           fetch-depth: 0  # Ensure full clone
 
-      - name: Debug repository
-        run: |
-          echo "Current Directory: $(pwd)"
-          ls -la
-          if [ -d .git ]; then
-            echo "Git repository found."
-          else
-            echo "ERROR: Git repository NOT found!"
-          fi
+      - name: Rerun workflow
+        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -24,8 +24,3 @@ jobs:
           else
             echo "ERROR: Git repository NOT found!"
           fi
-
-      # - name: Rerun workflow
-      #   run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,5 +1,3 @@
-# .github/workflows/rerun.yml
-
 name: Rerun Failed Workflow
 
 on:
@@ -12,8 +10,11 @@ jobs:
   rerun:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Rerun failed jobs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh run rerun ${{ inputs.run_id }} --failed
+          gh run rerun ${{ github.event.inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -21,5 +21,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rerun workflow
-        run: gh run rerun ${{ inputs.run_id }} --failed
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,19 @@
+# .github/workflows/rerun.yml
+
+name: Rerun Failed Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -21,5 +21,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rerun workflow
-        run: gh workflow run deb.yml -f run_id=${{ github.event.inputs.run_id }} --repo ${{ github.repository }}
+        run: gh run rerun ${{ inputs.run_id }} --failed
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -13,9 +13,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          fetch-depth: 0  # Ensure full clone
+
+      - name: Debug repository
+        run: |
+          echo "Current Directory: $(pwd)"
+          ls -la
+          if [ -d .git ]; then
+            echo "Git repository found."
+          else
+            echo "ERROR: Git repository NOT found!"
+          fi
 
       - name: Rerun workflow
-        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }}
+        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -16,6 +16,6 @@ jobs:
           fetch-depth: 0  # Ensure full clone
 
       - name: Rerun workflow
-        run: gh workflow run deb.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
+        run: gh run rerun ${{ github.event.inputs.run_id }} --failed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -7,14 +7,16 @@ on:
         required: true
 
 jobs:
-  rerun:
+  rerun_on_failure:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Rerun failed jobs
+      - name: Navigate to repository
+        run: cd ${{ github.workspace }}
+
+      - name: Rerun workflow
+        run: gh workflow run rerun.yml -f run_id=${{ github.event.workflow_run.id }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh run rerun ${{ github.event.inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -10,10 +10,10 @@ jobs:
   rerun_on_failure:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Ensure full clone
+      # - name: Checkout repository
+      #   uses: actions/checkout@v4
+      #   with:
+      #     fetch-depth: 0  # Ensure full clone
 
       - name: Rerun workflow
         run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -15,11 +15,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Rerun workflow
         run: |
           gh run watch ${{ inputs.run_id }} > /dev/null 2>&1

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,11 +1,9 @@
 name: Rerun Failed Workflow
-
 on:
   workflow_dispatch:
     inputs:
       run_id:
         required: true
-
 jobs:
   rerun_on_failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -16,5 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rerun workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -11,12 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Navigate to repository
-        run: cd ${{ github.workspace }}
+        uses: actions/checkout@v4
 
       - name: Rerun workflow
-        run: gh workflow run rerun.yml -f run_id=${{ github.event.workflow_run.id }}
+        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -13,9 +13,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Ensure full clone
+          fetch-depth: 0
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rerun workflow
-        run: gh run rerun ${{ github.event.inputs.run_id }} --failed
+        run: gh workflow run rerun.yml -f run_id=${{ github.event.inputs.run_id }} --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Rerun workflow
         run: gh workflow run rerun.yml -f run_id=${{ github.run_id }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -25,7 +25,7 @@ jobs:
             echo "ERROR: Git repository NOT found!"
           fi
 
-      - name: Rerun workflow
-        run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Rerun workflow
+      #   run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -21,6 +21,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rerun workflow
-        run: gh workflow run rerun.yml -f run_id=${{ github.event.inputs.run_id }} --repo ${{ github.repository }} --ref auto-rerun-failed-deb-workflows
-        env:
+        run: gh workflow run deb.yml -f run_id=${{ github.event.inputs.run_id }} --repo ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -4,6 +4,7 @@ on:
     inputs:
       run_id:
         required: true
+# TODO: Remove when crystal releases fix for bug affecting our debian workflow
 jobs:
   rerun_on_failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -17,5 +17,4 @@ jobs:
 
       - name: Rerun workflow
         run: |
-          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
           gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -10,10 +10,10 @@ jobs:
   rerun_on_failure:
     runs-on: ubuntu-latest
     steps:
-      # - name: Checkout repository
-      #   uses: actions/checkout@v4
-      #   with:
-      #     fetch-depth: 0  # Ensure full clone
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure full clone
 
       - name: Rerun workflow
         run: gh workflow run rerun.yml -f run_id=${{ github.run_id }} --repo ${{ github.repository }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -21,6 +21,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rerun workflow
-        run: gh workflow run rerun.yml -f run_id=${{ github.event.inputs.run_id }} --repo ${{ github.repository }}
+        run: gh workflow run rerun.yml -f run_id=${{ github.event.inputs.run_id }} --repo ${{ github.repository }} --ref auto-rerun-failed-deb-workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### WHAT is this pull request doing?
We've been dealing with random workflow failures on ubuntu-24.04 for linux/arm64, which usually get fixed when we manually rerun them. To cut down on these hiccups and the need for manual restarts, this pull request adds an automatic retry feature for any jobs that fail.

It only retries 2 times before it gives up.

