### PR TITLE
Fix cluster ID and advertised URI collision handling

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -139,7 +139,7 @@ describe LavinMQ::Clustering::Client do
     config2.http_port = 15672
     controller2 = LavinMQ::Clustering::Controller.new(config2)
 
-    listen = Channel(String).new
+    listen = Channel(String?).new
     spawn(name: "etcd elect leader spec") do
       etcd = LavinMQ::Etcd.new("localhost:12379")
       etcd.elect_listen("lavinmq/leader") do |value|
@@ -192,7 +192,7 @@ describe LavinMQ::Clustering::Client do
     election_done.receive?
 
     # The spec gets a lease to use in an election campaign
-    lease_id, _ttl = etcd.lease_grant(5)
+    lease = etcd.lease_grant(5)
 
     # graceful stop...
     spawn { launcher.stop }
@@ -200,7 +200,7 @@ describe LavinMQ::Clustering::Client do
     # Let the spec campaign for leadership...
     elected = Channel(Nil).new
     spawn do
-      etcd.election_campaign("lavinmq/leader", "spec", lease_id)
+      etcd.election_campaign("lavinmq/leader", "spec", lease.id)
       elected.close
     end
 

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -90,6 +90,10 @@ module LavinMQ
         end
       end
 
+      def follows?(_nil : Nil) : Bool
+        false
+      end
+
       def follows?(uri : String) : Bool
         follows? URI.parse(uri)
       end

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -24,21 +24,26 @@ class LavinMQ::Clustering::Controller
   # to start are met, i.e when the current node has been elected leader.
   # The method is blocking.
   def run(&)
+    lease = @lease = @etcd.lease_grant(id: @id)
     spawn(follow_leader, name: "Follower monitor")
     wait_to_be_insync
-    @lease = lease = @etcd.elect("#{@config.clustering_etcd_prefix}/leader", @advertised_uri) # blocks until becoming leader
+    @etcd.election_campaign("#{@config.clustering_etcd_prefix}/leader", @advertised_uri, lease: @id) # blocks until becoming leader
+    @is_leader = true
     @repli_client.try &.close
     # TODO: make sure we still are in the ISR set
     yield
     loop do
-      if lease.wait(30.seconds)
-        break if @stopped
-        Log.fatal { "Lost cluster leadership" }
-        exit 3
-      else
-        GC.collect
-      end
+      lease.wait(30.seconds)
+      GC.collect
     end
+  rescue Etcd::Lease::Lost
+    unless @stopped
+      Log.fatal { "Lost cluster leadership" }
+      exit 3
+    end
+  rescue Etcd::LeaseAlreadyExists
+    Log.fatal { "Cluster ID #{@id.to_s(36)} used by another node" }
+    exit 3
   end
 
   @stopped = false
@@ -58,21 +63,33 @@ class LavinMQ::Clustering::Controller
       id = rand(Int32::MAX)
       Dir.mkdir_p @config.data_dir
       File.write(id_file_path, id.to_s(36))
+      Log.info { "Generated new clustering ID" }
     end
-    Log.info { "ID: #{id.to_s(36)}" }
     id
   end
 
   # Replicate from the leader
   # Listens for leader change events
   private def follow_leader
-    repli_client = nil
     @etcd.elect_listen("#{@config.clustering_etcd_prefix}/leader") do |uri|
-      next if repli_client.try &.follows?(uri) # if lost connection to etcd we continue follow the leader as is
-      repli_client.try &.close
+      if repli_client = @repli_client # is currently following a leader
+        if repli_client.follows? uri
+          next # if lost connection to etcd we continue follow the leader as is
+        else
+          repli_client.close
+        end
+      end
+      if uri.nil? # no leader yet
+        Log.warn { "No leader available" }
+        next
+      end
       if uri == @advertised_uri # if this instance has become leader
-        Log.debug { "Is leader, don't replicate from self" }
-        return
+        if @is_leader
+          Log.debug { "Is leader, don't replicate from self" }
+          return
+        else
+          raise Error.new("Another node in the cluster is advertising the same URI")
+        end
       end
       Log.info { "Leader: #{uri}" }
       key = "#{@config.clustering_etcd_prefix}/clustering_secret"
@@ -84,10 +101,13 @@ class LavinMQ::Clustering::Controller
           break
         end
       end
-      @repli_client = repli_client = r = Clustering::Client.new(@config, @id, secret)
+      @repli_client = r = Clustering::Client.new(@config, @id, secret)
       spawn r.follow(uri), name: "Clustering client #{uri}"
       SystemD.notify_ready
     end
+  rescue ex : Error
+    Log.fatal { ex.message }
+    exit 36 # 36 for CF (Cluster Follower)
   rescue ex
     Log.fatal(exception: ex) { "Unhandled exception while following leader" }
     exit 36 # 36 for CF (Cluster Follower)
@@ -105,4 +125,6 @@ class LavinMQ::Clustering::Controller
       end
     end
   end
+
+  class Error < Exception; end
 end

--- a/src/lavinmq/etcd/lease.cr
+++ b/src/lavinmq/etcd/lease.cr
@@ -1,41 +1,43 @@
 module LavinMQ
   class Etcd
-    # Represents holding a Leadership
+    # Represents holding a Lease
     # Can be revoked or wait until lost
-    class Leadership
-      def initialize(@etcd : Etcd, @lease_id : Int64)
+    class Lease
+      getter id
+
+      def initialize(@etcd : Etcd, @id : Int64, ttl : Int32)
         @lost_leadership = Channel(Nil).new
-        spawn(keepalive_loop, name: "Etcd lease keepalive #{@lease_id}")
+        spawn(keepalive_loop(ttl), name: "Etcd lease keepalive #{@id}")
       end
 
       # Force release leadership
       def release
-        @etcd.lease_revoke(@lease_id)
+        @etcd.lease_revoke(@id)
         @lost_leadership.close
       end
 
       # Wait until looses leadership
-      # Returns true when lost leadership, false when timeout occured
-      def wait(timeout : Time::Span) : Bool
+      # Raises `Lost` if lost leadership, otherwise returns after `timeout`
+      def wait(timeout : Time::Span) : Nil
         select
         when @lost_leadership.receive?
-          true
+          raise Lost.new
         when timeout(timeout)
-          false
         end
       end
 
-      private def keepalive_loop
-        ttl = @etcd.lease_ttl(@lease_id)
+      private def keepalive_loop(ttl : Int32)
         loop do
           sleep (ttl * 0.7).seconds
-          ttl = @etcd.lease_keepalive(@lease_id)
+          ttl = @etcd.lease_keepalive(@id)
         end
       rescue ex
         Log.error(exception: ex) { "Lost leadership" } unless @lost_leadership.closed?
       ensure
         @lost_leadership.close
       end
+
+      class Lost < Exception; end
     end
   end
 end


### PR DESCRIPTION
- Add proper error detection for nodes with duplicate clustering IDs
- Add proper error detection for nodes advertising the same URI
- Use clustering ID as lease_id in etcd for better tracking
- Modify Leadership#wait to raise explicitly on loss
- Rename Leadership class to Lease for clarity

This prevents confusing behavior when multiple nodes have conflicting
identities in the cluster, which could happen if a data directory was
copied between nodes.
