### PR TITLE
logs page- added filter textbox and dynamic table

### DIFF
--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -45,7 +45,6 @@ class LiveLogDataSource {
     }
   }
 
-
   on (eventName, handler) {
     this._event.addEventListener(eventName, handler)
   }

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -43,7 +43,8 @@ class LiveLogDataSource {
       tblError.textContent = 'Access denied, administator access required'
       tblError.style.display = 'block'
     }
-}
+  }
+
 
   on (eventName, handler) {
     this._event.addEventListener(eventName, handler)

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -22,10 +22,11 @@ class LiveLogDataSource {
     // Event Source
     this._evtSource = new window.EventSource(streamUrl)
     this._evtSource.onmessage = (event) => {
-    const timestamp = new Date(parseInt(event.lastEventId, 10))
-    const [severity, source, message] = JSON.parse(event.data)
-    this.pushLog({ timestamp, severity, source, message })
-  }
+      const id = event.lastEventId
+      const timestamp = new Date(parseInt(id, 10))
+      const [severity, source, message] = JSON.parse(event.data)
+      this.pushLog({ id, timestamp, severity, source, message })
+    }
 
     this._evtSource.onerror = () => {
       window.fetch('api/whoami')
@@ -100,7 +101,7 @@ class LiveLogDataSource {
 
 // Let the filter regex match anywhere in the row.
 function joinFieldsForSearch (log) {
-  const isoTime = (log.timestamp).toISOString()
+  const isoTime = log.timestamp.toISOString()
   return `${isoTime} ${log.severity} ${log.source} ${log.message ?? log.msg ?? ''}`
 }
 
@@ -131,7 +132,7 @@ const logsDataSource = new LiveLogDataSource('api/livelog')
 
 const tableOptions = {
   dataSource: logsDataSource,
-  keyColumns: ['timestamp'],
+  keyColumns: ['id'],
   pagination: false,
   columnSelector: true, // TODO: improve position/placement
   search: true,
@@ -139,7 +140,7 @@ const tableOptions = {
 }
 
 const logsTable = Table.renderTable('table', tableOptions, (tr, item) => {
-  Table.renderCell(tr, 0, (item.timestamp).toLocaleString())
+  Table.renderCell(tr, 0, item.timestamp.toLocaleString())
   Table.renderCell(tr, 1, item.severity)
   Table.renderCell(tr, 2, item.source)
   const pre = document.createElement('pre')

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -8,14 +8,14 @@ class LiveLogDataSource {
     this.searchTerm = ''
     this.sortKey = null
     this.reverseOrder = false
-    
+
     // Internal state:
     this.allLogs = []
     this._event = new EventTarget()
   }
-  
-  on(eventName, handler) { 
-    this._event.addEventListener(eventName, handler) 
+
+  on (eventName, handler) {
+    this._event.addEventListener(eventName, handler)
   }
 
   reload () {
@@ -23,21 +23,22 @@ class LiveLogDataSource {
     if (this.searchTerm) {
       try {
         regex = new RegExp(this.searchTerm, 'i')
-      } catch (e) { 
-        regex = null }
+      } catch (e) {
+        regex = null
+      }
     }
-    let visible = regex 
-    ? this.allLogs.filter(log => regex.test(joinFieldsForSearch(log)))
-    : this.allLogs.slice()
+    const visible = regex
+      ? this.allLogs.filter(log => regex.test(joinFieldsForSearch(log)))
+      : this.allLogs.slice()
 
     if (this.sortKey) {
-      const direction= this.reverseOrder ? -1 : 1
+      const direction = this.reverseOrder ? -1 : 1
       visible.sort((a, b) => compareValues(a[this.sortKey], b[this.sortKey], direction))
     }
 
     this.items = visible
     this.totalCount = visible.length
-    this._event.dispatchEvent( new CustomEvent('update'))
+    this._event.dispatchEvent(new CustomEvent('update'))
   }
 
   pushLog (log) {
@@ -53,21 +54,24 @@ function joinFieldsForSearch (log) {
 }
 
 function compareValues (a, b, direction) {
-  const toNumber = (v) => 
-    v instanceof Date ? v.getTime()
-      : (typeof v === 'number' ? v
-      : (typeof v === 'string' && !Number.isNaN(+v) ? +v
-      : null))
+  const toNumber = (v) =>
+    v instanceof Date
+      ? v.getTime()
+      : (typeof v === 'number'
+          ? v
+          : (typeof v === 'string' && !Number.isNaN(+v)
+              ? +v
+              : null))
 
   const aNum = toNumber(a)
   const bNum = toNumber(b)
 
   if (aNum !== null && bNum !== null) {
-    return (aNum -bNum) * direction
+    return (aNum - bNum) * direction
   }
 
-  const aStr= String(a ?? '').toLowerCase()
-  const bStr= String(b ?? '').toLowerCase()
+  const aStr = String(a ?? '').toLowerCase()
+  const bStr = String(b ?? '').toLowerCase()
   return aStr.localeCompare(bStr) * direction
 }
 
@@ -77,7 +81,7 @@ const tableOptions = {
   dataSource: logsDataSource,
   keyColumns: ['timestamp', 'severity', 'source', 'message'],
   pagination: false,
-  columnSelector: true, //TODO: improve position/placement
+  columnSelector: true, // TODO: improve position/placement
   search: true,
   countId: 'pagename-label'
 }
@@ -131,4 +135,3 @@ logsTable.on('updated', () => {
 })
 
 livelog.addEventListener('beforeunload', () => evtSource.close())
-

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -48,13 +48,13 @@ class LiveLogDataSource {
 }
 
 // Time normalizers:
-function toMs(time) {
+function toMs (time) {
   if (time instanceof Date) return time.getTime()
   const n = Number(time)
   return Number.isFinite(n) ? n : 0
 }
 
-function formatLocal(time) {
+function formatLocal (time) {
   return new Date(toMs(time)).toLocaleString()
 }
 

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -77,7 +77,7 @@ function renderTable (id, options = {}, renderRow) {
           }
         } else {
           // New item, create new row
-          const tr = t.insertRow(i)
+          const tr = t.insertRow(Math.min(i, t.rows.length))
           setKeyAttributes(tr, item)
           renderRow(tr, item, true)
         }

--- a/static/main.css
+++ b/static/main.css
@@ -2026,7 +2026,7 @@ pre.arguments .inactive-argument:before {
 
 #livelog table td,
 #livelog table th {
-  padding: 0;
+  padding: 4px 16px;
 }
 
 #livelog table thead .livelog-timestamp {

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -9,7 +9,8 @@
     <% render "partials/header" %>
     <main class="main-grid">
       <div id="breadcrumbs" class="cols-12">
-          <h2 class="page-title"><span><%=pagename%></span></h2>
+          <h2 class="page-title"><span><%=pagename%></span>
+          <div class="tiny-badge" id="pagename-label"></div></h2>
       </div>
       <section id="livelog" class="card livelog">
         <button id="download-logs" class="btn btn-green"><a download href="api/logs">Download logs</a></button>
@@ -17,10 +18,10 @@
         <table id="table" class="table">
           <thead>
             <tr>
-              <th class="livelog-timestamp">Timestamp</th>
-              <th class="livelog-severity">Severity</th>
-              <th class="livelog-source">Source</th>
-              <th class="livelog-message">Message</th>
+              <th data-sort-key="timestamp" class="livelog-timestamp">Timestamp</th>
+              <th data-sort-key="severity" class="livelog-severity">Severity</th>
+              <th data-sort-key="source" class="livelog-source">Source</th>
+              <th data-sort-key="message" class="livelog-message">Message</th>
             </tr>
           </thead>
           <tbody id="livelog-body"></tbody>


### PR DESCRIPTION
### WHAT is this pull request doing?
Renders: a filter regex textbox, logs in a searchable and sortable table, the columnSelector, a list count.

Have included the small insertRow edit again in table.js (shared in PR Feat/filter textbox #1274) so that it can render enough logs, otherwise it errors beyond 16rows. 

Included TODO comments to note where known fixes are needed. 

p.s. Would have tried to break this up in separate commits, but the way the rendering all comes from one fx, renderTable - it felt better to create a complete working table and then get the feedback. 😄 always happy to get workflow suggestions as well!

### HOW can this pull request be tested?
Try out Logs page view to see new features from this branch.
