### PR TITLE
Use more refined synchronization primitives

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -20,6 +20,10 @@ shards:
     git: https://github.com/84codes/mqtt-protocol.cr.git
     version: 0.2.0+git.commit.d01a1210ed7adfed9aa5cd055f1788a45d9c4d52
 
+  sync:
+    git: https://github.com/ysbaddaden/sync.git
+    version: 0.1.0+git.commit.f838b4e8571217c48261421f9112c4273c11d8a1
+
   systemd:
     git: https://github.com/84codes/systemd.cr.git
     version: 2.0.0

--- a/shard.yml
+++ b/shard.yml
@@ -34,6 +34,8 @@ dependencies:
     github: 84codes/lz4.cr
   mqtt-protocol:
     github: 84codes/mqtt-protocol.cr
+  sync:
+    github: ysbaddaden/sync
 
 development_dependencies:
   ameba:

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -258,7 +258,7 @@ describe LavinMQ::Clustering::Client do
       when appended.receive?
       when timeout 0.1.seconds
         # @action is a Channel. Let's look at its internal deque
-        action_queue = replicator.@followers.first.@actions.@queue.not_nil!("no deque? no follower?")
+        action_queue = replicator.followers.first.@actions.@queue.not_nil!("no deque? no follower?")
         break if action_queue.size == action_queue.@capacity # full?
       end
     end
@@ -269,7 +269,7 @@ describe LavinMQ::Clustering::Client do
     select
     when appended.receive?
     when timeout 0.1.seconds
-      replicator.@followers.first.@actions.close
+      replicator.followers.first.@actions.close
       deadlock = true
     end
 

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -9,6 +9,7 @@ require "../mfile"
 require "crypto/subtle"
 require "lz4"
 require "../etcd"
+require "sync/shared"
 
 module LavinMQ
   module Clustering
@@ -28,10 +29,10 @@ module LavinMQ
       Log = LavinMQ::Log.for "clustering.server"
 
       @lock = Mutex.new(:unchecked)
-      @followers = Array(Follower).new(4)
+      @followers : Sync::Shared(Array(Follower)) = Sync::Shared.new(Array(Follower).new(4))
       @password : String
       @files = Hash(String, MFile?).new
-      @dirty_isr = true
+      @dirty_isr = Atomic(Bool).new true
       @id : Int32
       @config : Config
 
@@ -122,9 +123,7 @@ module LavinMQ
       end
 
       def followers : Array(Follower)
-        @lock.synchronize do
-          @followers.dup # for thread safety
-        end
+        @followers.read &.dup
       end
 
       def password : String
@@ -157,22 +156,22 @@ module LavinMQ
           Log.error { "Disconnecting follower with the clustering id of the leader" }
           return
         end
-        if stale_follower = @followers.find { |f| f.id == follower.id }
+        if stale_follower = @followers.read &.find { |f| f.id == follower.id }
           Log.error { "Disconnecting stale follower with id #{follower.id.to_s(36)}" }
           stale_follower.close
         end
         follower.full_sync # sync the bulk
-        @lock.synchronize do
+        @followers.write do |followers|
           follower.full_sync # sync the last
-          @followers << follower
-          update_isr
+          followers << follower
         end
+        update_isr
         begin
           follower.action_loop
         ensure
-          @lock.synchronize do
-            @followers.delete(follower)
-            @dirty_isr = true
+          @followers.write do |followers|
+            followers.delete(follower)
+            @dirty_isr.set true
           end
         end
       rescue ex : AuthenticationError
@@ -190,33 +189,33 @@ module LavinMQ
       private def update_isr
         isr_key = "#{@config.clustering_etcd_prefix}/isr"
         ids = String.build do |str|
-          @followers.each { |f| f.id.to_s(str, 36); str << "," }
+          @followers.read &.each { |f| f.id.to_s(str, 36); str << "," }
           @id.to_s(str, 36)
         end
         Log.info { "In-sync replicas: #{ids}" }
         @etcd.put(isr_key, ids)
-        @dirty_isr = false
+        @dirty_isr.set false
       end
 
       def close
         @listeners.each &.close
-        @lock.synchronize do
-          @followers.each &.close
-          @followers.clear
-        end
+        @followers.write &.reject! { |f| f.close; true }
         Fiber.yield # required for follower/listener fibers to actually finish
         @checksums.store
       end
 
       private def each_follower(& : Follower -> Nil) : Nil
-        @lock.synchronize do
-          update_isr if @dirty_isr
-          @followers.each do |f|
+        # remove stale follower from ISR set as new changes are coming
+        update_isr if @dirty_isr.get
+        any_closed = false
+        @followers.read do |followers|
+          followers.each do |f|
             yield f
           rescue Channel::ClosedError
-            Fiber.yield # Allow other fiber to run to remove the follower from array
+            any_closed = true
           end
         end
+        Fiber.yield if any_closed # let other fibers run to remove the follower
       end
 
       private def strip_datadir(path : String) : String


### PR DESCRIPTION
Use the sync library by @ysbaddaden with nsync inspired synchronization primitives.

First @followers was protected using a RWLock, yielding a big performance improvment, around 30% higher throughput, when clustering is enabled.