### PR TITLE
feat: Extend prerelease repos to include -beta and -alpha releases

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -75,7 +75,7 @@ jobs:
               -F "package[package_file]=@${PKG_FILE}" \
               https://packagecloud.io/api/v1/repos/${{ github.repository }}/packages.json
           done
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc') && !contains(github.ref, '-beta') && !contains(github.ref, '-alpha')
 
       - name: Upload to Packagecloud pre-release repo
         run: |
@@ -94,7 +94,7 @@ jobs:
               -F "package[package_file]=@${PKG_FILE}" \
               https://packagecloud.io/api/v1/repos/${{ github.repository }}-prerelease/packages.json
           done
-        if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')
+        if: startsWith(github.ref, 'refs/tags/v') && (contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha'))
 
   rerun_on_failure:
     needs: build_deb

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -69,7 +69,7 @@ jobs:
                   -F "package[package_file]=@${PKG_FILE}" \
                   https://packagecloud.io/api/v1/repos/${{ github.repository }}/packages.json
           done
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc') && !contains(github.ref, '-beta') && !contains(github.ref, '-alpha')
 
       - name: Upload to Packagecloud pre-release repo
         run: |
@@ -84,4 +84,4 @@ jobs:
                   -F "package[package_file]=@${PKG_FILE}" \
                   https://packagecloud.io/api/v1/repos/${{ github.repository }}-prerelease/packages.json
           done
-        if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')
+        if: startsWith(github.ref, 'refs/tags/v') && (contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha'))


### PR DESCRIPTION
## Summary
- Update deb.yml and rpm.yml workflows to upload releases with `-beta` or `-alpha` suffixes to prerelease repositories
- Ensure prerelease versions (including `-rc`, `-beta`, `-alpha`) are excluded from main package repositories

🤖 Generated with [Claude Code](https://claude.ai/code)