### PR TITLE
Dont log twice when user not found 

### DIFF
--- a/src/lavinmq/auth/authenticators/basic.cr
+++ b/src/lavinmq/auth/authenticators/basic.cr
@@ -10,6 +10,7 @@ module LavinMQ
       def authenticate(username : String, password : Bytes) : User?
         user = @users[username]
         return user if user && user.password && user.password.not_nil!.verify(password)
+      rescue KeyError # User not found
       rescue ex : Exception
         Log.error { "Basic authentication failed: #{ex.message}" }
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
Rescues `KeyError` in `BasicAuthenticator` so we dont log "Missing hash key" since we already log "User abc not found"


```
2025-05-20 13:46:42.090 lmq.amqp.connection_factory[address: "1.2.3.4:12345"] User "abc" not found 
2025-05-20 13:46:41.654 lmq.auth.handler Basic authentication failed: Missing hash key: "abc"
```

### HOW can this pull request be tested?
Manual
