### PR TITLE
Bugfix: federation upstream exchange doesn't route messages

### DIFF
--- a/src/lavinmq/amqp/exchange/federation.cr
+++ b/src/lavinmq/amqp/exchange/federation.cr
@@ -10,7 +10,7 @@ module LavinMQ
       def initialize(vhost, name, arguments)
         arguments["x-internal-purpose"] = "federation"
         arguments["x-max-hops"] ||= 1
-        super(vhost, name, true, true, true, arguments)
+        super(vhost, name, durable: true, auto_delete: true, internal: true, arguments: arguments)
       end
     end
   end

--- a/src/lavinmq/amqp/exchange/federation.cr
+++ b/src/lavinmq/amqp/exchange/federation.cr
@@ -1,8 +1,8 @@
-require "./topic"
+require "./fanout"
 
 module LavinMQ
   module AMQP
-    class FederationExchange < TopicExchange
+    class FederationExchange < FanoutExchange
       def type
         "x-federation-upstream"
       end


### PR DESCRIPTION
#190 states that bindings are not added to the queue, but the problem was that the federation upstream exchange was a topic exchange and not a fanout exchange.

Bindings are added between the federated exchange and the upstream exchange, and the latter should just forward everything to the queue.
z
Fixes #190