### PR TITLE
Bugfix: Mismatching hash for same file content in follower full sync

### DIFF
--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -1,0 +1,44 @@
+require "../spec_helper"
+require "./spec_helper"
+require "../../src/lavinmq/clustering/server"
+
+describe LavinMQ::Clustering::Server do
+  add_etcd_around_each
+
+  describe "#files_with_hash" do
+    describe "for MFile" do
+      it "should use mfile buffer when calculating hash" do
+        server = LavinMQ::Clustering::Server.new(
+          LavinMQ::Config.instance,
+          LavinMQ::Etcd.new("localhost:12379"),
+          0)
+        file = MFile.new(File.tempname, 1024)
+        file.print "foo"
+        server.register_file(file)
+        server.files_with_hash do |_path, hash|
+          hash.should eq Digest::SHA1.new.update("foo").final
+        end
+      ensure
+        file.try &.delete
+      end
+    end
+
+    describe "for File" do
+      it "should open and read file calculating hash" do
+        server = LavinMQ::Clustering::Server.new(
+          LavinMQ::Config.instance,
+          LavinMQ::Etcd.new("localhost:12379"),
+          0)
+        file = File.open(File.tempname, "w")
+        file.print "foo"
+        file.close
+        server.register_file(file)
+        server.files_with_hash do |_path, hash|
+          hash.should eq Digest::SHA1.new.update("foo").final
+        end
+      ensure
+        file.try &.delete
+      end
+    end
+  end
+end

--- a/spec/clustering/spec_helper.cr
+++ b/spec/clustering/spec_helper.cr
@@ -1,0 +1,36 @@
+macro add_etcd_around_each
+  around_each do |spec|
+    p = Process.new("etcd", {
+      "--data-dir=/tmp/clustering-spec.etcd",
+      "--logger=zap",
+      "--log-level=error",
+      "--unsafe-no-fsync=true",
+      "--force-new-cluster=true",
+      "--listen-peer-urls=http://127.0.0.1:12380",
+      "--listen-client-urls=http://127.0.0.1:12379",
+      "--advertise-client-urls=http://127.0.0.1:12379",
+    }, output: STDOUT, error: STDERR)
+
+    client = HTTP::Client.new("127.0.0.1", 12379)
+    i = 0
+    loop do
+      sleep 0.02.seconds
+      response = client.get("/version")
+      if response.status.ok?
+        next if response.body.includes? "not_decided"
+        break
+      end
+    rescue e : Socket::ConnectError
+      i += 1
+      raise "Cant connect to etcd on port 12379. Giving up after 100 tries. (#{e.message})" if i >= 100
+      next
+    end
+    client.close
+    begin
+      spec.run
+    ensure
+      p.terminate(graceful: false) rescue nil
+      FileUtils.rm_rf "/tmp/clustering-spec.etcd"
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?
Follower sometimes synced the same file in both full syncs even though nothing had happened between the two syncs. 

After some digging it turned out that the leader always used `Digest#file` when calculating the hash. This method will open the file and read the entire file to update the hash. However, it doesn't take into account that the file may be sparse which means that all zeros in the end of the file are included in the hash. On the follower the file isn't sparse so the hash calculation will be another value causing the file to always be synced, even though they are the same.

This PR will change the leader hash calculation to use the `MFile`'s buffer when possible, mitigation the problem.

### HOW can this pull request be tested?
Added a couple of specs that i guess verifies this
