### PR TITLE
Adds more logging during full sync, both on leader and follower

### DIFF
--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -159,6 +159,8 @@ module LavinMQ
               move_to_backup path
               requested_files << filename
               request_file(filename, socket)
+            else
+              Log.info { "Matching hash: #{path}" }
             end
           else
             requested_files << filename

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -97,13 +97,13 @@ module LavinMQ
       end
 
       private def send_file_list(lz4 = @lz4)
-        Log.info { "Calculating hashes" }
+        Log.info { "Calculating hashes for #{@file_index.nr_of_files} files" }
         count = 0
         @file_index.files_with_hash do |path, hash|
-          count &+= 1
           lz4.write_bytes path.bytesize.to_i32, IO::ByteFormat::LittleEndian
           lz4.write path.to_slice
           lz4.write hash
+          Log.info { "Calculated hash for #{count}/#{@file_index.nr_of_files} files" } if (count &+= 1) % 32 == 0
         end
         lz4.write_bytes 0i32 # 0 means end of file list
         lz4.flush

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -78,6 +78,10 @@ module LavinMQ
         each_follower &.delete(path, wg)
       end
 
+      def nr_of_files
+        @files.size
+      end
+
       def files_with_hash(& : Tuple(String, Bytes) -> Nil)
         sha1 = Digest::SHA1.new
         @files.each do |path, mfile|


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds more logging to both leader and follower during full sync of files, to make it more obvious what's happening. A full sync should happen pretty rarely (only when followers are added or restarted), so being more verbose should not be a big issue IMO. 

Fixes #1202 

### HOW can this pull request be tested?
Manual testing. 
