### PR TITLE
Switch from slash to chevron right in title bar breadcrumbs

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -29,6 +29,7 @@
   --color-text-muted: light-dark(#374151, #CDCBC9);
   --color-text-inverse: light-dark(#fafafa, #fafafa);
   --color-link: light-dark(#2c2c2c, #fafafa);
+  --color-text-tertiary: light-dark(#414141, #B6B6B6);
 
   --color-bg-primary: light-dark(#F4F4F4, #181818);
   --color-bg-secondary: light-dark(#FFFFFF, #1D1D1D);
@@ -590,19 +591,19 @@ body.login main {
 
 /* Components */
 .page-title {
-  font-size: 18px;
+  font-size: 14px;
   line-height: 20px;
   margin: 1.5rem 0 0.5rem;
   font-weight: 600;
-  color: var(--color-text-primary);
+  color: var(--color-text-tertiary);
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
 .subpage-title::before {
-  content: '/';
-  margin: 0 0.5rem;
+  content: '\203A';
+  margin: 0 1rem;
 }
 
 .card {

--- a/views/exchange.ecr
+++ b/views/exchange.ecr
@@ -9,7 +9,7 @@
   <% render "partials/header" %>
   <main class="main-grid">
     <div id="breadcrumbs" class="cols-12">
-        <h2 class="page-title"><%=pagename%><small class="tiny-badge" id="pagename-label"></small></h2>
+        <h2 class="page-title"><%=pagename%><div id="pagename-label" class="subpage-title"></div></h2>
     </div>
     <section class="card cols-4">
       <h3 class="title-m">Details</h3>


### PR DESCRIPTION
### WHAT is this pull request doing?
In the process of making breadcrumbs clearer and better and becoming more consistent in the use of the title bar, we are changing the slash to chevron right. More to come.

### HOW can this pull request be tested?
Click around in the UI and look at the title bar/breadcrumbs.
