### PR TITLE
Improve channel mode display to be more descriptive

### DIFF
--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -113,7 +113,7 @@ function updateChannel () {
     if (item.confirm) {
       const confirmSpan = document.createElement('span')
       confirmSpan.textContent = 'Confirm'
-      confirmSpan.title = 'Enables publisher acknowledgements for reliable message delivery'
+      confirmSpan.title = 'Confirm mode enables publisher acknowledgements for reliable message delivery'
       modeEl.appendChild(confirmSpan)
     }
     document.getElementById('ch-global-prefetch').textContent = Helpers.formatNumber(item.global_prefetch_count)

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -108,7 +108,14 @@ function updateChannel () {
     connectionLink.href = HTTP.url`connection#name=${item.connection_details.name}`
     connectionLink.textContent = item.connection_details.name
     prefetch.update(item.prefetch_count)
-    document.getElementById('ch-mode').textContent = `${item.confirm ? 'C' : ''}`
+    const modeEl = document.getElementById('ch-mode')
+    modeEl.textContent = ''
+    if (item.confirm) {
+      const confirmSpan = document.createElement('span')
+      confirmSpan.textContent = 'Confirm'
+      confirmSpan.title = 'Enables publisher acknowledgements for reliable message delivery'
+      modeEl.appendChild(confirmSpan)
+    }
     document.getElementById('ch-global-prefetch').textContent = Helpers.formatNumber(item.global_prefetch_count)
   })
 }

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -108,13 +108,12 @@ function updateChannel () {
     connectionLink.href = HTTP.url`connection#name=${item.connection_details.name}`
     connectionLink.textContent = item.connection_details.name
     prefetch.update(item.prefetch_count)
-    const modeEl = document.getElementById('ch-mode')
-    modeEl.textContent = ''
     if (item.confirm) {
+      const chMode = document.getElementById('ch-mode')
       const confirmSpan = document.createElement('span')
       confirmSpan.textContent = 'Confirm'
       confirmSpan.title = 'Confirm mode enables publisher acknowledgements for reliable message delivery'
-      modeEl.appendChild(confirmSpan)
+      chMode.replaceChildren(confirmSpan)
     }
     document.getElementById('ch-global-prefetch').textContent = Helpers.formatNumber(item.global_prefetch_count)
   })

--- a/static/js/channels.js
+++ b/static/js/channels.js
@@ -28,7 +28,7 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
   if (item.confirm) {
     const confirmSpan = document.createElement('span')
     confirmSpan.textContent = 'Confirm'
-    confirmSpan.title = 'Enables publisher acknowledgements for reliable message delivery'
+    confirmSpan.title = 'Confirm mode enables publisher acknowledgements for reliable message delivery'
     mode = confirmSpan.outerHTML
   }
   Table.renderCell(tr, 3, mode, 'center')

--- a/static/js/channels.js
+++ b/static/js/channels.js
@@ -25,7 +25,12 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     Table.renderCell(tr, 2, item.user)
   }
   let mode = ''
-  mode += item.confirm ? ' C' : ''
+  if (item.confirm) {
+    const confirmSpan = document.createElement('span')
+    confirmSpan.textContent = 'Confirm'
+    confirmSpan.title = 'Enables publisher acknowledgements for reliable message delivery'
+    mode = confirmSpan.outerHTML
+  }
   Table.renderCell(tr, 3, mode, 'center')
   Table.renderCell(tr, 4, Helpers.formatNumber(item.consumer_count), 'right')
   Table.renderCell(tr, 5, Helpers.formatNumber(item.prefetch_count), 'right')

--- a/static/js/channels.js
+++ b/static/js/channels.js
@@ -24,14 +24,12 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.user)
   }
-  let mode = ''
   if (item.confirm) {
     const confirmSpan = document.createElement('span')
     confirmSpan.textContent = 'Confirm'
     confirmSpan.title = 'Confirm mode enables publisher acknowledgements for reliable message delivery'
-    mode = confirmSpan.outerHTML
+    Table.renderCell(tr, 3, confirmSpan, 'center')
   }
-  Table.renderCell(tr, 3, mode, 'center')
   Table.renderCell(tr, 4, Helpers.formatNumber(item.consumer_count), 'right')
   Table.renderCell(tr, 5, Helpers.formatNumber(item.prefetch_count), 'right')
   Table.renderCell(tr, 6, Helpers.formatNumber(item.messages_unacknowledged), 'right')


### PR DESCRIPTION
Fixes #1101 
- Replace 'C' with 'Confirm' in channel mode display
- Add tooltip explaining confirm mode functionality
- Apply changes to both channels list and individual channel views

### WHAT is this pull request doing?
his pull request improves the user interface for the channel mode display in the LavinMQ web interface. It makes the following changes:

Replaces the single letter 'C' with the full word "Confirm" when a channel has confirm mode enabled
Adds a helpful tooltip that appears on hover, explaining what confirm mode does: "Enables publisher acknowledgements for reliable message delivery"
Applies these changes to both the channels list view and individual channel views for consistency

### HOW can this pull request be tested?
Manual Testing Steps:

Channels List View:
Navigate to the Channels section in the LavinMQ web interface
Look for any channel with confirm mode enabled
Verify that instead of 'C', you now see "Confirm"
Hover over the "Confirm" text to see the tooltip with the description
Individual Channel View:
Click on any channel to view its details
If the channel has confirm mode enabled, verify that it shows "Confirm" instead of 'C'
Hover over the "Confirm" text to see the tooltip
Edge Cases:
Check channels with confirm mode disabled to ensure they show nothing (not even an empty space)
Test the UI in different browsers to ensure consistent tooltip behavior
Verify that the changes don't affect the layout of the channels table or details view
