### PR TITLE
Refactor MFiles + the replication of them

### DIFF
--- a/spec/clustering/actions_spec.cr
+++ b/spec/clustering/actions_spec.cr
@@ -163,38 +163,5 @@ describe LavinMQ::Clustering::Action do
         end
       end
     end
-
-    describe "with FileRange" do
-      describe "#send" do
-        it "writes filename and data to IO" do
-          with_datadir do |data_dir|
-            filename = "file1"
-            absolute = File.join data_dir, filename
-            File.write absolute, "baz foo bar"
-            range = LavinMQ::Clustering::FileRange.new(MFile.new(absolute), 4, 3)
-            action = LavinMQ::Clustering::AppendAction.new data_dir, filename, range
-
-            io = IO::Memory.new
-            action.send io
-            io.rewind
-
-            read_and_verify_filename(io, filename)
-            read_and_verify_data(io, "foo".to_slice)
-          end
-        end
-      end
-      describe "#lag_size" do
-        it "should count filename and size of FileRange" do
-          with_datadir do |data_dir|
-            filename = "file1"
-            absolute = File.join data_dir, filename
-            File.write absolute, "foo bar baz"
-            range = LavinMQ::Clustering::FileRange.new(MFile.new(absolute), 4, 3)
-            action = LavinMQ::Clustering::AppendAction.new data_dir, filename, range
-            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + range.len)
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/clustering/actions_spec.cr
+++ b/spec/clustering/actions_spec.cr
@@ -29,14 +29,14 @@ def read_and_verify_data(io, expected_data)
 end
 
 describe LavinMQ::Clustering::Action do
-  describe "AddAction" do
+  describe "ReplaceAction" do
     describe "without @mfile" do
       describe "#send" do
         it "writes filename and data to IO" do
           with_datadir do |data_dir|
             filename = "file1"
             File.write File.join(data_dir, filename), "foo"
-            action = LavinMQ::Clustering::AddAction.new data_dir, filename
+            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
             io = IO::Memory.new
             action.send io
             io.rewind
@@ -52,7 +52,7 @@ describe LavinMQ::Clustering::Action do
           with_datadir do |data_dir|
             filename = "file1"
             File.write File.join(data_dir, filename), "foo"
-            action = LavinMQ::Clustering::AddAction.new data_dir, filename
+            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
             action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
           end
         end
@@ -66,7 +66,7 @@ describe LavinMQ::Clustering::Action do
             filename = "file1"
             absolute = File.join data_dir, filename
             File.write absolute, "foo"
-            action = LavinMQ::Clustering::AddAction.new data_dir, filename, MFile.new(absolute)
+            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename, MFile.new(absolute)
             io = IO::Memory.new
             action.send io
             io.rewind
@@ -81,7 +81,7 @@ describe LavinMQ::Clustering::Action do
           with_datadir do |data_dir|
             filename = "file1"
             File.write File.join(data_dir, filename), "foo"
-            action = LavinMQ::Clustering::AddAction.new data_dir, filename
+            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
             action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
           end
         end

--- a/spec/mfile_spec.cr
+++ b/spec/mfile_spec.cr
@@ -4,7 +4,9 @@ require "../src/lavinmq/mfile"
 describe MFile do
   it "can be double closed" do
     file = File.tempfile "mfile_spec"
+    file.sync = true
     begin
+      file.puts "foobar" # can't mmap empty file
       mfile = MFile.new file.path
       mfile.close
       mfile.close

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -8,13 +8,12 @@ describe LavinMQ::AMQP::Queue do
         q = ch.queue("qexpires", args: AMQP::Client::Arguments.new({"x-expires" => 100}))
         queue = s.vhosts["/"].queues["qexpires"]
         tag = q.subscribe { }
-        sleep 100.milliseconds
+        sleep 110.milliseconds
         queue.closed?.should be_false
         ch.basic_cancel(tag)
-        sleep 100.milliseconds
-        queue.closed?.should be_false
-        sleep 100.milliseconds
-        queue.closed?.should be_true
+        start = Time.monotonic
+        should_eventually(be_true) { queue.closed? }
+        (Time.monotonic - start).total_milliseconds.should be_close 100, 50
       end
     end
   end

--- a/src/lavinmq/amqp/queue/stream_queue_message_store.cr
+++ b/src/lavinmq/amqp/queue/stream_queue_message_store.cr
@@ -288,8 +288,7 @@ module LavinMQ::AMQP
           @offset_index.delete(seg_id)
           @timestamp_index.delete(seg_id)
           @bytesize -= mfile.size - 4
-          mfile.delete.close
-          @replicator.try &.delete_file(mfile.path)
+          delete_file(mfile)
           true
         end
       end

--- a/src/lavinmq/clustering/actions.cr
+++ b/src/lavinmq/clustering/actions.cr
@@ -2,12 +2,6 @@ require "../mfile"
 
 module LavinMQ
   module Clustering
-    record FileRange, mfile : MFile, pos : Int32, len : Int32 do
-      def to_slice : Bytes
-        mfile.to_slice(pos, len)
-      end
-    end
-
     abstract struct Action
       def initialize(@data_dir : String, @filename : String)
       end
@@ -69,8 +63,6 @@ module LavinMQ
         datasize = case obj = @obj
                    in Bytes
                      obj.bytesize.to_i64
-                   in FileRange
-                     obj.len.to_i64
                    in UInt32, Int32
                      4i64
                    end
@@ -86,10 +78,6 @@ module LavinMQ
           len = obj.bytesize.to_i64
           socket.write_bytes -len.to_i64, IO::ByteFormat::LittleEndian
           socket.write obj
-        in FileRange
-          len = obj.len.to_i64
-          socket.write_bytes -len.to_i64, IO::ByteFormat::LittleEndian
-          socket.write obj.to_slice
         in UInt32, Int32
           len = 4i64
           socket.write_bytes -len.to_i64, IO::ByteFormat::LittleEndian

--- a/src/lavinmq/clustering/actions.cr
+++ b/src/lavinmq/clustering/actions.cr
@@ -24,7 +24,7 @@ module LavinMQ
       end
     end
 
-    struct AddAction < Action
+    struct ReplaceAction < Action
       def initialize(@data_dir : String, @filename : String, @mfile : MFile? = nil)
         @mfile.try &.reserve
       end
@@ -40,7 +40,7 @@ module LavinMQ
       end
 
       def send(socket, log = Log) : Int64
-        log.debug { "Add #{@filename}" }
+        log.debug { "Replace #{@filename}" }
         send_filename(socket)
         if mfile = @mfile
           size = mfile.size.to_i64

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -120,7 +120,15 @@ module LavinMQ
           Log.info { "#{filename} requested" }
         end
         Log.info { "#{requested_files.size} files requested" }
-        total_requested_bytes = requested_files.sum { |p| File.size File.join(@data_dir, p) }
+        total_requested_bytes = requested_files.sum(0i64) do |p|
+          @file_index.with_file(p) do |f|
+            case f
+            when MFile then f.size
+            when File  then f.size
+            else            0
+            end
+          end
+        end
         sent_bytes = 0i64
         start = Time.monotonic
         requested_files.each do |filename|

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -144,7 +144,8 @@ module LavinMQ
           when MFile
             size = f.size.to_i64
             @lz4.write_bytes size, IO::ByteFormat::LittleEndian
-            f.copy_to(@lz4, size)
+            @lz4.write f.to_slice
+            f.dontneed
             size
           when File
             size = f.size.to_i64
@@ -167,8 +168,8 @@ module LavinMQ
         send_action AppendAction.new(@data_dir, path, obj)
       end
 
-      def delete(path) : Int64
-        send_action DeleteAction.new(@data_dir, path)
+      def delete(path, wg) : Int64
+        send_action DeleteAction.new(@data_dir, path, wg)
       end
 
       private def send_action(action : Action) : Int64

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -19,6 +19,7 @@ module LavinMQ
       def initialize(@socket : TCPSocket, @data_dir : String, @file_index : FileIndex)
         @socket.sync = true # Use buffering in lz4
         @socket.read_buffering = true
+        @socket.write_timeout = 3.seconds # don't wait for blocked followers
         @remote_address = @socket.remote_address
         @lz4 = Compress::LZ4::Writer.new(@socket, Compress::LZ4::CompressOptions.new(auto_flush: false, block_mode_linked: true))
       end

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -159,8 +159,8 @@ module LavinMQ
         end
       end
 
-      def add(path, mfile : MFile? = nil) : Int64
-        send_action AddAction.new(@data_dir, path, mfile)
+      def replace(path) : Int64
+        send_action ReplaceAction.new(@data_dir, path)
       end
 
       def append(path, obj) : Int64

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -6,7 +6,6 @@ module LavinMQ
       abstract def register_file(file : File)
       abstract def register_file(mfile : MFile)
       abstract def replace_file(path : String) # only non mfiles are ever replaced
-      abstract def append(path : String, file : MFile, position : Int32, length : Int32)
       abstract def append(path : String, obj)
       abstract def delete_file(path : String, wg : WaitGroup)
       abstract def followers : Array(Follower)

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -8,7 +8,7 @@ module LavinMQ
       abstract def replace_file(path : String) # only non mfiles are ever replaced
       abstract def append(path : String, file : MFile, position : Int32, length : Int32)
       abstract def append(path : String, obj)
-      abstract def delete_file(path : String)
+      abstract def delete_file(path : String, wg : WaitGroup)
       abstract def followers : Array(Follower)
       abstract def close
       abstract def listen(server : TCPServer)

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -62,7 +62,7 @@ module LavinMQ
         path = strip_datadir path
         @files[path] = nil
         @checksums.delete(path)
-        each_follower &.add(path)
+        each_follower &.replace(path)
       end
 
       def append(path : String, file : MFile, position : Int32, length : Int32)

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -65,10 +65,6 @@ module LavinMQ
         each_follower &.replace(path)
       end
 
-      def append(path : String, file : MFile, position : Int32, length : Int32)
-        append path, FileRange.new(file, position, length)
-      end
-
       def append(path : String, obj)
         path = strip_datadir path
         @checksums.delete(path)
@@ -238,9 +234,6 @@ module LavinMQ
       end
 
       def replace_file(path : String) # only non mfiles are ever replaced
-      end
-
-      def append(path : String, file : MFile, position : Int32, length : Int32)
       end
 
       def append(path : String, obj)

--- a/src/lavinmq/message.cr
+++ b/src/lavinmq/message.cr
@@ -85,7 +85,9 @@ module LavinMQ
       io.write_bytes @properties, format
       io.write_bytes @bodysize, format
       if io_mem = @body_io.as?(IO::Memory)
-        io.write(io_mem.to_slice)
+        slice = io_mem.to_slice
+        raise IO::Error.new("Unexpected body size: #{slice.bytesize} != #{@bodysize}") if slice.bytesize != @bodysize
+        io.write(slice)
         io_mem.pos = @bodysize # necessary for rewinding in Vhost#publish
       else
         copied = IO.copy(@body_io, io, @bodysize)

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -436,6 +436,7 @@ module LavinMQ
           rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
             @log.error { "Could not initialize segment, closing message store: Failed to read segment #{seg} at pos #{mfile.pos}. #{ex}" }
             close
+            return
           end
           mfile.pos = 4
           mfile.dontneed
@@ -463,8 +464,10 @@ module LavinMQ
               delete_file(ack)
             end
             delete_file(mfile)
+            true
+          else
+            false
           end
-          Fiber.yield
         end
       end
 

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -296,7 +296,7 @@ module LavinMQ
         wfile_id = @wfile_id
         sp = SegmentPosition.make(wfile_id, wfile.size.to_u32, msg)
         wfile.write_bytes msg
-        @replicator.try &.append(wfile.path, wfile, sp.position.to_i32, (wfile.size - sp.position).to_i32)
+        @replicator.try &.append(wfile.path, wfile.to_slice(sp.position, wfile.size - sp.position))
         @segment_msg_count[wfile_id] += 1
         sp
       end

--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -31,9 +31,9 @@ class MFile < IO
   getter capacity : Int64 = 0i64
   getter path : String
   getter fd : Int32
-  @buffer = Pointer(UInt8).null
+  @buffer : Pointer(UInt8)
   @deleted = false
-  @wg = WaitGroup.new
+  getter? closed = false
 
   # Map a file, if no capacity is given the file must exists and
   # the file will be mapped as readonly
@@ -48,6 +48,7 @@ class MFile < IO
       code = LibC.ftruncate(@fd, @capacity)
       raise File::Error.from_errno("Error truncating file", file: @path) if code < 0
     end
+    @buffer = mmap
   end
 
   def self.open(path, capacity : Int? = nil, writeonly = false, & : self -> _)
@@ -78,7 +79,6 @@ class MFile < IO
   end
 
   private def mmap(length = @capacity) : Pointer(UInt8)
-    return Pointer(UInt8).null if length.zero?
     protection = case
                  when @readonly  then LibC::PROT_READ
                  when @writeonly then LibC::PROT_WRITE
@@ -88,37 +88,29 @@ class MFile < IO
     ptr = LibC.mmap(nil, length, protection, flags, @fd, 0)
     raise RuntimeError.from_errno("mmap") if ptr == LibC::MAP_FAILED
     addr = ptr.as(UInt8*)
-    advise(Advice::DontDump, addr, 0, length)
-    advise(Advice::Sequential, addr, 0, length) unless @writeonly
+    advise(Advice::DontDump, addr, length)
     addr
   end
 
-  def delete(*, raise_on_missing = true) : self
+  def delete(*, raise_on_missing = true) : Nil
+    return if @deleted # avoid double deletes
     if raise_on_missing
       File.delete(@path)
     else
       File.delete?(@path)
     end
     @deleted = true
-    self
-  end
-
-  def reserve
-    @wg.add
-  end
-
-  def unreserve
-    @wg.done
   end
 
   # The file will be truncated to the current position unless readonly or deleted
   def close(truncate_to_size = true)
+    return if closed?
+    munmap
+    @closed = true # munmap checks if open so have to set closed here
     if truncate_to_size && !@readonly && !@deleted && @fd > 0
       code = LibC.ftruncate(@fd, @size)
       raise File::Error.from_errno("Error truncating file", file: @path) if code < 0
     end
-
-    unmap
   ensure
     unless @fd == -1
       code = LibC.close(@fd)
@@ -135,58 +127,9 @@ class MFile < IO
     msync(buffer, @size, LibC::MS_SYNC)
   end
 
-  def fsync : Nil
-    ret = LibC.fsync(@fd)
-    raise IO::Error.from_errno("Error syncing file") if ret != 0
-  end
-
-  # unload the memory mapping, will be remapped on demand
-  def unmap : Nil
-    # unmap if non has reserved the file, race condition prone?
-    if @wg.@counter.get(:acquire).zero?
-      unsafe_unmap
-    else
-      spawn(name: "munmap #{@path}") do
-        @wg.wait
-        unsafe_unmap
-      end
-    end
-  end
-
-  private def unsafe_unmap : Nil
-    b = @buffer
-    c = @capacity
-    @buffer = Pointer(UInt8).null
-    munmap(b, c)
-  end
-
-  def unmapped? : Bool
-    @buffer.null?
-  end
-
-  # Copies the file to another IO
-  # Won't mmap the file if it's unmapped already
-  def copy_to(output : IO, size = @size) : Int64
-    if unmapped? # don't remap unmapped files
-      raise ClosedError.new if @fd < 0
-      io = IO::FileDescriptor.new(@fd, blocking: true, close_on_finalize: false)
-      io.rewind
-      IO.copy(io, output, size) == size || raise IO::EOFError.new
-    else
-      output.write to_slice(0, size)
-    end
-    size.to_i64
-  end
-
-  # mmap on demand
-  private def buffer : Pointer(UInt8)
-    return @buffer unless @buffer.null?
-    @buffer = mmap
-  end
-
-  private def munmap(buffer = @buffer, length = @capacity)
-    return if length.zero? || buffer.null?
-    code = LibC.munmap(buffer, length)
+  private def munmap(addr = @buffer, length = @capacity)
+    check_open
+    code = LibC.munmap(addr, length)
     raise RuntimeError.from_errno("Error unmapping file") if code == -1
   end
 
@@ -196,18 +139,21 @@ class MFile < IO
     raise RuntimeError.from_errno("msync") if code < 0
   end
 
+  # Append only
   def write(slice : Bytes) : Nil
+    check_open
     size = @size
     new_size = size + slice.size
     raise IO::EOFError.new if new_size > @capacity
-    slice.copy_to(buffer + size, slice.size)
+    slice.copy_to(@buffer + size, slice.size)
     @size = new_size
   end
 
   def read(slice : Bytes)
+    check_open
     pos = @pos
     len = Math.min(slice.size, @size - pos)
-    slice.copy_from(buffer + pos, len)
+    slice.copy_from(@buffer + pos, len)
     @pos = pos + len
     len
   end
@@ -244,22 +190,21 @@ class MFile < IO
     bytes_count
   end
 
-  def to_unsafe
-    buffer
-  end
-
   def to_slice
-    Bytes.new(buffer, @size, read_only: true)
+    check_open
+    Bytes.new(@buffer, @size, read_only: true)
   end
 
   def to_slice(pos, size)
+    check_open
     raise IO::EOFError.new if pos + size > @size
-    Bytes.new(buffer + pos, size, read_only: true)
+    Bytes.new(@buffer + pos, size, read_only: true)
   end
 
-  def advise(advice : Advice, addr = buffer, offset = 0, length = @capacity) : Nil
-    if LibC.madvise(addr + offset, length, advice) != 0
-      raise IO::Error.from_errno("madvise")
+  def advise(advice : Advice, addr = @buffer, length = @capacity) : Nil
+    check_open
+    if LibC.madvise(addr, length, advice) != 0
+      raise IO::Error.from_errno("madvise, addr=#{addr} length=#{length} advice=#{advice.value}")
     end
   end
 
@@ -274,6 +219,10 @@ class MFile < IO
     {% else %}
       DontDump = 8 # is called NoCore in BSD/Darwin
     {% end %}
+  end
+
+  def dontneed
+    advise(Advice::DontNeed)
   end
 
   def resize(new_size : Int) : Nil
@@ -293,5 +242,9 @@ class MFile < IO
   def rename(new_path : String) : Nil
     File.rename @path, new_path
     @path = new_path
+  end
+
+  private def check_open
+    raise IO::Error.new "Closed mfile" if closed?
   end
 end

--- a/src/lavinmq/mqtt/retain_store.cr
+++ b/src/lavinmq/mqtt/retain_store.cr
@@ -118,7 +118,7 @@ module LavinMQ
             file.close
             file.delete
           end
-          @replicator.delete_file(File.join(@dir, file_name))
+          @replicator.delete_file(File.join(@dir, file_name), WaitGroup.new)
         end
       end
 


### PR DESCRIPTION
Prevent potential segfaults in MFile/mmap by never unmapping, instead advice the mmap with MADV_DONTNEED when it's no longer needed. Only unmap on close. Make replication delete_file synchrouns and only close it after the DeleteAction is sent. 
