### PR TITLE
Run etcd lease keepalive loop in a separate thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ VIEW_TARGETS := $(patsubst views/%.ecr,static/views/%.html,$(VIEW_SOURCES))
 VIEW_PARTIALS := $(wildcard views/partials/*.ecr)
 JS := static/js/lib/chunks/helpers.segment.js static/js/lib/chart.js static/js/lib/amqp-websocket-client.mjs static/js/lib/amqp-websocket-client.mjs.map static/js/lib/luxon.js static/js/lib/chartjs-adapter-luxon.esm.js static/js/lib/elements-8.2.0.js static/js/lib/elements-8.2.0.css static/js/lib/paho-mqtt.js
 LDFLAGS := $(shell (dpkg-buildflags --get LDFLAGS || rpm -E "%{build_ldflags}" || echo "-pie") 2>/dev/null)
-CRYSTAL_FLAGS := --release --stats
-override CRYSTAL_FLAGS += --error-on-warnings --link-flags="$(LDFLAGS)"
+CRYSTAL_FLAGS := --release
+override CRYSTAL_FLAGS += --stats --error-on-warnings -Dpreview_mt -Dexecution_context --link-flags="$(LDFLAGS)"
 
 .DEFAULT_GOAL := all
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Enable execution context, but only use one Isolated 

### HOW can this pull request be tested?

`bin/lavinmqperf throughput -y 300 -e amq.fanout -u ""` and monitor that the server isn't loosing the lease.
