### PR TITLE
spec: Make sure consumers "work" long enough with each message

### DIFF
--- a/spec/consumer_spec.cr
+++ b/spec/consumer_spec.cr
@@ -100,12 +100,18 @@ describe LavinMQ::Client::Channel::Consumer do
           subscriber_args = AMQP::Client::Arguments.new({"x-priority" => 5})
 
           msgs = Channel(Int32).new
+          # This is a sync channel to make sure each consumer
+          # is "working" long enough for the other consumer
+          # to retrive a message...
+          work = Channel(Bool).new
           q.subscribe(no_ack: false, args: subscriber_args) do |msg|
             msgs.send 1
+            work.send true
             msg.ack
           end
 
           q.subscribe(no_ack: false, args: subscriber_args) do |msg|
+            work.receive
             msgs.send 2
             msg.ack
           end


### PR DESCRIPTION
### WHAT is this pull request doing?
The spec `LavinMQ::Client::Channel::Consumer with x-priority should round-robin to high priority consumers` started to fail on MacOS, probably after 7a1455dc2acec9776e7549bc7902bba7bc06a980.

I believe the spec was to naive on in which order things happen.

This adds a channel to "fake work" for each consumer to make sure no of them is to fast.

### HOW can this pull request be tested?
Run specs
