### PR TITLE
Apply delivery-limit from policy if value is smaller than existing args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Multiple nodes could generate and set clustering secret, causing the leader to use another secret than the followers. [#998](https://github.com/cloudamqp/lavinmq/pull/998)
+- A policy with delivery-limit is now properly applied to a queue if the value is lower than the existing argument. [#1000](https://github.com/cloudamqp/lavinmq/pull/1000)
 
 ## [2.2.0] - 2025-03-13
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -226,7 +226,9 @@ module LavinMQ::AMQP
         when "dead-letter-routing-key"
           @dlrk ||= v.as_s
         when "delivery-limit"
-          @delivery_limit ||= v.as_i64
+          unless @delivery_limit.try &.< v.as_i64
+            @delivery_limit = v.as_i64
+          end
         when "federation-upstream"
           @vhost.upstreams.try &.link(v.as_s, self)
         when "federation-upstream-set"


### PR DESCRIPTION
### WHAT is this pull request doing?
Lets `delivery-limit` set in a policy overwrite existing `delivery-limit` from args if the value in the policy is smaller. Fixes #999 

### HOW can this pull request be tested?
Run specs