### PR TITLE
handle keepalive set to 0 in `MQTT::client`

### DIFF
--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -52,7 +52,7 @@ module LavinMQ
       private def read_loop
         socket = @socket
         if socket.responds_to?(:"read_timeout=")
-          socket.read_timeout = (@keepalive * 1.5).seconds # 1.5 according to [MQTT-3.1.2-24].
+          socket.read_timeout = @keepalive.zero? ? nil : (@keepalive * 1.5).seconds
         end
         loop do
           @log.trace { "waiting for packet" }

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -52,6 +52,7 @@ module LavinMQ
       private def read_loop
         socket = @socket
         if socket.responds_to?(:"read_timeout=")
+          # 50% grace period according to [MQTT-3.1.2-24]
           socket.read_timeout = @keepalive.zero? ? nil : (@keepalive * 1.5).seconds
         end
         loop do


### PR DESCRIPTION
### WHAT is this pull request doing?
Disclaimer, i had a hard time finding documentation for this, but I think setting read_timeout with a TimeSpan of 0 does not set an unlimited timer? rather it sets it to fire instantly? Since its a nilable value, we can set it to nil for an unlimited value. 


