### PR TITLE
Don't reset the sessions client on Subscribe on existing sessions

### DIFF
--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -75,8 +75,7 @@ module LavinMQ
       end
 
       def subscribe(client, topics)
-        session = sessions[client.client_id]? || sessions.declare(client)
-        session.client = client
+        session = sessions[client.client_id]? || sessions.declare(client).tap { |s| s.client = client }
         headers = AMQP::Table.new({RETAIN_HEADER => true})
         topics.map do |tf|
           session.subscribe(tf.topic, tf.qos)

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -75,7 +75,7 @@ module LavinMQ
       end
 
       def subscribe(client, topics)
-        session = sessions[client.client_id]? || sessions.declare(client).tap { |s| s.client = client }
+        session = sessions.declare(client)
         headers = AMQP::Table.new({RETAIN_HEADER => true})
         topics.map do |tf|
           session.subscribe(tf.topic, tf.qos)

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -21,6 +21,7 @@ module LavinMQ
       def declare(client : Client)
         self[client.client_id]? || begin
           @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, AMQP::Table.new({"x-queue-type": "mqtt"}))
+          self[client.client_id].client = client
           self[client.client_id]
         end
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
We have a bug where when a subscribe is done, the sessions client is re-set, meaning the old consumer(client) is removed, and the new client is added as a consumer on the session. For a clean session this causes issues, because when the consumer pool is empty it will auto delete the session. This means we end up with a variety of bad cases when subscribing to multiple topics when `clean_session = true` for the client. 

We fix this by only re-setting the client on a subscribe if needed, that is: if the session is new and needs to be declared. 

Fixes: #1074

### HOW can this pull request be tested?
Run MQTT specs
Run with and without changes, and try to subscribe to multiple topics with a client that has `clean_session = true` and see that without the changes you end up with only one topic subscription, and with the changes you have multiple. 
