### PR TITLE
fixes a bug where using routing_key or exchange with length 255 causes an ArithmeticOverflow

### DIFF
--- a/src/lavinmq/message.cr
+++ b/src/lavinmq/message.cr
@@ -37,9 +37,11 @@ module LavinMQ
 
     def self.skip(io, format = IO::ByteFormat::SystemEndian) : UInt64
       skipped = 0_u64
-      skipped += io.skip(sizeof(UInt64))                             # ts
-      skipped += io.skip(io.read_byte || raise IO::EOFError.new) + 1 # ex
-      skipped += io.skip(io.read_byte || raise IO::EOFError.new) + 1 # rk
+      skipped += io.skip(sizeof(UInt64))                         # ts
+      skipped += io.skip(io.read_byte || raise IO::EOFError.new) # ex
+      skipped += 1                                               # next pos
+      skipped += io.skip(io.read_byte || raise IO::EOFError.new) # rk
+      skipped += 1                                               # next pos
       skipped += AMQ::Protocol::Properties.skip(io, format)
       skipped += io.skip(UInt64.from_io io, format) + sizeof(UInt64)
       skipped


### PR DESCRIPTION
### WHAT is this pull request doing?
fixes a bug where using routing_key or exchange with length 255 causes an ArithmeticOverflow

Fixes #1093 

### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
