### PR TITLE
Remove enforced cache limit on deduplication cache

### DIFF
--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -3,7 +3,17 @@ require "../src/lavinmq/deduplication.cr"
 
 describe LavinMQ::Deduplication do
   describe LavinMQ::Deduplication::MemoryCache do
-    it "should have a max size" do
+    it "should default to infinite cache size" do
+      cache = LavinMQ::Deduplication::MemoryCache(String).new
+      cache.insert("item1")
+      cache.insert("item2")
+      cache.insert("item3")
+      cache.contains?("item1").should be_true
+      cache.contains?("item2").should be_true
+      cache.contains?("item3").should be_true
+    end
+
+    it "should have max size as optional setting" do
       cache = LavinMQ::Deduplication::MemoryCache(String).new(2)
       cache.insert("item1")
       cache.insert("item2")

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -176,7 +176,6 @@ describe LavinMQ::Exchange do
         with_channel(s) do |ch|
           args = AMQP::Client::Arguments.new({
             "x-message-deduplication" => true,
-            "x-cache-size"            => 10,
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
@@ -205,7 +204,6 @@ describe LavinMQ::Exchange do
         with_channel(s) do |ch|
           args = AMQP::Client::Arguments.new({
             "x-message-deduplication" => true,
-            "x-cache-size"            => 10,
             "x-deduplication-header"  => "custom",
           })
           ch.exchange("test", "topic", args: args)

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -449,7 +449,6 @@ describe LavinMQ::AMQP::Queue do
           queue_name = "dedup-queue"
           q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new({
             "x-message-deduplication" => true,
-            "x-cache-size"            => 10,
           }))
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -74,7 +74,6 @@ module LavinMQ
         if @arguments["x-message-deduplication"]?.try(&.as?(Bool))
           ttl = parse_header("x-cache-ttl", Int).try(&.to_u32)
           size = parse_header("x-cache-size", Int).try(&.to_u32)
-          raise LavinMQ::Error::PreconditionFailed.new("Invalid x-cache-size for message deduplication") unless size
           header_key = parse_header("x-deduplication-header", String)
           cache = Deduplication::MemoryCache(AMQ::Protocol::Field).new(size)
           @deduper = Deduplication::Deduper.new(cache, ttl, header_key)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -275,7 +275,6 @@ module LavinMQ::AMQP
       validate_positive("x-consumer-timeout", @consumer_timeout)
       if parse_header("x-message-deduplication", Bool)
         size = parse_header("x-cache-size", Int).try(&.to_u32)
-        raise LavinMQ::Error::PreconditionFailed.new("Invalid x-cache-size for message deduplication") unless size
         ttl = parse_header("x-cache-ttl", Int).try(&.to_u32)
         header_key = parse_header("x-deduplication-header", String)
         cache = Deduplication::MemoryCache(AMQ::Protocol::Field).new(size)

--- a/src/lavinmq/deduplication.cr
+++ b/src/lavinmq/deduplication.cr
@@ -6,7 +6,7 @@ module LavinMQ
     end
 
     class MemoryCache(T) < Cache(T)
-      def initialize(@size : UInt32)
+      def initialize(@size : UInt32? = nil)
         @lock = Mutex.new
         @store = Hash(T, Time::Span?).new(initial_capacity: @size)
       end
@@ -24,7 +24,9 @@ module LavinMQ
 
       def insert(key : T, ttl : UInt32? = nil)
         @lock.synchronize do
-          @store.shift if @store.size >= @size
+          if size = @size
+            @store.shift if @store.size >= size
+          end
           val = ttl.try { |v| RoughTime.monotonic + v.milliseconds }
           @store[key] = val
         end


### PR DESCRIPTION
### WHAT is this pull request doing?

Remove the check for `x-cache-size` when enabline deduplication on queues or exchanges. 
If no limit, defaults to infinite size.

Fixes #1014 

### HOW can this pull request be tested?
 
specs