### PR TITLE
Dont set x-delivery-count header on first delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- x-delivery-count is no longer included in the first delivery of a message, and the count is equal to number of delivery attempts before current delivery [#977](https://github.com/cloudamqp/lavinmq/pull/977)
+
 ## [2.2.0-rc.1] - 2025-01-16
 
 ### Added

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -963,10 +963,10 @@ describe LavinMQ::Server do
         q = ch.queue("delivery_limit", args: args)
         q.publish "m1"
         msg = q.get(no_ack: false).not_nil!
-        msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
+        msg.properties.headers.not_nil!.has_key?("x-delivery-count").should be_false # x-delivery-count is not set on first delivery
         msg.reject(requeue: true)
         msg = q.get(no_ack: false).not_nil!
-        msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 2
+        msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
         msg.reject(requeue: true)
         Fiber.yield
         q.get(no_ack: false).should be_nil

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -775,7 +775,8 @@ module LavinMQ::AMQP
           expire_msg(env, :delivery_limit)
           return nil
         end
-        headers["x-delivery-count"] = @deliveries[sp] = delivery_count + 1
+        headers["x-delivery-count"] = delivery_count if delivery_count > 0 # x-delivery-count not included in first delivery
+        @deliveries[sp] = delivery_count + 1
         env.message.properties.headers = headers
       end
       env


### PR DESCRIPTION
### WHAT is this pull request doing?
Dont set `x-delivery-count` header on first delivery and change `x-delivery-count` to count redeliveries.

Fixes #975 

### HOW can this pull request be tested?
Run spec
