### PR TITLE
Use `Hash` instead of `AMQP::Table` in headers exchange

### DIFF
--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -252,7 +252,16 @@ module MessageRoutingSpec
           msg_hdrs = hdrs_all.dup
           msg_hdrs.delete "x-match"
           msg_hdrs["org"] = "google"
-          matches(x, "", msg_hdrs).size.should eq 0
+          matches(x, "", msg_hdrs).should be_empty
+        end
+
+        it "should not match if args are missing" do
+          q = LavinMQ::AMQP::Queue.new(vhost, "q")
+          bind_hdrs = hdrs_all.clone.merge!({
+            "missing": "header",
+          })
+          x.bind(q, "", bind_hdrs)
+          matches(x, "", hdrs_all).should be_empty
         end
       end
 
@@ -273,7 +282,7 @@ module MessageRoutingSpec
           msg_hdrs.delete "x-match"
           msg_hdrs["org"] = "google"
           msg_hdrs["user"] = "hest"
-          matches(x, "", msg_hdrs).size.should eq 0
+          matches(x, "", msg_hdrs).should be_empty
         end
 
         it "should match nestled amq-protocol tables" do
@@ -328,7 +337,7 @@ module MessageRoutingSpec
         })
         x.bind(q12, "", hdrs1)
         x.unbind(q12, "", hdrs2)
-        matches(x, "", hdrs1).size.should eq 0
+        matches(x, "", hdrs1).should be_empty
       end
 
       describe "match empty" do

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -434,10 +434,10 @@ describe LavinMQ::Server do
         q = ch.queue
         hdrs = AMQP::Client::Arguments.new
         hdrs["x-match"] = "all"
+        x = ch.exchange("asdasdasd", "headers", passive: false, args: hdrs)
         hdrs["org"] = "84codes"
         hdrs["user"] = "test"
-        x = ch.exchange("asdasdasd", "headers", passive: false, args: hdrs)
-        q.bind(x.name, "")
+        q.bind(x.name, "", args: hdrs)
         x.publish_confirm "m1", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
         hdrs["user"] = "hest"
         x.publish_confirm "m2", q.name, props: AMQP::Client::Properties.new(headers: hdrs)

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -453,10 +453,10 @@ describe LavinMQ::Server do
         q = ch.queue
         hdrs = AMQP::Client::Arguments.new
         hdrs["x-match"] = "any"
+        x = ch.exchange("hx1", "headers", passive: false, args: hdrs)
         hdrs["org"] = "84codes"
         hdrs["user"] = "test"
-        x = ch.exchange("hx1", "headers", passive: false, args: hdrs)
-        q.bind(x.name, "")
+        q.bind(x.name, "", args: hdrs)
         x.publish "m1", q.name, props: AMQP::Client::Properties.new(headers: hdrs)
         hdrs["user"] = "hest"
         x.publish "m2", q.name, props: AMQP::Client::Properties.new(headers: hdrs)

--- a/src/lavinmq/amqp/exchange/headers.cr
+++ b/src/lavinmq/amqp/exchange/headers.cr
@@ -62,6 +62,7 @@ module LavinMQ
       end
 
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
+        default_x_match = @arguments["x-match"]?
         @bindings.each do |args, destinations|
           if headers.nil? || headers.empty?
             next unless args.empty?
@@ -69,7 +70,7 @@ module LavinMQ
               yield destination
             end
           else
-            x_match = (args["x-match"]? || @arguments["x-match"]?) == "any" ? :any : :all
+            x_match = (args["x-match"]? || default_x_match) == "any" ? :any : :all
             next unless deep_match?(args, headers, x_match)
             destinations.each do |destination|
               yield destination

--- a/src/lavinmq/amqp/exchange/headers.cr
+++ b/src/lavinmq/amqp/exchange/headers.cr
@@ -83,9 +83,9 @@ module LavinMQ
         return left == right unless left.is_a? Hash || left.is_a? AMQP::Table
         return false unless right.is_a? Hash || right.is_a? AMQP::Table
         if x_match == :any
-          left.any? { |k, v| !k.starts_with?("x-") && deep_match?(v, right[k], x_match) }
+          left.any? { |k, v| !k.starts_with?("x-") && deep_match?(v, right[k]?, x_match) }
         else
-          left.all? { |k, v| k.starts_with?("x-") || deep_match?(v, right[k], x_match) }
+          left.all? { |k, v| k.starts_with?("x-") || deep_match?(v, right[k]?, x_match) }
         end
       end
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
The header exchange stores stores bindings in a `Hash` with the binding arguments as key. This works as long as the hash contains eight or less elements, because then the hash will only use the `==` operator when comparing keys. When the hash has more than eight elements it will rely on `#hash(hasher)` instead.

Binding arguments is a `AMQP::Table` which doesn't implement `#hash(hasher)` which means that the hash won't treat two equal (==) tables as the same key meaning, that the hash may container many equal keys (the "same" key multiple times). This also makes it impossible to delete entries etc.

This PR will change header exchange to store its bindings as `Hash` which can be used as a key in a `Hash`. Since bind and unbind isn't in the hot path this is fine.

This PR will also remove the merging of exchange arguments with bind arguments, which must be seen as a bug (or an odd and undocmented feature).

### HOW can this pull request be tested?
Specs
