### PR TITLE
@unacked_sps Deque tracks unacked_count in Queue

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -576,7 +576,7 @@ describe LavinMQ::AMQP::Queue do
 
         # unacked_count should not have been decremented below 0
         # In the buggy scenario, this would underflow or cause issues
-        sq.unacked_count.should eq 0  # Should remain 0, not underflow
+        sq.unacked_count.should eq 0 # Should remain 0, not underflow
       end
     end
   end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -813,7 +813,7 @@ module LavinMQ::AMQP
         @msg_store_lock.synchronize do
           @msg_store.requeue(sp)
         end
-      raise ex
+        raise ex
       end
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes #1237. We substitute `@unacked_count` `Atomic` for the `@unacked_sps` `Deque`. This helps us safeguard from situations like the one in #1237 because we can not delete from a `Deque` twice. 

There have been thoughts of a bigger refactoring of `Queue`/`Channel` with the PR for introducing the `AcknowledgementTracker`, where we would keep track of counters for both `queue` and `channel` and centralize the acknowledgement handling. 

We opted out of that approach for 2.5.0 because we felt we were over engineering for this specific bug. It is more important to solve #1237 and do a well thought out stress-free refactor with `AcknowledgementTracker` in a later version. 

Average throughput rates for this branch (built with release flags) 
```
Average publish rate: 1239890.5 msgs/s
Average consume rate: 1142781.9 msgs/s
```

Average throughput rates for main
```
Average publish rate: 1216554.9 msgs/s
Average consume rate: 1166671.5 msgs/s
```
Note that we introduce a new lock, and that plus Deque management might make this solution slightly slower. 

### HOW can this pull request be tested?
Run the spec fleat, there is a spec added to queue_spec.cr
