### PR TITLE
Add Deleted vhost Message Counters and Prometheus Metrics

### DIFF
--- a/spec/global_counters_spec.cr
+++ b/spec/global_counters_spec.cr
@@ -1,0 +1,21 @@
+require "./spec_helper"
+require "../src/lavinmq/amqp"
+
+describe LavinMQ::DeletedVhostCounters do
+  it "tracks global counters correctly after vhost deletion" do
+    with_amqp_server do |server|
+      server.vhosts.create("test")
+
+      with_channel(server, vhost: "test") do |ch|
+        q = ch.queue("test_queue", durable: false)
+        q.publish("msg")
+
+        delivery = q.get(no_ack: false)
+        delivery.ack if delivery
+      end
+
+      server.update_deleted_vhost_counters(server.vhosts["test"])
+      server.deleted_vhost_messages_acknowledged_total.should eq 1
+    end
+  end
+end

--- a/src/lavinmq/deleted_vhost_counters.cr
+++ b/src/lavinmq/deleted_vhost_counters.cr
@@ -1,0 +1,15 @@
+module LavinMQ
+  module DeletedVhostCounters
+    property deleted_vhost_messages_delivered_total = 0
+    property deleted_vhost_messages_redelivered_total = 0
+    property deleted_vhost_messages_acknowledged_total = 0
+    property deleted_vhost_messages_confirmed_total = 0
+
+    def update_deleted_vhost_counters(vhost)
+      @deleted_vhost_messages_delivered_total += vhost.message_details[:message_stats][:deliver]
+      @deleted_vhost_messages_redelivered_total += vhost.message_details[:message_stats][:redeliver]
+      @deleted_vhost_messages_confirmed_total += vhost.message_details[:message_stats][:confirm]
+      @deleted_vhost_messages_acknowledged_total += vhost.message_details[:message_stats][:ack]
+    end
+  end
+end

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -53,7 +53,9 @@ module LavinMQ
         delete "/api/vhosts/:name" do |context, params|
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params, "name") do |vhost|
-            @amqp_server.vhosts.delete(vhost)
+            @amqp_server.vhosts.delete(vhost) do |v|
+              @amqp_server.update_deleted_vhost_counters(v)
+            end
             context.response.status_code = 204
           end
         end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -19,6 +19,7 @@ require "./amqp/connection_factory"
 require "./mqtt/connection_factory"
 require "./stats"
 require "./auth/chain"
+require "./deleted_vhost_counters"
 
 module LavinMQ
   class Server
@@ -30,6 +31,7 @@ module LavinMQ
     getter vhosts, users, data_dir, parameters
     getter? closed, flow
     include ParameterTarget
+    include DeletedVhostCounters
 
     @start = Time.monotonic
     @closed = false

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -42,8 +42,9 @@ module LavinMQ
       vhost
     end
 
-    def delete(name) : Nil
+    def delete(name, &) : Nil
       if vhost = @vhosts.delete name
+        yield vhost
         @users.rm_vhost_permissions_for_all(name)
         vhost.delete
         notify_observers(Event::Deleted, name)


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds the module GlobalCounters, keeping track of global stats that should persist when deleting a vhost. 

Fixes #916 
 

### HOW can this pull request be tested?
deliver some messages to a client and observe the metrics are still present when deleting the vhost. 
