### PR TITLE
specs: Fix macos etcd specs failing in CI

### DIFF
--- a/spec/support/etcd_helper.cr
+++ b/spec/support/etcd_helper.cr
@@ -30,6 +30,11 @@ def with_etcd(&)
   ensure
     p.terminate(graceful: false) rescue nil
     FileUtils.rm_rf "/tmp/clustering-spec.etcd"
+    i = 0
+    until p.terminated?
+      break if (i &+= 1) > 20
+      sleep 0.1.seconds
+    end
   end
 end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
An attempt to fix failing specs in macos in CI by making sure etcd has terminated before continuing. I think a process from a previous spec hasn't exited before an etcd is started in the next spec.

### HOW can this pull request be tested?
Run specs in CI multiple times
