### PR TITLE
add broad rescue in consumer deliver loop to avoid silent failures

### DIFF
--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -90,6 +90,8 @@ module LavinMQ
         end
       rescue ex : ClosedError | Queue::ClosedError | AMQP::Channel::ClosedError | ::Channel::ClosedError
         @log.debug { "deliver loop exiting: #{ex.inspect}" }
+      rescue ex
+        @log.error(exception: ex) { "deliver loop error: #{ex.message}" }
       end
 
       private def wait_for_global_capacity


### PR DESCRIPTION
### WHAT is this pull request doing?
We should not let the consumers deliver loop fail silently, this pr adds a broad rescue and logs the error. 

### HOW can this pull request be tested?
raise an unspecified error in the deliver loop and see that it gets rescued and logged. 