### PR TITLE
Bugfix: fix unbind button in bindings listing in queue view

### DIFF
--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -162,7 +162,7 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
     const e = encodeURIComponent(item.source)
     const btn = DOM.button.delete({
       text: 'Unbind',
-      onclick: function () {
+      click: function () {
         const p = encodeURIComponent(item.properties_key)
         const url = 'api/bindings/' + urlEncodedVhost + '/e/' + e + '/q/' + urlEncodedQueue + '/' + p
         HTTP.request('DELETE', url).then(() => { tr.parentNode.removeChild(tr) })


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes a bug introduced bug #1139 where the `Unbind` button in binding listing in queues view stopped working. I found this while working on #1140.

### HOW can this pull request be tested?
Manually (specs coming in #1140)
