### PR TITLE
Fix: default lavinmqperf protocol to amqp if not specified

### DIFF
--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -33,9 +33,9 @@ module LavinMQPerf
   when "mqtt"
     mode = ARGV.shift?
     case mode
-    when "throughput"       then MQTT::Throughput.new.run
-    when /^.+$/             then Perf.new.run([mode.not_nil!])
-    else                         abort Perf.new.mqtt_banner
+    when "throughput" then MQTT::Throughput.new.run
+    when /^.+$/       then Perf.new.run([mode.not_nil!])
+    else                   abort Perf.new.mqtt_banner
     end
   when /^.+$/
     Perf.new.run([protocol.not_nil!])

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -12,10 +12,9 @@ Signal::SEGV.reset # Let the OS generate a coredump
 Log.setup_from_env
 
 module LavinMQPerf
-  protocol = ARGV[0]?
   # Default to 'amqp' if the first argument is not a protocol or an option
-  ARGV.unshift("amqp") if ARGV[0]?.try { |a| a != "amqp" && a != "mqtt" && !a.starts_with?("-") } || ARGV.empty?
-  protocol = ARGV.shift? || "amqp"
+  protocols = {"amqp", "mqtt"}
+  protocol = protocols.includes?(ARGV[0]?) ? ARGV.shift : "amqp"
   case protocol
   when "amqp"
     mode = ARGV.shift?

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -12,6 +12,9 @@ Signal::SEGV.reset # Let the OS generate a coredump
 Log.setup_from_env
 
 module LavinMQPerf
+  protocol = ARGV[0]?
+  # Default to 'amqp' if the first argument is not a protocol or an option
+  ARGV.unshift("amqp") if ARGV[0]?.try { |a| a != "amqp" && a != "mqtt" && !a.starts_with?("-") } || ARGV.empty?
   protocol = ARGV.shift? || "amqp"
   case protocol
   when "amqp"
@@ -31,8 +34,9 @@ module LavinMQPerf
   when "mqtt"
     mode = ARGV.shift?
     case mode
-    when "throughput" then MQTT::Throughput.new.run
-    else                   abort Perf.new.mqtt_banner
+    when "throughput"       then MQTT::Throughput.new.run
+    when /^.+$/             then Perf.new.run([mode.not_nil!])
+    else                         abort Perf.new.mqtt_banner
     end
   when /^.+$/
     Perf.new.run([protocol.not_nil!])


### PR DESCRIPTION
### WHAT is this pull request doing?

If you do not specify a protocol when starting lavinmqperf, it will default to amqp.  

### HOW can this pull request be tested?
run lavinmqperf throughput