### PR TITLE
dont start metrics server for follower proxy spec

### DIFF
--- a/spec/follower_proxy_during_sync_spec.cr
+++ b/spec/follower_proxy_during_sync_spec.cr
@@ -68,6 +68,7 @@ describe "extract_conn_info during full_sync with syncing_followers" do
 
         begin
           follower_config = leader_config.dup.tap &.data_dir = follower_data_dir
+          follower_config.metrics_http_port = -1
           follower_client = LavinMQ::Clustering::Client.new(follower_config, 2, slow_replicator.password, proxy: false)
 
           spawn(name: "slow follower sync") do


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes an error we've been seeing periodically since [this commit](https://github.com/cloudamqp/lavinmq/commit/66a4580d907fd668c0a65d576347486a558bd9ae), on the spec `it "should handle PROXY protocol from syncing followers during full_sync" do`
 `Could not bind to '127.0.0.1:15692': Address already in use (Socket::BindError)`

### HOW can this pull request be tested?
Run the specs
