### PR TITLE
Add BasicAuth section to HTTP API docs

### DIFF
--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -10,7 +10,13 @@ info:
     email: contact@lavinmq.com
 servers:
 - url: /api
+security:
+- BasicAuth: []
 components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
   schemas:
     ErrorResponse:
       type: object


### PR DESCRIPTION
### WHAT is this pull request doing?
adds auth section to HTTP API docs.

Fixes #907 

### HOW can this pull request be tested?
Build LavinMQ, check that auth section is added to docs
