### PR TITLE
Fix: Handle help patterns in lavinmqperf

### DIFF
--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -34,6 +34,8 @@ module LavinMQPerf
     when "throughput" then MQTT::Throughput.new.run
     else                   abort Perf.new.mqtt_banner
     end
+  when /^.+$/
+    Perf.new.run([protocol.not_nil!])
   else abort Perf.new.amqp_banner
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
When introducing mqtt perf tools, i missed that we need to handle `/^.+$/` input in the protocol field also. This pullrequest introduces that so we don't get an error status exit if we want to use `--help` or `--version` etc. 

### HOW can this pull request be tested?
run lavinmqperf --help 