### PR TITLE
dont publish to dockerhub for PR's or for release candidate versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,8 +12,6 @@ on:
       - views/**
       - openapi/**
   push:
-    branches:
-      - main
     tags:
       - 'v*'
     paths:
@@ -30,6 +28,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   main:
+    if: "!contains(github.ref, '-rc')" # Skip the job if the tag includes '-rc'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,8 +43,7 @@ jobs:
         with:
           images: cloudamqp/lavinmq
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=latest
             type=ref,event=pr
 
       - name: Set up Depot CLI

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           images: cloudamqp/lavinmq
           tags: |
-            type=raw,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}},value=latest
             type=ref,event=pr
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
       - openapi/**
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+$'
     paths:
       - .github/workflows/docker.yml
       - Makefile
@@ -28,7 +28,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   main:
-    if: "!contains(github.ref, '-rc')" # Skip the job if the tag includes '-rc'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,6 +42,7 @@ jobs:
         with:
           images: cloudamqp/lavinmq
           tags: |
+            type=raw,enable={{is_default_branch}}
             type=semver,pattern={{version}},value=latest
             type=ref,event=pr
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Removes pushing to the main branch as a trigger for this workflow, now it will only be for tags 
Also specifies that only versions that follow "v1.2.3", and not e.g. "v.1.2.3-rc.1" will be tagged as latest

Fixes #985 
