### PR TITLE
added human friendly exchange type names in controller and exchanges.js

### DIFF
--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -9,6 +9,7 @@ module LavinMQ
 
       OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject"}
       EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers", "x-federation-upstream", "x-consistent-hash"}
+      EXCHANGE_TYPES_HUMAN = {"Direct", "Fanout", "Topic", "Headers", "Federation Upstream", "Consistent Hash"}
       CHURN_STATS    = {"connection_created", "connection_closed", "channel_created", "channel_closed",
                         "queue_declared", "queue_deleted"}
 
@@ -106,6 +107,7 @@ module LavinMQ
             {% end %} } {% end %},
             listeners:      @amqp_server.listeners,
             exchange_types: EXCHANGE_TYPES.map { |name| {name: name} },
+            exchange_types_human: EXCHANGE_TYPES_HUMAN.map { |name| {name: name} },
           }.to_json(context.response)
           context
         end

--- a/static/js/exchanges.js
+++ b/static/js/exchanges.js
@@ -6,7 +6,7 @@ import * as Table from './table.js'
 Helpers.addVhostOptions('addExchange')
 
 HTTP.request('GET', 'api/overview').then(function (response) {
-  const exchangeTypes = response.exchange_types
+  const exchangeTypes = response.exchange_types_human
   const select = document.forms.addExchange.elements.type
   exchangeTypes.forEach(type => {
     const opt = document.createElement('option')


### PR DESCRIPTION
### WHAT is this pull request doing?
Update Exchanges page to offer more readable Type selection categories. Addresses issue #891 [Add human friendly name when creating exchanges in the UI]

### HOW can this pull request be tested?
Look at Exchanges live view
