### PR TITLE
make it possible to filter on connection_name and user from /connections

### DIFF
--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -17,6 +17,12 @@ module LavinMQ
     class ConnectionsController < Controller
       include ConnectionsHelper
 
+      protected def match_value(value)
+        if client_properties = (value[:client_properties]? || value["client_properties"]?)
+          "#{value[:name]? || value["name"]?} #{client_properties["connection_name"]?} #{value[:user]? || value["user"]?}"
+        end
+      end
+
       private def register_routes
         get "/api/connections" do |context, _params|
           page(context, connections(user(context)).each)

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -20,6 +20,8 @@ module LavinMQ
       protected def match_value(value)
         if client_properties = (value[:client_properties]? || value["client_properties"]?)
           "#{value[:name]? || value["name"]?} #{client_properties["connection_name"]?} #{value[:user]? || value["user"]?}"
+        else
+          "#{value[:name]? || value["name"]?} #{value[:user]? || value["user"]?}"
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Make it possible to filter on `connection_name` and `user` from /connections in the GUI.

Fixes #1025 

### HOW can this pull request be tested?
Manual
