### PR TITLE
Fix flaky spec: close replicator wait for follower to drain action queue

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -33,6 +33,7 @@ describe LavinMQ::Clustering::Client do
         q = ch.queue("repli")
         q.publish_confirm "hello world"
       end
+      replicator.close
       repli.close
       done.receive
     end


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes a clustering spec that was flaky. Sometimes the action queue of the follower wasn't drained causing the spec to fail.

By closing the replicator before closing the follower client will wait for the follower action queue to be drained.

### HOW can this pull request be tested?
Run spec
