### PR TITLE
Add openapi docs for vhots-limits endpoints

### DIFF
--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -303,3 +303,5 @@ tags:
   description: Manage vhosts.
 - name: auth
   description: Hash a password.
+- name: vhost-limits
+  description: Manage vhost limits.

--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -266,6 +266,12 @@ paths:
     "$ref": "./paths/vhosts.yaml#/~1vhosts~1{name}~1permissions"
   "/auth/hash_password":
     "$ref": "./paths/auth.yaml#/~1auth~1hash_password"
+  "/vhost-limits":
+    "$ref": "./paths/vhost-limits.yaml#/~1vhost-limits"
+  "/vhost-limits/{vhost}":
+    "$ref": "./paths/vhost-limits.yaml#/~1vhost-limits~1{vhost}"
+  "/vhost-limits/{vhost}/{type}":
+    "$ref": "./paths/vhost-limits.yaml#/~1vhost-limits~1{vhost}~1{type}"
 tags:
 - name: bindings
   description: Manage bindings.

--- a/static/docs/paths/vhost-limits.yaml
+++ b/static/docs/paths/vhost-limits.yaml
@@ -1,0 +1,131 @@
+---
+"/vhost-limits":
+  get:
+    tags:
+    - vhost-limits
+    description: List all vhosts with their limits (max-connections, max-queues).
+    summary: List vhost limits
+    operationId: GetVhostLimits
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                "$ref": "../openapi.yaml#/components/schemas/vhost-limits"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/vhost-limits/{vhost}":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  get:
+    tags:
+    - vhost-limits
+    description: Get limits for a specific vhost.
+    summary: Get vhost limits
+    operationId: GetVhostLimitsByVhost
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/vhost-limits"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/vhost-limits/{vhost}/{type}":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  - in: path
+    name: type
+    required: true
+    schema:
+      type: string
+      enum:
+      - max-connections
+      - max-queues
+      description: Type of limit to set or delete.
+  put:
+    tags:
+    - vhost-limits
+    description: Set a specific limit (max-connections or max-queues) for a vhost.
+    summary: Set vhost limit
+    operationId: PutVhostLimit
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              value:
+                type: integer
+                description: Value of the limit. Use `null` to remove the limit.
+    responses:
+      '204':
+        description: The limit was successfully set.
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+  delete:
+    tags:
+    - vhost-limits
+    description: Remove a specific limit (max-connections or max-queues) for a vhost.
+    summary: Delete vhost limit
+    operationId: DeleteVhostLimit
+    responses:
+      '204':
+        description: The limit was successfully removed.
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds openapi docs for the `vhost-limits` endpoints 

Fixes #1076