### PR TITLE
Bugfix: priority queues always deliver messages with redelivered=true

### DIFF
--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -14,7 +14,7 @@ describe LavinMQ::AMQP::PriorityQueue do
   describe "PriorityMessageStore" do
     describe "clustering" do
       add_etcd_around_each
-      it "can stream changes to to priority queues" do
+      it "is replicated correctly" do
         with_clustering do |cluster|
           with_amqp_server(replicator: cluster.replicator) do |s|
             with_channel(s) do |ch|

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -60,7 +60,7 @@ describe LavinMQ::AMQP::PriorityQueue do
           props = AMQP::Client::Properties.new(priority: 10u8)
           msg = LavinMQ::Message.new("ex", "rk", "body", properties: props)
           store.push msg
-          store.@stores[0].size.should eq 1
+          store.@stores[-1].size.should eq 1
         end
       end
     end
@@ -121,7 +121,7 @@ describe LavinMQ::AMQP::PriorityQueue do
 
           store.requeue sp_prio_5
           store.requeue sp_prio_3
-          store.@stores[0].size.should eq 1
+          store.@stores[-1].size.should eq 1
         end
       end
     end

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -12,27 +12,29 @@ end
 
 describe LavinMQ::AMQP::PriorityQueue do
   describe "PriorityMessageStore" do
-    it "migrates old store" do
-      data_dir = File.tempname
-      Dir.mkdir data_dir
+    describe "migration" do
+      it "should migrate old store" do
+        data_dir = File.tempname
+        Dir.mkdir data_dir
 
-      old_store = LavinMQ::MessageStore.new(data_dir, nil, durable: true)
-      60u8.times do |prio|
-        props = AMQP::Client::Properties.new(priority: prio % 6)
-        msg = LavinMQ::Message.new("ex", "rk", "body", properties: props)
-        old_store.push msg
+        old_store = LavinMQ::MessageStore.new(data_dir, nil, durable: true)
+        60u8.times do |prio|
+          props = AMQP::Client::Properties.new(priority: prio % 6)
+          msg = LavinMQ::Message.new("ex", "rk", "body", properties: props)
+          old_store.push msg
+        end
+        old_store.close
+
+        store = LavinMQ::AMQP::PriorityQueue::PriorityMessageStore.new(5u8, data_dir, nil, durable: true)
+        store.size.should eq 60
+
+        6.times do |i|
+          store.@stores[i].size.should eq 10
+        end
+      ensure
+        store.delete if store
+        FileUtils.rm_rf data_dir if data_dir
       end
-      old_store.close
-
-      store = LavinMQ::AMQP::PriorityQueue::PriorityMessageStore.new(5u8, data_dir, nil, durable: true)
-      store.size.should eq 60
-
-      6.times do |i|
-        store.@stores[i].size.should eq 10
-      end
-    ensure
-      store.delete if store
-      FileUtils.rm_rf data_dir if data_dir
     end
 
     it "should use sub stores" do

--- a/spec/support/clustering_helper.cr
+++ b/spec/support/clustering_helper.cr
@@ -1,3 +1,6 @@
+require "../../src/lavinmq/clustering/client"
+require "../../src/lavinmq/clustering/server"
+
 class SpecClustering
   getter replicator, config, follower_config
 

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -119,7 +119,7 @@ module LavinMQ::AMQP
 
       def push(msg) : SegmentPosition
         raise ClosedError.new if @closed
-        prio = [msg.properties.priority || 0u8, @max_priority].min
+        prio = Math.min(msg.properties.priority || 0u8, @max_priority)
         sp = store_for prio, &.push(msg)
         was_empty = @size.zero?
         @bytesize += sp.bytesize

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -7,51 +7,120 @@ module LavinMQ::AMQP
       @effective_args << "x-max-priority"
     end
 
-    private def init_msg_store(data_dir)
+    private def init_msg_store(msg_dir)
       replicator = durable? ? @vhost.@replicator : nil
-      PriorityMessageStore.new(data_dir, replicator, metadata: @metadata)
+      max_priority = @arguments["x-max-priority"]?.try(&.as?(Int)) || 0u8
+      PriorityMessageStore.new(max_priority.to_u8, msg_dir, replicator, metadata: @metadata)
     end
 
     class PriorityMessageStore < MessageStore
-      # def initialize(@data_dir : String, metadata : ::Log::Metadata, @replicator : Clustering::Replicator?)
-      def initialize(*args, **kwargs)
-        super
-        order_messages
+      @stores : Array(MessageStore)
+
+      def initialize(@max_priority : UInt8, @msg_dir : String, @replicator : Clustering::Replicator?, @durable : Bool = true, @metadata : ::Log::Metadata = ::Log::Metadata.empty)
+        @stores = Array(MessageStore).new(1 + @max_priority)
+        @log = Log.for(self, @metadata)
+
+        (0..@max_priority).reverse_each do |i|
+          sub_msg_dir = File.join(@msg_dir, i.to_s)
+          Dir.mkdir_p sub_msg_dir
+          store = MessageStore.new(sub_msg_dir, @replicator, @durable, metadata: @metadata)
+          @size += store.size
+          @bytesize += store.bytesize
+          @stores << store
+        end
+        @empty.set empty?
       end
 
-      def order_messages
-        sps = Array(SegmentPosition).new(@size)
-        while env = shift?
-          sps << env.segment_position
+      # returns the substore for the priority
+      private def store_for(prio : UInt8, &)
+        yield @stores[@stores.size - prio - 1]
+      end
+
+      private def store_for(sp : SegmentPosition, &)
+        store_for(sp.priority) do |store|
+          yield store
         end
-        sps.each { |sp| requeue sp }
+      end
+
+      private def store_for(msg, &)
+        store_for(msg.properties.priority || 0u8) do |store|
+          yield store
+        end
       end
 
       def push(msg) : SegmentPosition
-        sp = super
-        # make sure that we don't read from disk, only from requeued
-        @rfile_id = @wfile_id
-        @rfile = @wfile
-        @rfile.seek(0, IO::Seek::End)
-        # order messages by priority in the requeue dequeue
-        if idx = @requeued.bsearch_index { |rsp| rsp.priority < sp.priority }
-          @requeued.insert(idx, sp)
-        else
-          @requeued.push(sp)
-        end
-        sp
-      end
-
-      def requeue(sp : SegmentPosition)
-        if idx = @requeued.bsearch_index { |rsp| rsp.priority < sp.priority }
-          @requeued.insert(idx, sp)
-        else
-          @requeued.push(sp)
-        end
+        raise ClosedError.new if @closed
+        sp = store_for msg, &.push(msg)
         was_empty = @size.zero?
         @bytesize += sp.bytesize
         @size += 1
         @empty.set false if was_empty
+        sp
+      end
+
+      def requeue(sp : SegmentPosition)
+        raise ClosedError.new if @closed
+        store_for sp, &.requeue(sp)
+        was_empty = @size.zero?
+        @bytesize += sp.bytesize
+        @size += 1
+        @empty.set false if was_empty
+      end
+
+      def first? : Envelope?
+        raise ClosedError.new if @closed
+        @stores.each do |s|
+          envelope = s.first?
+          return envelope unless envelope.nil?
+        end
+      end
+
+      def shift?(consumer = nil) : Envelope?
+        raise ClosedError.new if @closed
+        @stores.each do |s|
+          envelope = s.shift?(consumer)
+          return envelope unless envelope.nil?
+        end
+      end
+
+      def [](sp : SegmentPosition) : BytesMessage
+        raise ClosedError.new if @closed
+        store_for sp, &.[sp]
+      end
+
+      def delete(sp) : Nil
+        raise ClosedError.new if @closed
+        store_for sp, &.delete(sp)
+      end
+
+      def purge(max_count : Int = UInt32::MAX) : UInt32
+        raise ClosedError.new if @closed
+        count = 0u32
+        while count < max_count && (env = shift?)
+          delete(env.segment_position)
+          count += 1
+          break if count >= max_count
+          Fiber.yield if (count % PURGE_YIELD_INTERVAL).zero?
+        end
+        count
+      end
+
+      def purge_all
+        @stores.each &.purge_all
+      end
+
+      def delete
+        @closed = true
+        @empty.close
+        @stores.each &.delete
+        FileUtils.rm_rf @msg_dir
+      end
+
+      def close : Nil
+        return if @closed
+        @closed = true
+        @stores.each &.close
+        @empty.close
       end
     end
   end

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -47,7 +47,12 @@ module LavinMQ::AMQP
 
       # returns the substore for the priority
       private def store_for(prio : UInt8, &)
-        yield @stores[@stores.size - prio - 1]
+        unless 0 <= prio <= @max_priority
+          raise ArgumentError.new "Priority must be between 0 and #{@max_priority}, got #{prio}"
+        end
+        # Since @stores is sorted with highets prio first, we do lookup from
+        # end of the array. We must add one step because last item is -1 not -0.
+        yield @stores[-(1 + prio)]
       end
 
       private def store_for(sp : SegmentPosition, &)

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -52,8 +52,7 @@ module LavinMQ::AMQP
         return unless needs_migrate?
         unless empty?
           raise "Message store #{@msg_dir} contains messages that should be migrated, " \
-            "but substores are not empty. Migration aborted, manually intervention needed."
-          end
+                "but substores are not empty. Migration aborted, manually intervention needed."
         end
         old_store = MessageStore.new(@msg_dir, @replicator, @durable, metadata: @metadata)
         msg_count = old_store.size

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -79,15 +79,16 @@ module LavinMQ::AMQP
         @log.info { "Migration complete" }
         old_store.close
         i = 0u32
-        noop_wg = WaitGroup.new(0)
+        delete_wg = WaitGroup.new
         Dir.each_child(@msg_dir) do |f|
           if f.starts_with?("msgs.") || f.starts_with?("acks.")
             filepath = File.join(@msg_dir, f)
             File.delete? filepath
-            @replicator.try &.delete_file(filepath, noop_wg)
+            @replicator.try &.delete_file(filepath, delete_wg)
             Fiber.yield if (i &+= 8096).zero?
           end
         end
+        delete_wg.wait
       end
 
       private def needs_migrate?

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -114,7 +114,8 @@ module LavinMQ::AMQP
 
       def push(msg) : SegmentPosition
         raise ClosedError.new if @closed
-        sp = store_for msg, &.push(msg)
+        prio = [msg.properties.priority || 0u8, @max_priority].min
+        sp = store_for prio, &.push(msg)
         was_empty = @size.zero?
         @bytesize += sp.bytesize
         @size += 1

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -420,7 +420,7 @@ module LavinMQ
               next
             end
           rescue ex
-            @log.error { "Could not initialize segment, closing message store: #{ex.message}" }
+            @log.error { "Could not initialize segment #{seg}, closing message store: #{ex.message}" }
             close
           end
         end


### PR DESCRIPTION
### WHAT is this pull request doing?

Refactor `PriorityMessageStore` to use one message store per priority.

Fixes #1132
Fixes #1143

Supersedes #1154

### HOW can this pull request be tested?
Run specs
