### PR TITLE
Handle missing files in follower sync

### DIFF
--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -117,7 +117,6 @@ module LavinMQ
         loop do
           filename_len = socket.read_bytes Int32, IO::ByteFormat::LittleEndian
           break if filename_len.zero?
-
           filename = socket.read_string(filename_len)
           send_requested_file(filename)
           @lz4.flush


### PR DESCRIPTION
### WHAT is this pull request doing?
Haven't been able to reproduce it, but we've seen errors where the leader gets a `FileNotFound` when it hashes files (an ack file was missing) causing the sync to fail and the follower to disconnect.

This PR will add check existence of files before trying to read them.

### HOW can this pull request be tested?
Make sure an ack file exists when the leader is started, then remove it. Start follower and observe no hash being sent for the removed file.
