### PR TITLE
bugfix: channel.basic_get no longer increments deliver_count

### DIFF
--- a/spec/api/channels_spec.cr
+++ b/spec/api/channels_spec.cr
@@ -69,7 +69,7 @@ describe LavinMQ::HTTP::ChannelsController do
           ch.prefetch(1)
 
           ch.basic_get(q.name, no_ack: false)
-          q.subscribe {}
+          q.subscribe { }
 
           response = http.get("/api/channels")
           response.status_code.should eq 200

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -329,6 +329,9 @@ module LavinMQ
       def deliver(frame, msg, redelivered = false) : Nil
         raise ClosedError.new("Channel is closed") unless @running
         @client.deliver(frame, msg)
+      end
+
+      def increment_deliver_count(redelivered : Bool)
         if redelivered
           @redeliver_count.add(1)
           @client.vhost.event_tick(EventType::ClientRedeliver)

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -82,6 +82,7 @@ module LavinMQ
           queue.consume_get(@no_ack) do |env|
             deliver(env.message, env.segment_position, env.redelivered)
             delivered_bytes &+= env.message.bytesize
+            @channel.increment_deliver_count(env.redelivered)
           end
           if delivered_bytes > Config.instance.yield_each_delivered_bytes
             delivered_bytes = 0

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -671,7 +671,9 @@ module LavinMQ
       in EventType::ClientReject         then @reject_count.add(1)
       in EventType::ConsumerAdded        then @consumer_added_count.add(1)
       in EventType::ConsumerRemoved      then @consumer_removed_count.add(1)
-      in EventType::ClientGet            then @get_count.add(1)
+      in EventType::ClientGet
+        @get_count.add(1)
+        @deliver_get_count.add(1)
       in EventType::ClientDeliver
         @deliver_count.add(1)
         @deliver_get_count.add(1)


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes a bug where `basic_get` (and probably `basic_return` as well) would increment `deliver_count`, because `deliver_count` was incremented in `deliver()`, which is used by both `basic_get` and `consume`. 
This fixes it by increasing `deliver_count` in the `deliver_loop` on the consumer instead. 

### HOW can this pull request be tested?
Run included spec
