### PR TITLE
Fix flaky Deduplication spec

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -43,6 +43,11 @@ Lint/NotNil:
   Enabled: true
   Severity: Warning
 
+Lint/SpecFilename:
+  IgnoredFilenames:
+  - spec_helper
+  - rough_time
+
 # Problems found: 3
 # Run `ameba --only Documentation/DocumentationAdmonition` for details
 Documentation/DocumentationAdmonition:

--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -33,14 +33,16 @@ describe LavinMQ::Deduplication do
     end
 
     it "should respect ttl" do
-      cache = LavinMQ::Deduplication::MemoryCache(String).new(3)
-      cache.insert("item1", 1)
-      cache.insert("item2", 300)
-      cache.insert("item3")
-      sleep 0.2.seconds
-      cache.contains?("item1").should be_false
-      cache.contains?("item2").should be_true
-      cache.contains?("item3").should be_true
+      RoughTime.paused do |t|
+        cache = LavinMQ::Deduplication::MemoryCache(String).new(3)
+        cache.insert("item1", 1)
+        cache.insert("item2", 300)
+        cache.insert("item3")
+        t.travel 0.2.seconds
+        cache.contains?("item1").should be_false
+        cache.contains?("item2").should be_true
+        cache.contains?("item3").should be_true
+      end
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -14,6 +14,7 @@ require "../src/lavinmq/server"
 require "../src/lavinmq/http/http_server"
 require "http/client"
 require "amqp-client"
+require "./support/*"
 
 def init_config(config = LavinMQ::Config.instance)
   config.data_dir = "/tmp/lavinmq-spec"

--- a/spec/support/rough_time.cr
+++ b/spec/support/rough_time.cr
@@ -1,0 +1,51 @@
+module RoughTime
+  @@paused_utc = Time.utc
+  @@paused_unix_ms : Int64 = @@paused_utc.to_unix_ms // 100 * 100
+  @@paused_monotonic = Time.monotonic
+  @@paused = false
+
+  def self.utc : Time
+    if @@paused
+      return @@paused_utc
+    end
+    previous_def
+  end
+
+  def self.unix_ms : Int64
+    if @@paused
+      return @@paused_unix_ms
+    end
+    previous_def
+  end
+
+  def self.monotonic : Time::Span
+    if @@paused
+      return @@paused_monotonic
+    end
+    previous_def
+  end
+
+  def self.pause
+    @@paused = true
+    @@paused_utc = Time.utc
+    @@paused_unix_ms = @@paused_utc.to_unix_ms // 100 * 100
+    @@paused_monotonic = Time.monotonic
+  end
+
+  def self.travel(time : Time::Span)
+    @@paused_utc += time
+    @@paused_unix_ms += @@paused_utc.to_unix_ms // 100 * 100
+    @@paused_monotonic += time
+  end
+
+  def self.resume
+    @@paused = false
+  end
+
+  def self.paused(&)
+    self.pause
+    yield self
+  ensure
+    self.resume
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?

This will fix a flaky (at least on macos) deduplication spec. The spec relies on sleep which of course makes it flaky.

To fix this I introduced a `RoughTime` helper to "pause" the time and make it possible to "travel" while paused. We should probably use this in more places.

I had to add `rough_time` as ignored file name in ameba config, because it seems like the `Lint/SpecFilename` rule's `IgnoredDirs` isn't working properly.

### HOW can this pull request be tested?
Run specs
