### PR TITLE
Multiple filter values on messages in stream queues. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Cleaner CLI output with separators [#1018](https://github.com/cloudamqp/lavinmq/pull/1018)
 - Default limit of 128 items in deduplication cache [#1019](https://github.com/cloudamqp/lavinmq/pull/1019)
+- Messages in stream queues now support multiple filter values [#1022](https://github.com/cloudamqp/lavinmq/pull/1022)
+- Filtering on stream queues now requires all filters on a consumer to match [#1022](https://github.com/cloudamqp/lavinmq/pull/1022)
 
 ## [2.2.0] - 2025-03-13
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,25 @@ lavinmq --data-dir /var/lib/lavinmq --clustering --clustering-bind :: --clusteri
 
 Stream queues are like append-only logs and can be consumed multiple times. Each consumer can start to read from anywhere in the queue (using the `x-stream-offset` consumer argument) over and over again.  Stream queues are different from normal queues in that messages are not deleted (see #retention) when a consumer acknowledge them.
 
+### Stream Queue Filtering
+
+Stream queues support message filtering, allowing consumers to receive only messages that match specific criteria. This is useful for consuming a subset of messages without creating multiple queues.
+
+#### How Filtering Works
+- A consumer with filter values will only receive messages that contain ALL the filter values it has specified.
+- A consumer with filter values will not receive messages without filter values unless they have set `x-stream-match-unfiltered` to true.
+- Consumers without any filter values will receive all messages.
+
+#### Publishing Filtered Messages
+When publishing messages that should be filtered, include the `x-stream-filter-value` header. `x-stream-filter-value` should be a string of comma-separated values.
+
+#### Consuming Filtered Messages
+
+To enable filtering on the consumer, set the following arguments when creating a consumer:
+
+- `x-stream-filter`: A comma-separated string of filter values the consumer is interested in
+- `x-stream-match-unfiltered`: A boolean (default: `false`) that determines whether to receive messages that don't have any filter values
+
 ## MQTT
 
 LavinMQ natively supports the MQTT 3.1.1 protocol, facilitating seamless integration with IoT devices, sensors, and mobile applications. Each MQTT session is backed by an AMQP queue, ensuring consistent and reliable message storage. Messages within these sessions are persistently stored on disk. 

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -133,7 +133,7 @@ module LavinMQ
         return true if @filter.empty?
         if msg_filters = filter_value_from_msg_headers(msg_headers)
           @filter.each do |consumer_filter|
-            return false unless msg_filters.bsearch { |f| f >= consumer_filter } == consumer_filter
+            return false unless msg_filters.find { |f| f == consumer_filter }
           end
           true
         else
@@ -142,7 +142,7 @@ module LavinMQ
       end
 
       private def filter_value_from_msg_headers(msg_headers) : Array(String)?
-        msg_headers.try &.fetch("x-stream-filter-value", nil).try &.to_s.split(',').sort!
+        msg_headers.try &.fetch("x-stream-filter-value", nil).try &.to_s.split(',')
       end
     end
   end

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -131,15 +131,18 @@ module LavinMQ
 
       def filter_match?(msg_headers) : Bool
         return true if @filter.empty?
-        if filter_value = filter_value_from_msg_headers(msg_headers)
-          @filter.bsearch { |f| f >= filter_value } == filter_value
+        if msg_filters = filter_value_from_msg_headers(msg_headers)
+          @filter.each do |consumer_filter|
+            return false unless msg_filters.bsearch { |f| f >= consumer_filter } == consumer_filter
+          end
+          true
         else
           @match_unfiltered
         end
       end
 
-      private def filter_value_from_msg_headers(msg_headers) : String?
-        msg_headers.try &.fetch("x-stream-filter-value", nil).try &.to_s
+      private def filter_value_from_msg_headers(msg_headers) : Array(String)?
+        msg_headers.try &.fetch("x-stream-filter-value", nil).try &.to_s.split(',').sort!
       end
     end
   end

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -9,7 +9,7 @@ module LavinMQ
       property segment : UInt32
       property pos : UInt32
       getter requeued = Deque(SegmentPosition).new
-      @filter = Array(String).new
+      @consumer_filters = Array(String).new
       @match_unfiltered = false
       @track_offset = false
 
@@ -66,7 +66,7 @@ module LavinMQ
       private def validate_stream_filter(arg)
         case arg
         when String
-          @filter = arg.split(',').sort!
+          @consumer_filters = arg.split(',')
         when Nil
           # noop
         else raise LavinMQ::Error::PreconditionFailed.new("x-stream-filter-value must be a string")
@@ -130,19 +130,20 @@ module LavinMQ
       end
 
       def filter_match?(msg_headers) : Bool
-        return true if @filter.empty?
-        if msg_filters = filter_value_from_msg_headers(msg_headers)
-          @filter.each do |consumer_filter|
-            return false unless msg_filters.find { |f| f == consumer_filter }
+        return true if @consumer_filters.empty?
+        if msg_filter_values = filter_value_from_msg_headers(msg_headers)
+          matched_filters = 0
+          msg_filter_values.split(',') do |msg_filter_value|
+            matched_filters &+= 1 if @consumer_filters.includes?(msg_filter_value)
           end
-          true
+          matched_filters == @consumer_filters.size
         else
           @match_unfiltered
         end
       end
 
-      private def filter_value_from_msg_headers(msg_headers) : Array(String)?
-        msg_headers.try &.fetch("x-stream-filter-value", nil).try &.to_s.split(',')
+      private def filter_value_from_msg_headers(msg_headers) : String?
+        msg_headers.try &.fetch("x-stream-filter-value", nil).try &.to_s
       end
     end
   end


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds support for multiple filter values on messages in streams. 

This also changes the behavior when supplying multiple filter values on a consumer to matching all provided filter values with AND. 

### HOW can this pull request be tested?
Run specs. 

