### PR TITLE
Prevent delayed exchanges to bind to its internal delayed queue

### DIFF
--- a/src/lavinmq/amqp/exchange/consistent_hash.cr
+++ b/src/lavinmq/amqp/exchange/consistent_hash.cr
@@ -19,6 +19,7 @@ module LavinMQ
       end
 
       def bind(destination : Destination, routing_key : String, arguments : AMQP::Table?)
+        validate_delayed_binding(destination)
         w = weight(routing_key)
         binding_key = BindingKey.new(routing_key, arguments)
         return false unless @bindings.add?({destination, binding_key})

--- a/src/lavinmq/amqp/exchange/direct.cr
+++ b/src/lavinmq/amqp/exchange/direct.cr
@@ -20,6 +20,7 @@ module LavinMQ
       end
 
       def bind(destination : Destination, routing_key, arguments = nil) : Bool
+        validate_delayed_binding(destination)
         binding_key = BindingKey.new(routing_key, arguments)
         return false unless @bindings[routing_key].add?({destination, binding_key})
         data = BindingDetails.new(name, vhost.name, binding_key, destination)

--- a/src/lavinmq/amqp/exchange/fanout.cr
+++ b/src/lavinmq/amqp/exchange/fanout.cr
@@ -16,6 +16,7 @@ module LavinMQ
       end
 
       def bind(destination : Destination, routing_key, arguments = nil)
+        validate_delayed_binding(destination)
         binding_key = BindingKey.new(routing_key, arguments)
         return false unless @bindings.add?({destination, binding_key})
         data = BindingDetails.new(name, vhost.name, binding_key, destination)

--- a/src/lavinmq/amqp/exchange/headers.cr
+++ b/src/lavinmq/amqp/exchange/headers.cr
@@ -27,6 +27,7 @@ module LavinMQ
       end
 
       def bind(destination : Destination, routing_key, arguments)
+        validate_delayed_binding(destination)
         validate!(arguments)
         arguments ||= AMQP::Table.new
         binding_key = BindingKey.new(routing_key, arguments)

--- a/src/lavinmq/amqp/exchange/topic.cr
+++ b/src/lavinmq/amqp/exchange/topic.cr
@@ -20,6 +20,7 @@ module LavinMQ
       end
 
       def bind(destination : AMQP::Destination, routing_key, arguments = nil)
+        validate_delayed_binding(destination)
         binding_key = BindingKey.new(routing_key, arguments)
         return false unless @bindings[routing_key.split(".")].add?({destination, binding_key})
         data = BindingDetails.new(name, vhost.name, binding_key, destination)


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes #1229 by adding a valdiation check when we bind an exchange, so its not allowed to bind to its own internal delayed queue. 

### HOW can this pull request be tested?
Run the spec that was added in this pull request. 