### PR TITLE
Fix(mqtt/session): Remove consumer after requeueing unacked messages when setting client

### DIFF
--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -47,9 +47,11 @@ module LavinMQ
         return if @closed
         @last_get_time = RoughTime.monotonic
 
-        @msg_store_lock.synchronize do
-          @unacked.values.each do |sp|
-            @msg_store.requeue(sp)
+        if !clean_session?
+          @msg_store_lock.synchronize do
+            @unacked.values.each do |sp|
+              @msg_store.requeue(sp)
+            end
           end
         end
         @unacked.clear

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -46,9 +46,6 @@ module LavinMQ
       def client=(client : MQTT::Client?)
         return if @closed
         @last_get_time = RoughTime.monotonic
-        @consumers.each do |c|
-          rm_consumer c
-        end
 
         @msg_store_lock.synchronize do
           @unacked.values.each do |sp|
@@ -56,6 +53,10 @@ module LavinMQ
           end
         end
         @unacked.clear
+
+        @consumers.each do |c|
+          rm_consumer c
+        end
 
         if c = client
           add_consumer MQTT::Consumer.new(c, self)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -47,7 +47,7 @@ module LavinMQ
         return if @closed
         @last_get_time = RoughTime.monotonic
 
-        if !clean_session?
+        unless clean_session?
           @msg_store_lock.synchronize do
             @unacked.values.each do |sp|
               @msg_store.requeue(sp)


### PR DESCRIPTION
### WHAT is this pull request doing? 

When a new MQTT client tries to connect with an ID already in use by a MQTT client with unacknowledged messages, the old connection isn't properly removed and gets stuck. This happens because the Session tries to requeue the unacked messages after it has removed the consumer.  

This PR makes sure we try to requeue messages frist, and remove the consumer after that is finished. 
It also adds so we don't requeue messages if the session is an auto_delete/unclean session