### PR TITLE
add separators to parser for nicer output

### DIFF
--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -52,6 +52,7 @@ class LavinMQCtl
       @options["host"] = host
     end
     global_options
+    @parser.separator ("\nCommands:")
     COMPAT_CMDS.each do |cmd|
       @parser.on(cmd[0], cmd[1]) do
         @cmd = cmd[0]
@@ -217,6 +218,7 @@ class LavinMQCtl
   end
 
   private def global_options
+    @parser.separator ("\nGlobal options:")
     @parser.on("-p vhost", "--vhost=vhost", "Specify vhost") do |v|
       @options["vhost"] = v
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds separators to parser for a nicer output. 

Before: 
```
Usage: lavinmqctl [arguments] entity
    -p vhost, --vhost=vhost          Specify vhost
    -H host, --host=host             Specify host
    -n node, --node=node             Specify node
    -q, --quiet                      suppress informational messages
    -s, --silent                     suppress informational messages and table formatting
    -f format, --format=format       Format output (text, json)
    add_user                         Creates a new user
    change_password                  Change the user password
    delete_user                      Delete a user
    list_users                       List user names and tags
    set_user_tags                    Sets user tags
    list_vhosts                      Lists virtual hosts
    add_vhost                        Creates a virtual host
    delete_vhost                     Deletes a virtual host
    clear_policy                     Clears (removes) a policy
    list_policies                    Lists all policies in a virtual host
    list_connections                 Lists AMQP 0.9.1 connections for the node
    list_queues                      Lists queues and their properties
    purge_queue                      Purges a queue (removes all messages in it)
    pause_queue                      Pause all consumers on a queue
    resume_queue                     Resume all consumers on a queue
    delete_queue                     Delete queue
    export_definitions               Exports definitions in JSON
    import_definitions               Import definitions in JSON
    close_all_connections            Instructs the broker to close all connections for the specified vhost or entire node
    close_connection                 Instructs the broker to close a connection by pid
    stop_app                         Stop the AMQP broker
    start_app                        Starts the AMQP broker
    list_exchanges                   Lists exchanges
    delete_exchange                  Delete exchange
    set_vhost_limits                 Set VHost limits (max-connections, max-queues)
    set_permissions                  Set permissions for a user
    hash_password                    Hash a password
    set_policy                       Sets or updates a policy
    create_queue                     Create queue
    create_exchange                  Create exchange
    status                           Display server status
    cluster_status                   Display cluster status
    definitions                      Generate definitions json from a data directory
    -v, --version                    Show version
    --build-info                     Show build information
    -h, --help                       Show this help
```

After: 
```
Usage: lavinmqctl [arguments] entity

Global options:
    -p vhost, --vhost=vhost          Specify vhost
    -H host, --host=host             Specify host
    -n node, --node=node             Specify node
    -q, --quiet                      suppress informational messages
    -s, --silent                     suppress informational messages and table formatting
    -f format, --format=format       Format output (text, json)

Commands:
    add_user                         Creates a new user
    change_password                  Change the user password
    delete_user                      Delete a user
    list_users                       List user names and tags
    set_user_tags                    Sets user tags
    list_vhosts                      Lists virtual hosts
    add_vhost                        Creates a virtual host
    delete_vhost                     Deletes a virtual host
    clear_policy                     Clears (removes) a policy
    list_policies                    Lists all policies in a virtual host
    list_connections                 Lists AMQP 0.9.1 connections for the node
    list_queues                      Lists queues and their properties
    purge_queue                      Purges a queue (removes all messages in it)
    pause_queue                      Pause all consumers on a queue
    resume_queue                     Resume all consumers on a queue
    delete_queue                     Delete queue
    export_definitions               Exports definitions in JSON
    import_definitions               Import definitions in JSON
    close_all_connections            Instructs the broker to close all connections for the specified vhost or entire node
    close_connection                 Instructs the broker to close a connection by pid
    stop_app                         Stop the AMQP broker
    start_app                        Starts the AMQP broker
    list_exchanges                   Lists exchanges
    delete_exchange                  Delete exchange
    set_vhost_limits                 Set VHost limits (max-connections, max-queues)
    set_permissions                  Set permissions for a user
    hash_password                    Hash a password
    set_policy                       Sets or updates a policy
    create_queue                     Create queue
    create_exchange                  Create exchange
    status                           Display server status
    cluster_status                   Display cluster status
    definitions                      Generate definitions json from a data directory
    -v, --version                    Show version
    --build-info                     Show build information
    -h, --help                       Show this help
```

### HOW can this pull request be tested?
Run `lavinmqctl -h` to see output
