### PR TITLE
feature(shovels): persist pause state across broker restarts #1148

### DIFF
--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -658,7 +658,6 @@ describe LavinMQ::Shovel do
         shovel.pause
         shovel.paused?.should eq true
         s.restart
-        # Server restart is not applying shovels?
         should_eventually(be_true) { s.vhosts[vhost.name].shovels[shovel.name].paused? }
       end
     end

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -470,6 +470,11 @@ module LavinMQ
         Log.info &.emit("Paused", name: @name, vhost: @vhost.name)
       end
 
+      def delete
+        terminate
+        FileUtils.rm(@paused_file_path) if File.exists?(@paused_file_path)
+      end
+
       # Does not trigger reconnect, but a graceful close
       def terminate
         @state = State::Terminated

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -462,7 +462,7 @@ module LavinMQ
       end
 
       def pause
-        FileUtils.touch(@paused_file_path)
+        File.write(@paused_file_path, @name)
         Log.info { "Pausing shovel #{@name} vhost=#{@vhost.name}" }
         @state = State::Paused
         @source.stop

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -472,7 +472,7 @@ module LavinMQ
 
       def delete
         terminate
-        FileUtils.rm(@paused_file_path) if File.exists?(@paused_file_path)
+        delete_paused_file
       end
 
       # Does not trigger reconnect, but a graceful close
@@ -485,9 +485,7 @@ module LavinMQ
       end
 
       def delete_paused_file
-        if File.exists?(@paused_file_path)
-          FileUtils.rm(@paused_file_path)
-        end
+        FileUtils.rm(@paused_file_path) if File.exists?(@paused_file_path)
       end
 
       def should_stop_loop?

--- a/src/lavinmq/shovel/shovel.cr
+++ b/src/lavinmq/shovel/shovel.cr
@@ -376,9 +376,8 @@ module LavinMQ
 
       def initialize(@source : AMQPSource, @destination : Destination,
                      @name : String, @vhost : VHost, @reconnect_delay : Time::Span = DEFAULT_RECONNECT_DELAY)
-        #TODO1148 naive
-        FileUtils.mkdir_p(File.join(@config.data_dir, "shovels"))
-        @paused_file_path = File.join(@config.data_dir, "shovels", "#{@name}.paused")
+        filename = "shovels.#{Digest::SHA1.hexdigest @name}.paused"
+        @paused_file_path = File.join(@config.data_dir, filename)
         if File.exists?(@paused_file_path)
           @state = State::Paused
         end

--- a/src/lavinmq/shovel/shovel_store.cr
+++ b/src/lavinmq/shovel/shovel_store.cr
@@ -43,7 +43,7 @@ module LavinMQ
 
     def delete(name)
       if shovel = @shovels.delete name
-        shovel.terminate
+        shovel.delete
         shovel
       end
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
Make `paused` state be persisted across restarts
https://github.com/cloudamqp/lavinmq/issues/1148

### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
- Spec
- Manual
Create shovel, pause it. Restart broker and ensure the state is yet `paused`. Resume, ensure messages flow, pause, ensure messages paused.
