### PR TITLE
Add Prometheus metrics for `global_message_*` counters 

### DIFF
--- a/spec/api/vhosts_spec.cr
+++ b/spec/api/vhosts_spec.cr
@@ -37,7 +37,8 @@ describe LavinMQ::HTTP::VHostsController do
       end
     end
   end
-  describe "GET /api/vhosts/vhost" do
+
+  describe "GET /api/vhosts/:vhost" do
     it "should return vhost" do
       with_http_server do |http, _|
         response = http.get("/api/vhosts/%2f")
@@ -52,6 +53,7 @@ describe LavinMQ::HTTP::VHostsController do
       end
     end
   end
+
   describe "PUT /api/vhosts/vhost" do
     it "should create vhost" do
       with_http_server do |http, _|
@@ -93,12 +95,20 @@ describe LavinMQ::HTTP::VHostsController do
       end
     end
   end
-  describe "DELETE /api/vhosts/vhost" do
-    it "should delete vhost" do
+
+  describe "DELETE /api/vhosts/:vhost" do
+    it "should return 204 when deleting vhost" do
       with_http_server do |http, s|
         s.vhosts.create("test")
         response = http.delete("/api/vhosts/test")
         response.status_code.should eq 204
+      end
+    end
+
+    it "should return 404 when trying to delete non existing vhost" do
+      with_http_server do |http, _|
+        response = http.delete("/api/vhosts/nonexisting")
+        response.status_code.should eq 404
       end
     end
 
@@ -111,6 +121,7 @@ describe LavinMQ::HTTP::VHostsController do
       end
     end
   end
+
   describe "GET /api/vhosts/vhost/permissions" do
     it "should return permissions for vhosts" do
       with_http_server do |http, _|

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -90,6 +90,7 @@ module LavinMQ
             overview_queue_metrics(vhosts, writer)
             custom_metrics(writer)
             gc_metrics(writer)
+            global_metrics(writer)
           end
           context
         end
@@ -204,6 +205,25 @@ module LavinMQ
                       value: @amqp_server.mem_limit,
                       type:  "gauge",
                       help:  "Memory high watermark in bytes"})
+      end
+
+      private def global_metrics(writer)
+        writer.write({name:  "global_messages_delivered_total",
+                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:deliver] },
+                      type:  "counter",
+                      help:  ""})
+        writer.write({name:  "global_messages_redelivered_total",
+                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:redeliver] },
+                      type:  "counter",
+                      help:  "Total number of messages redelivered to consumers"})
+        writer.write({name:  "global_messages_acknowledged_total",
+                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:ack] },
+                      type:  "counter",
+                      help:  "Total number of messages acknowledged by consumers"})
+        writer.write({name:  "global_messages_confirmed_total",
+                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:confirm] },
+                      type:  "counter",
+                      help:  "Total number of messages confirmed to publishers"})
       end
 
       private def overview_queue_metrics(vhosts, writer)

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -209,21 +209,25 @@ module LavinMQ
 
       private def global_metrics(writer)
         writer.write({name:  "global_messages_delivered_total",
-                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:deliver] },
-                      type:  "counter",
-                      help:  ""})
+                      value: @amqp_server.deleted_vhosts_messages_delivered_total +
+                             @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:deliver] },
+                      type: "counter",
+                      help: "Total number of messaged delivered to consumers"})
         writer.write({name:  "global_messages_redelivered_total",
-                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:redeliver] },
-                      type:  "counter",
-                      help:  "Total number of messages redelivered to consumers"})
+                      value: @amqp_server.deleted_vhosts_messages_redelivered_total +
+                             @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:redeliver] },
+                      type: "counter",
+                      help: "Total number of messages redelivered to consumers"})
         writer.write({name:  "global_messages_acknowledged_total",
-                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:ack] },
-                      type:  "counter",
-                      help:  "Total number of messages acknowledged by consumers"})
+                      value: @amqp_server.deleted_vhosts_messages_acknowledged_total +
+                             @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:ack] },
+                      type: "counter",
+                      help: "Total number of messages acknowledged by consumers"})
         writer.write({name:  "global_messages_confirmed_total",
-                      value: @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:confirm] },
-                      type:  "counter",
-                      help:  "Total number of messages confirmed to publishers"})
+                      value: @amqp_server.deleted_vhosts_messages_confirmed_total +
+                             @amqp_server.vhosts.sum { |_, v| v.message_details[:message_stats][:confirm] },
+                      type: "counter",
+                      help: "Total number of messages confirmed to publishers"})
       end
 
       private def overview_queue_metrics(vhosts, writer)

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -53,7 +53,8 @@ module LavinMQ
         delete "/api/vhosts/:name" do |context, params|
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params, "name") do |vhost|
-            @amqp_server.vhosts.each_value(&.reset_stats) # Reset all vhosts to maintain accurate metrics after deletion
+            # Reset all vhosts to maintain accurate Prometheus counters
+            @amqp_server.vhosts.each_value(&.reset_stats)
             @amqp_server.vhosts.delete(vhost)
             context.response.status_code = 204
           end

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -53,7 +53,7 @@ module LavinMQ
         delete "/api/vhosts/:name" do |context, params|
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params, "name") do |vhost|
-            @amqp_server.vhosts.each_value(&.reset_stats)
+            @amqp_server.vhosts.each_value(&.reset_stats) # Reset all vhosts to maintain accurate metrics after deletion
             @amqp_server.vhosts.delete(vhost)
             context.response.status_code = 204
           end

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -53,6 +53,7 @@ module LavinMQ
         delete "/api/vhosts/:name" do |context, params|
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params, "name") do |vhost|
+            @amqp_server.vhosts.each_value(&.reset_stats)
             @amqp_server.vhosts.delete(vhost)
             context.response.status_code = 204
           end

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -52,15 +52,18 @@ module LavinMQ
 
         delete "/api/vhosts/:name" do |context, params|
           refuse_unless_administrator(context, user(context))
-          with_vhost(context, params, "name") do |vhost|
-            message_stats = vhost.message_details[:message_stats]
-            # Add stats to global stats for accurate prometheus metrics counters
-            @amqp_server.deleted_vhosts_messages_delivered_total += message_stats[:deliver]
-            @amqp_server.deleted_vhosts_messages_redelivered_total += message_stats[:redeliver]
-            @amqp_server.deleted_vhosts_messages_acknowledged_total += message_stats[:ack]
-            @amqp_server.deleted_vhosts_messages_confirmed_total += message_stats[:confirm]
-            @amqp_server.vhosts.delete(vhost)
-            context.response.status_code = 204
+          with_vhost(context, params, "name") do |vhost_name|
+            if vhost = @amqp_server.vhosts.delete(vhost_name)
+              message_stats = vhost.message_details[:message_stats]
+              # Add stats to global stats for accurate prometheus metrics counters
+              @amqp_server.deleted_vhosts_messages_delivered_total += message_stats[:deliver]
+              @amqp_server.deleted_vhosts_messages_redelivered_total += message_stats[:redeliver]
+              @amqp_server.deleted_vhosts_messages_acknowledged_total += message_stats[:ack]
+              @amqp_server.deleted_vhosts_messages_confirmed_total += message_stats[:confirm]
+              context.response.status_code = 204
+            else
+              context.response.status_code = 404
+            end
           end
         end
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -456,6 +456,12 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
     getter gc_stats = GC.prof_stats
 
+    # Message stats for deleted vhosts, required to keep accurate global counters
+    property deleted_vhosts_messages_delivered_total = 0_u64
+    property deleted_vhosts_messages_redelivered_total = 0_u64
+    property deleted_vhosts_messages_acknowledged_total = 0_u64
+    property deleted_vhosts_messages_confirmed_total = 0_u64
+
     private def control_flow!
       if disk_full?
         if flow?

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -39,14 +39,6 @@ module LavinMQ
         }
       end
 
-      def reset_stats
-        {% for name in stats_keys %}
-          @{{name.id}}_count = 0_u64
-          @{{name.id}}_count_prev = 0_u64
-          @{{name.id}}_rate = 0_f64
-        {% end %}
-      end
-
       def update_rates : Nil
         interval = Config.instance.stats_interval // 1000
         log_size = Config.instance.stats_log_size

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -39,6 +39,14 @@ module LavinMQ
         }
       end
 
+      def reset_stats
+        {% for name in stats_keys %}
+          @{{name.id}}_count = 0_u64
+          @{{name.id}}_count_prev = 0_u64
+          @{{name.id}}_rate = 0_f64
+        {% end %}
+      end
+
       def update_rates : Nil
         interval = Config.instance.stats_interval // 1000
         log_size = Config.instance.stats_log_size

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -42,13 +42,14 @@ module LavinMQ
       vhost
     end
 
-    def delete(name) : Nil
+    def delete(name) : VHost?
       if vhost = @vhosts.delete name
         @users.rm_vhost_permissions_for_all(name)
         vhost.delete
         notify_observers(Event::Deleted, name)
         Log.info { "Deleted vhost #{name}" }
         save!
+        vhost
       end
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Introduce reset_stats into the rate_stats macro, so we can reset all counters when a vhost gets deleted. 
This ensures consistency for our variables and allows us to add global variables. 

adresses #916 

### HOW can this pull request be tested?
create multiple vhosts, and publish so stats go up, then delete one of the vhosts and see that all stats are zeroed
