### PR TITLE
Cache checksums used to compare files between leader and followers

### DIFF
--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -2,41 +2,27 @@ require "../spec_helper"
 require "lz4"
 
 module FollowerSpec
-  def self.sha1(str : String)
-    sha1 = Digest::SHA1.new
-    hash = Bytes.new(sha1.digest_size)
-    sha1.update str.to_slice
-    sha1.final hash
-    sha1.reset
-    hash
-  end
-
   class FakeFileIndex
     include LavinMQ::Clustering::FileIndex
 
     alias FileType = MFile | File
 
-    DEFAULT_WITH_FILE = {} of String => FileType
-
-    @files_with_hash : Hash(String, Bytes)
-
-    def initialize(data_dir : String, files_with_hash : Hash(String, Bytes)? = nil,
-                   @with_file : Hash(String, FileType) = DEFAULT_WITH_FILE)
-      @files_with_hash = files_with_hash || Hash(String, Bytes){
-        File.join(data_dir, "file1") => FollowerSpec.sha1("hash1"),
-        File.join(data_dir, "file2") => FollowerSpec.sha1("hash2"),
-        File.join(data_dir, "file3") => FollowerSpec.sha1("hash3"),
+    def initialize(@data_dir : String)
+      @files_with_hash = {
+        "file1" => Digest::SHA1.digest("hash1"),
+        "file2" => Digest::SHA1.digest("hash2"),
+        "file3" => Digest::SHA1.digest("hash3"),
       }
     end
 
-    def files_with_hash(& : Tuple(String, Bytes) -> Nil)
+    def files_with_hash(& : Tuple(String, Bytes) -> _)
       @files_with_hash.each do |values|
         yield values
       end
     end
 
-    def with_file(filename : String, &) : Nil
-      yield @with_file[filename]?
+    def with_file(filename : String, &)
+      yield nil
     end
   end
 
@@ -144,10 +130,6 @@ module FollowerSpec
         when done.receive
         when timeout(1.second)
           fail "timeout reading file list"
-        end
-
-        file_list = file_list.transform_keys do |k|
-          File.join data_dir, k
         end
 
         file_list.should eq file_index.@files_with_hash

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -47,8 +47,6 @@ describe LavinMQ::Clustering::Client do
     ensure
       server.close
     end
-  ensure
-    replicator.try &.close
   end
 
   it "replicates and streams retained messages to followers" do
@@ -247,7 +245,7 @@ describe LavinMQ::Clustering::Client do
     spawn do
       # Fill the action queue
       loop do
-        replicator.append("path", 1)
+        replicator.append("#{LavinMQ::Config.instance.data_dir}/path", 1)
         appended.send true
       rescue Channel::ClosedError
         break
@@ -280,6 +278,7 @@ describe LavinMQ::Clustering::Client do
       fail "deadlock detected"
     end
   ensure
+    FileUtils.mkdir_p LavinMQ::Config.instance.data_dir
     replicator.try &.close
   end
 end

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -1,0 +1,53 @@
+module LavinMQ
+  module Clustering
+    class Checksums
+      Log = LavinMQ::Log.for "clustering.checksums"
+      @checksums = Hash(String, Bytes).new
+
+      def initialize(@data_dir : String)
+      end
+
+      def store : Nil
+        File.open(File.join(@data_dir, "checksums.sha1"), "w") do |f|
+          @checksums.each do |path, hash|
+            f.puts "#{hash.hexstring} *#{path}"
+          end
+        end
+        Log.info { "Wrote #{@checksums.size} checksums to disk" }
+      end
+
+      def restore : Nil
+        File.open(File.join(@data_dir, "checksums.sha1")) do |f|
+          loop do
+            hash = f.read_string(40).hexbytes
+            f.skip(2) # " *"
+            path = f.read_line
+            @checksums[path] = hash
+          rescue IO::EOFError
+            break
+          end
+          f.delete # prevent out-of-date hashes to be restored in the event of a crash
+          Log.info { "Restored #{@checksums.size} checksums from disk" }
+        end
+      rescue File::NotFoundError
+        Log.info { "Checksums not found" }
+      end
+
+      def []?(path)
+        @checksums[path]?
+      end
+
+      def []=(path, value)
+        @checksums[path] = value
+      end
+
+      def delete(path)
+        @checksums.delete(path)
+      end
+
+      def clear
+        @checksums.clear
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -79,7 +79,7 @@ module LavinMQ
         loop do
           @socket = socket = TCPSocket.new(host, port)
           socket.sync = true
-          socket.read_buffering = false
+          socket.read_buffering = false # use lz4 buffering
           lz4 = Compress::LZ4::Reader.new(socket)
           sync(socket, lz4)
           Log.info { "Streaming changes" }

--- a/src/lavinmq/clustering/file_index.cr
+++ b/src/lavinmq/clustering/file_index.cr
@@ -2,7 +2,7 @@ module LavinMQ
   module Clustering
     module FileIndex
       abstract def files_with_hash(& : Tuple(String, Bytes) -> Nil)
-      abstract def with_file(filename : String, & : MFile | File | Nil -> Nil) : Nil
+      abstract def with_file(filename : String, & : MFile | File | Nil -> _)
     end
   end
 end

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -95,18 +95,17 @@ module LavinMQ
         end
       end
 
-      private def send_file_list(socket = @lz4)
+      private def send_file_list(lz4 = @lz4)
         Log.info { "Calculating hashes" }
         count = 0
         @file_index.files_with_hash do |path, hash|
           count &+= 1
-          socket.write_bytes path.bytesize.to_i32, IO::ByteFormat::LittleEndian
-          socket.write path.to_slice
-          socket.write hash
-          Fiber.yield
+          lz4.write_bytes path.bytesize.to_i32, IO::ByteFormat::LittleEndian
+          lz4.write path.to_slice
+          lz4.write hash
         end
-        socket.write_bytes 0i32 # 0 means end of file list
-        socket.flush
+        lz4.write_bytes 0i32 # 0 means end of file list
+        lz4.flush
         Log.info { "File list sent (#{count} files)" }
         count
       end

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -119,7 +119,9 @@ module LavinMQ
           break if filename_len.zero?
           filename = socket.read_string(filename_len)
           requested_files << filename
+          Log.info { "#{filename} requested" }
         end
+        Log.info { "#{requested_files.size} files requested" }
         total_requested_bytes = requested_files.sum { |p| File.size File.join(@data_dir, p) }
         sent_bytes = 0i64
         start = Time.monotonic

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -17,8 +17,8 @@ module LavinMQ
       getter remote_address
 
       def initialize(@socket : TCPSocket, @data_dir : String, @file_index : FileIndex)
-        @socket.write_timeout = 5.seconds
-        @socket.read_timeout = 5.seconds
+        @socket.write_timeout = 60.seconds
+        @socket.read_timeout = 60.seconds
         @remote_address = @socket.remote_address
         @lz4 = Compress::LZ4::Writer.new(@socket, Compress::LZ4::CompressOptions.new(auto_flush: false, block_mode_linked: true))
       end

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -36,7 +36,7 @@ module LavinMQ
           @socket.tcp_keepalive_interval = keepalive[1]
           @socket.tcp_keepalive_count = keepalive[2]
         end
-        Log.info { "Accepted ID #{@id}" }
+        Log.info { "Accepted ID #{@id.to_s(36)}" }
       end
 
       def full_sync : Nil

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -125,7 +125,6 @@ module LavinMQ
         start = Time.monotonic
         requested_files.each do |filename|
           file_size = send_requested_file(filename)
-          @lz4.flush
 
           sent_bytes += file_size
           total_requested_bytes -= file_size
@@ -136,6 +135,7 @@ module LavinMQ
           Log.info { "#{total_requested_bytes.humanize_bytes} left, expected #{time_left}s left" }
           Fiber.yield
         end
+        @lz4.flush
       end
 
       private def send_requested_file(filename) : Int

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -101,7 +101,6 @@ module LavinMQ
         count = 0
         @file_index.files_with_hash do |path, hash|
           count &+= 1
-          path = path[@data_dir.bytesize + 1..]
           socket.write_bytes path.bytesize.to_i32, IO::ByteFormat::LittleEndian
           socket.write path.to_slice
           socket.write hash
@@ -109,7 +108,7 @@ module LavinMQ
         end
         socket.write_bytes 0i32 # 0 means end of file list
         socket.flush
-        Log.info { "File list sent (#{count} files}" }
+        Log.info { "File list sent (#{count} files)" }
         count
       end
 
@@ -144,17 +143,14 @@ module LavinMQ
       end
 
       def add(path, mfile : MFile? = nil) : Int64
-        path = path[(@data_dir.size + 1)..] if Path[path].absolute?
         send_action AddAction.new(@data_dir, path, mfile)
       end
 
       def append(path, obj) : Int64
-        path = path[(@data_dir.size + 1)..] if Path[path].absolute?
         send_action AppendAction.new(@data_dir, path, obj)
       end
 
       def delete(path) : Int64
-        path = path[(@data_dir.size + 1)..] if Path[path].absolute?
         send_action DeleteAction.new(@data_dir, path)
       end
 

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -96,8 +96,9 @@ module LavinMQ
                 file.unreserve
               end
             else
-              next unless File.exists? path
-              sha1.file path
+              filename = File.join(@data_dir, path)
+              next unless File.exists? filename
+              sha1.file filename
             end
             hash = sha1.final
             @checksums[path] = hash

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -88,7 +88,6 @@ module LavinMQ
           if calculated_hash = @checksums[path]?
             yield({path, calculated_hash})
           else
-            sha1.reset
             if file = mfile
               begin
                 file.reserve
@@ -102,6 +101,8 @@ module LavinMQ
             end
             hash = sha1.final
             @checksums[path] = hash
+            sha1.reset
+            Fiber.yield # CPU bound so allow other fibers to run here
             yield({path, hash})
           end
         end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -78,6 +78,8 @@ module LavinMQ
       @runner.run do
         start
       end
+      @replicator.close
+      @data_dir_lock.try &.release
     end
 
     def stop
@@ -88,8 +90,6 @@ module LavinMQ
       @http_server.try &.close rescue nil
       @amqp_server.try &.close rescue nil
       @runner.stop
-      @replicator.close
-      @data_dir_lock.try &.release
     end
 
     private def print_environment_info


### PR DESCRIPTION
Cache the checksums used to compare files between leader and followers, both in memory and to disk. 

A risk that this introduces is that the files has been modified between store (shutdown of server) and restore (start of server). This doesn't detect bit rot either. 