### PR TITLE
Show MQTT client keepalive in mgmt ui

### DIFF
--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -140,6 +140,7 @@ module LavinMQ
           protocol:          "MQTT 3.1.1",
           client_id:         @client_id,
           name:              @name,
+          timeout:           @keepalive,
           connected_at:      @connected_at,
           state:             state,
           ssl:               @connection_info.ssl?,


### PR DESCRIPTION
### WHAT is this pull request doing?
This will export MQTT client's keepalive as timeout, which will then displayed in mgmt ui as `heartbeat`

### HOW can this pull request be tested?
Manual
