### PR TITLE
dev ui improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ watch-views:
 .PHONY: dev-ui
 dev-ui:
 	@trap '$(MAKE) clean-views; trap - EXIT' EXIT INT TERM; \
+   $(MAKE) bin/lavinmq CRYSTAL_FLAGS= ; \
 	 $(MAKE) livereload & \
 	 livereload_pid=$$!; \
 	 $(MAKE) -s watch-views; \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ views: $(VIEW_TARGETS)
 
 .PHONY: watch-views
 watch-views:
-	while true; do $(MAKE) -q -s views || $(MAKE) -j views; sleep 0.5; done
+	@MAKE_FLAGS=$$([ "$$(uname)" = "Darwin" ] || echo "-j"); \
+	while true; do $(MAKE) -q -s views || $(MAKE) $$MAKE_FLAGS views; sleep 0.5; done
 
 .PHONY: dev-ui
 dev-ui:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ override CRYSTAL_FLAGS += --stats --error-on-warnings -Dpreview_mt -Dexecution_c
 livereload:
 	@echo "Starting livereload server..."
 	@which livereload > /dev/null || npm install -g livereload
-	@(pid=$$!; trap 'kill -TERM $$pid' INT; livereload static &)
+	@(pid=$$!; trap 'kill -TERM $$pid' INT; livereload -p 35629 static &)
 
 .PHONY: views
 views: $(VIEW_TARGETS)

--- a/views/partials/head.ecr
+++ b/views/partials/head.ecr
@@ -11,5 +11,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="google" content="notranslate">
 <%- {% unless flag?(:release) %} -%>
-  <script async src="http://localhost:35729/livereload.js"></script>
+  <script async src="http://localhost:35629/livereload.js"></script>
 <%- {% end %} -%>


### PR DESCRIPTION
- **Use non-standard livereload port to avoid conflicts**
- **Dont make in parallel on macos, causes invalid memory access**
- **Make sure build is not in release mode, required for dev-ui to work**
