### PR TITLE
Logs - with filtering and sticky headers

### DIFF
--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -53,7 +53,7 @@ evtSource.onmessage = (event) => {
   buffer.push(log)
 
   if (matches(log)) {
-    const row = tbody.appendChild(buildRow(log))  
+    tbody.appendChild(buildRow(log))  
     if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
   }
 
@@ -100,6 +100,7 @@ filterInput.addEventListener('keydown', (e) => {
     e.preventDefault()
     rebuildFromBuffer()
   } else if (e.key === 'Escape' && filterInput.value) {
+    currentRegex = null
     filterInput.value = ''
     rebuildFromBuffer()
   }

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -4,59 +4,22 @@ const tbody = document.getElementById('livelog-body')
 const filterInput = document.getElementById('log-filter')
 const btnToTop = document.getElementById('to-top')
 const btnToBottom = document.getElementById('to-bottom')
-const buffer = []
+const allLogs = []
+const pendingLogs = []
+const MAX_ROWS = 2000
+const INITIAL_ROWS = 500
+const ROWS_PER_FRAME = 250
+let isFrameQueued = false
 let shouldAutoScroll = true
 let currentRegex = null
 
-// Helpers
-const joinForSearch = (log) => {
-  return `${log.timestamp.toISOString()} ${log.severity} ${log.source}${log.message ?? ''}`
-}
-
-const matches = (log) => {
-  return !currentRegex || currentRegex.test(joinForSearch(log))
-}
-
-// Build Table
-const buildRow = (log) => {
-  const tdTs = document.createElement('td')
-  tdTs.textContent = log.timestamp.toLocaleString()
-  const tdSev = document.createElement('td')
-  tdSev.textContent = log.severity
-  const tdSrc = document.createElement('td')
-  tdSrc.textContent = log.source
-  const preMsg = document.createElement('pre')
-  preMsg.textContent = log.message
-  const tdMsg = document.createElement('td')
-  tdMsg.appendChild(preMsg)
-
-  const tr = document.createElement('tr')
-  tr.append(tdTs, tdSev, tdSrc, tdMsg)
-  return tr
-}
-
-// DocumentFragment = build off-DOM, append once → single layout/paint (fast).
-const rebuildFromBuffer = () => {
-  const frag = document.createDocumentFragment()
-  for (const log of buffer) {
-    if (matches(log)) frag.appendChild(buildRow(log))
-  }
-  tbody.textContent = ''
-  tbody.appendChild(frag)
-  if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
-}
-
-// SSE: append-only
+// SSE
 evtSource.onmessage = (event) => {
   const timestamp = new Date(parseInt(event.lastEventId))
   const [severity, source, message] = JSON.parse(event.data)
   const log = { timestamp, severity, source, message }
-  buffer.push(log)
-
-  if (matches(log)) {
-    tbody.appendChild(buildRow(log))
-    if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
-  }
+  pendingLogs.push(log)
+  requestPaint()
 }
 
 evtSource.onerror = () => {
@@ -75,6 +38,80 @@ function forbidden () {
   tblError.style.display = 'block'
 }
 
+// Build Table
+const buildRow = (log) => {
+  const tdTs = document.createElement('td')
+  tdTs.textContent = log.timestamp.toLocaleString()
+  const tdSev = document.createElement('td')
+  tdSev.textContent = log.severity
+  const tdSrc = document.createElement('td')
+  tdSrc.textContent = log.source
+  const preMsg = document.createElement('pre')
+  preMsg.textContent = log.message
+  const tdMsg = document.createElement('td')
+  tdMsg.appendChild(preMsg)
+  
+  const tr = document.createElement('tr')
+  tr.append(tdTs, tdSev, tdSrc, tdMsg)
+  return tr
+}
+
+// DocumentFragment = save logs off-DOM, render to DOM as directed. Use rAF for smooth updates, batch rendering large logs
+const paintIncoming = () => {
+  const domPaint = Math.min(
+    (tbody.rows.length === 0 ? INITIAL_ROWS : ROWS_PER_FRAME),
+    pendingLogs.length
+  )
+  if (domPaint === 0) return
+
+  const batch = pendingLogs.splice(0, domPaint)
+
+  const frag = document.createDocumentFragment()
+  for (const log of batch) {
+    allLogs.push(log)
+    if (allLogs.length > MAX_ROWS) allLogs.shift()
+    if (matches(log)) frag.appendChild(buildRow(log))
+  }
+
+  if (frag.childNodes.length) tbody.appendChild(frag)
+  
+  while (tbody.rows.length > MAX_ROWS) tbody.deleteRow(0)
+
+  if (pendingLogs.length) requestPaint()
+}
+
+// Request Animation Frame
+const requestPaint = () => {
+  if (isFrameQueued) return
+  isFrameQueued = true
+  requestAnimationFrame(() => {
+    isFrameQueued = false
+    paintIncoming()
+  })
+}
+
+// Helpers
+const matches = (log) => {
+  if (!currentRegex) return true
+  const searchString = `${log.timestamp.toISOString()} ${log.severity} ${log.source}${log.message ?? ''}`
+  return currentRegex.test(searchString)
+}
+// On filter change:
+const rebuildFromAllLogs = () => {
+  const frag = document.createDocumentFragment()
+  for (const log of allLogs) {
+    if (matches(log)) frag.appendChild(buildRow(log))
+  }
+    tbody.textContent = ''
+    tbody.appendChild(frag)
+
+    while (tbody.rows.length > MAX_ROWS) {
+      tbody.deleteRow(0)
+    }
+
+  if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
+}
+
 // Live typing: compile & rebuild
 filterInput.addEventListener('input', () => {
   const q = filterInput.value.trim()
@@ -85,25 +122,25 @@ filterInput.addEventListener('input', () => {
     currentRegex = null
     filterInput.classList.toggle('invalid', true)
   }
-  rebuildFromBuffer()
+  rebuildFromAllLogs()
 })
 
 // Fires when the native clear “×” is clicked (because type="search")
 filterInput.addEventListener('search', () => {
   if (filterInput.value === '') {
     currentRegex = null
-    rebuildFromBuffer()
+    rebuildFromAllLogs()
   }
 })
 
 filterInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter') {
     e.preventDefault()
-    rebuildFromBuffer()
+    rebuildFromAllLogs()
   } else if (e.key === 'Escape' && filterInput.value) {
     currentRegex = null
     filterInput.value = ''
-    rebuildFromBuffer()
+    rebuildFromAllLogs()
   }
 })
 
@@ -129,5 +166,19 @@ livelog.addEventListener('scroll', event => {
   }
   lastScrollTop = st <= 0 ? 0 : st
 })
+
+// Add 1000 fake logs quickly to test batching:
+let n = 0
+const fake = setInterval(() => {
+  const log = {
+    timestamp: new Date(),
+    severity: ['INFO','WARN','ERROR'][Math.floor(Math.random()*3)],
+    source: 'dev',
+    message: 'test #' + (++n)
+  }
+  pendingLogs.push(log)
+  requestPaint()
+  if (n >= 1000) clearInterval(fake)
+}, 2)
 
 window.addEventListener('beforeunload', () => evtSource.close())

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -57,22 +57,22 @@ evtSource.onmessage = (event) => {
     tbody.appendChild(buildRow(log))
     if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
   }
+}
 
-  evtSource.onerror = () => {
-    window.fetch('api/whoami')
-      .then(response => response.json())
-      .then(whoami => {
-        if (!whoami.tags.includes('administrator')) {
-          forbidden()
-        }
-      })
-  }
+evtSource.onerror = () => {
+  window.fetch('api/whoami')
+    .then(response => response.json())
+    .then(whoami => {
+      if (!whoami.tags.includes('administrator')) {
+        forbidden()
+      }
+    })
+}
 
-  function forbidden () {
-    const tblError = document.getElementById('table-error')
-    tblError.textContent = 'Access denied, administator access required'
-    tblError.style.display = 'block'
-  }
+function forbidden () {
+  const tblError = document.getElementById('table-error')
+  tblError.textContent = 'Access denied, administator access required'
+  tblError.style.display = 'block'
 }
 
 // Live typing: compile & rebuild

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -1,45 +1,115 @@
-let shouldAutoScroll = true
 const evtSource = new window.EventSource('api/livelog')
 const livelog = document.getElementById('livelog')
 const tbody = document.getElementById('livelog-body')
+const filterInput = document.getElementById('log-filter')
+const btnToTop = document.getElementById('to-top')
+const buffer = []
+let shouldAutoScroll = true
+let currentRegex = null
 
-evtSource.onmessage = (event) => {
-  const timestamp = new Date(parseInt(event.lastEventId))
-  const [severity, source, message] = JSON.parse(event.data)
+// Helpers
+const joinForSearch = (log) => {
+  return `${log.timestamp.toISOString()} ${log.severity} ${log.source}${log.message ?? ''}`
+}
 
+const matches = (log) => {
+  return !currentRegex || currentRegex.test(joinForSearch(log))
+}
+  
+// Build Table
+const buildRow = (log) => {
   const tdTs = document.createElement('td')
-  tdTs.textContent = timestamp.toLocaleString()
+  tdTs.textContent = log.timestamp.toLocaleString()
   const tdSev = document.createElement('td')
-  tdSev.textContent = severity
+  tdSev.textContent = log.severity
   const tdSrc = document.createElement('td')
-  tdSrc.textContent = source
+  tdSrc.textContent = log.source
   const preMsg = document.createElement('pre')
-  preMsg.textContent = message
+  preMsg.textContent = log.message
   const tdMsg = document.createElement('td')
   tdMsg.appendChild(preMsg)
 
   const tr = document.createElement('tr')
   tr.append(tdTs, tdSev, tdSrc, tdMsg)
-  const row = tbody.appendChild(tr)
-
-  if (shouldAutoScroll) row.scrollIntoView()
+  return tr
 }
 
-evtSource.onerror = () => {
-  window.fetch('api/whoami')
-    .then(response => response.json())
-    .then(whoami => {
-      if (!whoami.tags.includes('administrator')) {
-        forbidden()
-      }
-    })
+// DocumentFragment = build off-DOM, append once → single layout/paint (fast).
+const rebuildFromBuffer = () => {
+  const frag = document.createDocumentFragment()
+  for (const log of buffer) {
+    if (matches(log)) frag.appendChild(buildRow(log))
+    }
+  tbody.textContent = ''
+  tbody.appendChild(frag)
+  if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
 }
 
-function forbidden () {
-  const tblError = document.getElementById('table-error')
-  tblError.textContent = 'Access denied, administator access required'
-  tblError.style.display = 'block'
+// SSE: append-only
+evtSource.onmessage = (event) => {
+  const timestamp = new Date(parseInt(event.lastEventId))
+  const [severity, source, message] = JSON.parse(event.data)
+  const log = { timestamp, severity, source, message }
+  buffer.push(log)
+
+  if (matches(log)) {
+    const row = tbody.appendChild(buildRow(log))  
+    if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
+  }
+
+  evtSource.onerror = () => {
+    window.fetch('api/whoami')
+      .then(response => response.json())
+      .then(whoami => {
+        if (!whoami.tags.includes('administrator')) {
+          forbidden()
+        }
+      })
+  }
+
+  function forbidden () {
+    const tblError = document.getElementById('table-error')
+    tblError.textContent = 'Access denied, administator access required'
+    tblError.style.display = 'block'
+  }
 }
+
+// Live typing: compile & rebuild
+filterInput.addEventListener('input', () => {
+  const q = filterInput.value.trim()
+  try { 
+    currentRegex = q ? new RegExp(q, 'i') : null 
+    filterInput.classList.toggle('invalid', false)
+  } catch { 
+    currentRegex = null 
+    filterInput.classList.toggle('invalid', true)
+  }
+  rebuildFromBuffer()
+})
+
+// Fires when the native clear “×” is clicked (because type="search")
+filterInput.addEventListener('search', () => {
+  if (filterInput.value === '') {
+    currentRegex = null
+    rebuildFromBuffer()
+  }
+})
+
+filterInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    rebuildFromBuffer()
+  } else if (e.key === 'Escape' && filterInput.value) {
+    filterInput.value = ''
+    rebuildFromBuffer()
+  }
+})
+
+// Scrolling 
+btnToTop?.addEventListener('click', () => {
+  livelog.scrollTop = 0
+  shouldAutoScroll = false
+})
 
 let lastScrollTop = livelog.pageYOffset || livelog.scrollTop
 livelog.addEventListener('scroll', event => {
@@ -53,4 +123,4 @@ livelog.addEventListener('scroll', event => {
   lastScrollTop = st <= 0 ? 0 : st
 })
 
-livelog.addEventListener('beforeunload', () => livelog.close())
+window.addEventListener('beforeunload', () => evtSource.close())

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -3,6 +3,7 @@ const livelog = document.getElementById('livelog')
 const tbody = document.getElementById('livelog-body')
 const filterInput = document.getElementById('log-filter')
 const btnToTop = document.getElementById('to-top')
+const btnToBottom = document.getElementById('to-bottom')
 const buffer = []
 let shouldAutoScroll = true
 let currentRegex = null
@@ -110,6 +111,11 @@ filterInput.addEventListener('keydown', (e) => {
 btnToTop?.addEventListener('click', () => {
   livelog.scrollTop = 0
   shouldAutoScroll = false
+})
+
+btnToBottom?.addEventListener('click', () => {
+  livelog.scrollTop = livelog.scrollHeight
+  shouldAutoScroll = true
 })
 
 let lastScrollTop = livelog.pageYOffset || livelog.scrollTop

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -16,7 +16,7 @@ const joinForSearch = (log) => {
 const matches = (log) => {
   return !currentRegex || currentRegex.test(joinForSearch(log))
 }
-  
+
 // Build Table
 const buildRow = (log) => {
   const tdTs = document.createElement('td')
@@ -40,7 +40,7 @@ const rebuildFromBuffer = () => {
   const frag = document.createDocumentFragment()
   for (const log of buffer) {
     if (matches(log)) frag.appendChild(buildRow(log))
-    }
+  }
   tbody.textContent = ''
   tbody.appendChild(frag)
   if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
@@ -54,7 +54,7 @@ evtSource.onmessage = (event) => {
   buffer.push(log)
 
   if (matches(log)) {
-    tbody.appendChild(buildRow(log))  
+    tbody.appendChild(buildRow(log))
     if (shouldAutoScroll) livelog.scrollTop = livelog.scrollHeight
   }
 
@@ -78,11 +78,11 @@ evtSource.onmessage = (event) => {
 // Live typing: compile & rebuild
 filterInput.addEventListener('input', () => {
   const q = filterInput.value.trim()
-  try { 
-    currentRegex = q ? new RegExp(q, 'i') : null 
+  try {
+    currentRegex = q ? new RegExp(q, 'i') : null
     filterInput.classList.toggle('invalid', false)
-  } catch { 
-    currentRegex = null 
+  } catch {
+    currentRegex = null
     filterInput.classList.toggle('invalid', true)
   }
   rebuildFromBuffer()
@@ -107,7 +107,7 @@ filterInput.addEventListener('keydown', (e) => {
   }
 })
 
-// Scrolling 
+// Scrolling
 btnToTop?.addEventListener('click', () => {
   livelog.scrollTop = 0
   shouldAutoScroll = false

--- a/static/main.css
+++ b/static/main.css
@@ -2157,47 +2157,30 @@ pre.arguments .inactive-argument:before {
 }
 
 #livelog {
-  max-height: 75vh;
+  max-height: 50vh;
   overflow: auto;
   scrollbar-gutter: stable both-edges;
-  padding:0 1.5rem 1.5rem;
 }
 
-#livelog td {
-  white-space: normal;
-}
-
-.log-toolbar {
+#livelog table {
   width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+#livelog thead th {
+  position: sticky;
+  top: 0;
   background: var(--color-bg-secondary);
-  border-bottom: 1px solid rgba(0,0,0,0.08);
-  box-shadow: 0 1px 0 rgba(0,0,0,0.04);
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-  padding: 0.75rem 1.5rem;
-}
-
-.log-toolbar .toolbar-actions {
-  display: flex;
-  gap: 0.5rem;
-  margin-left: auto;
-}
-
-.btn-primary a,
-.btn-primary a:visited {
-  color: var(--color-text-inverse);
-}
-
-#download-logs {
-  margin: 5px 0 16px 0;
-  text-decoration: none;
+  border-bottom: 2px solid rgba(0,0,0,0.08);
+  z-index: 2;
 }
 
 #livelog table td,
 #livelog table th {
   padding: 4px 8px;
+  text-align: left;
 }
 
 #livelog table thead .livelog-timestamp {
@@ -2216,8 +2199,42 @@ pre.arguments .inactive-argument:before {
   width: auto;
 }
 
-#livelog table th {
-  text-align: left;
+#livelog td {
+  white-space: normal;
+}
+
+.log-toolbar-container {
+  width: 100%;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.04);
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0.75rem 1.5rem;
+}
+
+.log-toolbar {
+  flex: 0 1 auto;
+}
+
+.toolbar-action {
+  flex: 0 0 auto;
+}
+
+#download-logs {
+  margin: 5px 0 16px 0;
+  text-decoration: none;
+}
+
+#to-top {
+  margin: 0.5rem 1.5rem;
+}
+
+.btn-primary a,
+.btn-primary a:visited {
+  color: var(--color-text-inverse);
 }
 
 .version-tab {

--- a/static/main.css
+++ b/static/main.css
@@ -2157,12 +2157,32 @@ pre.arguments .inactive-argument:before {
 }
 
 #livelog {
-  max-height: 85vh;
-  overflow-y: scroll;
+  max-height: 75vh;
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
+  padding:0 1.5rem 1.5rem;
 }
 
 #livelog td {
   white-space: normal;
+}
+
+.log-toolbar {
+  width: 100%;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.04);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.75rem 1.5rem;
+}
+
+.log-toolbar .toolbar-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
 }
 
 .btn-primary a,
@@ -2172,9 +2192,6 @@ pre.arguments .inactive-argument:before {
 
 #download-logs {
   margin: 5px 0 16px 0;
-}
-
-#download-logs a {
   text-decoration: none;
 }
 

--- a/static/main.css
+++ b/static/main.css
@@ -2180,7 +2180,7 @@ pre.arguments .inactive-argument:before {
 
 #livelog table td,
 #livelog table th {
-  padding: 0;
+  padding: 4px 8px;
 }
 
 #livelog table thead .livelog-timestamp {

--- a/static/main.css
+++ b/static/main.css
@@ -2157,9 +2157,10 @@ pre.arguments .inactive-argument:before {
 }
 
 #livelog {
-  max-height: 50vh;
+  max-height: 85vh;
   overflow: auto;
   scrollbar-gutter: stable both-edges;
+  scroll-behavior: auto;
 }
 
 #livelog table {

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -12,11 +12,14 @@
           <h2 class="page-title"><span><%=pagename%></span></h2>
           <div class="tiny-badge" id="pagename-label"></div></h2>
       </div>
-      <section id="livelog" class="card livelog">
-        <label for="log-filter" class="sr-only"></label>
-        <input id="log-filter" class="filter-table" type="search" placeholder="Filter regex">
-        <button id="to-bottom" class="btn-outlined">⬇</button>
-        <button id="download-logs" class="btn btn-green"><a download href="api/logs">Download logs</a></button>
+      <section class="card">
+       <div class="log-toolbar">
+          <label for="log-filter" class="sr-only"></label>
+            <input id="log-filter" class="filter-table" type="search" placeholder="Filter regex">
+            <button id="to-bottom" class="btn-outlined">⬇</button>
+            <a id="download-logs" class="btn btn-green toolbar-actions" download href="api/logs">Download logs</a>
+        </div>
+        <div id="livelog" class="livelog">
         <div id="table-error"></div>
         <table id="table" class="table">
           <thead>
@@ -29,6 +32,7 @@
           </thead>
           <tbody id="livelog-body"></tbody>
         </table>
+        </div>
         <button id="to-top" class="btn-outlined">⬆</button>
       </section>
     </main>

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -13,11 +13,11 @@
           <div class="tiny-badge" id="pagename-label"></div></h2>
       </div>
       <section class="card">
-       <div class="log-toolbar">
+       <div class="log-toolbar-container">
+            <button id="to-bottom" class="btn-outlined log-toolbar">⬇</button>
           <label for="log-filter" class="sr-only"></label>
-            <input id="log-filter" class="filter-table" type="search" placeholder="Filter regex">
-            <button id="to-bottom" class="btn-outlined">⬇</button>
-            <a id="download-logs" class="btn btn-green toolbar-actions" download href="api/logs">Download logs</a>
+            <input id="log-filter" class="filter-table log-toolbar" type="search" placeholder="Filter regex">
+            <a id="download-logs" class="btn btn-green toolbar-action" download href="api/logs">Download logs</a>
         </div>
         <div id="livelog" class="livelog">
         <div id="table-error"></div>

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -10,8 +10,11 @@
     <main class="main-grid">
       <div id="breadcrumbs" class="cols-12">
           <h2 class="page-title"><span><%=pagename%></span></h2>
+          <div class="tiny-badge" id="pagename-label"></div></h2>
       </div>
       <section id="livelog" class="card livelog">
+        <label for="log-filter" class="sr-only"></label>
+        <input id="log-filter" class="filter-table" type="search" placeholder="Filter regex">
         <button id="download-logs" class="btn btn-green"><a download href="api/logs">Download logs</a></button>
         <div id="table-error"></div>
         <table id="table" class="table">
@@ -25,6 +28,7 @@
           </thead>
           <tbody id="livelog-body"></tbody>
         </table>
+        <button id="to-top" class="btn-outlined">🔝</button>
       </section>
     </main>
     <% render "partials/footer" %>

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -15,6 +15,7 @@
       <section id="livelog" class="card livelog">
         <label for="log-filter" class="sr-only"></label>
         <input id="log-filter" class="filter-table" type="search" placeholder="Filter regex">
+        <button id="to-bottom" class="btn-outlined">⬇</button>
         <button id="download-logs" class="btn btn-green"><a download href="api/logs">Download logs</a></button>
         <div id="table-error"></div>
         <table id="table" class="table">
@@ -28,7 +29,7 @@
           </thead>
           <tbody id="livelog-body"></tbody>
         </table>
-        <button id="to-top" class="btn-outlined">🔝</button>
+        <button id="to-top" class="btn-outlined">⬆</button>
       </section>
     </main>
     <% render "partials/footer" %>


### PR DESCRIPTION
### WHAT is this pull request doing?
Addresses issue: Logs page filter #993, generally improving UX. 
Implements dynamic filtering from regex textbox, jump buttons to reach top and bottom of table quickly. 
Adjust download button to < a > tag with button css, vs button element wrapping link. 
Sticky toolbar so user can always access actions(filter, download) regardless of table location.
Minimal styling of toolbar and jump buttons, table head row now also sticky.

TODO: 
Timestamp sort
Severity sort - ?? maybe add icons or color?

### HOW can this pull request be tested?
Checkout branch, test logs page filter box, jump buttons and scroll. 
