### PR TITLE
Move initialization of some BoolChannel to prevent leaks

### DIFF
--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -20,7 +20,7 @@ module LavinMQ
       @flow : Bool
       @metadata : ::Log::Metadata
       @unacked = Atomic(UInt32).new(0_u32)
-      getter has_capacity = BoolChannel.new(true)
+      getter has_capacity : BoolChannel
 
       def initialize(@channel : AMQP::Channel, @queue : Queue, frame : AMQP::Frame::Basic::Consume)
         @tag = frame.consumer_tag
@@ -29,10 +29,11 @@ module LavinMQ
         @priority = consumer_priority(frame) # Must be before ConsumeOk, can close channel
         @prefetch_count = @channel.prefetch_count
         @flow = @channel.flow?
-        @flow_change = BoolChannel.new(@flow)
         @metadata = @channel.@metadata.extend({consumer: @tag})
         @log = Logger.new(Log, @metadata)
         spawn deliver_loop, name: "Consumer deliver loop"
+        @flow_change = BoolChannel.new(@flow)
+        @has_capacity = BoolChannel.new(true)
       end
 
       def close

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -34,7 +34,7 @@ module LavinMQ::AMQP
         init_sub_stores(@stores)
         migrate_from_single_store
 
-        @empty.set empty?
+        @empty = BoolChannel.new(empty?)
       end
 
       private def init_sub_stores(stores)

--- a/src/lavinmq/amqp/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream_consumer.cr
@@ -20,6 +20,7 @@ module LavinMQ
         offset = frame.arguments["x-stream-offset"]?
         @offset, @segment, @pos = stream_queue.find_offset(offset, @tag, @track_offset)
         super
+        @new_message_available = BoolChannel.new(false)
       end
 
       private def validate_preconditions(frame)
@@ -142,8 +143,6 @@ module LavinMQ
           return true
         end
       end
-
-      @new_message_available = BoolChannel.new(false)
 
       def notify_new_message
         @new_message_available.set(true)

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -17,13 +17,13 @@ class LavinMQ::Clustering::Controller
     @id = clustering_id
     @advertised_uri = @config.clustering_advertised_uri ||
                       "tcp://#{System.hostname}:#{@config.clustering_port}"
+    @is_leader = BoolChannel.new(false)
   end
 
   # This method is called by the Launcher#run.
   # The block will be yielded when the controller's prerequisites for a leader
   # to start are met, i.e when the current node has been elected leader.
   # The method is blocking.
-  @is_leader = BoolChannel.new(false)
 
   def run(&)
     lease = @lease = @etcd.lease_grant(id: @id)


### PR DESCRIPTION
### WHAT is this pull request doing?
A `BoolChannel` will spawn a fiber in it's initializer, meaning that if a `BoolChannel` is created in the "class body" `@i = BoolChannel.new(true)` and not in the initializer of the class using it, an exception will abort the initialization but the `BoolChannel` won't be closed.

We should make sure to initialize `BoolChannels` as late as possible in initializer to prevent unnecessary fiber spawning and cleanup.

This PR is the result of narrowing down a memory leak in `StreamConsumer`. The problem was that `@new_message_available` and `@has_capacity` (in `Consumer`) was initialized before `validate_preconditions` was called in the initializer of `StreamConsumer`. If `validate_preconditions` raised because of invalid frame we ended up with two dangling `BoolChannels`.

### HOW can this pull request be tested?
Uhm, manually by observing fibers before and after this PR...
