### PR TITLE
Do not delete message before delivering packet

### DIFF
--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -107,7 +107,7 @@ module LavinMQ
             begin
               packet = build_packet(env, nil)
               yield packet
-            rescue ex   # requeue failed delivery
+            rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
               raise ex
             end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -39,7 +39,7 @@ module LavinMQ
         rescue ex
           @log.error(exception: ex) { "Failed to deliver message in deliver_loop" }
           @consumers.each &.close
-          client = nil
+          self.client = nil
         end
       end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -107,9 +107,11 @@ module LavinMQ
             begin
               packet = build_packet(env, nil)
               yield packet
-            ensure
-              delete_message(sp)
+            rescue ex   # requeue failed delivery
+              @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+              raise ex
             end
+            delete_message(sp)
           else
             id = next_id
             return false unless id


### PR DESCRIPTION
### WHAT is this pull request doing?
The build_packet method constructs an `MQTT::Publish` packet using the message data stored in `env.message`.
If the message has already been deleted (via `delete_message(sp)`), the `env.message` reference becomes invalid, leading to a segmentation fault when accessed.

This PR also fixes a bug where the `@consumers.empty?` never got triggered because the `deliver_loop` didn't yield in time for the `read_loop` to take over and set the `client=nil`, so the `deliver_loop` would continue to loop errors. 
Now we set `client=nil `when the `deliver_loop` experiences an error, so the `consumers.empty?` channel triggers and the loop waits for a new client connection. 

### HOW can this pull request be tested?
run `lavinmqperf mqtt throughput` via the `mqtt-perf` branch and make sure there are no segment faults. 
