### PR TITLE
Dont re-raise InvalidDefinitions when encountering invalid frames during startup

### DIFF
--- a/src/lavinmq/error.cr
+++ b/src/lavinmq/error.cr
@@ -15,8 +15,5 @@ module LavinMQ
 
     class ExchangeTypeError < Error
     end
-
-    class InvalidDefinitions < Error
-    end
   end
 end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -554,7 +554,6 @@ module LavinMQ
       apply frame, loading: true
     rescue ex : LavinMQ::Error
       @log.error(exception: ex) { "Failed to apply frame #{frame.inspect}" }
-      raise Error::InvalidDefinitions.new("Invalid frame: in definitions file")
     end
 
     private def load_default_definitions


### PR DESCRIPTION
### WHAT is this pull request doing?
Removes the re-raise of `InvalidDefinitions` on errors when loading definitions on startup, so that LavinMQ can startup even if there are errors when loading definitions. Any queues/exchanges with invalid frames will not be created, and there will be logs detailing why. 

Fixes #1014 

### HOW can this pull request be tested?
 Create a queue with `x-message-deduplication = true` (and no `x-cache-size`) in v2.1.0, it will fail if upgraded to v2.2.0, but should work with this change. 