### PR TITLE
UI: Improve behaviour of multi control popup

### DIFF
--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -56,7 +56,12 @@ document.querySelector('#multiselect-controls .popup-close').addEventListener('c
   toggleMultiActionControls(false, 0)
 })
 const toggleMultiActionControls = (show, count) => {
-  multiSelectControls.classList.toggle('hide', !(show && count > 0))
+  const currentlyHidden = multiSelectControls.classList.contains('hide')
+  if (currentlyHidden && show && count > 0) {
+    multiSelectControls.classList.remove('hide')
+  } else if (!currentlyHidden && !show) {
+    multiSelectControls.classList.add('hide')
+  }
   document.getElementById('multi-queue-count').textContent = count
 }
 const rowCheckboxChanged = (e) => {
@@ -136,7 +141,7 @@ document.querySelector('#declare').addEventListener('submit', function (evt) {
 })
 queuesTable.on('updated', _ => {
   const checked = document.querySelectorAll('input[data-name]:checked')
-  toggleMultiActionControls(true, checked.length)
+  document.getElementById('multi-queue-count').textContent = checked.length
 })
 
 document.querySelector('#dataTags').onclick = e => {


### PR DESCRIPTION
### WHAT is this pull request doing?
The multi control popup on the queues page was acting very weird. E.g. it was opened when the queues data is refreshed, even though one had closed it just before.

This will change so the dialog is only opened when checkboxes are checked. The count of selected queues is still updated when the queue listing is updated, since one could have added a search filter so some of the selected queues are gone.

`toggleMultiActionControls` is also a little bit more explicit and easier follow (the `force` argument to `toggle` makes it a little bit ambiguous imo)

### HOW can this pull request be tested?
Manually. Specs coming with #1140