### PR TITLE
`list_connections`: don't fail on missing key

### DIFF
--- a/src/lavinmqctl.cr
+++ b/src/lavinmqctl.cr
@@ -501,7 +501,7 @@ class LavinMQCtl
             when "client_properties"
               print_erlang_terms(conn[c].as_h)
             else
-              print conn[c]
+              print conn[c]?
             end
             print "\t" unless i == columns.size - 1
           end


### PR DESCRIPTION
Before this change:

    $ bin/lavinmqctl list_connections
    Listing connections ...
    user	peer_host	peer_port	state
    guest	Unhandled exception: Missing hash key: "peer_host" (KeyError)
      from /opt/homebrew/Cellar/crystal/1.17.1_1/share/crystal/src/array.cr:114:31 in 'list_connections'
      from src/lavinmqctl.cr:178:39 in 'run_cmd'
      from src/lavinmqctl.cr:753:1 in '__crystal_main'
      from /opt/homebrew/Cellar/crystal/1.17.1_1/share/crystal/src/crystal/main.cr:129:5 in 'main'
      from /opt/homebrew/Cellar/crystal/1.17.1_1/share/crystal/src/crystal/system/unix/main.cr:10:3 in 'main'

After this change:

    $ bin/lavinmqctl list_connections
    Listing connections ...
    user	peer_host	peer_port	state
    guest			running

Close #1225
