### PR TITLE
feat(amqp/channels): support consumer_max_per_channel configuration to limit amount of consumers #938

### DIFF
--- a/spec/channel_spec.cr
+++ b/spec/channel_spec.cr
@@ -2,25 +2,36 @@ require "./spec_helper"
 require "amqp-client"
 
 describe LavinMQ::AMQP::Channel do
-  describe "Configurations" do
-    it "should respect consumer_max_per_channel" do
-      config = LavinMQ::Config.new
-      config.consumer_max_per_channel = 1
-      with_amqp_server(config: config) do |s|
-        connection = AMQP::Client.new(port: amqp_port(s)).connect
-        channel = connection.channel
-        channel.queue("test:queue:1")
-        channel.queue("test:queue:2")
-        channel.basic_consume("test:queue:1") { }
-        begin
-          channel.basic_consume("test:queue:2") { }
-          fail "Expected error when trying to surpass consumer_max_per_channel"
-        rescue ex : Exception
-          ex.should be_a(AMQP::Client::Channel::ClosedException)
-          error_message = ex.message || ""
-          error_message.should contain "RESOURCE_ERROR"
-        end
+  it "should respect consumer_max_per_channel config" do
+    config = LavinMQ::Config.new
+    config.max_consumers_per_channel = 1
+    with_amqp_server(config: config) do |s|
+      connection = AMQP::Client.new(port: amqp_port(s)).connect
+      channel = connection.channel
+      channel.queue("test:queue:1")
+      channel.queue("test:queue:2")
+      channel.basic_consume("test:queue:1") { }
+      begin
+        channel.basic_consume("test:queue:2") { }
+        fail "Expected error when trying to surpass consumer_max_per_channel"
+      rescue ex : Exception
+        ex.should be_a(AMQP::Client::Channel::ClosedException)
+        error_message = ex.message || ""
+        error_message.should contain "RESOURCE_ERROR"
       end
+    end
+  end
+
+  it "consumer_max_per_channel = 0 allows unlimited consumers" do
+    config = LavinMQ::Config.new
+    config.max_consumers_per_channel = 0
+    with_amqp_server(config: config) do |s|
+      connection = AMQP::Client.new(port: amqp_port(s)).connect
+      channel = connection.channel
+      channel.queue("test:queue:1")
+      channel.queue("test:queue:2")
+      channel.basic_consume("test:queue:1") { }
+      channel.basic_consume("test:queue:1") { }
     end
   end
 end

--- a/spec/channel_spec.cr
+++ b/spec/channel_spec.cr
@@ -7,13 +7,11 @@ describe LavinMQ::AMQP::Channel do
       config = LavinMQ::Config.new
       config.consumer_max_per_channel = 1
       with_amqp_server(config: config) do |s|
-        puts "Creating resources"
         connection = AMQP::Client.new(port: amqp_port(s)).connect
         channel = connection.channel
         channel.queue("test:queue:1")
         channel.queue("test:queue:2")
         channel.basic_consume("test:queue:1") {}
-        puts "Consuming Q1"
         begin
           channel.basic_consume("test:queue:2") {}
           fail "Expected NOT_ALLOWED error when trying to surpass consumer_max_per_channel"

--- a/spec/channel_spec.cr
+++ b/spec/channel_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+require "amqp-client"
+
+describe LavinMQ::AMQP::Channel do
+  describe "Configurations" do
+    it "should respect consumer_max_per_channel" do
+      config = LavinMQ::Config.new
+      config.consumer_max_per_channel = 1
+      with_amqp_server(config: config) do |s|
+        puts "Creating resources"
+        connection = AMQP::Client.new(port: amqp_port(s)).connect
+        channel = connection.channel
+        channel.queue("test:queue:1")
+        channel.queue("test:queue:2")
+        channel.basic_consume("test:queue:1") {}
+        puts "Consuming Q1"
+        begin
+          channel.basic_consume("test:queue:2") {}
+          fail "Expected NOT_ALLOWED error when trying to surpass consumer_max_per_channel"
+        rescue ex : Exception 
+          ex.should be_a(AMQP::Client::Channel::ClosedException)
+        end
+      end
+    end
+  end
+end

--- a/spec/channel_spec.cr
+++ b/spec/channel_spec.cr
@@ -11,12 +11,14 @@ describe LavinMQ::AMQP::Channel do
         channel = connection.channel
         channel.queue("test:queue:1")
         channel.queue("test:queue:2")
-        channel.basic_consume("test:queue:1") {}
+        channel.basic_consume("test:queue:1") { }
         begin
-          channel.basic_consume("test:queue:2") {}
-          fail "Expected NOT_ALLOWED error when trying to surpass consumer_max_per_channel"
-        rescue ex : Exception 
+          channel.basic_consume("test:queue:2") { }
+          fail "Expected error when trying to surpass consumer_max_per_channel"
+        rescue ex : Exception
           ex.should be_a(AMQP::Client::Channel::ClosedException)
+          error_message = ex.message || ""
+          error_message.should contain "RESOURCE_ERROR"
         end
       end
     end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -340,6 +340,10 @@ module LavinMQ
       end
 
       def consume(frame)
+        if (@consumers.size + 1) > Config.instance.consumer_max_per_channel
+          @client.send_not_allowed(frame, "Channel consumers #{@consumers.size} reached max consumers #{Config.instance.consumer_max_per_channel}")
+          return
+        end
         if frame.consumer_tag.empty?
           frame.consumer_tag = "amq.ctag-#{Random::Secure.urlsafe_base64(24)}"
         end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -340,8 +340,8 @@ module LavinMQ
       end
 
       def consume(frame)
-        if (@consumers.size + 1) > Config.instance.consumer_max_per_channel
-          @client.send_not_allowed(frame, "Channel consumers #{@consumers.size} reached max consumers #{Config.instance.consumer_max_per_channel}")
+        if @consumers.size >= Config.instance.consumer_max_per_channel
+          @client.send_resource_error(frame, "Max #{Config.instance.consumer_max_per_channel} consumers per channel reached")
           return
         end
         if frame.consumer_tag.empty?

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -340,8 +340,8 @@ module LavinMQ
       end
 
       def consume(frame)
-        if @consumers.size >= Config.instance.consumer_max_per_channel
-          @client.send_resource_error(frame, "Max #{Config.instance.consumer_max_per_channel} consumers per channel reached")
+        if @consumers.size >= Config.instance.max_consumers_per_channel > 0
+          @client.send_resource_error(frame, "Max #{Config.instance.max_consumers_per_channel} consumers per channel reached")
           return
         end
         if frame.consumer_tag.empty?

--- a/src/lavinmq/amqp/channel_reply_code.cr
+++ b/src/lavinmq/amqp/channel_reply_code.cr
@@ -7,13 +7,13 @@ module LavinMQ
       NOT_FOUND           = 404
       RESOURCE_LOCKED     = 405
       PRECONDITION_FAILED = 406
-      NOT_ALLOWED         = 530
       # 540 is marked as connection level reply-code at
       # but also mentioned in text "MUST raise a channel exception with reply code 540 (not implemented)"
       # indicating it's ok to use as channel close reply code as well
       NOT_IMPLEMENTED = 540
       # TODO: Is this reply code ok to use on channel close? Does not look like that from the spec
       UNEXPECTED_FRAME = 505
+      RESOURCE_ERROR   = 506
     end
   end
 end

--- a/src/lavinmq/amqp/channel_reply_code.cr
+++ b/src/lavinmq/amqp/channel_reply_code.cr
@@ -7,6 +7,7 @@ module LavinMQ
       NOT_FOUND           = 404
       RESOURCE_LOCKED     = 405
       PRECONDITION_FAILED = 406
+      NOT_ALLOWED = 530
       # 540 is marked as connection level reply-code at
       # but also mentioned in text "MUST raise a channel exception with reply code 540 (not implemented)"
       # indicating it's ok to use as channel close reply code as well

--- a/src/lavinmq/amqp/channel_reply_code.cr
+++ b/src/lavinmq/amqp/channel_reply_code.cr
@@ -7,7 +7,7 @@ module LavinMQ
       NOT_FOUND           = 404
       RESOURCE_LOCKED     = 405
       PRECONDITION_FAILED = 406
-      NOT_ALLOWED = 530
+      NOT_ALLOWED         = 530
       # 540 is marked as connection level reply-code at
       # but also mentioned in text "MUST raise a channel exception with reply code 540 (not implemented)"
       # indicating it's ok to use as channel close reply code as well

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -535,9 +535,9 @@ module LavinMQ
         close_connection(nil, ConnectionReplyCode::INTERNAL_ERROR, "Unexpected error, please report")
       end
 
-      def send_not_allowed(frame, message)
-        @log.warn { "Not allowed channel=#{frame.channel} reason=\"#{message}\"" }
-        close_channel(frame, ChannelReplyCode::NOT_ALLOWED, message)
+      def send_resource_error(frame, message)
+        @log.warn { "Resource error channel=#{frame.channel} reason=\"#{message}\"" }
+        close_channel(frame, ChannelReplyCode::RESOURCE_ERROR, message)
       end
 
       def send_frame_error(message = nil)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -535,6 +535,11 @@ module LavinMQ
         close_connection(nil, ConnectionReplyCode::INTERNAL_ERROR, "Unexpected error, please report")
       end
 
+      def send_not_allowed(frame, message)
+        @log.warn { "Not allowed channel=#{frame.channel} reason=\"#{message}\"" }
+        close_channel(frame, ChannelReplyCode::NOT_ALLOWED, message)
+      end
+
       def send_frame_error(message = nil)
         close_connection(nil, ConnectionReplyCode::FRAME_ERROR, message)
       end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -66,7 +66,7 @@ module LavinMQ
     property max_deleted_definitions = 8192         # number of deleted queues, unbinds etc that compacts the definitions file
     property consumer_timeout : UInt64? = nil
     property consumer_timeout_loop_interval = 60 # seconds
-    property consumer_max_per_channel = UInt64::MAX
+    property consumer_max_per_channel = UInt16::MAX
     property default_consumer_prefetch = UInt16::MAX
     property yield_each_received_bytes = 131_072    # max number of bytes to read from a client connection without letting other tasks in the server do any work
     property yield_each_delivered_bytes = 1_048_576 # max number of bytes sent to a client without tending to other tasks in the server

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -66,6 +66,7 @@ module LavinMQ
     property max_deleted_definitions = 8192         # number of deleted queues, unbinds etc that compacts the definitions file
     property consumer_timeout : UInt64? = nil
     property consumer_timeout_loop_interval = 60 # seconds
+    property consumer_max_per_channel = UInt64::MAX
     property default_consumer_prefetch = UInt16::MAX
     property yield_each_received_bytes = 131_072    # max number of bytes to read from a client connection without letting other tasks in the server do any work
     property yield_each_delivered_bytes = 1_048_576 # max number of bytes sent to a client without tending to other tasks in the server


### PR DESCRIPTION
### WHAT is this pull request doing?
Adding a new configuration - at broker-level that ensures a limit for consumers per channel
Closes #938

### HOW can this pull request be tested?
Mainly new spec on the PR that ensures the Client throws a Channel exception when going over the threshold