### PR TITLE
Filtering for bindings on exchange

### DIFF
--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -102,23 +102,6 @@ module LavinMQ
           end
         end
 
-        get "/api/exchanges/:vhost/:name/bindings/source" do |context, params|
-          with_vhost(context, params) do |vhost|
-            refuse_unless_management(context, user(context), vhost)
-            e = exchange(context, params, vhost)
-            page(context, e.bindings_details.each)
-          end
-        end
-
-        get "/api/exchanges/:vhost/:name/bindings/destination" do |context, params|
-          with_vhost(context, params) do |vhost|
-            refuse_unless_management(context, user(context), vhost)
-            e = exchange(context, params, vhost)
-            itr = bindings(e.vhost).select { |b| b.destination.name == e.name }
-            page(context, itr)
-          end
-        end
-
         post "/api/exchanges/:vhost/:name/publish" do |context, params|
           with_vhost(context, params) do |vhost|
             user = user(context)

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -49,7 +49,8 @@ updateExchange()
 const tableOptions = {
   dataSource: new UrlDataSource(exchangeUrl + '/bindings/source', { useQueryState: false }),
   pagination: true,
-  keyColumns: ['destination', 'properties_key']
+  keyColumns: ['destination', 'properties_key'],
+  search: true
 }
 const bindingsTable = Table.renderTable('bindings-table', tableOptions, function (tr, item, all) {
   if (!all) return


### PR DESCRIPTION


### WHAT is this pull request doing?
Adds filtering for bindings on /exchange. Moves some routes to `BindingsController` to make sure we can filter on the correct fields in `match_value`. 

Fixes #1026 

### HOW can this pull request be tested?
Manual