### PR TITLE
Keep track of depricated configs 

### DIFF
--- a/src/lavinmq/deprecation.cr
+++ b/src/lavinmq/deprecation.cr
@@ -8,9 +8,8 @@ module LavinMQ
     @@features = [] of NamedTuple(name: String, deprecated_in: String, remove_in: String, message: String)
 
     macro deprecated(name, deprecated_in, remove_in, message)
-      {% current_version = `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") %}
-      {% if current_version.split(".")[0].to_i >= remove_in.split(".")[0].to_i %}
-        {% raise "DEPRECATION ERROR: '#{name.id}' was marked for removal in #{remove_in.id} but is still present in version #{current_version.id}. #{message.id}" %}
+      {% if compare_versions(LavinMQ::VERSION, remove_in) >= 0 %}
+        {% raise "DEPRECATION ERROR: '#{name.id}' was marked for removal in #{remove_in.id} but is still present in version #{LavinMQ::VERSION.id}. #{message.id}" %}
       {% end %}
 
       LavinMQ::Deprecation.add({{ name }}, {{ deprecated_in }}, {{ remove_in }}, {{ message }})
@@ -19,10 +18,6 @@ module LavinMQ
     def self.add(name : String, deprecated_in : String, remove_in : String, message : String)
       @@features << {name: name, deprecated_in: deprecated_in, remove_in: remove_in, message: message}
     end
-
-    # def self.warn(feature_name : String, deprecated_in : String, remove_in : String, message : String)
-    #   Log.warn { "DEPRECATED: '#{feature_name}' was deprecated in #{deprecated_in} and will be removed in #{remove_in}. #{message}" }
-    # end
 
     def self.log_startup_warnings
       return if @@features.empty?

--- a/src/lavinmq/deprecation.cr
+++ b/src/lavinmq/deprecation.cr
@@ -1,0 +1,35 @@
+require "./version"
+require "log"
+
+module LavinMQ
+  module Deprecation
+    Log = ::Log.for("deprecation")
+
+    @@features = [] of NamedTuple(name: String, deprecated_in: String, remove_in: String, message: String)
+
+    macro deprecated(name, deprecated_in, remove_in, message)
+      {% current_version = `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") %}
+      {% if current_version.split(".")[0].to_i >= remove_in.split(".")[0].to_i %}
+        {% raise "DEPRECATION ERROR: '#{name.id}' was marked for removal in #{remove_in.id} but is still present in version #{current_version.id}. #{message.id}" %}
+      {% end %}
+
+      LavinMQ::Deprecation.add({{ name }}, {{ deprecated_in }}, {{ remove_in }}, {{ message }})
+    end
+
+    def self.add(name : String, deprecated_in : String, remove_in : String, message : String)
+      @@features << {name: name, deprecated_in: deprecated_in, remove_in: remove_in, message: message}
+    end
+
+    # def self.warn(feature_name : String, deprecated_in : String, remove_in : String, message : String)
+    #   Log.warn { "DEPRECATED: '#{feature_name}' was deprecated in #{deprecated_in} and will be removed in #{remove_in}. #{message}" }
+    # end
+
+    def self.log_startup_warnings
+      return if @@features.empty?
+      Log.warn { "This version contains #{@@features.size} deprecated feature(s):" }
+      @@features.each do |f|
+        Log.warn { "  - #{f[:name]} (deprecated in #{f[:deprecated_in]}, will be removed in #{f[:remove_in]}): #{f[:message]}" }
+      end
+    end
+  end
+end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -70,6 +70,7 @@ module LavinMQ
       setup_log_exchange(amqp_server)
       start_listeners(amqp_server, http_server)
       start_metrics_server(amqp_server) unless @config.metrics_http_port == -1
+      Deprecation.log_startup_warnings
       SystemD.notify_ready
       Fiber.yield # Yield to let listeners spawn before logging startup time
       Log.info { "Finished startup in #{(Time.monotonic - started_at).total_seconds}s" }

--- a/src/lavinmq/version.cr
+++ b/src/lavinmq/version.cr
@@ -1,5 +1,7 @@
 module LavinMQ
-  VERSION = {{ `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") }}
+  {% begin %}
+    VERSION = {{ `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") }}
+  {% end %}
 
   macro build_flags
     String.build do |flags|


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a deprecation module to track deprecated configuration options. Registers deprecations at compile-time and fails compilation if a deprecated feature reaches its removal version. 

If you add a depricated config var, it will log a warning during startup. 

Currently tracks two deprecated config options:
  - guest_only_loopback (deprecated in 2.2.0, will be removed in 3.0.0) - replaced by default_user_only_loopback
  - default_password (deprecated in 2.2.0, will be removed in 3.0.0) - replaced by default_password_hash

### HOW can this pull request be tested?
 Compile and see logs, or try to build `version=3.0.0 crystal build src/lavinmq.cr `
 

