### PR TITLE
Adjust consumer prefetch UI

### DIFF
--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -32,20 +32,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             user = user(context)
             refuse_unless_management(context, user, vhost)
-            consumer_tag = URI.decode_www_form(params["consumer_tag"])
-            conn_id = URI.decode_www_form(params["connection"])
-            ch_id = URI.decode_www_form(params["channel"]).to_i
-            connection = connections(user).find { |conn| conn.vhost.name == vhost && conn.name == conn_id }
-            unless connection
-              context.response.status_code = 404
-              break
-            end
-            channel = connection.channels[ch_id]?
-            unless channel
-              context.response.status_code = 404
-              break
-            end
-            consumer = channel.consumers.find(&.tag.==(consumer_tag))
+            consumer = find_consumer_from_params(user, vhost, params)
             unless consumer
               context.response.status_code = 404
               break
@@ -55,6 +42,37 @@ module LavinMQ
           end
           context
         end
+
+        put "/api/consumers/:vhost/:connection/:channel/:consumer_tag" do |context, params|
+          with_vhost(context, params) do |vhost|
+            user = user(context)
+            refuse_unless_management(context, user, vhost)
+            consumer = find_consumer_from_params(user, vhost, params)
+            unless consumer
+              context.response.status_code = 404
+              break
+            end
+            body = parse_body(context)
+            if prefetch = body["prefetch"]?.try(&.as_i?)
+              prefetch = 0 if prefetch < 0
+              prefetch = UInt16::MAX if prefetch > UInt16::MAX
+              consumer.prefetch_count = prefetch.to_u16
+            end
+            context.response.status_code = 204
+          end
+          context
+        end
+      end
+
+      private def find_consumer_from_params(user, vhost, params)
+        consumer_tag = URI.decode_www_form(params["consumer_tag"])
+        conn_id = URI.decode_www_form(params["connection"])
+        ch_id = URI.decode_www_form(params["channel"]).to_i
+        connection = connections(user).find { |conn| conn.vhost.name == vhost && conn.name == conn_id }
+        return unless connection
+        channel = connection.channels[ch_id]?
+        return unless channel
+        channel.consumers.find(&.tag.==(consumer_tag))
       end
 
       private def all_consumers(user)


### PR DESCRIPTION
### WHAT is this pull request doing?

Example on how you could edit prefetch 

![image](https://github.com/user-attachments/assets/05c3a5e1-ee75-4095-8aac-bceb38b722da)

+/- adjust prefetch by 10 for each click. 

In this example the callback has a debounce function if the user clicks a lot of times, only one request is sent in the end. 

Related:  #974 

### HOW can this pull request be tested?

Manual 

Run this branch, connect a consumer and try it out. 