### PR TITLE
Drop msg on requeue if above delivery_limit

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -959,7 +959,7 @@ describe LavinMQ::Server do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         args = AMQP::Client::Arguments.new
-        args["x-delivery-limit"] = 2
+        args["x-delivery-limit"] = 1
         q = ch.queue("delivery_limit", args: args)
         q.publish "m1"
         msg = q.get(no_ack: false).not_nil!

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -969,7 +969,6 @@ describe LavinMQ::Server do
         msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
         msg.reject(requeue: true)
         Fiber.yield
-        q.get(no_ack: false).should be_nil
         s.vhosts["/"].queues["delivery_limit"].empty?.should be_true
       end
     end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -789,7 +789,7 @@ module LavinMQ::AMQP
     end
 
     private def with_delivery_count_header(env) : Envelope?
-      if limit = @delivery_limit
+      if @delivery_limit
         sp = env.segment_position
         headers = env.message.properties.headers || AMQP::Table.new
         delivery_count = @deliveries.fetch(sp, 0)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -816,6 +816,11 @@ module LavinMQ::AMQP
         if has_expired?(sp, requeue: true) # guarantee to not deliver expired messages
           expire_msg(sp, :expired)
         else
+          if delivery_limit = @delivery_limit
+            if @deliveries.fetch(sp, 0) >= delivery_limit
+              return expire_msg(sp, :delivery_limit)
+            end
+          end
           @msg_store_lock.synchronize do
             @msg_store.requeue(sp)
           end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -228,6 +228,7 @@ module LavinMQ::AMQP
         when "delivery-limit"
           unless @delivery_limit.try &.< v.as_i64
             @delivery_limit = v.as_i64
+            drop_redelivered
           end
         when "federation-upstream"
           @vhost.upstreams.try &.link(v.as_s, self)
@@ -478,6 +479,27 @@ module LavinMQ::AMQP
             env = @msg_store.shift? || break
             @log.debug { "Overflow drop head sp=#{env.segment_position}" }
             expire_msg(env, :maxlenbytes)
+            counter &+= 1
+            if counter >= 16 * 1024
+              Fiber.yield
+              counter = 0
+            end
+          end
+        end
+      end
+    end
+
+    private def drop_redelivered : Nil
+      counter = 0
+      if limit = @delivery_limit
+        @msg_store_lock.synchronize do
+          loop do
+            env = @msg_store.first? || break
+            delivery_count = @deliveries.fetch(env.segment_position, 0) || break
+            break unless delivery_count > limit
+            env = @msg_store.shift? || break
+            @log.debug { "Over delivery limit, drop sp=#{env.segment_position}" }
+            expire_msg(env, :delivery_limit)
             counter &+= 1
             if counter >= 16 * 1024
               Fiber.yield
@@ -771,11 +793,6 @@ module LavinMQ::AMQP
         sp = env.segment_position
         headers = env.message.properties.headers || AMQP::Table.new
         delivery_count = @deliveries.fetch(sp, 0)
-        # @log.debug { "Delivery count: #{delivery_count} Delivery limit: #{@delivery_limit}" }
-        if delivery_count >= limit
-          expire_msg(env, :delivery_limit)
-          return nil
-        end
         headers["x-delivery-count"] = delivery_count if delivery_count > 0 # x-delivery-count not included in first delivery
         @deliveries[sp] = delivery_count + 1
         env.message.properties.headers = headers
@@ -817,7 +834,7 @@ module LavinMQ::AMQP
           expire_msg(sp, :expired)
         else
           if delivery_limit = @delivery_limit
-            if @deliveries.fetch(sp, 0) >= delivery_limit
+            if @deliveries.fetch(sp, 0) > delivery_limit
               return expire_msg(sp, :delivery_limit)
             end
           end


### PR DESCRIPTION
### WHAT is this pull request doing?
Drops messages directly on requeue if they have been redelivered more than `x-delivery-limit` times, instead of waiting for the next time we try to deliver them. Also drops messages when a new policy is applied and removes the check on delivery-count on delivery. 

Fixes #976 

### HOW can this pull request be tested?
Run specs
