### PR TITLE
let -b also set the mqtt_port

### DIFF
--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -106,6 +106,9 @@ module LavinMQ
         p.on("--mqtts-port=PORT", "MQTTS port to listen on (default: 8883)") do |v|
           @mqtts_port = v.to_i
         end
+        p.on("--mqtt-bind=BIND", "IP address that the MQTT server will listen on (default: 127.0.0.1)") do |v|
+          @mqtt_bind = v
+        end
         p.on("--http-port=PORT", "HTTP port to listen on (default: 15672)") do |v|
           @http_port = v.to_i
         end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -89,6 +89,7 @@ module LavinMQ
         p.on("-b BIND", "--bind=BIND", "IP address that both the AMQP and HTTP servers will listen on (default: 127.0.0.1)") do |v|
           @amqp_bind = v
           @http_bind = v
+          @mqtt_bind = v
         end
         p.on("-p PORT", "--amqp-port=PORT", "AMQP port to listen on (default: 5672)") do |v|
           @amqp_port = v.to_i


### PR DESCRIPTION
### WHAT is this pull request doing?
let @mqtt_port be set by the -b port flag. Also introduces the --mqtt_bind flag.

Adresses #991 

### HOW can this pull request be tested?

Start lavinmq while setting the -b flag, or --mqtt_bind