### PR TITLE
frontend: use tagged template literal instead of encodeURIComponent

### DIFF
--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -6,8 +6,7 @@ import * as Chart from './chart.js'
 import { DataSource } from './datasource.js'
 
 const channel = new URLSearchParams(window.location.hash.substring(1)).get('name')
-const urlEncodedChannel = encodeURIComponent(channel)
-const channelUrl = 'api/channels/' + urlEncodedChannel
+const channelUrl = HTTP.url`api/channels/${channel}`
 const chart = Chart.render('chart', 'msgs/s')
 let vhost = null
 document.title = channel + ' | LavinMQ'
@@ -26,7 +25,7 @@ const consumerTableOpts = {
 Table.renderTable('table', consumerTableOpts, function (tr, item) {
   Table.renderCell(tr, 0, item.consumer_tag)
   const queueLink = document.createElement('a')
-  queueLink.href = `queue#vhost=${encodeURIComponent(vhost)}&name=${encodeURIComponent(item.queue.name)}`
+  queueLink.href = HTTP.url`queue#vhost=${vhost}&name=${item.queue.name}`
   queueLink.textContent = item.queue.name
   const ack = item.ack_required ? '●' : '○'
   const exclusive = item.exclusive ? '●' : '○'
@@ -106,7 +105,7 @@ function updateChannel () {
     document.getElementById('pagename-label').textContent = `${channel} in virtual host ${item.vhost}`
     document.getElementById('ch-username').textContent = item.user
     const connectionLink = document.querySelector('#ch-connection a')
-    connectionLink.href = `connection#name=${encodeURIComponent(item.connection_details.name)}`
+    connectionLink.href = HTTP.url`connection#name=${item.connection_details.name}`
     connectionLink.textContent = item.connection_details.name
     prefetch.update(item.prefetch_count)
     document.getElementById('ch-mode').textContent = `${item.confirm ? 'C' : ''}`

--- a/static/js/channels.js
+++ b/static/js/channels.js
@@ -1,10 +1,11 @@
 import * as Table from './table.js'
 import * as Helpers from './helpers.js'
+import * as HTTP from './http.js'
 
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/channels'
 if (vhost && vhost !== '_all') {
-  url = 'api/vhosts/' + encodeURIComponent(vhost) + '/channels'
+  url = HTTP.url`api/vhosts/${vhost}/channels`
 }
 const tableOptions = {
   url,
@@ -17,9 +18,8 @@ const tableOptions = {
 Table.renderTable('table', tableOptions, function (tr, item, all) {
   if (all) {
     const channelLink = document.createElement('a')
-    const urlEncodedChannel = encodeURIComponent(item.name)
     channelLink.textContent = item.name
-    channelLink.href = `channel#name=${urlEncodedChannel}`
+    channelLink.href = HTTP.url`channel#name=${item.name}`
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.user)

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -69,9 +69,8 @@ const tableOptions = {
 Table.renderTable('table', tableOptions, function (tr, item, all) {
   if (all) {
     const channelLink = document.createElement('a')
-    const urlEncodedChannel = encodeURIComponent(item.name)
     channelLink.textContent = item.name
-    channelLink.href = `channel#name=${urlEncodedChannel}`
+    channelLink.href = HTTP.url`channel#name=${item.name}`
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.username)

--- a/static/js/connections.js
+++ b/static/js/connections.js
@@ -1,10 +1,11 @@
+import * as HTTP from './http.js'
 import * as Table from './table.js'
 
 const vhost = window.sessionStorage.getItem('vhost')
 const numFormatter = new Intl.NumberFormat()
 let url = 'api/connections'
 if (vhost && vhost !== '_all') {
-  url = `api/vhosts/${encodeURIComponent(vhost)}/connections`
+  url = HTTP.url`api/vhosts/${vhost}/connections`
 }
 const tableOptions = {
   url,
@@ -18,7 +19,7 @@ const tableOptions = {
 Table.renderTable('table', tableOptions, function (tr, item, all) {
   if (all) {
     const connectionLink = document.createElement('a')
-    connectionLink.href = `connection#name=${encodeURIComponent(item.name)}`
+    connectionLink.href = HTTP.url`connection#name=${item.name}`
     connectionLink.appendChild(document.createElement('span')).textContent = item.name
     connectionLink.appendChild(document.createElement('br'))
     connectionLink.appendChild(document.createElement('small')).textContent = item.client_properties.connection_name

--- a/static/js/consumers.js
+++ b/static/js/consumers.js
@@ -5,7 +5,7 @@ import * as DOM from './dom.js'
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/consumers'
 if (vhost && vhost !== '_all') {
-  url = `api/consumers/${encodeURIComponent(vhost)}`
+  url = HTTP.url`api/consumers/${vhost}`
 }
 
 const tableOptions = {
@@ -20,7 +20,7 @@ const tableOptions = {
 Table.renderTable('table', tableOptions, function (tr, item, firstRender) {
   if (!firstRender) return
   const channelLink = document.createElement('a')
-  channelLink.href = 'channel#name=' + encodeURIComponent(item.channel_details.name)
+  channelLink.href = HTTP.url`channel#name=${item.channel_details.name}`
   channelLink.textContent = item.channel_details.name
   const ack = item.ack_required ? '●' : '○'
   const exclusive = item.exclusive ? '●' : '○'
@@ -31,11 +31,11 @@ Table.renderTable('table', tableOptions, function (tr, item, firstRender) {
   })
 
   cancelForm.appendChild(btn)
-  const urlEncodedVhost = encodeURIComponent(item.queue.vhost)
-  const urlEncodedConsumerTag = encodeURIComponent(item.consumer_tag)
-  const conn = encodeURIComponent(item.channel_details.connection_name)
-  const ch = encodeURIComponent(item.channel_details.number)
-  const actionPath = `api/consumers/${urlEncodedVhost}/${conn}/${ch}/${urlEncodedConsumerTag}`
+  const vhost = item.queue.vhost
+  const consumerTag = item.consumer_tag
+  const conn = item.channel_details.connection_name
+  const ch = item.channel_details.number
+  const actionPath = HTTP.url`api/consumers/${vhost}/${conn}/${ch}/${consumerTag}`
   cancelForm.addEventListener('submit', function (evt) {
     evt.preventDefault()
     if (!window.confirm('Are you sure?')) return false

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -67,9 +67,9 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
     const btn = DOM.button.delete({
       text: 'Unbind',
       click: function () {
-      const type = item.destination_type === 'exchange' ? 'e' : 'q'
-      const url = HTTP.url`api/bindings/${vhost}/e/${item.source}/${type}/${item.destination}/${item.properties_key}`
-         HTTP.request('DELETE', url).then(() => { tr.parentNode.removeChild(tr) })
+        const type = item.destination_type === 'exchange' ? 'e' : 'q'
+        const url = HTTP.url`api/bindings/${vhost}/e/${item.source}/${type}/${item.destination}/${item.properties_key}`
+        HTTP.request('DELETE', url).then(() => { tr.parentNode.removeChild(tr) })
       }
     })
 

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -8,13 +8,11 @@ import { UrlDataSource } from './datasource.js'
 const search = new URLSearchParams(window.location.hash.substring(1))
 const exchange = search.get('name')
 const vhost = search.get('vhost')
-const urlEncodedExchange = encodeURIComponent(exchange)
-const urlEncodedVhost = encodeURIComponent(vhost)
 const chart = Chart.render('chart', 'msgs/s')
 
 document.title = exchange + ' | LavinMQ'
 
-const exchangeUrl = 'api/exchanges/' + urlEncodedVhost + '/' + urlEncodedExchange
+const exchangeUrl = HTTP.url`api/exchanges/${vhost}/${exchange}`
 function updateExchange () {
   HTTP.request('GET', exchangeUrl).then(item => {
     Chart.update(chart, item.message_stats)
@@ -45,7 +43,7 @@ function updateExchange () {
     document.getElementById('e-arguments').appendChild(argList)
     if (item.policy) {
       const policyLink = document.createElement('a')
-      policyLink.href = 'policies#name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+      policyLink.href = HTTP.url`policies#name=${item.policy}&vhost=${item.vhost}`
       policyLink.textContent = item.policy
       document.getElementById('e-policy').appendChild(policyLink)
     }
@@ -69,17 +67,14 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
     const btn = DOM.button.delete({
       text: 'Unbind',
       click: function () {
-        const s = encodeURIComponent(item.source)
-        const d = encodeURIComponent(item.destination)
-        const p = encodeURIComponent(item.properties_key)
-        const t = item.destination_type === 'exchange' ? 'e' : 'q'
-        const url = 'api/bindings/' + urlEncodedVhost + '/e/' + s + '/' + t + '/' + d + '/' + p
-        HTTP.request('DELETE', url).then(() => { tr.parentNode.removeChild(tr) })
+      const type = item.destination_type === 'exchange' ? 'e' : 'q'
+      const url = HTTP.url`api/bindings/${vhost}/e/${item.source}/${type}/${item.destination}/${item.properties_key}`
+         HTTP.request('DELETE', url).then(() => { tr.parentNode.removeChild(tr) })
       }
     })
 
     const destinationLink = document.createElement('a')
-    destinationLink.href = `${item.destination_type}#vhost=${urlEncodedVhost}&name=${encodeURIComponent(item.destination)}`
+    destinationLink.href = HTTP.url`${item.destination_type}#vhost=${vhost}&name=${item.destination}`
     destinationLink.textContent = item.destination
     const argsPre = document.createElement('pre')
     argsPre.textContent = JSON.stringify(item.arguments || {})
@@ -94,9 +89,9 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
 document.querySelector('#addBinding').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const d = encodeURIComponent(data.get('destination').trim())
+  const d = data.get('destination').trim()
   const t = data.get('dest-type')
-  const url = 'api/bindings/' + urlEncodedVhost + '/e/' + urlEncodedExchange + '/' + t + '/' + d
+  const url = HTTP.url`api/bindings/${vhost}/e/${exchange}/${t}/${d}`
   const args = DOM.parseJSON(data.get('arguments'))
   const body = {
     routing_key: data.get('routing_key').trim(),
@@ -112,7 +107,7 @@ document.querySelector('#addBinding').addEventListener('submit', function (evt) 
 document.querySelector('#publishMessage').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const url = 'api/exchanges/' + urlEncodedVhost + '/' + urlEncodedExchange + '/publish'
+  const url = HTTP.url`api/exchanges/${vhost}/${exchange}/publish`
   const properties = DOM.parseJSON(data.get('properties'))
   properties.delivery_mode = parseInt(data.get('delivery_mode'))
   properties.headers = { ...properties.headers, ...DOM.parseJSON(data.get('headers')) }
@@ -130,7 +125,7 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
 
 document.querySelector('#deleteExchange').addEventListener('submit', function (evt) {
   evt.preventDefault()
-  const url = 'api/exchanges/' + urlEncodedVhost + '/' + urlEncodedExchange
+  const url = HTTP.url`api/exchanges/${vhost}/${exchange}`
   if (window.confirm('Are you sure? This object cannot be recovered after deletion.')) {
     HTTP.request('DELETE', url)
       .then(() => { window.location = 'exchanges' })
@@ -139,7 +134,7 @@ document.querySelector('#deleteExchange').addEventListener('submit', function (e
 
 function updateAutocomplete (val) {
   const type = val === 'q' ? 'queues' : 'exchanges'
-  Helpers.autoCompleteDatalist('exchange-dest-list', type, urlEncodedVhost)
+  Helpers.autoCompleteDatalist('exchange-dest-list', type, vhost)
 }
 updateAutocomplete('q')
 document.getElementById('dest-type').onchange = (e) => updateAutocomplete(e.target.value)

--- a/static/js/exchanges.js
+++ b/static/js/exchanges.js
@@ -18,7 +18,7 @@ HTTP.request('GET', 'api/overview').then(function (response) {
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/exchanges'
 if (vhost && vhost !== '_all') {
-  url += HTTP.url(`/${vhost}`)
+  url += HTTP.url`/${vhost}`
 }
 const tableOptions = {
   url,

--- a/static/js/exchanges.js
+++ b/static/js/exchanges.js
@@ -18,7 +18,7 @@ HTTP.request('GET', 'api/overview').then(function (response) {
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/exchanges'
 if (vhost && vhost !== '_all') {
-  url += '/' + encodeURIComponent(vhost)
+  url += HTTP.url(`/${vhost}`)
 }
 const tableOptions = {
   url,
@@ -39,7 +39,7 @@ const exchangeTable = Table.renderTable('table', tableOptions, function (tr, ite
     features += item.internal ? ' I' : ''
     features += item.arguments['x-delayed-exchange'] ? ' d' : ''
     const exchangeLink = document.createElement('a')
-    exchangeLink.href = `exchange#vhost=${encodeURIComponent(item.vhost)}&name=${encodeURIComponent(item.name)}`
+    exchangeLink.href = HTTP.url`exchange#vhost=${item.vhost}&name=${item.name}`
     exchangeLink.textContent = item.name
     Table.renderCell(tr, 0, item.vhost)
     Table.renderCell(tr, 1, exchangeLink)
@@ -49,7 +49,7 @@ const exchangeTable = Table.renderTable('table', tableOptions, function (tr, ite
   let policyLink = ''
   if (item.policy) {
     policyLink = document.createElement('a')
-    policyLink.href = 'policies#name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+    policyLink.href = HTTP.url`policies#name=${item.policy}&vhost=${item.vhost}`
     policyLink.textContent = item.policy
   }
   Table.renderCell(tr, 4, policyLink, 'center')

--- a/static/js/exchanges.js
+++ b/static/js/exchanges.js
@@ -60,9 +60,9 @@ const exchangeTable = Table.renderTable('table', tableOptions, function (tr, ite
 document.querySelector('#addExchange').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const vhost = encodeURIComponent(data.get('vhost'))
-  const exchange = encodeURIComponent(data.get('name').trim())
-  const url = 'api/exchanges/' + vhost + '/' + exchange
+  const vhost = data.get('vhost')
+  const exchange = data.get('name').trim()
+  const url = HTTP.url`api/exchanges/${vhost}/${exchange}`
   const body = {
     durable: data.get('durable') === '1',
     auto_delete: data.get('auto_delete') === '1',

--- a/static/js/federation.js
+++ b/static/js/federation.js
@@ -10,9 +10,8 @@ let url = 'api/parameters/federation-upstream'
 let linksUrl = 'api/federation-links'
 const vhost = window.sessionStorage.getItem('vhost')
 if (vhost && vhost !== '_all') {
-  const urlEncodedVhost = encodeURIComponent(vhost)
-  url += '/' + urlEncodedVhost
-  linksUrl += '/' + urlEncodedVhost
+  url += HTTP.url`/${vhost}`
+  linksUrl += HTTP.url`/${vhost}`
 }
 
 const utOpts = { url, keyColumns: ['vhost', 'name'], interval: 5000 }
@@ -33,9 +32,7 @@ const upstreamsTable = Table.renderTable('upstreamTable', utOpts, (tr, item) => 
   buttons.classList.add('buttons')
   const deleteBtn = DOM.button.delete({
     click: function () {
-      const name = encodeURIComponent(item.name)
-      const vhost = encodeURIComponent(item.vhost)
-      const url = 'api/parameters/federation-upstream/' + vhost + '/' + name
+      const url = HTTP.url`api/parameters/federation-upstream/${item.vhost}/${item.name}`
       if (!window.confirm(`Delete federation upstream ${item.name} ?`)) return
       HTTP.request('DELETE', url)
         .then(() => {
@@ -48,6 +45,7 @@ const upstreamsTable = Table.renderTable('upstreamTable', utOpts, (tr, item) => 
   const editBtn = DOM.button.edit({
     click: function () { Form.editItem('#createUpstream', item) }
   })
+
   buttons.append(editBtn, deleteBtn)
   Table.renderCell(tr, 11, buttons, 'right')
 })
@@ -69,9 +67,9 @@ Table.renderTable('linksTable', linksOpts, (tr, item) => {
 document.querySelector('#createUpstream').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const name = encodeURIComponent(data.get('name').trim())
-  const vhost = encodeURIComponent(data.get('vhost'))
-  const url = 'api/parameters/federation-upstream/' + vhost + '/' + name
+  const name = data.get('name').trim()
+  const vhost = data.get('vhost')
+  const url = HTTP.url`api/parameters/federation-upstream/${vhost}/${name}`
   const body = {
     value: {
       uri: data.get('uri'),

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -106,7 +106,7 @@ function formatTimestamp (timestamp) {
  * @param type input content, accepts: queues, exchanges, vhosts, users
  */
 function autoCompleteDatalist (datalistID, type, vhost) {
-  HTTP.request('GET', `api/${type}/${vhost}?columns=name`).then(res => {
+  HTTP.request('GET', HTTP.url`api/${type}/${vhost}?columns=name`).then(res => {
     const datalist = document.getElementById(datalistID)
     while (datalist.firstChild) {
       datalist.removeChild(datalist.lastChild)
@@ -181,5 +181,5 @@ export {
   argumentHelperJSON,
   formatJSONargument,
   autoCompleteDatalist,
-  formatTimestamp
+  formatTimestamp,
 }

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -181,5 +181,5 @@ export {
   argumentHelperJSON,
   formatJSONargument,
   autoCompleteDatalist,
-  formatTimestamp,
+  formatTimestamp
 }

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -61,14 +61,12 @@ class NoUrlEscapeString {
   }
 }
 
-
-function noescape(v) {
+function noencode(v) {
   return new NoUrlEscapeString(v)
-
 }
 
 export {
- request,
- url,
-  noescape
+  request,
+  url,
+  noencode
 }

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -42,11 +42,33 @@ function standardErrorHandler (e) {
 
 function url(strings, ...params) {
   return params.reduce(
-    (res, param, i) => res + encodeURIComponent(param) + strings[i + 1],
+    (res, param, i) => {
+      if (param instanceof NoUrlEscapeString) {
+        return res + param.toString() + strings[i + 1]
+      } else {
+        return res + encodeURIComponent(param) + strings[i + 1]
+      }
+    }
     strings[0])
+}
+
+class NoUrlEscapeString {
+  constructor(value) {
+    this.value = value
+  }
+  toString() {
+    return this.value
+  }
+}
+
+
+function noescape(v) {
+  return new NoUrlEscapeString(v)
+
 }
 
 export {
  request,
- url
+ url,
+  noescape
 }

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -40,6 +40,16 @@ function standardErrorHandler (e) {
   throw e
 }
 
+function url(strings, ...params) {
+  params = params.map(p => encodeURIComponent(p))
+  const result = [strings[0]]
+  params.forEach((p, i) => {
+    result.push(p, strings[i + 1])
+  })
+  return result.join('')
+}
+
 export {
-  request
+ request,
+ url
 }

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -40,7 +40,7 @@ function standardErrorHandler (e) {
   throw e
 }
 
-function url(strings, ...params) {
+function url (strings, ...params) {
   return params.reduce(
     (res, param, i) => {
       if (param instanceof NoUrlEscapeString) {
@@ -53,15 +53,16 @@ function url(strings, ...params) {
 }
 
 class NoUrlEscapeString {
-  constructor(value) {
+  constructor (value) {
     this.value = value
   }
-  toString() {
+
+  toString () {
     return this.value
   }
 }
 
-function noencode(v) {
+function noencode (v) {
   return new NoUrlEscapeString(v)
 }
 

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -48,7 +48,7 @@ function url(strings, ...params) {
       } else {
         return res + encodeURIComponent(param) + strings[i + 1]
       }
-    }
+    },
     strings[0])
 }
 

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -41,12 +41,9 @@ function standardErrorHandler (e) {
 }
 
 function url(strings, ...params) {
-  params = params.map(p => encodeURIComponent(p))
-  const result = [strings[0]]
-  params.forEach((p, i) => {
-    result.push(p, strings[i + 1])
-  })
-  return result.join('')
+  return params.reduce(
+    (res, param, i) => res + encodeURIComponent(param) + strings[i + 1],
+    strings[0])
 }
 
 export {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -8,7 +8,7 @@ const numFormatter = new Intl.NumberFormat()
 let url = 'api/nodes'
 const vhost = window.sessionStorage.getItem('vhost')
 if (vhost && vhost !== '_all') {
-  url += '?vhost=' + encodeURIComponent(vhost)
+  url += HTTP.url`?vhost=${vhost}`
 }
 
 function update (cb) {

--- a/static/js/overview.js
+++ b/static/js/overview.js
@@ -33,7 +33,7 @@ document.querySelector('#importDefinitions').addEventListener('submit', function
   if (body.get('vhost') === '_all') {
     url += 'upload'
   } else {
-    url += encodeURIComponent(body.get('vhost')) + '/upload'
+    url += HTTP.url`${body.get('vhost')}/upload`
   }
   HTTP.request('POST', url, { body }).then(function () {
     window.location.assign('.')
@@ -48,7 +48,7 @@ document.querySelector('#exportDefinitions').addEventListener('submit', function
   const body = new window.FormData(this)
   let url = 'api/definitions'
   if (body.get('vhost') !== '_all') {
-    url += '/' + encodeURIComponent(body.get('vhost'))
+    url += HTTP.url`/${body.get('vhost')}`
   }
   HTTP.request('GET', url).then(function (data) {
     const a = document.createElement('a')

--- a/static/js/policies.js
+++ b/static/js/policies.js
@@ -35,7 +35,7 @@ const policiesTable = Table.renderTable('table', tableOptions, (tr, item) => {
     click: function () {
       const name = item.name
       const vhost = item.vhost
-      const url = HTTP.url`${HTTP.noescape(baseUrl)}/${vhost}/${name}`
+      const url = HTTP.url`${HTTP.noencode(baseUrl)}/${vhost}/${name}`
       if (window.confirm('Are you sure? This policy cannot be recovered after deletion.')) {
         HTTP.request('DELETE', url)
           .then(() => tr.parentNode.removeChild(tr))
@@ -58,7 +58,7 @@ document.querySelector('#createPolicy').addEventListener('submit', function (evt
   const data = new window.FormData(this)
   const name = data.get('name').trim()
   const vhost = data.get('vhost')
-  const url = HTTP.url`${HTTP.noescape(baseUrl)}/${vhost}/${name}`
+  const url = HTTP.url`${HTTP.noencode(baseUrl)}/${vhost}/${name}`
   const body = {
     pattern: data.get('pattern').trim(),
     definition: DOM.parseJSON(data.get('definition')),

--- a/static/js/policies.js
+++ b/static/js/policies.js
@@ -11,7 +11,7 @@ let url = baseUrl
 
 const vhost = window.sessionStorage.getItem('vhost')
 if (vhost && vhost !== '_all') {
-  url += '/' + encodeURIComponent(vhost)
+  url += HTTP.url`/${vhost}`
 }
 const policiesDataSource = new UrlDataSource(url)
 const tableOptions = {
@@ -33,9 +33,9 @@ const policiesTable = Table.renderTable('table', tableOptions, (tr, item) => {
   buttons.classList.add('buttons')
   const deleteBtn = DOM.button.delete({
     click: function () {
-      const name = encodeURIComponent(item.name)
-      const vhost = encodeURIComponent(item.vhost)
-      const url = `${baseUrl}/${vhost}/${name}`
+      const name = item.name
+      const vhost = item.vhost
+      const url = HTTP.url`${HTTP.noescape(baseUrl)}/${vhost}/${name}`
       if (window.confirm('Are you sure? This policy cannot be recovered after deletion.')) {
         HTTP.request('DELETE', url)
           .then(() => tr.parentNode.removeChild(tr))
@@ -56,9 +56,9 @@ const policiesTable = Table.renderTable('table', tableOptions, (tr, item) => {
 document.querySelector('#createPolicy').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const name = encodeURIComponent(data.get('name').trim())
-  const vhost = encodeURIComponent(data.get('vhost'))
-  const url = `${baseUrl}/${vhost}/${name}`
+  const name = data.get('name').trim()
+  const vhost = data.get('vhost')
+  const url = HTTP.url`${HTTP.noescape(baseUrl)}/${vhost}/${name}`
   const body = {
     pattern: data.get('pattern').trim(),
     definition: DOM.parseJSON(data.get('definition')),

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -289,7 +289,7 @@ document.querySelector('#purgeQueue').addEventListener('submit', function (evt) 
   if (countElem && countElem.value) {
     params = `?count=${countElem.value}`
   }
-  const url = HTTP.url`api/queues/${vhost}/${queue}/contents${HTTP.noescape(params)}`
+  const url = HTTP.url`api/queues/${vhost}/${queue}/contents${HTTP.noencode(params)}`
   if (window.confirm('Are you sure? Messages cannot be recovered after purging.')) {
     HTTP.request('DELETE', url)
       .then(() => { DOM.toast('Queue purged!') })

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -156,7 +156,6 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
     const td = Table.renderCell(tr, 0, '(Default exchange binding)')
     td.setAttribute('colspan', 4)
   } else {
-    const e = encodeURIComponent(item.source)
     const btn = DOM.button.delete({
       text: 'Unbind',
       click: function () {

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -8,7 +8,7 @@ Helpers.addVhostOptions('declare')
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/queues'
 if (vhost && vhost !== '_all') {
-  url += '/' + encodeURIComponent(vhost)
+  url += HTTP.url`/${vhost}`
 }
 const queueDataSource = new UrlDataSource(url)
 const tableOptions = {
@@ -28,10 +28,10 @@ const performMultiAction = (el) => {
     let url
     switch (action) {
       case 'delete':
-        url = `api/queues/${data.vhost}/${data.name}`
+        url = HTTP.url`api/queues/${data.vhost}/${data.name}`
         break
       case 'purge':
-        url = `api/queues/${data.vhost}/${data.name}/contents`
+        url = HTTP.url`api/queues/${data.vhost}/${data.name}/contents`
         break
     }
     if (!url) return
@@ -86,13 +86,13 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
     features += item.exclusive ? ' E' : ''
     features += Object.keys(item.arguments).length > 0 ? ' Args ' : ''
     const queueLink = document.createElement('a')
-    queueLink.href = 'queue#vhost=' + encodeURIComponent(item.vhost) + '&name=' + encodeURIComponent(item.name)
+    queueLink.href = HTTP.url`queue#vhost=${item.vhost}&name=${item.name}`
     queueLink.textContent = item.name
 
     const checkbox = document.createElement('input')
     checkbox.type = 'checkbox'
-    checkbox.setAttribute('data-vhost', encodeURIComponent(item.vhost))
-    checkbox.setAttribute('data-name', encodeURIComponent(item.name))
+    checkbox.setAttribute('data-vhost', item.vhost)
+    checkbox.setAttribute('data-name', item.name)
     checkbox.addEventListener('change', rowCheckboxChanged)
     Table.renderCell(tr, 0, checkbox, 'checkbox')
     Table.renderCell(tr, 1, item.vhost)
@@ -103,7 +103,7 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
   let policyLink = ''
   if (item.policy) {
     policyLink = document.createElement('a')
-    policyLink.href = 'policies#name=' + encodeURIComponent(item.policy) + '&vhost=' + encodeURIComponent(item.vhost)
+    policyLink.href = HTTP.url`policies#name=${item.policy}&vhost=${item.vhost}`
     policyLink.textContent = item.policy
   }
   Table.renderCell(tr, 4, policyLink, 'center')
@@ -122,9 +122,9 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
 document.querySelector('#declare').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const vhost = encodeURIComponent(data.get('vhost'))
-  const queue = encodeURIComponent(data.get('name').trim())
-  const url = 'api/queues/' + vhost + '/' + queue
+  const vhost = data.get('vhost')
+  const queue = data.get('name').trim()
+  const url = HTTP.url`api/queues/${vhost}/${queue}`
   const body = {
     durable: data.get('durable') === '1',
     auto_delete: data.get('auto_delete') === '1',

--- a/static/js/shovels.js
+++ b/static/js/shovels.js
@@ -116,12 +116,10 @@ Table.renderTable('table', tableOptions, (tr, item, all) => {
   const pauseLabel = ['Running', 'Starting'].includes(item.state) ? 'Pause' : 'Resume'
   const pauseBtn = DOM.button.edit({
     click: function () {
-      const name = encodeURIComponent(item.name)
-      const vhost = encodeURIComponent(item.vhost)
       const isRunning = item.state === 'Running'
       const action = isRunning ? 'pause' : 'resume'
 
-      const url = `api/shovels/${vhost}/${name}/${action}`
+      const url = HTTP.url`api/shovels/${item.vhost}/${item.name}/${action}`
 
       if (window.confirm('Are you sure?')) {
         HTTP.request('PUT', url)

--- a/static/js/shovels.js
+++ b/static/js/shovels.js
@@ -26,9 +26,8 @@ const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/parameters/shovel'
 let statusUrl = 'api/shovels'
 if (vhost && vhost !== '_all') {
-  const urlEncodedVhost = encodeURIComponent(vhost)
-  url += '/' + urlEncodedVhost
-  statusUrl += '/' + urlEncodedVhost
+  url += HTTP.url`/${vhost}`
+  statusUrl += HTTP.url`/${vhost}`
 }
 
 class ShovelsDataSource extends UrlDataSource {
@@ -93,9 +92,7 @@ Table.renderTable('table', tableOptions, (tr, item, all) => {
   btns.classList.add('buttons')
   const deleteBtn = DOM.button.delete({
     click: function () {
-      const name = encodeURIComponent(item.name)
-      const vhost = encodeURIComponent(item.vhost)
-      const url = 'api/parameters/shovel/' + vhost + '/' + name
+    const url = HTTP.url`api/parameters/shovel/${item.vhost}/${item.name}`
       if (window.confirm('Are you sure? This shovel can not be restored after deletion.')) {
         HTTP.request('DELETE', url)
           .then(() => {
@@ -158,9 +155,9 @@ document.querySelector('[name=dest-uri]').addEventListener('change', function ()
 document.querySelector('#createShovel').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const name = encodeURIComponent(data.get('name').trim())
-  const vhost = encodeURIComponent(data.get('vhost'))
-  const url = 'api/parameters/shovel/' + vhost + '/' + name
+  const name = data.get('name').trim()
+  const vhost = data.get('vhost')
+  const url = HTTP.url`api/parameters/shovel/${vhost}/${name}`
   const body = {
     value: {
       'src-uri': data.get('src-uri'),

--- a/static/js/shovels.js
+++ b/static/js/shovels.js
@@ -92,7 +92,7 @@ Table.renderTable('table', tableOptions, (tr, item, all) => {
   btns.classList.add('buttons')
   const deleteBtn = DOM.button.delete({
     click: function () {
-    const url = HTTP.url`api/parameters/shovel/${item.vhost}/${item.name}`
+      const url = HTTP.url`api/parameters/shovel/${item.vhost}/${item.name}`
       if (window.confirm('Are you sure? This shovel can not be restored after deletion.')) {
         HTTP.request('DELETE', url)
           .then(() => {

--- a/static/js/unacked.js
+++ b/static/js/unacked.js
@@ -1,12 +1,13 @@
 import * as Table from './table.js'
 import { UrlDataSource } from './datasource.js'
+import * as HTTP from './http.js'
 
 const search = new URLSearchParams(window.location.hash.substring(1))
 const queue = search.get('name')
 const vhost = search.get('vhost')
-const url = `api/queues/${encodeURIComponent(vhost)}/${encodeURIComponent(queue)}/unacked`
+const url = HTTP.url`api/queues/${vhost}/${queue}/unacked`
 const channelBaseUrl = 'channel#name='
-document.getElementById('queue-link').href = `queue#vhost=${encodeURIComponent(vhost)}&name=${encodeURIComponent(queue)}`
+document.getElementById('queue-link').href = HTTP.url`queue#vhost=${vhost}&name=${queue}`
 document.getElementById('queue-link').innerHTML = queue
 document.querySelector('#pagename-label').textContent = `${queue} in virtual host ${vhost}`
 
@@ -25,7 +26,7 @@ Table.renderTable('table', tableOptions, function (tr, item, firstRender) {
     Table.renderCell(tr, 0, item.delivery_tag)
     Table.renderCell(tr, 1, item.consumer_tag)
     const channel = document.createElement('a')
-    channel.href = channelBaseUrl + encodeURIComponent(item.channel_name)
+    channel.href = HTTP.url`channel#name=${item.channel_name}`
     channel.textContent = item.channel_name
     Table.renderCell(tr, 2, channel)
   }

--- a/static/js/unacked.js
+++ b/static/js/unacked.js
@@ -6,7 +6,6 @@ const search = new URLSearchParams(window.location.hash.substring(1))
 const queue = search.get('name')
 const vhost = search.get('vhost')
 const url = HTTP.url`api/queues/${vhost}/${queue}/unacked`
-const channelBaseUrl = 'channel#name='
 document.getElementById('queue-link').href = HTTP.url`queue#vhost=${vhost}&name=${queue}`
 document.getElementById('queue-link').innerHTML = queue
 document.querySelector('#pagename-label').textContent = `${queue} in virtual host ${vhost}`

--- a/static/js/user.js
+++ b/static/js/user.js
@@ -37,7 +37,7 @@ const permissionsTable = Table.renderTable('permissions', tableOptions, (tr, ite
     const deleteBtn = DOM.button.delete({
       text: 'Clear',
       click: function () {
-      const url = HTTP.url`api/permissions/${item.vhost}/${item.username}`
+      const url = HTTP.url`api/permissions/${item.vhost}/${item.user}`
         HTTP.request('DELETE', url)
           .then(() => {
             tr.parentNode.removeChild(tr)

--- a/static/js/user.js
+++ b/static/js/user.js
@@ -5,10 +5,9 @@ import * as DOM from './dom.js'
 import * as Form from './form.js'
 
 const user = new URLSearchParams(window.location.hash.substring(1)).get('name')
-const urlEncodedUsername = encodeURIComponent(user)
 
 function updateUser () {
-  const userUrl = 'api/users/' + urlEncodedUsername
+  const userUrl = HTTP.url`api/users/${user}`
   HTTP.request('GET', userUrl)
     .then(item => {
       const hasPassword = item.password_hash ? '●' : '○'
@@ -26,7 +25,7 @@ function tagHelper (tags) {
   })
 }
 
-const permissionsUrl = 'api/users/' + urlEncodedUsername + '/permissions'
+const permissionsUrl = HTTP.url`api/users/${user}/permissions`
 const tableOptions = { url: permissionsUrl, keyColumns: ['vhost'], interval: 0, countId: 'permissions-count' }
 const permissionsTable = Table.renderTable('permissions', tableOptions, (tr, item, all) => {
   Table.renderCell(tr, 1, item.configure)
@@ -38,9 +37,7 @@ const permissionsTable = Table.renderTable('permissions', tableOptions, (tr, ite
     const deleteBtn = DOM.button.delete({
       text: 'Clear',
       click: function () {
-        const username = encodeURIComponent(item.user)
-        const vhost = encodeURIComponent(item.vhost)
-        const url = 'api/permissions/' + vhost + '/' + username
+      const url = HTTP.url`api/permissions/${item.vhost}/${item.username}`
         HTTP.request('DELETE', url)
           .then(() => {
             tr.parentNode.removeChild(tr)
@@ -63,8 +60,8 @@ Helpers.addVhostOptions('setPermission')
 document.querySelector('#setPermission').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const vhost = encodeURIComponent(data.get('vhost'))
-  const url = 'api/permissions/' + vhost + '/' + urlEncodedUsername
+  const vhost = data.get('vhost')
+  const url = HTTP.url`api/permissions/${vhost}/${user}`
   const body = {
     configure: data.get('configure'),
     write: data.get('write'),
@@ -91,7 +88,7 @@ document.querySelector('#updateUser').addEventListener('submit', function (evt) 
   evt.preventDefault()
   const pwd = document.querySelector('[name=password]')
   const data = new window.FormData(this)
-  const url = 'api/users/' + urlEncodedUsername
+  const url = HTTP.url`api/users/${user}`
   const body = {
     tags: data.get('tags')
   }
@@ -116,7 +113,7 @@ document.querySelector('#dataTags').onclick = e => {
 
 document.querySelector('#deleteUser').addEventListener('submit', function (evt) {
   evt.preventDefault()
-  const url = 'api/users/' + urlEncodedUsername
+  const url = HTTP.url`api/users/${user}`
   if (window.confirm('Are you sure? This object cannot be recovered after deletion.')) {
     HTTP.request('DELETE', url)
       .then(() => { window.location = 'users' })

--- a/static/js/user.js
+++ b/static/js/user.js
@@ -37,7 +37,7 @@ const permissionsTable = Table.renderTable('permissions', tableOptions, (tr, ite
     const deleteBtn = DOM.button.delete({
       text: 'Clear',
       click: function () {
-      const url = HTTP.url`api/permissions/${item.vhost}/${item.user}`
+        const url = HTTP.url`api/permissions/${item.vhost}/${item.user}`
         HTTP.request('DELETE', url)
           .then(() => {
             tr.parentNode.removeChild(tr)

--- a/static/js/users.js
+++ b/static/js/users.js
@@ -16,7 +16,7 @@ HTTP.request('GET', 'api/permissions').then(permissions => {
   usersTable = Table.renderTable('users', tableOptions, (tr, item, all) => {
     if (all) {
       const userLink = document.createElement('a')
-      userLink.href = 'user#name=' + encodeURIComponent(item.name)
+      userLink.href = HTTP.url`user#name=${item.name}`
       userLink.textContent = item.name
       Table.renderCell(tr, 0, userLink)
     }
@@ -33,8 +33,8 @@ HTTP.request('GET', 'api/permissions').then(permissions => {
 document.querySelector('#createUser').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const username = encodeURIComponent(data.get('username').trim())
-  const url = 'api/users/' + username
+  const username = data.get('username').trim()
+  const url = HTTP.url`api/users/${username}`
   let toastText = `User created: '${username}'`
   const trs = document.querySelectorAll('#table tbody tr')
   trs.forEach((tr) => {

--- a/static/js/vhosts.js
+++ b/static/js/vhosts.js
@@ -11,8 +11,7 @@ const tableOptions = {
   search: true
 }
 const vhostTable = Table.renderTable('table', tableOptions, (tr, item, all) => {
-  const urlEncodedVhost = encodeURIComponent(item.name)
-  const permissionsUrl = 'api/vhosts/' + urlEncodedVhost + '/permissions'
+  const permissionsUrl = HTTP.url`api/vhosts/${item.name}/permissions`
   HTTP.request('GET', permissionsUrl)
     .then(permissions => {
       window.sessionStorage.setItem(permissionsUrl, JSON.stringify(permissions))
@@ -35,8 +34,8 @@ const vhostTable = Table.renderTable('table', tableOptions, (tr, item, all) => {
 document.querySelector('#createVhost').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const name = encodeURIComponent(data.get('name').trim())
-  const url = 'api/vhosts/' + name
+  const name = data.get('name').trim()
+  const url = HTTP.url`'api/vhosts/${name}`
   HTTP.request('PUT', url)
     .then(() => {
       vhostTable.reload()

--- a/static/js/vhosts.js
+++ b/static/js/vhosts.js
@@ -17,7 +17,7 @@ const vhostTable = Table.renderTable('table', tableOptions, (tr, item, all) => {
       window.sessionStorage.setItem(permissionsUrl, JSON.stringify(permissions))
       if (all) {
         const vhostLink = document.createElement('a')
-        vhostLink.href = `vhost#name=${urlEncodedVhost}`
+        vhostLink.href = HTTP.url`vhost#name=${item.name}`
         vhostLink.textContent = item.name
         Table.renderCell(tr, 0, vhostLink)
       }
@@ -35,7 +35,7 @@ document.querySelector('#createVhost').addEventListener('submit', function (evt)
   evt.preventDefault()
   const data = new window.FormData(this)
   const name = data.get('name').trim()
-  const url = HTTP.url`'api/vhosts/${name}`
+  const url = HTTP.url`api/vhosts/${name}`
   HTTP.request('PUT', url)
     .then(() => {
       vhostTable.reload()


### PR DESCRIPTION
### WHAT is this pull request doing?
The frontend code is sprinkled with `encodeURIComponent` to construct URLs. It makes the code cluttered and it's easy to forget to encode what's necessary.

This PR will replace all `encodeURIComponent` with [tagged template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) and a custom `HTTP.url` tag that will automatically encode all expressions in the template literal.

```javascript
const url = HTTP.url`/path/${myVar}/slug/${otherVar}`
// is equivalent to
const url = `/path/${encodeURIComponent(myVar)}/slug/${encodeURIComponent(otherVar)}`
```

I'm not sure about the name, maybe it should say something about encode?

It's possible to make an expression not being encoded by using the `HTTP.noencode` (rename to `raw`?) method like 

```javascript
const url = HTTP.url`/path/${HTTP.noencode(myVar)}/slug/${otherVar}`
```

### HOW can this pull request be tested?
Specs and manually
