### PR TITLE
Dont run specs that LavinMQ doesn't support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,8 @@ jobs:
           sed -i /rabbitmq_http_api_client/d Gemfile
           bundle add rabbitmq_http_api_client --version=">= 3" --group=test --require=rabbitmq/http/client
           bundle install
+          sed -i '211,212d' spec/lower_level_api/integration/queue_declare_spec.rb
+          sed -i '112,146d' spec/lower_level_api/integration/queue_declare_spec.rb
           bundle exec rspec \
             --pattern "spec/*/integration/*_spec.rb, spec/issues/*_spec.rb" \
             --exclude-pattern "**/*/tls_*, **/*/connection_recovery_*, **/*/default_queue_type*"


### PR DESCRIPTION
### WHAT is this pull request doing?

There are specs in Bunny that LavinMQ doesn't support, this change will stop them from being run in CI

Specs removed: 
* Dont raise PreconditionFailed when changing `x-consumer-timeout`: LavinMQ will raise PreconditionFailed as stated by the AMQP protocol
* Dont raise PreconditionFailed when changing `x-alternate-exchange`: LavinMQ will raise PreconditionFailed as stated by the AMQP protocol
* Specs related to defaulting to classic queue type: LavinMQ doesn't have classic and quorum queues so no need for this


### HOW can this pull request be tested?

Check CI 