### PR TITLE
Cleaner CLI output with separators

### DIFF
--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -84,8 +84,35 @@ module LavinMQ
     def parse
       parser = OptionParser.new do |p|
         p.banner = "Usage: #{PROGRAM_NAME} [arguments]"
+        p.separator("\nOptions:")
         p.on("-c CONF", "--config=CONF", "Config file (INI format)") { |v| @config_file = v }
         p.on("-D DATADIR", "--data-dir=DATADIR", "Data directory") { |v| @data_dir = v }
+        p.on("-l", "--log-level=LEVEL", "Log level (Default: info)") do |v|
+          level = ::Log::Severity.parse?(v.to_s)
+          @log_level = level if level
+        end
+        p.on("-d", "--debug", "Verbose logging") { @log_level = ::Log::Severity::Debug }
+        p.on("--default-user-only-loopback=BOOL", "Limit default user to only connect from loopback address") do |v|
+          @default_user_only_loopback = {"true", "yes", "y", "1"}.includes? v.to_s
+        end
+        p.on("--guest-only-loopback=BOOL", "(Deprecated) Limit default user to only connect from loopback address") do |v|
+          # TODO: guest-only-loopback was deprecated in 2.2.x, remove in 3.0
+          STDERR.puts "WARNING: 'guest_only_loopback' is deprecated, use '--default-user-only-loopback' instead"
+          @default_user_only_loopback = {"true", "yes", "y", "1"}.includes? v.to_s
+        end
+        p.on("--default-consumer-prefetch=NUMBER", "Default consumer prefetch (default: 65535)") do |v|
+          @default_consumer_prefetch = v.to_u16
+        end
+        p.on("--default-user=USER", "Default user (default: guest)") do |v|
+          @default_user = v
+        end
+        p.on("--default-password=PASSWORD", "Hashed password for default user (default: '+pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+' (guest))") do |v|
+          @default_password = v
+        end
+        p.on("--no-data-dir-lock", "Don't put a file lock in the data directory (default: true)") { @data_dir_lock = false }
+        p.on("--raise-gc-warn", "Raise on GC warnings (default: false)") { @raise_gc_warn = true }
+
+        p.separator("\nBindings & TLS:")
         p.on("-b BIND", "--bind=BIND", "IP address that the AMQP, MQTT and HTTP servers will listen on (default: 127.0.0.1)") do |v|
           @amqp_bind = v
           @http_bind = v
@@ -131,24 +158,8 @@ module LavinMQ
         p.on("--key FILE", "Private key for the TLS certificate") { |v| @tls_key_path = v }
         p.on("--ciphers CIPHERS", "List of TLS ciphers to allow") { |v| @tls_ciphers = v }
         p.on("--tls-min-version=VERSION", "Mininum allowed TLS version (default 1.2)") { |v| @tls_min_version = v }
-        p.on("-l", "--log-level=LEVEL", "Log level (Default: info)") do |v|
-          level = ::Log::Severity.parse?(v.to_s)
-          @log_level = level if level
-        end
-        p.on("--raise-gc-warn", "Raise on GC warnings") { @raise_gc_warn = true }
-        p.on("--no-data-dir-lock", "Don't put a file lock in the data directory (default true)") { @data_dir_lock = false }
-        p.on("-d", "--debug", "Verbose logging") { @log_level = ::Log::Severity::Debug }
-        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-        p.on("-v", "--version", "Show version") { puts LavinMQ::VERSION; exit 0 }
-        p.on("--build-info", "Show build information") { puts LavinMQ::BUILD_INFO; exit 0 }
-        p.on("--default-user-only-loopback=BOOL", "Limit default user to only connect from loopback address") do |v|
-          @default_user_only_loopback = {"true", "yes", "y", "1"}.includes? v.to_s
-        end
-        p.on("--guest-only-loopback=BOOL", "(Deprecated) Limit default user to only connect from loopback address") do |v|
-          # TODO: guest-only-loopback was deprecated in 2.2.x, remove in 3.0
-          STDERR.puts "WARNING: 'guest_only_loopback' is deprecated, use '--default-user-only-loopback' instead"
-          @default_user_only_loopback = {"true", "yes", "y", "1"}.includes? v.to_s
-        end
+
+        p.separator("\nClustering:")
         p.on("--clustering", "Enable clustering") do
           @clustering = true
         end
@@ -170,15 +181,11 @@ module LavinMQ
         p.on("--clustering-etcd-endpoints=URIs", "Comma separeted host/port pairs (default: 127.0.0.1:2379)") do |v|
           @clustering_etcd_endpoints = v
         end
-        p.on("--default-consumer-prefetch=NUMBER", "Default consumer prefetch (default 65535)") do |v|
-          @default_consumer_prefetch = v.to_u16
-        end
-        p.on("--default-user=USER", "Default user (default: guest)") do |v|
-          @default_user = v
-        end
-        p.on("--default-password=PASSWORD", "Hashed password for default user (default: '+pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+' (guest))") do |v|
-          @default_password = v
-        end
+
+        p.separator("\nCommands:")
+        p.on("-v", "--version", "Show version") { puts LavinMQ::VERSION; exit 0 }
+        p.on("--build-info", "Show build information") { puts LavinMQ::BUILD_INFO; exit 0 }
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |arg| abort "Invalid argument: #{arg}" }
       end
       parser.parse(ARGV.dup) # only parse args to get config_file

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -182,7 +182,7 @@ module LavinMQ
           @clustering_etcd_endpoints = v
         end
 
-        p.separator("\nCommands:")
+        p.separator("\nMiscellaneous:")
         p.on("-v", "--version", "Show version") { puts LavinMQ::VERSION; exit 0 }
         p.on("--build-info", "Show build information") { puts LavinMQ::BUILD_INFO; exit 0 }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds some separators to CLI output for lavinmq to make it a little easier to read. Also re-orders some arguments to fit into categories of options: 
`Options` for general options
`Bindings & TLS` for binds, ports & tls
`Clustering` for clustering
`Commands` for commands: help, build-info, version

Old look: 
```
Usage: lavinmq [arguments]
    -c CONF, --config=CONF           Config file (INI format)
    -D DATADIR, --data-dir=DATADIR   Data directory
    -b BIND, --bind=BIND             IP address that the AMQP, MQTT and HTTP servers will listen on (default: 127.0.0.1)
    -p PORT, --amqp-port=PORT        AMQP port to listen on (default: 5672)
    --amqps-port=PORT                AMQPS port to listen on (default: -1)
    --amqp-bind=BIND                 IP address that the AMQP server will listen on (default: 127.0.0.1)
    --mqtt-port=PORT                 MQTT port to listen on (default: 1883)
    --mqtts-port=PORT                MQTTS port to listen on (default: 8883)
    --mqtt-bind=BIND                 IP address that the MQTT server will listen on (default: 127.0.0.1)
    --http-port=PORT                 HTTP port to listen on (default: 15672)
    --https-port=PORT                HTTPS port to listen on (default: -1)
    --http-bind=BIND                 IP address that the HTTP server will listen on (default: 127.0.0.1)
    --amqp-unix-path=PATH            AMQP UNIX path to listen to
    --http-unix-path=PATH            HTTP UNIX path to listen to
    --mqtt-unix-path=PATH            MQTT UNIX path to listen to
    --cert FILE                      TLS certificate (including chain)
    --key FILE                       Private key for the TLS certificate
    --ciphers CIPHERS                List of TLS ciphers to allow
    --tls-min-version=VERSION        Mininum allowed TLS version (default 1.2)
    -l, --log-level=LEVEL            Log level (Default: info)
    --raise-gc-warn                  Raise on GC warnings
    --no-data-dir-lock               Don't put a file lock in the data directory (default true)
    -d, --debug                      Verbose logging
    -h, --help                       Show this help
    -v, --version                    Show version
    --build-info                     Show build information
    --default-user-only-loopback=BOOL
                                     Limit default user to only connect from loopback address
    --guest-only-loopback=BOOL       (Deprecated) Limit default user to only connect from loopback address
    --clustering                     Enable clustering
    --clustering-advertised-uri=URI  Advertised URI for the clustering server
    --clustering-etcd-prefix=KEY     Key prefix used in etcd (default: lavinmq)
    --clustering-port=PORT           Listen for clustering followers on this port (default: 5679)
    --clustering-bind=BIND           Listen for clustering followers on this address (default: localhost)
    --clustering-max-unsynced-actions=ACTIONS
                                     Maximum unsynced actions
    --clustering-etcd-endpoints=URIs Comma separeted host/port pairs (default: 127.0.0.1:2379)
    --default-consumer-prefetch=NUMBER
                                     Default consumer prefetch (default 65535)
    --default-user=USER              Default user (default: guest)
    --default-password=PASSWORD      Hashed password for default user (default: '+pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+' (guest))
```

New look: 
```
Usage: lavinmq [arguments]

Options:
    -c CONF, --config=CONF           Config file (INI format)
    -D DATADIR, --data-dir=DATADIR   Data directory
    -l, --log-level=LEVEL            Log level (Default: info)
    -d, --debug                      Verbose logging
    --default-user-only-loopback=BOOL
                                     Limit default user to only connect from loopback address
    --guest-only-loopback=BOOL       (Deprecated) Limit default user to only connect from loopback address
    --default-consumer-prefetch=NUMBER
                                     Default consumer prefetch (default: 65535)
    --default-user=USER              Default user (default: guest)
    --default-password=PASSWORD      Hashed password for default user (default: '+pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+' (guest))
    --no-data-dir-lock               Don't put a file lock in the data directory (default: true)
    --raise-gc-warn                  Raise on GC warnings (default: false)

Bindings & TLS:
    -b BIND, --bind=BIND             IP address that the AMQP, MQTT and HTTP servers will listen on (default: 127.0.0.1)
    -p PORT, --amqp-port=PORT        AMQP port to listen on (default: 5672)
    --amqps-port=PORT                AMQPS port to listen on (default: -1)
    --amqp-bind=BIND                 IP address that the AMQP server will listen on (default: 127.0.0.1)
    --mqtt-port=PORT                 MQTT port to listen on (default: 1883)
    --mqtts-port=PORT                MQTTS port to listen on (default: 8883)
    --mqtt-bind=BIND                 IP address that the MQTT server will listen on (default: 127.0.0.1)
    --http-port=PORT                 HTTP port to listen on (default: 15672)
    --https-port=PORT                HTTPS port to listen on (default: -1)
    --http-bind=BIND                 IP address that the HTTP server will listen on (default: 127.0.0.1)
    --amqp-unix-path=PATH            AMQP UNIX path to listen to
    --http-unix-path=PATH            HTTP UNIX path to listen to
    --mqtt-unix-path=PATH            MQTT UNIX path to listen to
    --cert FILE                      TLS certificate (including chain)
    --key FILE                       Private key for the TLS certificate
    --ciphers CIPHERS                List of TLS ciphers to allow
    --tls-min-version=VERSION        Mininum allowed TLS version (default 1.2)

Clustering:
    --clustering                     Enable clustering
    --clustering-advertised-uri=URI  Advertised URI for the clustering server
    --clustering-etcd-prefix=KEY     Key prefix used in etcd (default: lavinmq)
    --clustering-port=PORT           Listen for clustering followers on this port (default: 5679)
    --clustering-bind=BIND           Listen for clustering followers on this address (default: localhost)
    --clustering-max-unsynced-actions=ACTIONS
                                     Maximum unsynced actions
    --clustering-etcd-endpoints=URIs Comma separeted host/port pairs (default: 127.0.0.1:2379)

Commands:
    -v, --version                    Show version
    --build-info                     Show build information
    -h, --help                       Show this help
```

### HOW can this pull request be tested?
run `lavinmq --help`, look at output
