### PR TITLE
Bugfix: shovel api not returning 422 when resuming running shovel

### DIFF
--- a/spec/api/shovels_spec.cr
+++ b/spec/api/shovels_spec.cr
@@ -1,76 +1,86 @@
 require "../spec_helper.cr"
 require "uri"
 
-describe LavinMQ::HTTP::ShovelsController do
-  describe "PUT api/shovels/:vhost/:pause" do
-    with_http_server do |http, s|
-      vhost_url_encoded = URI.encode_path_segment("/")
-      body = %({
-        "value": {
-          "src-uri": "#{s.amqp_url}",
-          "dest-uri": "#{s.amqp_url}",
-          "dest-queue":"q1",
-          "src-queue":"q2",
-          "src-prefetch-count":1000,
-          "src-delete-after":"never",
-          "reconnect-delay":5,
-          "ack-mode":"on-confirm"
-        }
-      })
-      response = http.put("/api/parameters/shovel/#{vhost_url_encoded}/name", body: body)
-      response.status_code.should eq 201
-      wait_for {
-        current_state = JSON.parse(http.get("/api/shovels/#{vhost_url_encoded}/name").body)["state"]
-        current_state === "Running"
-      }
-      response = http.put("/api/shovels/#{vhost_url_encoded}/name/pause")
-      response.status_code.should eq 204
+def create_shovel(server, name = "spec-shovel", config = NamedTuple.new, paused = false)
+  config = NamedTuple.new(
+    "src-uri": server.amqp_url,
+    "dest-uri": server.amqp_url,
+    "dest-queue": "q1",
+    "src-queue": "q2",
+    "src-prefetch-count": 1000,
+    "src-delete-after": "never",
+    "reconnect-delay": 5,
+    "ack-mode": "on-confirm",
+  ).merge(config)
+  shovel = server.vhosts["/"].shovels.create(name, JSON.parse(config.to_json))
+  wait_for { shovel.state.running? }
+  if paused
+    shovel.pause
+    wait_for { shovel.state.paused? }
+  end
+  shovel
+end
 
-      wait_for {
-        current_state = JSON.parse(http.get("/api/shovels/#{vhost_url_encoded}/name").body)["state"]
-        current_state === "Paused"
-      }
+describe LavinMQ::HTTP::ShovelsController do
+  describe "PUT api/shovels/:vhost/:name/pause" do
+    it "should return 404 for non-existing shovel" do
+      with_http_server do |http, _s|
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.put("/api/shovels/#{vhost_url_encoded}/non-existing/pause")
+        response.status_code.should eq 404
+      end
+    end
+
+    it "should pause shovel and return 204" do
+      with_http_server do |http, s|
+        shovel = create_shovel(s)
+        vhost_url_encoded = URI.encode_path_segment(shovel.vhost.name)
+
+        response = http.put("/api/shovels/#{vhost_url_encoded}/#{shovel.name}/pause")
+        response.status_code.should eq 204
+
+        shovel.state.paused?.should be_true
+      end
+    end
+
+    it "should return 422 if shovel is already paused" do
+      with_http_server do |http, s|
+        shovel = create_shovel(s, paused: true)
+        vhost_url_encoded = URI.encode_path_segment(shovel.vhost.name)
+
+        response = http.put("/api/shovels/#{vhost_url_encoded}/#{shovel.name}/pause")
+        response.status_code.should eq 422
+      end
     end
   end
 
   describe "PUT api/shovels/:vhost/:name/resume" do
-    with_http_server do |http, s|
-      vhost_url_encoded = URI.encode_path_segment("/")
-      body = %({
-          "value": {
-            "src-uri": "#{s.amqp_url}",
-            "dest-uri": "#{s.amqp_url}",
-            "dest-queue":"q1",
-            "src-queue":"q2",
-            "src-prefetch-count":1000,
-            "src-delete-after":"never",
-            "reconnect-delay":5,
-            "ack-mode":"on-confirm"
-          }
-        })
-      response = http.put("/api/parameters/shovel/#{vhost_url_encoded}/name", body: body)
-      response.status_code.should eq 201
-      wait_for {
-        current_state = JSON.parse(http.get("/api/shovels/#{vhost_url_encoded}/name").body)["state"]
-        current_state === "Running"
-      }
-      response = http.put("/api/shovels/%2F/name/pause")
-      response.status_code.should eq 204
+    it "should return 404 for non-existing shovel" do
+      with_http_server do |http, _s|
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.put("/api/shovels/#{vhost_url_encoded}/non-existing/resume")
+        response.status_code.should eq 404
+      end
+    end
 
-      wait_for {
-        current_state = JSON.parse(http.get("/api/shovels/#{vhost_url_encoded}/name").body)["state"]
-        current_state === "Paused"
-      }
+    it "should resume a paused shovel and return 204" do
+      with_http_server do |http, s|
+        shovel = create_shovel(s, paused: true)
+        vhost_url_encoded = URI.encode_path_segment(shovel.vhost.name)
+        status_code = http.put("/api/shovels/#{vhost_url_encoded}/#{shovel.name}/resume").status_code
+        status_code.should eq 204
 
-      status_code = http.put("/api/shovels/#{vhost_url_encoded}/name/resume").status_code
-      status_code.should eq 204
+        wait_for { shovel.state.running? }
+      end
+    end
 
-      wait_for {
-        response = http.get("/api/shovels/#{vhost_url_encoded}/name")
-        response.status_code.should eq 200
-        current_state = JSON.parse(response.body)["state"]?
-        current_state === "Running"
-      }
+    it "should return 422 if shovel is already running" do
+      with_http_server do |http, s|
+        shovel = create_shovel(s, paused: false)
+        vhost_url_encoded = URI.encode_path_segment(shovel.vhost.name)
+        status_code = http.put("/api/shovels/#{vhost_url_encoded}/#{shovel.name}/resume").status_code
+        status_code.should eq 422
+      end
     end
   end
 end

--- a/src/lavinmq/http/controller/shovels.cr
+++ b/src/lavinmq/http/controller/shovels.cr
@@ -52,6 +52,7 @@ module LavinMQ
             if current_shovel = @amqp_server.vhosts[vhost].shovels[shovel_name]?
               if !current_shovel.paused?
                 context.response.status_code = 422
+                next
               end
               current_shovel.resume
               context.response.status_code = 204


### PR DESCRIPTION
### WHAT is this pull request doing?
Shovel API specs was flaky for me locally. I then noticed that the shovel http api didn't return 422 when trying to resume a running shovel.

I fixed the 422 return and refactored the shovel API specs to remove the flakieness and add specs to verify all(?) http responses.

### HOW can this pull request be tested?
Run specs
