### PR TITLE
remove job that publishes deb and rpm package to lavinmq-head

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -99,25 +99,6 @@ jobs:
           done
         if: startsWith(github.ref, 'refs/tags/v') && env.is_prerelease == 'false'
 
-      - name: Upload to Packagecloud head repo
-        run: |
-          set -eux
-          ID=$(cut -d- -f1 <<< ${{ matrix.os }})
-          VERSION_ID=$(cut -d- -f2 <<< ${{ matrix.os }})
-          if [ "$ID" = "debian" ]
-          then VERSION_ID=${VERSION_ID}.0
-          fi
-          curl -fsSO -u "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json
-          DIST_ID=$(jq ".deb[] | select(.index_name == \"${ID}\").versions[] | select(.version_number == \"${VERSION_ID}\").id" distributions.json)
-          for f in $(find builds -name "*.ddeb"); do mv -- "$f" "${f%.ddeb}.deb"; done
-          for PKG_FILE in $(find builds -name "*.deb")
-          do curl -u "${{ secrets.packagecloud_token }}:" -XPOST --no-progress-meter \
-              -F "package[distro_version_id]=${DIST_ID}" \
-              -F "package[package_file]=@${PKG_FILE}" \
-              https://packagecloud.io/api/v1/repos/${{ github.repository }}-head/packages.json
-          done
-        if: github.event_name != 'pull_request'
-
       - name: Upload to Packagecloud pre-release repo
         run: |
           set -eux

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -93,21 +93,6 @@ jobs:
           done
         if: startsWith(github.ref, 'refs/tags/v') && env.is_prerelease == 'false'
 
-      - name: Upload to Packagecloud head repo
-        run: |
-          set -eux
-          curl -fsSO -u "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json
-          ID=$(cut -d- -f1 <<< ${{ matrix.os }})
-          VERSION_ID=$(cut -d- -f2 <<< ${{ matrix.os }})
-          DIST_ID=$(jq ".rpm[] | select(.index_name == \"${ID}\").versions[] | select(.index_name == \"${VERSION_ID}\").id" distributions.json)
-          for PKG_FILE in $(find RPMS -name "*.rpm" | sort -u -t/ -k3)
-          do curl -fsS -u "${{ secrets.packagecloud_token }}:" -XPOST \
-                  -F "package[distro_version_id]=${DIST_ID}" \
-                  -F "package[package_file]=@${PKG_FILE}" \
-                  https://packagecloud.io/api/v1/repos/${{ github.repository }}-head/packages.json
-          done
-        if: github.event_name != 'pull_request'
-
       - name: Upload to Packagecloud pre-release repo
         run: |
           set -eux


### PR DESCRIPTION
### WHAT is this pull request doing?
This removes the job that publishes RPM and Debian packages to the lavinmq-head repository

### HOW can this pull request be tested?
observe the workflow