### PR TITLE
Refactor paging and details_tuple to avoid SEGV and improve performance

### DIFF
--- a/spec/proxy_protocol_spec.cr
+++ b/spec/proxy_protocol_spec.cr
@@ -8,8 +8,8 @@ describe "ProxyProtocol" do
       w.write "PROXY TCP 1.2.3.4 127.0.0.2 34567 1234\r\n".to_slice
 
       conn_info = LavinMQ::ProxyProtocol::V1.parse(r)
-      conn_info.src.to_s.should eq "1.2.3.4:34567"
-      conn_info.dst.to_s.should eq "127.0.0.2:1234"
+      conn_info.remote_address.to_s.should eq "1.2.3.4:34567"
+      conn_info.local_address.to_s.should eq "127.0.0.2:1234"
       conn_info.ssl?.should be_false
     end
 
@@ -59,8 +59,8 @@ describe "ProxyProtocol" do
       w.write pp_bytes.to_slice
 
       conn_info = LavinMQ::ProxyProtocol::V2.parse(r)
-      conn_info.src.to_s.should eq "127.0.0.1:37424"
-      conn_info.dst.to_s.should eq "127.0.0.1:5671"
+      conn_info.remote_address.to_s.should eq "127.0.0.1:37424"
+      conn_info.local_address.to_s.should eq "127.0.0.1:5671"
       conn_info.ssl?.should be_true
       conn_info.ssl_version.should eq "TLSv1.3"
       conn_info.ssl_cipher.should eq "TLS_AES_256_GCM_SHA384"

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -1,3 +1,4 @@
+require "../stats"
 require "./client"
 require "./consumer"
 require "./stream_consumer"
@@ -6,7 +7,6 @@ require "../logger"
 require "./queue"
 require "../exchange"
 require "../amqp"
-require "../stats"
 require "../sortable_json"
 require "./channel_reply_code"
 
@@ -61,12 +61,12 @@ module LavinMQ
           number:                  @id,
           name:                    @name,
           vhost:                   @client.vhost.name,
-          user:                    @client.user.try(&.name),
+          user:                    @client.user.name,
           consumer_count:          @consumers.size,
           prefetch_count:          @prefetch_count,
           global_prefetch_count:   @global_prefetch_count,
           confirm:                 @confirm,
-          transactional:           false,
+          transactional:           @tx,
           messages_unacknowledged: @unacked.size,
           connection_details:      @client.connection_details,
           state:                   state,

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -44,7 +44,7 @@ module LavinMQ
       Log = LavinMQ::Log.for "amqp.channel"
 
       def initialize(@client : Client, @id : UInt16)
-        @metadata = ::Log::Metadata.new(nil, {client: @client.remote_address.to_s, channel: @id.to_i})
+        @metadata = ::Log::Metadata.new(nil, {client: @client.connection_info.remote_address.to_s, channel: @id.to_i})
         @name = "#{@client.channel_name_prefix}[#{@id}]"
         @log = Logger.new(Log, @metadata)
       end

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -103,6 +103,18 @@ module LavinMQ
         }.merge(stats_details)
       end
 
+      def search_match?(value : String) : Bool
+        @name.includes?(value) ||
+          @user.name.includes?(value) ||
+          @client_properties["connection_name"]?.try(&.to_s.includes?(value)) || false
+      end
+
+      def search_match?(value : Regex) : Bool
+        value === @name ||
+          value === @user.name ||
+          value === @client_properties["connection_name"]?
+      end
+
       private def read_loop
         received_bytes = 0_u32
         socket = @socket

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -260,8 +260,8 @@ module LavinMQ
           prefetch_count:  @prefetch_count,
           priority:        @priority,
           channel_details: {
-            peer_host:       channel_details[:connection_details][:peer_host]?,
-            peer_port:       channel_details[:connection_details][:peer_port]?,
+            peer_host:       channel_details[:connection_details][:peer_host],
+            peer_port:       channel_details[:connection_details][:peer_port],
             connection_name: channel_details[:connection_details][:name],
             user:            channel_details[:user],
             number:          channel_details[:number],

--- a/src/lavinmq/binding_details.cr
+++ b/src/lavinmq/binding_details.cr
@@ -29,5 +29,15 @@ module LavinMQ
         properties_key:   @binding_key.properties_key,
       }
     end
+
+    def search_match?(value : String) : Bool
+      @destination.name.includes?(value) ||
+        @binding_key.routing_key.includes?(value)
+    end
+
+    def search_match?(value : Regex) : Bool
+      value === @destination.name ||
+        value === @binding_key.routing_key
+    end
   end
 end

--- a/src/lavinmq/client/channel.cr
+++ b/src/lavinmq/client/channel.cr
@@ -5,6 +5,7 @@ module LavinMQ
   abstract class Client
     abstract class Channel
       include SortableJSON
+      @name = ""
     end
   end
 end

--- a/src/lavinmq/client/channel/consumer.cr
+++ b/src/lavinmq/client/channel/consumer.cr
@@ -5,6 +5,7 @@ module LavinMQ
     abstract class Channel
       abstract class Consumer
         include SortableJSON
+        @name = ""
       end
     end
   end

--- a/src/lavinmq/client/client.cr
+++ b/src/lavinmq/client/client.cr
@@ -4,5 +4,6 @@ require "./channel"
 module LavinMQ
   abstract class Client
     include SortableJSON
+    @name = ""
   end
 end

--- a/src/lavinmq/exchange.cr
+++ b/src/lavinmq/exchange.cr
@@ -5,6 +5,7 @@ require "./sortable_json"
 module LavinMQ
   abstract class Exchange
     include SortableJSON
+    @name = ""
 
     class AccessRefused < Error
       def initialize(@exchange : Exchange)

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -49,6 +49,14 @@ module LavinMQ
           }
         end
 
+        def search_match?(value : String) : Bool
+          @upstream.name.includes? value
+        end
+
+        def search_match?(value : Regex) : Bool
+          value === @upstream.name
+        end
+
         def run
           @log.info { "Starting" }
           spawn(run_loop, name: "Federation link #{@upstream.vhost.name}/#{name}")

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -18,92 +18,83 @@ module LavinMQ
 
       private abstract def register_routes
 
-      private def filter_values(params, iterator)
-        return iterator unless raw_name = params["name"]?
-        term = URI.decode_www_form(raw_name)
-        if params["use_regex"]?.try { |v| v == "true" }
-          iterator.select { |v| match_value(v).to_s =~ /#{term}/ }
-        else
-          iterator.select { |v| match_value(v).to_s.includes?(term) }
-        end
-      end
-
-      # Can be overridden in sub controllers
-      protected def match_value(value)
-        value[:name]? || value["name"]?
-      end
-
       private def page(context, iterator : Iterator(SortableJSON))
         params = context.request.query_params
-        page = params["page"]?.try(&.to_i) || 1
-        page_size = params["page_size"]?.try(&.to_i) || 100
-        if page_size > MAX_PAGE_SIZE
-          context.response.status_code = 413
-          {error: "payload_too_large", reason: "Max allowed page_size #{MAX_PAGE_SIZE}"}.to_json(context.response)
-          return context
-        end
-        iterator = iterator.map do |i|
+        page_size = extract_page_size(context)
+        search_term = extract_search_term(params)
+        total_count = 0
+        all_items = iterator.compact_map do |i|
+          total_count += 1
+          next unless i.search_match?(search_term) if search_term
           i.details_tuple
-        rescue e
-          {error: e.message}
+        rescue ex
+          Log.warn(exception: ex) { "Could not list all items" }
+          next
         end
-        all_items = filter_values(params, iterator)
-        if sort_by = params.fetch("sort", nil).try &.split(".")
-          sorted_items = all_items.to_a
-          filtered_count = sorted_items.size
-          if first_element = sorted_items.first?
-            {% begin %}
-              case dig(first_element, sort_by)
-                {% for k in {Int32, UInt16, UInt32, UInt64, Float64} %}
-                when {{k.id}}
-                  sorted_items.sort_by! { |i| dig(i, sort_by).as({{k.id}}) }
-                {% end %}
-              else
-                sorted_items.sort_by! { |i| dig(i, sort_by).to_s.downcase }
-              end
-            {% end %}
-          end
-          sorted_items.reverse! if params["sort_reverse"]?.try { |s| !(s =~ /^false$/i) }
-          all_items = sorted_items.each
-        end
+        all_items = sort(all_items, context)
         columns = params["columns"]?.try(&.split(','))
-        unless params.has_key?("page")
-          JSON.build(context.response) do |json|
+        JSON.build(context.response) do |json|
+          if page = params["page"]?.try(&.to_i)
+            json.object do
+              item_count, filtered_count = json.field("items") do
+                start = (page - 1) * page_size
+                array_iterator_to_json(json, all_items, columns, start, page_size)
+              end
+              json.field("filtered_count", filtered_count)
+              json.field("item_count", item_count)
+              json.field("page", page)
+              json.field("page_count", ((filtered_count + page_size - 1) / page_size).to_i)
+              json.field("page_size", page_size)
+              json.field("total_count", total_count)
+            end
+          else
             items, total = array_iterator_to_json(json, all_items, columns, 0, MAX_PAGE_SIZE)
             if total > MAX_PAGE_SIZE
               Log.warn { "Result set truncated: #{items}/#{total}" }
             end
           end
-          return context
-        end
-        JSON.build(context.response) do |json|
-          json.object do
-            item_count, total_count = json.field("items") do
-              start = (page - 1) * page_size
-              array_iterator_to_json(json, all_items, columns, start, page_size)
-            end
-            filtered_count ||= total_count
-            json.field("filtered_count", filtered_count)
-            json.field("item_count", item_count)
-            json.field("page", page)
-            json.field("page_count", ((total_count + page_size - 1) / page_size).to_i)
-            json.field("page_size", page_size)
-            json.field("total_count", total_count)
-          end
         end
         context
       end
 
-      private def dig(i : NamedTuple, keys : Array(String))
-        if keys.size > 1
-          nt = i[keys.first].as?(NamedTuple) || return
-          dig(nt, keys[1..])
+      private def sort(all_items, context)
+        if sort_by = context.request.query_params.fetch("sort", nil).try &.split(".")
+          sorted_items = all_items.to_a
+          begin
+            if first_element = sorted_items.first?
+              case v = dig(first_element, sort_by)
+              when Number
+                sorted_items.sort_by! { |i| dig(i, sort_by).as(Number) }
+              when String
+                sorted_items.sort_by! { |i| dig(i, sort_by).as(String).downcase }
+              else
+                bad_request(context, "Can't sort on type #{v.class}")
+              end
+            end
+          rescue KeyError | TypeCastError
+            bad_request(context, "Sort key #{sort_by.join(".")} is not valid")
+          end
+          if context.request.query_params["sort_reverse"]?.try { |s| !(s =~ /^false$/i) }
+            sorted_items.reverse!
+          end
+          sorted_items.each
         else
-          i[keys.first]? || 0
+          all_items
         end
       end
 
-      private def array_iterator_to_json(json, iterator, columns : Array(String)?, start : Int, page_size : Int)
+      private def dig(tuple : NamedTuple, keys : Array(String))
+        if keys.size > 1
+          nt = tuple[keys.first].as?(NamedTuple) || raise KeyError.new("'#{keys.first}' is not a nested tuple")
+          dig(nt, keys[1..])
+        else
+          tuple[keys.first] || 0
+        end
+      end
+
+      # Writes the items to the json, but also counts all items by iterating the whole iterator
+      # Reruns the number of number of written to the json and the total items in the iterator
+      private def array_iterator_to_json(json, iterator, columns : Array(String)?, start : Int, page_size : Int) : Tuple(Int32, Int32)
         size = 0
         total = 0
         json.array do
@@ -125,6 +116,25 @@ module LavinMQ
           end
         end
         {size, total}
+      end
+
+      private def extract_page_size(context) : Int32
+        page_size = context.request.query_params["page_size"]?.try(&.to_i) || 100
+        if page_size > MAX_PAGE_SIZE
+          halt(context, 413, {error: "payload_too_large", reason: "Max allowed page_size #{MAX_PAGE_SIZE}"})
+        end
+        page_size
+      end
+
+      private def extract_search_term(params)
+        if raw_name = params["name"]?
+          term = URI.decode_www_form(raw_name)
+          if params["use_regex"]? == "true"
+            Regex.new(term)
+          else
+            term
+          end
+        end
       end
 
       private def redirect_back(context)

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -17,14 +17,6 @@ module LavinMQ
     class ConnectionsController < Controller
       include ConnectionsHelper
 
-      protected def match_value(value)
-        if client_properties = (value[:client_properties]? || value["client_properties"]?)
-          "#{value[:name]? || value["name"]?} #{client_properties["connection_name"]?} #{value[:user]? || value["user"]?}"
-        else
-          "#{value[:name]? || value["name"]?} #{value[:user]? || value["user"]?}"
-        end
-      end
-
       private def register_routes
         get "/api/connections" do |context, _params|
           page(context, connections(user(context)).each)

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -7,10 +7,6 @@ module LavinMQ
     class ConsumersController < Controller
       include ConnectionsHelper
 
-      protected def match_value(value)
-        value[:consumer_tag]? || value["consumer_tag"]?
-      end
-
       private def register_routes
         get "/api/consumers" do |context, _params|
           page(context, all_consumers(user(context)))

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -17,6 +17,14 @@ module LavinMQ
           vhost:     @vhost,
         }
       end
+
+      def search_match?(value : String) : Bool
+        @p.parameter_name.includes? value
+      end
+
+      def search_match?(value : Regex) : Bool
+        value === @p.parameter_name
+      end
     end
 
     class ParametersController < Controller

--- a/src/lavinmq/http/controller/permissions.cr
+++ b/src/lavinmq/http/controller/permissions.cr
@@ -13,6 +13,14 @@ module LavinMQ
       def details_tuple
         @user.permissions_details(@vhost, @p)
       end
+
+      def search_match?(value : String) : Bool
+        @user.name.includes? value
+      end
+
+      def search_match?(value : Regex) : Bool
+        value === @user.name
+      end
     end
 
     class PermissionsController < Controller

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -11,6 +11,14 @@ module LavinMQ
       def details_tuple
         @user.user_details
       end
+
+      def search_match?(value : String) : Bool
+        @user.name.includes? value
+      end
+
+      def search_match?(value : Regex) : Bool
+        value === @user.name
+      end
     end
 
     module UserHelpers

--- a/src/lavinmq/http/controller/vhost-limits.cr
+++ b/src/lavinmq/http/controller/vhost-limits.cr
@@ -71,12 +71,12 @@ module LavinMQ
         end
 
         def details_tuple
-          value = Hash(String, Int32).new
+          value = NamedTuple.new
           if max = @vhost.max_connections
-            value["max-connections"] = max
+            value = value.merge({"max-connections": max})
           end
           if max = @vhost.max_queues
-            value["max-queues"] = max
+            value = value.merge({"max-queues": max})
           end
           {
             vhost: @vhost.name,

--- a/src/lavinmq/http/controller/vhost-limits.cr
+++ b/src/lavinmq/http/controller/vhost-limits.cr
@@ -83,6 +83,14 @@ module LavinMQ
             value: value,
           }
         end
+
+        def search_match?(value : String) : Bool
+          @vhost.name.includes? value
+        end
+
+        def search_match?(value : Regex) : Bool
+          value === @vhost.name
+        end
       end
     end
   end

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -5,8 +5,10 @@ module LavinMQ
   module HTTP
     struct VHostView
       include SortableJSON
+      @name : String
 
       def initialize(@vhost : VHost)
+        @name = @vhost.name
       end
 
       def details_tuple

--- a/src/lavinmq/http/handler/defaults_handler.cr
+++ b/src/lavinmq/http/handler/defaults_handler.cr
@@ -4,10 +4,21 @@ module LavinMQ
   module HTTP
     class ApiDefaultsHandler
       include ::HTTP::Handler
+      Log = LavinMQ::Log.for "http.performance"
 
       def call(context)
         context.response.content_type = "application/json"
-        call_next(context)
+        {% if flag?(:release) %}
+          call_next(context)
+        {% else %}
+          elapsed = Time::Span.new
+          mem = Benchmark.memory do
+            elapsed = Benchmark.realtime do
+              call_next(context)
+            end
+          end
+          Log.info { "request=#{context.request.path}?#{context.request.query} memory=#{mem.humanize_bytes} elapsed=#{elapsed.total_milliseconds.to_i}ms" }
+        {% end %}
       end
     end
   end

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -39,7 +39,7 @@ module LavinMQ
 
       def add_client(socket, connection_info, user, packet)
         if prev_client = @clients[packet.client_id]?
-          prev_client.close("New client #{connection_info.src} (username=#{packet.username}) connected as #{packet.client_id}")
+          prev_client.close("New client #{connection_info.remote_address} (username=#{packet.username}) connected as #{packet.client_id}")
         end
         client = MQTT::Client.new(socket,
           connection_info,

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -57,6 +57,7 @@ module LavinMQ
           end
         end
         @clients[packet.client_id] = client
+        @vhost.add_connection client
       end
 
       def remove_client(client)
@@ -66,7 +67,7 @@ module LavinMQ
           sessions.delete(client_id) if session.clean_session?
         end
         @clients.delete client_id
-        vhost.rm_connection(client)
+        @vhost.rm_connection(client)
       end
 
       def publish(packet : MQTT::Publish)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -38,7 +38,6 @@ module LavinMQ
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
         metadata = ::Log::Metadata.new(nil, {vhost: @broker.vhost.name, address: @connection_info.remote_address.to_s, client_id: client_id})
         @log = Logger.new(Log, metadata)
-        @broker.vhost.add_connection(self)
         @log.info { "Connection established for user=#{@user.name}" }
         spawn read_loop, name: "MQTT read_loop #{@connection_info.remote_address}"
       end
@@ -59,7 +58,7 @@ module LavinMQ
           # The disconnect packet has been handled and the socket has been closed.
           # If we dont breakt the loop here we'll get a IO/Error on next read.
           if packet.is_a?(MQTT::Disconnect)
-            @log.debug { "Recieved disconnect" }
+            @log.debug { "Received disconnect" }
             break
           end
         end

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -160,6 +160,16 @@ module LavinMQ
         }.merge(stats_details)
       end
 
+      def search_match?(value : String) : Bool
+        @name.includes?(value) ||
+          @user.name.includes?(value)
+      end
+
+      def search_match?(value : Regex) : Bool
+        value === @name ||
+          value === @user.name
+      end
+
       private def publish_will
         if will = @will
           @broker.publish MQTT::Publish.new(

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -17,8 +17,7 @@ module LavinMQ
       end
 
       def start(socket : ::IO, connection_info : ConnectionInfo)
-        remote_address = connection_info.src
-        metadata = ::Log::Metadata.build({address: remote_address.to_s})
+        metadata = ::Log::Metadata.build({address: connection_info.remote_address.to_s})
         logger = Logger.new(Log, metadata)
         begin
           io = MQTT::IO.new(socket)

--- a/src/lavinmq/queue.cr
+++ b/src/lavinmq/queue.cr
@@ -3,5 +3,6 @@ require "./sortable_json"
 module LavinMQ
   abstract class Queue
     include SortableJSON
+    @name = ""
   end
 end

--- a/src/lavinmq/sortable_json.cr
+++ b/src/lavinmq/sortable_json.cr
@@ -5,5 +5,13 @@ module LavinMQ
     def to_json(json : JSON::Builder)
       details_tuple.to_json(json)
     end
+
+    def search_match?(value : String)
+      @name.includes? value
+    end
+
+    def search_match?(value : Regex)
+      value === @name
+    end
   end
 end

--- a/src/lavinmq/unacked_message.cr
+++ b/src/lavinmq/unacked_message.cr
@@ -17,5 +17,13 @@ module LavinMQ
         channel_name:        @channel.name,
       }
     end
+
+    def search_match?(value : String) : Bool
+      @delivery_tag.to_s == value
+    end
+
+    def search_match?(value : Regex) : Bool
+      value === @delivery_tag.to_s
+    end
   end
 end

--- a/views/consumers.ecr
+++ b/views/consumers.ecr
@@ -17,9 +17,9 @@
           <table id="table" class="table">
             <thead>
               <tr>
-                <th data-sort-key="vhost">Virtual host</th>
-                <th data-sort-key="queue">Queue</th>
-                <th data-sort-key="channel">Channel</th>
+                <th data-sort-key="queue.vhost">Virtual host</th>
+                <th data-sort-key="queue.name">Queue</th>
+                <th data-sort-key="channel_details.name">Channel</th>
                 <th data-sort-key="consumer_tag" class="left">Consumer tag</th>
                 <th>Ack required</th>
                 <th>Exclusive</th>


### PR DESCRIPTION
# Big refactor Controller#page

Improved performance for listing many entities, searching for one queue
among 25000 now uses 70KiB instead of 1.52MiB.

Filter out items that doesn't match before calling the more expensive
`details_tuple`.

Each class that implemented SortableJSON now have to have a
`search_match?`, finding if it maches either a string or regex.

Calculate correct total and filter count (wasn't before).

Sorting is a bit easier to read now and avoid macros (which have the
added benefit that it will be easier to debug if this part is involved
in the segfaults).

# Align MQTT Consumers details_tuple with the AMQP one

A segfault stacktrace indicated that this discrepancy
might been the issue, could not replicate but let's
fix it anyway.

# ConnectionInfo changes

ConnectionInfo is a class (so it can be referenced and don't need to be
copied).

ConnectionInfo#remote_/local_address instead of src/dst, clearer that it
is from the perspective of the server.

At one point we suspected a memory problem with Socket::IPAddress so
created a local replacement.

# Log memory usage and time for each http request

Used when optimizing the paging method