### PR TITLE
Use /usr/src/lavinmq as build dir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Base layer
 FROM 84codes/crystal:latest-ubuntu-24.04 AS base
 RUN apt-get update && apt-get install -y liblz4-dev dpkg-dev
-WORKDIR /tmp
+WORKDIR /usr/src/lavinmq
 COPY shard.yml shard.lock .
 RUN shards install --production
 COPY ./static ./static
@@ -34,7 +34,7 @@ FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y libssl3 ca-certificates liblz4-1 && \
     rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/*
-COPY --from=builder /tmp/bin/* /usr/bin/
+COPY --from=builder /usr/src/lavinmq/bin/* /usr/bin/
 EXPOSE 5672 15672
 VOLUME /var/lib/lavinmq
 WORKDIR /var/lib/lavinmq


### PR DESCRIPTION
Paths of source files in stack traces will look nicer, than `/tmp`.

Albeit longer:
`/usr/src/lavinmq/src/lavinmq.cr`
`/tmp/src/lavinmq.cr`
