### PR TITLE
Faster queue purge if no unacked messages

### DIFF
--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -201,12 +201,10 @@ module LavinMQ
       end
 
       def purge_all
-        while f = @segments.shift?
-          delete_file(f[1])
-        end
-        while f = @acks.shift?
-          delete_file(f[1])
-        end
+        @segments.each_value { |f| delete_file(f) }
+        @segments.clear
+        @acks.each_value { |f| delete_file(f) }
+        @acks.clear
         @deleted.clear
         @segment_msg_count.clear
         @requeued.clear

--- a/src/lavinmq/amqp/queue/message_store.cr
+++ b/src/lavinmq/amqp/queue/message_store.cr
@@ -202,12 +202,12 @@ module LavinMQ
 
       def purge_all
         @segments.each_value { |f| delete_file(f) }
-        @segments.clear
+        @segments = Hash(UInt32, MFile).new
         @acks.each_value { |f| delete_file(f) }
-        @acks.clear
-        @deleted.clear
-        @segment_msg_count.clear
-        @requeued.clear
+        @acks = Hash(UInt32, MFile).new
+        @deleted = Hash(UInt32, Array(UInt32)).new
+        @segment_msg_count = Hash(UInt32, UInt32).new(0u32)
+        @requeued = Deque(SegmentPosition).new
         @bytesize = 0_u64
         @size = 0_u32
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -884,6 +884,7 @@ module LavinMQ::AMQP
 
     def purge(max_count : Int = UInt32::MAX) : UInt32
       if unacked_count == 0 && max_count >= message_count
+        # If there's no unacked and we're purging all messages, we can purge faster by deleting files
         delete_count = message_count
         @msg_store_lock.synchronize { @msg_store.purge_all }
       else

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -883,7 +883,12 @@ module LavinMQ::AMQP
     end
 
     def purge(max_count : Int = UInt32::MAX) : UInt32
-      delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
+      if unacked_count == 0 && max_count >= message_count
+        delete_count = message_count
+        @msg_store_lock.synchronize { @msg_store.purge_all }
+      else
+        delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
+      end
       @log.info { "Purged #{delete_count} messages" }
       delete_count
     rescue ex : MessageStore::Error

--- a/src/lavinmq/amqp/queue/stream_queue.cr
+++ b/src/lavinmq/amqp/queue/stream_queue.cr
@@ -155,6 +155,16 @@ module LavinMQ::AMQP
       end
     end
 
+    def purge(max_count : Int = UInt32::MAX) : UInt32
+      delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
+      @log.info { "Purged #{delete_count} messages" }
+      delete_count
+    rescue ex : MessageStore::Error
+      @log.error(ex) { "Queue closed due to error" }
+      close
+      raise ex
+    end
+
     private def unmap_and_remove_segments_loop
       sleep rand(60).seconds
       until closed?


### PR DESCRIPTION
### WHAT is this pull request doing?
When all messages in a queue is to be purged, and there's no unacked messages, we can just delete the files instead of deleting each message one by one. This makes purging large queues **much** faster. 

Before:
`Purged 50000000 messages in 00:00:04.349915974`
After: 
`Purged 50000000 messages in 00:00:00.002632290`

This is sort of going back to previous functionality that was changed [here](https://github.com/cloudamqp/lavinmq/commit/465e1f768af0b04b78fd378b051e14ec3663f4cc), but now we make sure there's no unacked messages. 

Also makes sure that stream_queues are not affected, since they can not be completely purged. 

Fixes #1079 

### HOW can this pull request be tested?
Specs should cover most cases. 
