### PR TITLE
Bugfix: memory leak in `MQTT::Consumer`

### DIFF
--- a/src/lavinmq/bool_channel.cr
+++ b/src/lavinmq/bool_channel.cr
@@ -5,6 +5,8 @@ class BoolChannel
   getter when_false = Channel(Nil).new
   @value = Channel(Bool).new
 
+  class_getter(dummy : BoolChannel) { BoolChannel.new(true).tap &.close }
+
   def initialize(value : Bool)
     spawn(name: "BoolChannel#send_loop") do
       send_loop(value)

--- a/src/lavinmq/bool_channel.cr
+++ b/src/lavinmq/bool_channel.cr
@@ -5,8 +5,6 @@ class BoolChannel
   getter when_false = Channel(Nil).new
   @value = Channel(Bool).new
 
-  class_getter(dummy : BoolChannel) { BoolChannel.new(true).tap &.close }
-
   def initialize(value : Bool)
     spawn(name: "BoolChannel#send_loop") do
       send_loop(value)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -228,7 +228,7 @@ module LavinMQ
       getter tag : String
 
       def has_capacity : BoolChannel
-        self.dummy_has_capacity
+        self.class.dummy_has_capacity
       end
 
       property prefetch_count = 0_u16

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -220,9 +220,17 @@ module LavinMQ
     end
 
     class Consumer < LavinMQ::Client::Channel::Consumer
+      # MQTT::Consumer to not have to create a new channel per consumer. It's
+      # not used, only needed for compilation. Create one shared and closed object.
+      class_getter(dummy_has_capacity : BoolChannel) { BoolChannel.new(true).tap &.close }
+
       getter unacked = 0_u32
       getter tag : String
-      getter has_capacity = BoolChannel.dummy
+
+      def has_capacity : BoolChannel
+        self.dummy_has_capacity
+      end
+
       property prefetch_count = 0_u16
 
       def initialize(@client : Client, @session : MQTT::Session)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -222,7 +222,7 @@ module LavinMQ
     class Consumer < LavinMQ::Client::Channel::Consumer
       getter unacked = 0_u32
       getter tag : String
-      getter has_capacity = BoolChannel.new(true)
+      getter has_capacity = BoolChannel.dummy
       property prefetch_count = 0_u16
 
       def initialize(@client : Client, @session : MQTT::Session)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -220,8 +220,9 @@ module LavinMQ
     end
 
     class Consumer < LavinMQ::Client::Channel::Consumer
-      # MQTT::Consumer to not have to create a new channel per consumer. It's
-      # not used, only needed for compilation. Create one shared and closed object.
+      # `MQTT::Consumer` only has the `has_capacity` method to satisfy the interface.
+      # Since it's never used a shared object can be used. It's also closed immediately
+      # to not have a fiber running.
       class_getter(dummy_has_capacity : BoolChannel) { BoolChannel.new(true).tap &.close }
 
       getter unacked = 0_u32


### PR DESCRIPTION
### WHAT is this pull request doing?
The `MQTT::Consumer` is a very special implementation of a `Consumer` and only a subset of the real consumer interface is used.

To satisfy the interface (`#has_capacity`) a `BoolChannel` was created for each `MQTT::Consumer`. It turned out that this `BoolChannel` was never closed, resulting in dangling fibers and a memory leak.

Since this property is never used, i introduced a "dummy" `BoolChannel` which is closed instantly. All `MQTT::Consumers` will reference the same dummy instance, meaning less memory is allocated and no fiber needs to be stopped (or started).

This bug shows that we probably need to do the job of getting rid of MQTT entities inheriting AMQP entities.

### HOW can this pull request be tested?
Manually.
Run lavinmq with old code, connect mqtt clients that also subscribes. Disconnect them. Check with `-USR1` that there are BoolChannels running
Run lavinmq with this PR connect mqtt clients that also subscribes. Disconnect them. Check with `-USR1` that there are no BoolChannels running.

