### PR TITLE
Bugfix: bindings added despite invalid weight in ConsitentHashExchange

### DIFF
--- a/src/lavinmq/amqp/exchange/consistent_hash.cr
+++ b/src/lavinmq/amqp/exchange/consistent_hash.cr
@@ -20,9 +20,9 @@ module LavinMQ
       end
 
       def bind(destination : Destination, routing_key : String, headers : AMQP::Table?)
+        w = weight(routing_key)
         return false if @bindings.has_key? destination
         @bindings[destination] = routing_key
-        w = weight(routing_key)
         @hasher.add(destination.name, w, destination)
         binding_key = BindingKey.new(routing_key, @arguments)
         data = BindingDetails.new(name, vhost.name, binding_key, destination)
@@ -31,8 +31,8 @@ module LavinMQ
       end
 
       def unbind(destination : Destination, routing_key : String, headers : AMQP::Table?)
-        return false unless @bindings.delete destination
         w = weight(routing_key)
+        return false unless @bindings.delete destination
         @hasher.remove(destination.name, w)
 
         binding_key = BindingKey.new(routing_key, @arguments)


### PR DESCRIPTION
### WHAT is this pull request doing?
When adding bindings to a consistent hash exchange routing key must be a number. This is validated in both `#bind` and `#unbind`. However, it was done too late in `#bind` so binding information was added to `@bindings` and thus visible in the binding list in the management UI.

The validation was however done before the destination was added to the `@hasher` meaning that even though a binding was visible in the UI, no message is routed.

This PR will make sure that weight is calculated and validated first in `#bind` and `#unbind`.

It also reorganizes the specs for consistent hash exchange.

### HOW can this pull request be tested?
Run specs
