### PR TITLE
bugfix(lavinmqperf/throughput): rescue when reconnecting a broker and waitgroup counter is negative

### DIFF
--- a/src/lavinmqperf/throughput.cr
+++ b/src/lavinmqperf/throughput.cr
@@ -322,8 +322,10 @@ module LavinMQPerf
     # Announce that the client is connected
     # and then wait for all other clients to be connected too
     private def wait_until_all_are_connected(connected)
-      connected.done rescue nil
+      connected.done
       connected.wait
+    rescue
+      # when we reconnect a broker the waitgroup will have a negative counter
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
Previously we only rescued on `waitgroup.done`, but `waitgroup.wait` will also crash if the counter is negative. 
If we reconnect the broker, we will start with a waitgroup with a counter thats 0 and will become negative when we call done again. 
We need to rescue both `done` and `wait` in order for lavinmqperf not to crash. 

### HOW can this pull request be tested?
run lavinmqperf against LavinMQ, then stop/start the LavinMQ process and see that lavinmqperf does not crash. 
