### PR TITLE
Show active arguments on queues & exchanges

### DIFF
--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -6,6 +6,7 @@ module LavinMQ::AMQP
       super
       @effective_args << "x-max-priority"
     end
+
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
       PriorityMessageStore.new(data_dir, replicator, metadata: @metadata)

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -2,6 +2,10 @@ require "./durable_queue"
 
 module LavinMQ::AMQP
   class PriorityQueue < Queue
+    private def handle_arguments
+      super
+      @effective_args << "x-max-priority"
+    end
     private def init_msg_store(data_dir)
       replicator = durable? ? @vhost.@replicator : nil
       PriorityMessageStore.new(data_dir, replicator, metadata: @metadata)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -427,7 +427,7 @@ module LavinMQ::AMQP
         state:                       @state,
         effective_policy_definition: Policy.merge_definitions(@policy, @operator_policy),
         message_stats:               current_stats_details,
-        effective_arguments:         @effective_args.join(','),
+        effective_arguments:         @effective_args,
       }
     end
 

--- a/src/lavinmq/amqp/queue/stream_queue.cr
+++ b/src/lavinmq/amqp/queue/stream_queue.cr
@@ -109,6 +109,7 @@ module LavinMQ::AMQP
 
     private def handle_arguments
       super
+      @effective_args << "x-queue-type"
       if @dlx
         raise LavinMQ::Error::PreconditionFailed.new("x-dead-letter-exchange not allowed for stream queues")
       end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -198,6 +198,11 @@ module LavinMQ
         @count = next_id
         next_id
       end
+
+      private def handle_arguments
+        super
+        @effective_args << "x-queue-type"
+      end
     end
   end
 end

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -33,6 +33,13 @@ function updateExchange () {
       }
       const el = document.createElement('div')
       el.textContent = key + ' = ' + item.arguments[key]
+      if (item.effective_arguments.includes(key)){
+        el.classList.add('active-argument')
+        el.title = 'Active argument'
+      }else{
+        el.classList.add('inactive-argument')
+        el.title = 'Inactive argument'
+      }
       argList.appendChild(el)
     })
     document.getElementById('e-arguments').appendChild(argList)

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -33,10 +33,10 @@ function updateExchange () {
       }
       const el = document.createElement('div')
       el.textContent = key + ' = ' + item.arguments[key]
-      if (item.effective_arguments.includes(key)){
+      if (item.effective_arguments.includes(key)) {
         el.classList.add('active-argument')
         el.title = 'Active argument'
-      }else{
+      } else {
         el.classList.add('inactive-argument')
         el.title = 'Inactive argument'
       }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -136,7 +136,6 @@ function updateQueue (all) {
         for (const arg in item.arguments) {
           let div = document.createElement('div')
           div.textContent = `${arg}: ${item.arguments[arg]}`
-          div.classList.add('arg-tooltip');
           if (item.effective_arguments.includes(arg)) {
             div.classList.add('active-argument');
             div.title = 'Active argument'

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -134,13 +134,13 @@ function updateQueue (all) {
         }
         const qArgs = document.getElementById('q-arguments')
         for (const arg in item.arguments) {
-          let div = document.createElement('div')
+          const div = document.createElement('div')
           div.textContent = `${arg}: ${item.arguments[arg]}`
           if (item.effective_arguments.includes(arg)) {
-            div.classList.add('active-argument');
+            div.classList.add('active-argument')
             div.title = 'Active argument'
-          }else{
-            div.classList.add('inactive-argument');
+          } else {
+            div.classList.add('inactive-argument')
             div.title = 'Passive argument'
           }
           qArgs.appendChild(div)

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -134,7 +134,17 @@ function updateQueue (all) {
         }
         const qArgs = document.getElementById('q-arguments')
         for (const arg in item.arguments) {
-          qArgs.appendChild(document.createElement('div')).textContent = `${arg}: ${item.arguments[arg]}`
+          let div = document.createElement('div')
+          div.textContent = `${arg}: ${item.arguments[arg]}`
+          div.classList.add('arg-tooltip');
+          if (item.effective_arguments.includes(arg)) {
+            div.classList.add('active-argument');
+            div.title = 'Active argument'
+          }else{
+            div.classList.add('inactive-argument');
+            div.title = 'Passive argument'
+          }
+          qArgs.appendChild(div)
         }
       }
     })

--- a/static/main.css
+++ b/static/main.css
@@ -1772,7 +1772,14 @@ pre.arguments > div {
 }
 
 .arguments {
+  color: var(--font-color-darker);
+}
+.arguments .arg-tooltip {
+  display: block;
+}
+.arguments .active-argument {
   color: var(--font-color-light);
+  font-weight: bold;
 }
 
 #dataTags {

--- a/static/main.css
+++ b/static/main.css
@@ -30,6 +30,7 @@
   --bg-color-dark: #1D1D1D;
   --border-color-light: rgb(247 245 242 / 0.1);
   --bg-green-dark: #54BE7E;
+  --trafficlight-green: #44FC70;
   scrollbar-width: thin;
 }
 
@@ -358,7 +359,7 @@ button {
   color: #141414;
 
   &:hover {
-    background-color: #44FC70;
+    background-color: var(--trafficlight-green);
   }
 }
 
@@ -1562,7 +1563,7 @@ a:visited {
 
 .state-running:after {
   content: "●";
-  color: #44FC70;
+  color: var(--trafficlight-green);
 }
 
 .state-flow:after {
@@ -1780,7 +1781,7 @@ pre.arguments .inactive-argument:before {
 }
 pre.arguments .active-argument:before {
   content: "●";
-  color: #44FC70;
+  color: var(--trafficlight-green);
 }
 pre.arguments .inactive-argument:before {
   content: "○";

--- a/static/main.css
+++ b/static/main.css
@@ -1769,17 +1769,21 @@ fieldset.inline {
 pre.arguments > div {
   padding-left: 1em;
   text-indent: -1em;
+  padding-top: 2px;
 }
-
-.arguments {
-  color: var(--font-color-darker);
-}
-.arguments .arg-tooltip {
-  display: block;
-}
-.arguments .active-argument {
+pre.arguments .active-argument {
   color: var(--font-color-light);
-  font-weight: bold;
+}
+pre.arguments .active-argument:before,
+pre.arguments .inactive-argument:before {
+  padding-right: 5px;
+}
+pre.arguments .active-argument:before {
+  content: "●";
+  color: #44FC70;
+}
+pre.arguments .inactive-argument:before {
+  content: "○";
 }
 
 #dataTags {

--- a/views/exchange.ecr
+++ b/views/exchange.ecr
@@ -23,19 +23,19 @@
           <td id="e-features"></td>
         </tr>
         <tr>
-          <th>Arguments</th>
-          <td id="e-arguments"></td>
-        </tr>
-        <tr>
           <th>Policy</th>
           <td id="e-policy"></td>
         </tr>
       </table>
     </section>
-    <section class="card cols-8">
+    <section class="card cols-4">
       <h3 class="title-m">Rates</h3>
       <div class="chart-container" id="chart"></div>
     </section>
+    <section class="card cols-4">
+        <h3>Arguments</h3>
+        <pre class="arguments" id="e-arguments"></pre>
+      </section>
     <section class="card">
       <h3 class="has-badge">
         Bindings


### PR DESCRIPTION
### WHAT is this pull request doing?
Displays arguments as active or inactive on both queues and exchanges. An active argument is an argument that enables certain functionality in LavinMQ, whereas an inactive argument is any other argument. 
![image](https://github.com/user-attachments/assets/53ce766b-62a8-4734-8188-674adb11a2ee)

Fixes #1024 

### HOW can this pull request be tested?
Check in GUI.
