### PR TITLE
upload pre-releases to specific pre-release repo on package-cloud

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -71,6 +71,15 @@ jobs:
           name: deb-packages-${{ matrix.os }}
           path: builds
 
+      - name: Determine if pre-release
+        id: determine-prerelease
+        run: |
+          if [[ "${{ github.ref }}" == *"-rc"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_ENV
+          else
+            echo "is_prerelease=false" >> $GITHUB_ENV
+          fi
+
       - name: Upload to Packagecloud
         run: |
           set -eux
@@ -88,7 +97,7 @@ jobs:
               -F "package[package_file]=@${PKG_FILE}" \
               https://packagecloud.io/api/v1/repos/${{ github.repository }}/packages.json
           done
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && env.is_prerelease == 'false'
 
       - name: Upload to Packagecloud head repo
         run: |
@@ -108,6 +117,26 @@ jobs:
               https://packagecloud.io/api/v1/repos/${{ github.repository }}-head/packages.json
           done
         if: github.event_name != 'pull_request'
+
+      - name: Upload to Packagecloud pre-release repo
+        run: |
+          set -eux
+          ID=$(cut -d- -f1 <<< ${{ matrix.os }})
+          VERSION_ID=$(cut -d- -f2 <<< ${{ matrix.os }})
+          if [ "$ID" = "debian" ]
+          then VERSION_ID=${VERSION_ID}.0
+          fi
+          curl -fsSO -u "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json
+          DIST_ID=$(jq ".deb[] | select(.index_name == \"${ID}\").versions[] | select(.version_number == \"${VERSION_ID}\").id" distributions.json)
+          for f in $(find builds -name "*.ddeb"); do mv -- "$f" "${f%.ddeb}.deb"; done
+          for PKG_FILE in $(find builds -name "*.deb")
+          do curl -u "${{ secrets.packagecloud_token }}:" -XPOST --no-progress-meter \
+              -F "package[distro_version_id]=${DIST_ID}" \
+              -F "package[package_file]=@${PKG_FILE}" \
+              https://packagecloud.io/api/v1/repos/${{ github.repository }}-prerelease/packages.json
+          done
+        if: startsWith(github.ref, 'refs/tags/v') && env.is_prerelease == 'true'
+
   rerun_on_failure:
     needs: build_deb
     if: failure() && github.run_attempt < 3

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -69,6 +69,15 @@ jobs:
           name: rpm-packages-${{ matrix.os }}
           path: RPMS
 
+      - name: Determine if pre-release
+        id: determine-prerelease
+        run: |
+          if [[ "${{ github.ref }}" == *"-rc"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_ENV
+          else
+            echo "is_prerelease=false" >> $GITHUB_ENV
+          fi
+
       - name: Upload to Packagecloud
         run: |
           set -eux
@@ -82,7 +91,7 @@ jobs:
                   -F "package[package_file]=@${PKG_FILE}" \
                   https://packagecloud.io/api/v1/repos/${{ github.repository }}/packages.json
           done
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && env.is_prerelease == 'false'
 
       - name: Upload to Packagecloud head repo
         run: |
@@ -98,3 +107,18 @@ jobs:
                   https://packagecloud.io/api/v1/repos/${{ github.repository }}-head/packages.json
           done
         if: github.event_name != 'pull_request'
+
+      - name: Upload to Packagecloud pre-release repo
+        run: |
+          set -eux
+          curl -fsSO -u "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json
+          ID=$(cut -d- -f1 <<< ${{ matrix.os }})
+          VERSION_ID=$(cut -d- -f2 <<< ${{ matrix.os }})
+          DIST_ID=$(jq ".rpm[] | select(.index_name == \"${ID}\").versions[] | select(.index_name == \"${VERSION_ID}\").id" distributions.json)
+          for PKG_FILE in $(find RPMS -name "*.rpm" | sort -u -t/ -k3)
+          do curl -fsS -u "${{ secrets.packagecloud_token }}:" -XPOST \
+                  -F "package[distro_version_id]=${DIST_ID}" \
+                  -F "package[package_file]=@${PKG_FILE}" \
+                  https://packagecloud.io/api/v1/repos/${{ github.repository }}-prerelease/packages.json
+          done
+        if: startsWith(github.ref, 'refs/tags/v') && env.is_prerelease == 'true'


### PR DESCRIPTION
### WHAT is this pull request doing?
Don't upload release candidate versions to main lavinmq repository on package-cloud, instead create a pre-release repository and upload rc versions to that. 

discussion: should rc versions be published to the lavinmq head repo on package-cloud? 


### HOW can this pull request be tested?
run workflow