### PR TITLE
Update example lavinmq.ini conf file with current configs

### DIFF
--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -2,18 +2,36 @@
 data_dir = /var/lib/lavinmq
 default_user_only_loopback = true
 log_level = info
+;free_disk_min = 0
+;free_disk_warn = 0
 ;log_file = /var/log/lavinmq.log
 ;socket_buffer_size = 16384
 ;tls_cert = /etc/lavinmq/cert.pem
 ;tls_key = /etc/lavinmq/key.pem
 ;tls_min_version = 1.2
+;tls_ciphers = nil
 ;tcp_keepalive = 60:10:3
+;tcp_nodelay = false
+;tcp_recv_buffer_size = nil
+;tcp_send_buffer_size = nil
+;consumer_timeout = 0
+;data_dir_lock = true
+;default_consumer_prefetch = 65535
+;default_user = guest
+;default_password = +pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+
+;log_exchange = false
+;max_deleted_definitions = 8192
+;segment_size = 8388608
+;set_timestamp = false
+;stats_interval = 5000
+;stats_log_size = 120
 
 [mgmt]
 bind = 0.0.0.0
 port = 15672
 tls_port = 15671
 unix_path = /tmp/lavinmq-http.sock
+;systemd_socket_name = lavinmq-http.socket
 
 [amqp]
 bind = 0.0.0.0
@@ -22,3 +40,25 @@ tcp_proxy_protocol = false
 tls_port = 5671
 unix_path = /tmp/lavinmq.sock
 unix_proxy_protocol = true
+;channel_max = 2048
+;frame_max = 1048576
+;heartbeat = 0
+;max_message_size = 128 * 1024**2
+;systemd_socket_name = lavinmq-amqp.socket
+
+[mqtt]
+bind = 0.0.0.0
+port = 1883
+tls_port = 8883
+unix_path = /tmp/lavinmq-mqtt.sock
+;max_inflight_messages = 65535
+;default_vhost = /
+
+[clustering]
+enabled = true
+bind = 0.0.0.0
+port = 5679
+;etcd_prefix = lavinmq
+;etcd_endpoints = localhost:2379
+;max_unsynced_actions = 8192
+;advertised_uri = nil


### PR DESCRIPTION
### WHAT is this pull request doing?
I noticed that the lavinmq.ini example config file is not up to date with all the current configs. 
We have more configs documented on [the website](https://lavinmq.com/documentation/configuration-files). 
Cross checking with what is available in [config.cr](https://github.com/cloudamqp/lavinmq/blob/115ce4a0e3de586badb328b19eefadd0c13a0eb3/src/lavinmq/config.cr), we need to update the website too. I can update the website once I know we have a good example config file. 

Need some input on the below:
- consumer_timeout can't be nil as mentioned on our website. Only ints allowed or? 
- what configs should or shouldn't be commented out?
- any configs I'm missing?

### HOW can this pull request be tested?
Uncommented all configs and started LavinMQ with the updated lavinmq example config file.
