### PR TITLE
let restore_index logging have trace level, instead of info

### DIFF
--- a/src/lavinmq/mqtt/retain_store.cr
+++ b/src/lavinmq/mqtt/retain_store.cr
@@ -34,7 +34,7 @@ module LavinMQ
       end
 
       private def restore_index(index : IndexTree, index_file : ::IO)
-        Log.info { "restoring index" }
+        Log.trace { "restoring index" }
         dir = @dir
         msg_count = 0u64
         msg_file_segments = Set(String).new(
@@ -60,7 +60,7 @@ module LavinMQ
             File.delete? File.join(dir, file_name)
           end
         end
-        Log.info { "restoring index done, msg_count = #{msg_count}" }
+        Log.trace { "restoring index done, msg_count = #{msg_count}" }
       end
 
       def retain(topic : String, body_io : ::IO, size : UInt64) : Nil

--- a/src/lavinmq/mqtt/retain_store.cr
+++ b/src/lavinmq/mqtt/retain_store.cr
@@ -34,7 +34,7 @@ module LavinMQ
       end
 
       private def restore_index(index : IndexTree, index_file : ::IO)
-        Log.trace { "restoring index" }
+        Log.debug { "restoring index" }
         dir = @dir
         msg_count = 0u64
         msg_file_segments = Set(String).new(
@@ -60,7 +60,7 @@ module LavinMQ
             File.delete? File.join(dir, file_name)
           end
         end
-        Log.trace { "restoring index done, msg_count = #{msg_count}" }
+        Log.debug { "restoring index done, msg_count = #{msg_count}" }
       end
 
       def retain(topic : String, body_io : ::IO, size : UInt64) : Nil


### PR DESCRIPTION
### WHAT is this pull request doing?
Some log lines in `restore_index`in `RetainStore` have an unnecessarily high log level, this PR sets it down to `trace`

Also open to removing the lines, wdyt?

### HOW can this pull request be tested?
Inspect the logs. 
