### PR TITLE
remove double logs when a client disconnects and when a queue is deleted

### DIFF
--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -130,7 +130,7 @@ module LavinMQ
             frame_size_ok?(frame) || return
             case frame
             when AMQP::Frame::Connection::Close
-              @log.info { "Client disconnected: #{frame.reply_text}" } unless frame.reply_text.empty?
+              @log.debug { "Client disconnected: #{frame.reply_text}" } unless frame.reply_text.empty?
               send AMQP::Frame::Connection::CloseOk.new
               @running = false
               next

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -184,7 +184,7 @@ module LavinMQ
 
     def delete_queue(name)
       apply AMQP::Frame::Queue::Delete.new(0_u16, 0_u16, name, false, false, false)
-      @log.info { "Deleted queue: #{name}" }
+      @log.debug { "Deleted queue: #{name}" }
     end
 
     def declare_exchange(name, type, durable, auto_delete, internal = false,


### PR DESCRIPTION
### WHAT is this pull request doing?
Removes double log rows when a client disconnects and when a queue is deleted by logging the extra rows as `debug` instead of `info`. 

Clicked around in the UI and did some testing with a client but didn't find any other double logs. 

Fixes #1046 

### HOW can this pull request be tested?
Manual.
