### PR TITLE
ReplaceAction will handle underlaying file being replaced again

### DIFF
--- a/spec/clustering/actions_spec.cr
+++ b/spec/clustering/actions_spec.cr
@@ -64,6 +64,24 @@ describe LavinMQ::Clustering::Action do
           read_and_verify_data(io, "foo")
         end
       end
+
+      it "sends the original file even though it has been appended to" do
+        with_datadir do |data_dir|
+          filename = "file1"
+          File.write File.join(data_dir, filename), "foo"
+          action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
+
+          # append
+          File.write File.join(data_dir, filename), "bar", mode: "a"
+
+          io = IO::Memory.new
+          action.send io
+          io.rewind
+
+          read_and_verify_filename(io, filename)
+          read_and_verify_data(io, "foo")
+        end
+      end
     end
 
     describe "#lag_size" do

--- a/spec/clustering/actions_spec.cr
+++ b/spec/clustering/actions_spec.cr
@@ -30,60 +30,49 @@ end
 
 describe LavinMQ::Clustering::Action do
   describe "ReplaceAction" do
-    describe "without @mfile" do
-      describe "#send" do
-        it "writes filename and data to IO" do
-          with_datadir do |data_dir|
-            filename = "file1"
-            File.write File.join(data_dir, filename), "foo"
-            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
-            io = IO::Memory.new
-            action.send io
-            io.rewind
+    describe "#send" do
+      it "writes filename and data to IO" do
+        with_datadir do |data_dir|
+          filename = "file1"
+          File.write File.join(data_dir, filename), "foo"
+          action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
+          io = IO::Memory.new
+          action.send io
+          io.rewind
 
-            read_and_verify_filename(io, filename)
-            read_and_verify_data(io, "foo")
-          end
+          read_and_verify_filename(io, filename)
+          read_and_verify_data(io, "foo")
         end
       end
 
-      describe "#lag_size" do
-        it "should count filename and filesize" do
-          with_datadir do |data_dir|
-            filename = "file1"
-            File.write File.join(data_dir, filename), "foo"
-            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
-            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
+      it "sends the original file even though it has been replaced again" do
+        with_datadir do |data_dir|
+          filename = "file1"
+          File.write File.join(data_dir, filename), "foo"
+          action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
+
+          # replace
+          File.open(File.join(data_dir, "#{filename}.tmp"), "w") do |f|
+            f.print "bar"
+            f.rename File.join(data_dir, filename)
           end
+          io = IO::Memory.new
+          action.send io
+          io.rewind
+
+          read_and_verify_filename(io, filename)
+          read_and_verify_data(io, "foo")
         end
       end
     end
 
-    describe "with @mfile" do
-      describe "#send" do
-        it "writes filename and data to IO" do
-          with_datadir do |data_dir|
-            filename = "file1"
-            absolute = File.join data_dir, filename
-            File.write absolute, "foo"
-            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename, MFile.new(absolute)
-            io = IO::Memory.new
-            action.send io
-            io.rewind
-
-            read_and_verify_filename(io, filename)
-            read_and_verify_data(io, "foo")
-          end
-        end
-      end
-      describe "#lag_size" do
-        it "should count filename and filesize" do
-          with_datadir do |data_dir|
-            filename = "file1"
-            File.write File.join(data_dir, filename), "foo"
-            action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
-            action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
-          end
+    describe "#lag_size" do
+      it "should count filename and filesize" do
+        with_datadir do |data_dir|
+          filename = "file1"
+          File.write File.join(data_dir, filename), "foo"
+          action = LavinMQ::Clustering::ReplaceAction.new data_dir, filename
+          action.lag_size.should eq(sizeof(Int32) + filename.bytesize + sizeof(Int64) + "foo".bytesize)
         end
       end
     end

--- a/src/lavinmq/clustering/actions.cr
+++ b/src/lavinmq/clustering/actions.cr
@@ -19,39 +19,27 @@ module LavinMQ
     end
 
     struct ReplaceAction < Action
-      def initialize(@data_dir : String, @filename : String, @mfile : MFile? = nil)
+      def initialize(@data_dir : String, @filename : String)
+        @file = File.new(File.join(@data_dir, @filename))
+        @file_size = @file.size
       end
 
       def lag_size : Int64
-        if mfile = @mfile
-          0i64 + sizeof(Int32) + @filename.bytesize +
-            sizeof(Int64) + mfile.size.to_i64
-        else
-          0i64 + sizeof(Int32) + @filename.bytesize +
-            sizeof(Int64) + File.size(File.join(@data_dir, @filename)).to_i64
-        end
+        0i64 + sizeof(Int32) + @filename.bytesize + sizeof(Int64) + @file_size
       end
 
       def send(socket, log = Log) : Int64
         log.debug { "Replace #{@filename}" }
         send_filename(socket)
-        if mfile = @mfile
-          size = mfile.size.to_i64
-          socket.write_bytes size, IO::ByteFormat::LittleEndian
-          socket.write mfile.to_slice(0, size)
-          mfile.dontneed
-          size
-        else
-          File.open(File.join(@data_dir, @filename)) do |f|
-            size = f.size.to_i64
-            socket.write_bytes size, IO::ByteFormat::LittleEndian
-            IO.copy(f, socket, size) == size || raise IO::EOFError.new
-            size
-          end
-        end
+        socket.write_bytes @file_size.to_i64, IO::ByteFormat::LittleEndian
+        IO.copy(@file, socket, @file_size) == @file_size || raise IO::EOFError.new
+        @file_size
+      ensure
+        done
       end
 
       def done
+        @file.close
       end
     end
 


### PR DESCRIPTION
When a file replacement is replicated using ReplaceAction, there was a bug that if the file was replaced again by the time the ReplaceAction was sent to a slow follower, the filesize could mismatch. This fixes it by opening the File when the ReplaceAction is constructed.

In LavinMQ replaced files are always written to a tempfile file and then renamed, the content of them are not modified.

This also drops support for `MFile` in `ReplaceAction`, it was already dropped from `Replicator` and `Follower`.