### PR TITLE
Make it possible to pass arguments to `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ lint-openapi:
 
 .PHONY: test
 test: lib
-	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context
+	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(SPEC)
 
 .PHONY: format
 format:


### PR DESCRIPTION
Such as: `make test SPEC=spec/server_spec.cr:1234`

Because the crystal spec needs so many arguments now (execution_context etc)
