### PR TITLE
Version uses env var if available, so does the RPM spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,7 @@ uninstall:
 rpm:
 	rpmdev-setuptree
 	git archive --prefix lavinmq/ --output ~/rpmbuild/SOURCES/lavinmq.tar.gz HEAD
-	sed -E "s/^(Version:).*/\1 $(shell ./packaging/rpm/rpm-version)/" packaging/rpm/lavinmq.spec > ~/rpmbuild/SPECS/lavinmq.spec
-	rpmbuild -bb ~/rpmbuild/SPECS/lavinmq.spec
+	env version="$(shell ./packaging/rpm/rpm-version)" rpmbuild -bb packaging/rpm/lavinmq.spec
 
 .PHONY: clean
 clean:

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -9,7 +9,6 @@ COPY extras/lavinmq.service extras/lavinmq.ini extras/
 COPY static/ static/
 COPY views/ views/
 COPY src/ src/
-RUN sed -i -E "s/(VERSION =) .*/\1 \"$version\"/" src/lavinmq/version.cr
 RUN tar -czf ../lavinmq_${version}.orig.tar.gz -C /usr/src lavinmq_${version}
 COPY packaging/debian/ debian/
 RUN sed -i -E "s/^(lavinmq) \(.*\)/\1 \(${version}-1\)/" debian/changelog

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -6,7 +6,6 @@ RUN dnf install -y --nodocs --setopt=install_weak_deps=False \
 RUN rpmdev-setuptree
 COPY packaging/rpm/lavinmq.spec /root/rpmbuild/SPECS/
 ARG version
-RUN sed -i -E "s/^(Version:).*/\1 $version/" /root/rpmbuild/SPECS/lavinmq.spec
 RUN rpmlint /root/rpmbuild/SPECS/lavinmq.spec
 WORKDIR /usr/src/lavinmq
 COPY Makefile README.md LICENSE NOTICE CHANGELOG.md shard.yml shard.lock ./
@@ -14,7 +13,6 @@ COPY extras/lavinmq.service extras/lavinmq.ini extras/
 COPY static/ static/
 COPY views/ views/
 COPY src/ src/
-RUN sed -i -E "s/(VERSION =) .*/\1 \"$version\"/" src/lavinmq/version.cr
 RUN tar -czf /root/rpmbuild/SOURCES/lavinmq.tar.gz -C /usr/src lavinmq
 ARG MAKEFLAGS=-j2
 RUN rpmbuild -ba /root/rpmbuild/SPECS/lavinmq.spec

--- a/packaging/rpm/lavinmq.spec
+++ b/packaging/rpm/lavinmq.spec
@@ -1,6 +1,6 @@
 Name:    lavinmq
 Summary: Message queue server that implements the AMQP 0-9-1 protocol
-Version: 2.0.0
+Version: %{getenv:version}
 Release: 1%{?dist}
 
 License: Apache 2.0

--- a/src/lavinmq/version.cr
+++ b/src/lavinmq/version.cr
@@ -1,5 +1,5 @@
 module LavinMQ
-  VERSION = {{ `git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") }}
+  VERSION = {{ `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.sub(/^v/, "") }}
 
   macro build_flags
     String.build do |flags|


### PR DESCRIPTION
No need to `sed` anymore