### PR TITLE
fix(mqtt/connection-factory) Dont log EOF errors(closed by peer) for connect attempts

### DIFF
--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -40,6 +40,8 @@ module LavinMQ
             connack io, false, Connack::ReturnCode.new(ex.return_code)
           end
           socket.close
+        rescue ex : ::IO::EOFError
+          socket.close
         rescue ex
           logger.warn { "Received invalid Connect packet: #{ex.inspect}" }
           socket.close


### PR DESCRIPTION
### WHAT is this pull request doing?
Have same behaviour for `MQTT::ConnectionFactory` as in the `AMQP::ConnectionFactory` for reading from a closed socket. 

Now it will just close socket silently. Before if you send to ping `1883`/`8883` with zero-i/o mode, it will log `IO::EOFError` because socket will get closed by peer.

### HOW can this pull request be tested?
`nc -vz localhost 1883`
LavinMQ should not log EOF error. 