### PR TITLE
sticky header on logs

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -2165,22 +2165,33 @@ pre.arguments .inactive-argument:before {
   white-space: normal;
 }
 
-.btn-primary a,
-.btn-primary a:visited {
-  color: var(--color-text-inverse);
+#livelog {
+  max-height: 65vh;
+  overflow: auto;
+  overflow-anchor: none;
+  scrollbar-gutter: stable both-edges;
+  scroll-behavior: auto;
 }
 
-#download-logs {
-  margin: 5px 0 16px 0;
+#livelog table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
 }
 
-#download-logs a {
-  text-decoration: none;
+#livelog thead th {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-secondary);
+  border-bottom: 2px solid rgba(0,0,0,0.08);
+  z-index: 2;
 }
 
 #livelog table td,
 #livelog table th {
-  padding: 0;
+  padding: 4px 8px;
+  text-align: left;
 }
 
 #livelog table thead .livelog-timestamp {
@@ -2199,8 +2210,33 @@ pre.arguments .inactive-argument:before {
   width: auto;
 }
 
-#livelog table th {
-  text-align: left;
+#livelog td {
+  white-space: normal;
+}
+
+.log-toolbar-container {
+  width: 100%;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.04);
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0.75rem 1.5rem;
+}
+
+.log-toolbar {
+  flex: 0 1 auto;
+}
+
+.toolbar-action {
+  flex: 0 0 auto;
+}
+
+.btn-primary a,
+.btn-primary a:visited {
+  color: var(--color-text-inverse);
 }
 
 .version-tab {

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -10,9 +10,13 @@
     <main class="main-grid">
       <div id="breadcrumbs" class="cols-12">
           <h2 class="page-title"><span><%=pagename%></span></h2>
+          <div class="tiny-badge" id="pagename-label"></div></h2>
       </div>
-      <section id="livelog" class="card livelog">
-        <button id="download-logs" class="btn btn-green"><a download href="api/logs">Download logs</a></button>
+      <section class="card">
+       <div class="log-toolbar-container">
+         <a id="download-logs" class="btn btn-green toolbar-action" download href="api/logs">Download logs</a>
+        </div>
+        <div id="livelog" class="livelog">
         <div id="table-error"></div>
         <table id="table" class="table">
           <thead>
@@ -25,6 +29,7 @@
           </thead>
           <tbody id="livelog-body"></tbody>
         </table>
+        </div>
       </section>
     </main>
     <% render "partials/footer" %>


### PR DESCRIPTION
### WHAT is this pull request doing?
Sticky actions over table for better ux viewing logs stream.

### HOW can this pull request be tested?
Checkout branch and scroll to see sticky toolbar and table header over rows.

*Note: I am compartmentalizing into smaller branches for reading simplicity of all changes applied to new-logs. Working backwards from larger commits, so apologies if it's unclear or mismatched changes in individual branches.* 😅