### PR TITLE
use paused instead of .paused as filename for paused queues

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -91,11 +91,24 @@ describe LavinMQ::AMQP::Queue do
         v.declare_queue("q", true, false)
         data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         s.vhosts["/"].queues["q"].pause!
-        File.exists?(File.join(data_dir, ".paused")).should be_true
+        File.exists?(File.join(data_dir, "paused")).should be_true
         s.restart
         s.vhosts["/"].queues["q"].state.paused?.should be_true
         s.vhosts["/"].queues["q"].resume!
-        File.exists?(File.join(data_dir, ".paused")).should be_false
+        File.exists?(File.join(data_dir, "paused")).should be_false
+      end
+    end
+
+    it "should handle '.paused' files and rename to 'paused'" do
+      with_amqp_server do |s|
+        s.vhosts.create("/")
+        v = s.vhosts["/"].not_nil!
+        v.declare_queue("q", true, false)
+        data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        File.touch(File.join(data_dir, ".paused"))
+        s.restart
+        File.exists?(File.join(data_dir, "paused")).should be_true
+        s.vhosts["/"].queues["q"].state.paused?.should be_true
       end
     end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -143,7 +143,10 @@ module LavinMQ::AMQP
       @metadata = ::Log::Metadata.new(nil, {queue: @name, vhost: @vhost.name})
       @log = Logger.new(Log, @metadata)
       File.open(File.join(@data_dir, ".queue"), "w") { |f| f.sync = true; f.print @name }
-      if File.exists?(File.join(@data_dir, ".paused"))
+      if File.exists?(File.join(@data_dir, ".paused")) # Legacy support
+        File.rename(File.join(@data_dir, ".paused"), File.join(@data_dir, "paused"))
+      end
+      if File.exists?(File.join(@data_dir, "paused"))
         @state = QueueState::Paused
         @paused.set(true)
       end
@@ -354,7 +357,7 @@ module LavinMQ::AMQP
       @state = QueueState::Paused
       @log.debug { "Paused" }
       @paused.set(true)
-      File.touch(File.join(@data_dir, ".paused"))
+      File.touch(File.join(@data_dir, "paused"))
     end
 
     def resume!
@@ -362,7 +365,7 @@ module LavinMQ::AMQP
       @state = QueueState::Running
       @log.debug { "Resuming" }
       @paused.set(false)
-      File.delete(File.join(@data_dir, ".paused"))
+      File.delete(File.join(@data_dir, "paused"))
     end
 
     def close : Bool


### PR DESCRIPTION
### WHAT is this pull request doing?
Use `paused` instead of `.paused` as filename for paused queues. Files starting with `.` are hidden by default in linux, meaning they can be missed. 

This will also rename any existing `.paused` file in a queue dir to `paused`. 

Fixes #1208

### HOW can this pull request be tested?
Run specs. 
