### PR TITLE
/metrics on a separate port

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -1,10 +1,10 @@
 require "../spec_helper"
 require "string_scanner"
 
-describe LavinMQ::HTTP::ConsumersController do
+describe LavinMQ::HTTP::PrometheusController do
   describe "GET /metrics" do
     it "should return metrics in prometheus style" do
-      with_http_server do |http, _|
+      with_metrics_server do |http, _|
         response = http.get("/metrics")
         response.status_code.should eq 200
         response.body.lines.any?(&.starts_with? "telemetry_scrape_duration_seconds").should be_true
@@ -12,7 +12,7 @@ describe LavinMQ::HTTP::ConsumersController do
     end
 
     it "should perform sanity check on sampled metrics" do
-      with_http_server do |http, s|
+      with_metrics_server do |http, s|
         vhost = s.vhosts.create("pmths")
         vhost.declare_queue("test1", true, false)
         vhost.delete_queue("test1")
@@ -31,7 +31,7 @@ describe LavinMQ::HTTP::ConsumersController do
     end
 
     it "should support specifying prefix" do
-      with_http_server do |http, _|
+      with_metrics_server do |http, _|
         prefix = "testing"
         response = http.get("/metrics?prefix=#{prefix}")
         lines = response.body.lines
@@ -43,7 +43,7 @@ describe LavinMQ::HTTP::ConsumersController do
     end
 
     it "should not support a prefix longer than 20" do
-      with_http_server do |http, _|
+      with_metrics_server do |http, _|
         prefix = "abcdefghijklmnopqrstuvwxyz"
         response = http.get("/metrics?prefix=#{prefix}")
         response.status_code.should eq 400
@@ -54,7 +54,7 @@ describe LavinMQ::HTTP::ConsumersController do
 
   describe "GET /metrics/detailed" do
     it "should support specifying families" do
-      with_http_server do |http, _|
+      with_metrics_server do |http, _|
         response = http.get("/metrics/detailed?family=connection_churn_metrics")
         response.status_code.should eq 200
         lines = response.body.lines
@@ -68,7 +68,7 @@ describe LavinMQ::HTTP::ConsumersController do
     end
 
     it "should perform sanity check on sampled metrics" do
-      with_http_server do |http, s|
+      with_metrics_server do |http, s|
         with_channel(s) do |_|
         end
         with_channel(s) do |_|

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -41,7 +41,16 @@ module LavinMQ
           @unix_http_proxy = Proxy.new(@config.http_unix_path) unless @config.http_unix_path.empty?
           @unix_mqtt_proxy = Proxy.new(@config.mqtt_unix_path) unless @config.mqtt_unix_path.empty?
         end
+        start_metrics_server unless @config.metrics_http_port == -1
         HTTP::Server.follower_internal_socket_http_server
+      end
+
+      private def start_metrics_server
+        @metrics_server = metrics_server = LavinMQ::HTTP::MetricsServer.new
+        metrics_server.bind_tcp(@config.metrics_http_bind, @config.metrics_http_port)
+        spawn(name: "HTTP metrics listener") do
+          metrics_server.listen
+        end
       end
 
       def follow(uri : String)

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -36,6 +36,8 @@ module LavinMQ
     property http_unix_path = ""
     property http_systemd_socket_name = "lavinmq-http.socket"
     property amqp_systemd_socket_name = "lavinmq-amqp.socket"
+    property metrics_http_bind = "127.0.0.1"
+    property metrics_http_port = 15693
     property heartbeat = 300_u16                     # second
     property frame_max = 131_072_u32                 # bytes
     property channel_max = 2048_u16                  # number
@@ -159,6 +161,12 @@ module LavinMQ
         end
         p.on("--mqtt-unix-path=PATH", "MQTT UNIX path to listen to") do |v|
           @mqtt_unix_path = v
+        end
+        p.on("--metrics-http-bind=BIND", "IP address that the Prometheus server will bind to (default: 127.0.0.1)") do |v|
+          @metrics_http_bind = v
+        end
+        p.on("--metrics-http-port=PORT", "HTTP port that prometheus will listen to (default: 15692)") do |v|
+          @metrics_http_port = v.to_i
         end
         p.on("--cert FILE", "TLS certificate (including chain)") { |v| @tls_cert_path = v }
         p.on("--key FILE", "Private key for the TLS certificate") { |v| @tls_key_path = v }
@@ -288,6 +296,8 @@ module LavinMQ
         when "max_deleted_definitions"   then @max_deleted_definitions = v.to_i
         when "consumer_timeout"          then @consumer_timeout = v.to_u64
         when "default_consumer_prefetch" then @default_consumer_prefetch = v.to_u16
+        when "metrics_http_bind"         then @metrics_http_bind = v
+        when "metrics_http_port"         then @metrics_http_port = v.to_i
         when "default_user"              then @default_user = v
         when "default_password_hash"     then @default_password = v
         when "default_password"

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -68,10 +68,118 @@ module LavinMQ
       end
     end
 
+    module Prometheus
+      def report(io, &)
+        mem = 0
+        elapsed = Time.measure do
+          mem = Benchmark.memory do
+            begin
+              yield
+            rescue ex
+              Log.error(exception: ex) { "Error while reporting prometheus metrics" }
+            end
+          end
+        end
+        writer = PrometheusWriter.new(io, "telemetry")
+        writer.write({name:  "scrape_duration_seconds",
+                      type:  "gauge",
+                      value: elapsed.total_seconds,
+                      help:  "Duration for metrics collection in seconds"})
+        writer.write({name:  "scrape_mem",
+                      type:  "gauge",
+                      value: mem,
+                      help:  "Memory used for metrics collections in bytes"})
+      end
+
+      def gc_metrics(writer)
+        gc_stats = GC.prof_stats
+
+        writer.write({name: "gc_heap_size_bytes", value: gc_stats.heap_size,
+                      type: "gauge",
+                      help: "Heap size in bytes (including the area unmapped to OS)"})
+
+        writer.write({name: "gc_free_bytes", value: gc_stats.free_bytes,
+                      type: "gauge",
+                      help: "Total bytes contained in free and unmapped blocks"})
+
+        writer.write({name: "gc_unmapped_bytes", value: gc_stats.unmapped_bytes,
+                      type: "gauge",
+                      help: "Amount of memory unmapped to OS"})
+
+        writer.write({name: "gc_since_recent_collection_allocated_bytes", value: gc_stats.bytes_since_gc,
+                      type: "gauge",
+                      help: "Number of bytes allocated since the recent GC"})
+
+        writer.write({name: "gc_before_recent_collection_allocated_bytes_total", value: gc_stats.bytes_before_gc,
+                      type: "counter",
+                      help: "Number of bytes allocated before the recent GC (value may wrap)"})
+
+        writer.write({name: "gc_non_candidate_bytes", value: gc_stats.non_gc_bytes,
+                      type: "gauge",
+                      help: "Number of bytes not considered candidates for GC"})
+
+        writer.write({name: "gc_cycles_total", value: gc_stats.gc_no,
+                      type: "counter",
+                      help: "Garbage collection cycle number (value may wrap)"})
+
+        writer.write({name: "gc_marker_threads", value: gc_stats.markers_m1,
+                      type: "gauge",
+                      help: "Number of marker threads (excluding the initiating one)"})
+
+        writer.write({name: "gc_since_recent_collection_reclaimed_bytes", value: gc_stats.bytes_reclaimed_since_gc,
+                      type: "gauge",
+                      help: "Approximate number of reclaimed bytes after recent GC"})
+
+        writer.write({name: "gc_before_recent_collection_reclaimed_bytes_total", value: gc_stats.reclaimed_bytes_before_gc,
+                      type: "counter",
+                      help: "Approximate number of bytes reclaimed before the recent GC (value may wrap)"})
+
+        writer.write({name: "gc_since_recent_collection_explicitly_freed_bytes", value: gc_stats.expl_freed_bytes_since_gc,
+                      type: "counter",
+                      help: "Number of bytes freed explicitly since the recent GC"})
+
+        writer.write({name: "gc_from_os_obtained_bytes_total", value: gc_stats.obtained_from_os_bytes,
+                      type: "counter",
+                      help: "Total amount of memory obtained from OS, in bytes"})
+      end
+    end
+
+    class FollowerPrometheusController
+      include Router
+      include Prometheus
+
+      Log = LavinMQ::Log.for "http.prometheus"
+
+      def initialize
+        register_routes
+      end
+
+      private def register_routes
+        get "/metrics" do |context, _|
+          context.response.content_type = "text/plain"
+          prefix = context.request.query_params["prefix"]? || "lavinmq"
+          if prefix.bytesize > 20
+            context.response.status_code = 400
+            reason = "Prefix too long (max 20 characters)"
+            body = {error: "bad_request", reason: reason}
+              .to_json(context.response)
+            raise Controller::HaltRequest.new(reason)
+          end
+
+          report(context.response) do
+            writer = PrometheusWriter.new(context.response, prefix)
+            gc_metrics(writer)
+          end
+          context
+        end
+      end
+    end
+
     class PrometheusController < Controller
+      include Prometheus
+
       private def target_vhosts(context)
-        u = user(context)
-        vhosts = vhosts(u)
+        vhosts = @amqp_server.vhosts.values
         selected = context.request.query_params.fetch_all("vhost")
         vhosts = vhosts.select { |vhost| selected.includes? vhost.name } unless selected.empty?
         vhosts.to_a
@@ -122,28 +230,6 @@ module LavinMQ
           end
           context
         end
-      end
-
-      private def report(io, &)
-        mem = 0
-        elapsed = Time.measure do
-          mem = Benchmark.memory do
-            begin
-              yield
-            rescue ex
-              Log.error(exception: ex) { "Error while reporting prometheus metrics" }
-            end
-          end
-        end
-        writer = PrometheusWriter.new(io, "telemetry")
-        writer.write({name:  "scrape_duration_seconds",
-                      type:  "gauge",
-                      value: elapsed.total_seconds,
-                      help:  "Duration for metrics collection in seconds"})
-        writer.write({name:  "scrape_mem",
-                      type:  "gauge",
-                      value: mem,
-                      help:  "Memory used for metrics collections in bytes"})
       end
 
       private def overview_broker_metrics(vhosts, writer)
@@ -311,58 +397,6 @@ module LavinMQ
                         type:   "gauge",
                         help:   "Bytes that hasn't been synchronized with the follower yet"})
         end
-      end
-
-      private def gc_metrics(writer)
-        gc_stats = @amqp_server.gc_stats
-
-        writer.write({name: "gc_heap_size_bytes", value: gc_stats.heap_size,
-                      type: "gauge",
-                      help: "Heap size in bytes (including the area unmapped to OS)"})
-
-        writer.write({name: "gc_free_bytes", value: gc_stats.free_bytes,
-                      type: "gauge",
-                      help: "Total bytes contained in free and unmapped blocks"})
-
-        writer.write({name: "gc_unmapped_bytes", value: gc_stats.unmapped_bytes,
-                      type: "gauge",
-                      help: "Amount of memory unmapped to OS"})
-
-        writer.write({name: "gc_since_recent_collection_allocated_bytes", value: gc_stats.bytes_since_gc,
-                      type: "gauge",
-                      help: "Number of bytes allocated since the recent GC"})
-
-        writer.write({name: "gc_before_recent_collection_allocated_bytes_total", value: gc_stats.bytes_before_gc,
-                      type: "counter",
-                      help: "Number of bytes allocated before the recent GC (value may wrap)"})
-
-        writer.write({name: "gc_non_candidate_bytes", value: gc_stats.non_gc_bytes,
-                      type: "gauge",
-                      help: "Number of bytes not considered candidates for GC"})
-
-        writer.write({name: "gc_cycles_total", value: gc_stats.gc_no,
-                      type: "counter",
-                      help: "Garbage collection cycle number (value may wrap)"})
-
-        writer.write({name: "gc_marker_threads", value: gc_stats.markers_m1,
-                      type: "gauge",
-                      help: "Number of marker threads (excluding the initiating one)"})
-
-        writer.write({name: "gc_since_recent_collection_reclaimed_bytes", value: gc_stats.bytes_reclaimed_since_gc,
-                      type: "gauge",
-                      help: "Approximate number of reclaimed bytes after recent GC"})
-
-        writer.write({name: "gc_before_recent_collection_reclaimed_bytes_total", value: gc_stats.reclaimed_bytes_before_gc,
-                      type: "counter",
-                      help: "Approximate number of bytes reclaimed before the recent GC (value may wrap)"})
-
-        writer.write({name: "gc_since_recent_collection_explicitly_freed_bytes", value: gc_stats.expl_freed_bytes_since_gc,
-                      type: "counter",
-                      help: "Number of bytes freed explicitly since the recent GC"})
-
-        writer.write({name: "gc_from_os_obtained_bytes_total", value: gc_stats.obtained_from_os_bytes,
-                      type: "counter",
-                      help: "Total amount of memory obtained from OS, in bytes"})
       end
 
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -24,7 +24,6 @@ module LavinMQ
           ViewsController.new,
           ApiErrorHandler.new,
           AuthHandler.new(@amqp_server),
-          PrometheusController.new(@amqp_server),
           ApiDefaultsHandler.new,
           MainController.new(@amqp_server),
           DefinitionsController.new(@amqp_server),

--- a/src/lavinmq/http/metrics_server.cr
+++ b/src/lavinmq/http/metrics_server.cr
@@ -1,0 +1,44 @@
+require "http/server"
+require "json"
+require "./constants"
+require "./handler/*"
+require "./controller"
+require "./controller/prometheus"
+
+module LavinMQ
+  module HTTP
+    class MetricsServer
+      Log = LavinMQ::Log.for "metrics.server"
+
+      def initialize(amqp_server : LavinMQ::Server? = nil)
+        controller = if s = amqp_server
+                       PrometheusController.new(amqp_server)
+                     else
+                       FollowerPrometheusController.new
+                     end
+        handlers = [
+          ApiErrorHandler.new,
+          ApiDefaultsHandler.new,
+          controller,
+        ] of ::HTTP::Handler
+        handlers.unshift(::HTTP::LogHandler.new(log: Log)) if Log.level == ::Log::Severity::Debug
+        @http = ::HTTP::Server.new(handlers)
+      end
+
+      def bind_tcp(address, port)
+        addr = @http.bind_tcp address, port
+        Log.info { "Bound to #{addr}" }
+        addr
+      end
+
+      def listen
+        @http.listen
+      end
+
+      def close
+        @http.try &.close
+        File.delete?(INTERNAL_UNIX_SOCKET)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes #1162  and #1082 

Adds a MetricsServer that serves /metrics endpoints on a separate port. 
This also resolves the issue where /metrics requests was forwarded to the leader, now we can collect metrics from a follower as well. Current it only reports GC metrics on the follow. 

### HOW can this pull request be tested?

Specs and manual 