### PR TITLE
Don't raise in queue constructors

### DIFF
--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -27,7 +27,7 @@ describe LavinMQ::VHost do
 
   it "should remove policy from resource when deleted" do
     PoliciesSpec.with_vhost do |vhost|
-      vhost.queues["test1"] = LavinMQ::AMQP::Queue.new(vhost, "test")
+      vhost.queues["test1"] = LavinMQ::QueueFactory.make(vhost, "test")
       vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
       sleep 10.milliseconds
       vhost.queues["test1"].policy.try(&.name).should eq "test"
@@ -58,7 +58,7 @@ describe LavinMQ::VHost do
   it "should apply policy" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      vhost.queues["test"] = LavinMQ::AMQP::Queue.new(vhost, "test")
+      vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
       vhost.add_policy("ml", "^.*$", "queues", defs, 11_i8)
       sleep 10.milliseconds
       vhost.queues["test"].policy.not_nil!.name.should eq "ml"
@@ -68,7 +68,7 @@ describe LavinMQ::VHost do
   it "should respect priority" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      vhost.queues["test2"] = LavinMQ::AMQP::Queue.new(vhost, "test")
+      vhost.queues["test2"] = LavinMQ::QueueFactory.make(vhost, "test")
       vhost.add_policy("ml2", "^.*$", "queues", defs, 1_i8)
       vhost.add_policy("ml1", "^.*$", "queues", defs, 0_i8)
       sleep 10.milliseconds
@@ -280,7 +280,7 @@ describe LavinMQ::VHost do
                               "federation-upstream", "federation-upstream-set",
                               "delivery-limit", "max-age", "alternate-exchange",
                               "delayed-message"}
-        vhost.queues["test"] = LavinMQ::AMQP::Queue.new(vhost, "test")
+        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
         vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
         sleep 10.milliseconds
         vhost.queues["test"].details_tuple[:effective_policy_definition].as(Hash(String, JSON::Any)).each_key do |k|
@@ -310,8 +310,8 @@ describe LavinMQ::VHost do
 
     it "should use the lowest value" do
       PoliciesSpec.with_vhost do |vhost|
-        vhost.queues["test1"] = LavinMQ::AMQP::Queue.new(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64}))
-        vhost.queues["test2"] = LavinMQ::AMQP::Queue.new(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64}))
+        vhost.queues["test1"] = LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64}))
+        vhost.queues["test2"] = LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64}))
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
         vhost.queues["test1"].as(LavinMQ::AMQP::Queue).@max_length.should eq 1
@@ -325,9 +325,9 @@ describe LavinMQ::VHost do
 
     it "should use the lowest value for delivery-limit" do
       PoliciesSpec.with_vhost do |vhost|
-        vhost.queues["test1"] = LavinMQ::AMQP::Queue.new(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 1_i64}))
-        vhost.queues["test2"] = LavinMQ::AMQP::Queue.new(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 11_i64}))
-        vhost.queues["test3"] = LavinMQ::AMQP::Queue.new(vhost, "test3")
+        vhost.queues["test1"] = LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 1_i64}))
+        vhost.queues["test2"] = LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 11_i64}))
+        vhost.queues["test3"] = LavinMQ::QueueFactory.make(vhost, "test3")
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
         vhost.queues["test1"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1

--- a/spec/queue_factory_spec.cr
+++ b/spec/queue_factory_spec.cr
@@ -72,14 +72,44 @@ describe LavinMQ::QueueFactory do
         end
       end
 
-      # Argument name, {valid values}, {invalid values}
+      # {Argument name, {valid values}, {invalid values}}
       matrix = {
-        {"x-expires", {1, 10}, {0, -1}},
-        {"x-max-length", {0, 10}, {-1, -10}},
-        {"x-max-length-bytes", {0, 10}, {-1, -10}},
-        {"x-message-ttl", {0, 10}, {-1, -10}},
-        {"x-delivery-limit", {0, 10}, {-1, -10}},
-        {"x-consumer-timeout", {0, 10}, {-1, -10}},
+        {"x-expires",
+         {1, 10},
+         {0, -1, "str", true}},
+        {"x-max-length",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-max-length-bytes",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-message-ttl",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-delivery-limit",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-consumer-timeout",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-cache-size",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-cache-ttl",
+         {0, 10},
+         {-1, -10, "str", true}},
+        {"x-dead-letter-exchange",
+         {"str", ""},
+         {1, -10, true}},
+        {"x-dead-letter-routing-key",
+         {"str", ""},
+         {1, -10, true}},
+        {"x-overflow",
+         {"str", ""},
+         {1, -10, true}},
+        {"x-deduplication-header",
+         {"str", ""},
+         {1, -10, true}},
       }
 
       matrix.each do |header, valid, invalid|

--- a/spec/queue_factory_spec.cr
+++ b/spec/queue_factory_spec.cr
@@ -29,6 +29,20 @@ describe LavinMQ::QueueFactory do
         q = LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args, durable: true)
         q.is_a?(LavinMQ::AMQP::PriorityQueue).should be_true
       end
+
+      it "should reject x-max-priority < 0" do
+        queue_args = AMQ::Protocol::Table.new({"x-max-priority": -1})
+        expect_raises(LavinMQ::Error::PreconditionFailed) do
+          LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args)
+        end
+      end
+
+      it "should reject x-max-priority > 255" do
+        queue_args = AMQ::Protocol::Table.new({"x-max-priority": 256})
+        expect_raises(LavinMQ::Error::PreconditionFailed) do
+          LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args)
+        end
+      end
     end
 
     describe "with x-queue-type=stream" do

--- a/spec/queue_factory_spec.cr
+++ b/spec/queue_factory_spec.cr
@@ -2,72 +2,75 @@ require "amq-protocol"
 require "./spec_helper"
 
 describe LavinMQ::QueueFactory do
-  it "should create a non_durable queue" do
-    with_amqp_server do |s|
-      durable = false
-      queue_args = AMQ::Protocol::Table.new({"t" => 1})
-      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-        false, false, queue_args)
-      q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
-      q.is_a?(LavinMQ::Queue).should be_true
-    end
-  end
+  with_amqp_server do |s|
+    vhost = s.vhosts["/"]
 
-  it "should create a durable queue" do
-    with_amqp_server do |s|
-      durable = true
-      queue_args = AMQ::Protocol::Table.new({"t" => 1})
-      frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-        false, false, queue_args)
-      q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
-      q.is_a?(LavinMQ::AMQP::DurableQueue).should be_true
-    end
-  end
+    describe "without x-queue-type" do
+      it "should create a non_durable queue" do
+        q = LavinMQ::QueueFactory.make(vhost, "q1", durable: false)
+        q.is_a?(LavinMQ::Queue).should be_true
+      end
 
-  describe "priority queues" do
-    it "should create a non_durable queue" do
-      with_amqp_server do |s|
-        durable = false
-        queue_args = AMQ::Protocol::Table.new({"x-max-priority" => 1})
-        frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-          false, false, queue_args)
-        q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+      it "should create a durable queue" do
+        q = LavinMQ::QueueFactory.make(s.vhosts["/"], "q1", durable: true)
+        q.is_a?(LavinMQ::AMQP::DurableQueue).should be_true
+      end
+    end
+
+    describe "with x-max-priority" do
+      it "should create a non_durable priority queue" do
+        queue_args = AMQ::Protocol::Table.new({"x-max-priority": 1})
+        q = LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args, durable: false)
+        q.is_a?(LavinMQ::AMQP::PriorityQueue).should be_true
+      end
+
+      it "should create a durable queue" do
+        queue_args = AMQ::Protocol::Table.new({"x-max-priority": 1})
+        q = LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args, durable: true)
         q.is_a?(LavinMQ::AMQP::PriorityQueue).should be_true
       end
     end
 
-    it "should create a durable queue" do
-      with_amqp_server do |s|
-        durable = true
-        queue_args = AMQ::Protocol::Table.new({"x-max-priority" => 1})
-        frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, durable, false,
-          false, false, queue_args)
-        q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
-        q.is_a?(LavinMQ::AMQP::DurablePriorityQueue).should be_true
-      end
-    end
-
-    it "should create a stream queue" do
-      with_amqp_server do |s|
-        queue_args = AMQ::Protocol::Table.new({"x-queue-type" => "stream"})
-        frame = AMQ::Protocol::Frame::Method::Queue::Declare.new(0, 0, "test", false, true, false,
-          false, false, queue_args)
-        q = LavinMQ::QueueFactory.make(s.vhosts["/"], frame)
+    describe "with x-queue-type=stream" do
+      it "should create a stream queue" do
+        queue_args = AMQ::Protocol::Table.new({"x-queue-type": "stream"})
+        q = LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args)
         q.should be_a LavinMQ::AMQP::Stream
       end
+
+      it "should reject if exclusive" do
+        queue_args = AMQ::Protocol::Table.new({"x-queue-type": "stream"})
+        expect_raises(LavinMQ::Error::PreconditionFailed) do
+          LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args, exclusive: true)
+        end
+      end
+
+      it "should reject if auto-delete" do
+        queue_args = AMQ::Protocol::Table.new({"x-queue-type": "stream"})
+        expect_raises(LavinMQ::Error::PreconditionFailed) do
+          LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args, auto_delete: true)
+        end
+      end
+
+      it "should reject x-max-priority argument" do
+        queue_args = AMQ::Protocol::Table.new({
+          "x-queue-type":   "stream",
+          "x-max-priority": 10,
+        })
+        expect_raises(LavinMQ::Error::PreconditionFailed) do
+          LavinMQ::QueueFactory.make(vhost, "q1", arguments: queue_args, durable: true)
+        end
+      end
     end
-  end
 
-  describe "amqp argument" do
-    with_amqp_server do |s|
-      vhost = s.vhosts["/"]
-
+    describe "amqp argument" do
       describe "x-dead-letter-routing-key" do
         it "is rejected if x-dead-letter-exchange is missing" do
-          arguments = LavinMQ::AMQP::Table.new
-          arguments["x-dead-letter-routing-key"] = "a.b.c"
+          queue_args = LavinMQ::AMQP::Table.new({
+            "x-dead-letter-routing-key": "a.b.c",
+          })
           expect_raises(LavinMQ::Error::PreconditionFailed) do
-            LavinMQ::QueueFactory.make vhost, "q1", arguments: arguments
+            LavinMQ::QueueFactory.make vhost, "q1", arguments: queue_args
           end
         end
       end
@@ -102,7 +105,7 @@ describe LavinMQ::QueueFactory do
          {"str", ""},
          {1, -10, true}},
         {"x-dead-letter-routing-key",
-         {"str", ""},
+         Tuple.new, # can't test valid values because x-dead-letter-exchange is required too
          {1, -10, true}},
         {"x-overflow",
          {"str", ""},
@@ -115,19 +118,19 @@ describe LavinMQ::QueueFactory do
       matrix.each do |header, valid, invalid|
         describe header do
           valid.each do |value|
-            it "is accepted when #{value}" do
-              arguments = LavinMQ::AMQP::Table.new
-              arguments[header] = value
-              q = LavinMQ::QueueFactory.make vhost, "q1", arguments: arguments
+            it "is accepted when '#{value}'" do
+              queue_args = LavinMQ::AMQP::Table.new
+              queue_args[header] = value
+              q = LavinMQ::QueueFactory.make vhost, "q1", arguments: queue_args
               q.should be_a(LavinMQ::Queue)
             end
           end
           invalid.each do |value|
-            it "is rejected when #{value}" do
-              arguments = LavinMQ::AMQP::Table.new
-              arguments[header] = value
+            it "is rejected when '#{value}'" do
+              queue_args = LavinMQ::AMQP::Table.new
+              queue_args[header] = value
               expect_raises(LavinMQ::Error::PreconditionFailed) do
-                LavinMQ::QueueFactory.make vhost, "q1", arguments: arguments
+                LavinMQ::QueueFactory.make vhost, "q1", arguments: queue_args
               end
             end
           end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -21,9 +21,11 @@ describe LavinMQ::AMQP::Queue do
   it "Should dead letter expired messages" do
     with_amqp_server do |s|
       with_channel(s) do |ch|
+        puts "BEFORE QUEUE"
         q = ch.queue("ttl", args: AMQP::Client::Arguments.new(
           {"x-message-ttl" => 1, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "dlq"}
         ))
+        puts "AFTER QUEUE"
         dlq = ch.queue("dlq")
         x = ch.default_exchange
         x.publish_confirm("ttl", q.name)

--- a/spec/support/queue_factory.cr
+++ b/spec/support/queue_factory.cr
@@ -1,0 +1,25 @@
+module LavinMQ
+  class QueueFactory
+    def self.make(
+      vhost : VHost,
+      name : String,
+      exclusive : Bool = false,
+      auto_delete : Bool = false,
+      durable : Bool = true,
+      arguments : AMQP::Table = AMQP::Table.new,
+    )
+      frame = AMQP::Frame::Queue::Declare.new(
+        1u16,
+        0u16,
+        name,
+        passive: false,
+        durable: durable,
+        exclusive: exclusive,
+        auto_delete: auto_delete,
+        no_wait: true,
+        arguments: arguments
+      )
+      self.make(vhost, frame)
+    end
+  end
+end

--- a/src/lavinmq/amqp/argument_validator.cr
+++ b/src/lavinmq/amqp/argument_validator.cr
@@ -15,13 +15,11 @@ module LavinMQ
         raise LavinMQ::Error::PreconditionFailed.new(msg)
       end
 
-      struct DeadLetterRoutingKeyValidator
+      struct DeadLetteringValidator
         include ArgumentValidator
 
         def validate!(header : String, value : AMQP::Field, arguments) : Nil
           return if value.nil?
-          puts "VALIDATE #{caller}"
-          sleep 2.seconds
           dlrk = value.as?(String)
           raise_invalid!("#{header} header not a string") if dlrk.nil?
           dlx = arguments["x-dead-letter-exchange"]?.try &.as?(String)
@@ -32,6 +30,7 @@ module LavinMQ
         end
       end
 
+      # Validates that value is an Int and optionally greater and/or smaller than given valuea
       struct IntValidator
         include ArgumentValidator
 

--- a/src/lavinmq/amqp/argument_validator.cr
+++ b/src/lavinmq/amqp/argument_validator.cr
@@ -1,0 +1,75 @@
+module LavinMQ
+  module AMQP
+    module ArgumentValidator
+      # Most validators only requires header and value...
+      def validate!(header : String, value : AMQP::Field) : Nil
+        raise NotImplementedError.new("validate! must be implemented in #{self.class}")
+      end
+
+      # ...but if they need arguments this method can be overloaded
+      def validate!(header : String, value : AMQP::Field, arguments) : Nil
+        validate!(header, value)
+      end
+
+      def raise_invalid!(msg)
+        raise LavinMQ::Error::PreconditionFailed.new(msg)
+      end
+
+      struct DeadLetterRoutingKeyValidator
+        include ArgumentValidator
+
+        def validate!(header : String, value : AMQP::Field, arguments) : Nil
+          return if value.nil?
+          puts "VALIDATE #{caller}"
+          sleep 2.seconds
+          dlrk = value.as?(String)
+          raise_invalid!("#{header} header not a string") if dlrk.nil?
+          dlx = arguments["x-dead-letter-exchange"]?.try &.as?(String)
+          if dlx.nil?
+            raise_invalid!("x-dead-letter-exchange required if x-dead-letter-routing-key is defined")
+          end
+          nil
+        end
+      end
+
+      struct IntValidator
+        include ArgumentValidator
+
+        def initialize(@min_value : Int32? = nil, @max_value : Int32? = nil)
+        end
+
+        def validate!(header : String, value : AMQP::Field) : Nil
+          return if value.nil?
+          int_value = value.as?(Int) || raise_invalid!("#{header} header not an integer")
+          if (min_value = @min_value) && int_value < min_value
+            raise_invalid!("#{header} header less than minimum value #{min_value}")
+          end
+          if (max_value = @max_value) && int_value > max_value
+            raise_invalid!("#{header} header greater than maximum value #{max_value}")
+          end
+          nil
+        end
+      end
+
+      struct StringValidator
+        include ArgumentValidator
+
+        def validate!(header : String, value : AMQP::Field) : Nil
+          return if value.nil?
+          value.as?(String) || raise_invalid!("#{header} header not a string")
+          nil
+        end
+      end
+
+      struct BoolValidator
+        include ArgumentValidator
+
+        def validate!(header : String, value : AMQP::Field) : Nil
+          return if value.nil?
+          value.as?(Bool) || raise_invalid!("#{header} header not a boolean")
+          nil
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/amqp/argument_validator.cr
+++ b/src/lavinmq/amqp/argument_validator.cr
@@ -18,12 +18,17 @@ module LavinMQ
       struct DeadLetteringValidator
         include ArgumentValidator
 
+        @dlx : String?
+
+        def initialize(arguments : AMQP::Table)
+          @dlx = arguments["x-dead-letter-exchange"]?.try &.as?(String)
+        end
+
         def validate!(header : String, value : AMQP::Field, arguments) : Nil
           return if value.nil?
           dlrk = value.as?(String)
           raise_invalid!("#{header} header not a string") if dlrk.nil?
-          dlx = arguments["x-dead-letter-exchange"]?.try &.as?(String)
-          if dlx.nil?
+          if @dlx.nil?
             raise_invalid!("x-dead-letter-exchange required if x-dead-letter-routing-key is defined")
           end
           nil

--- a/src/lavinmq/amqp/queue/durable_queue.cr
+++ b/src/lavinmq/amqp/queue/durable_queue.cr
@@ -2,6 +2,13 @@ require "./queue"
 
 module LavinMQ::AMQP
   class DurableQueue < Queue
+    def self.create(vhost : VHost, name : String,
+                    exclusive : Bool = false, auto_delete : Bool = false,
+                    arguments : AMQP::Table = AMQP::Table.new)
+      self.validate_arguments!(arguments)
+      new vhost, name, exclusive, auto_delete, arguments
+    end
+
     def durable?
       true
     end

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -21,7 +21,7 @@ module LavinMQ::AMQP
       @wfile_id = 0
       @rfile_id = 0
 
-      def initialize(
+      protected def initialize(
         @max_priority : UInt8,
         @msg_dir : String,
         @replicator : Clustering::Replicator?,

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -2,6 +2,24 @@ require "./durable_queue"
 
 module LavinMQ::AMQP
   class PriorityQueue < Queue
+    def self.create(vhost : VHost, name : String,
+                    exclusive : Bool = false, auto_delete : Bool = false,
+                    arguments : AMQP::Table = AMQP::Table.new)
+      self.validate_arguments!(arguments)
+      new vhost, name, exclusive, auto_delete, arguments
+    end
+
+    def self.validate_arguments!(arguments)
+      int_zero_255 = ArgumentValidator::IntValidator.new(min_value: 0, max_value: 255)
+      if value = arguments["x-max-priority"]?
+        int_zero_255.validate!("x-max-priority", value)
+      else
+        # should never end up here
+        raise LavinMQ::Error::PreconditionFailed.new("x-max-priority argument is required for priority queues")
+      end
+      super
+    end
+
     private def handle_arguments
       super
       @effective_args << "x-max-priority"
@@ -196,6 +214,13 @@ module LavinMQ::AMQP
   end
 
   class DurablePriorityQueue < PriorityQueue
+    def self.create(vhost : VHost, name : String,
+                    exclusive : Bool = false, auto_delete : Bool = false,
+                    arguments : AMQP::Table = AMQP::Table.new)
+      self.validate_arguments!(arguments)
+      new vhost, name, exclusive, auto_delete, arguments
+    end
+
     def durable?
       true
     end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -136,9 +136,9 @@ module LavinMQ::AMQP
     @metadata : ::Log::Metadata
     @deduper : Deduplication::Deduper?
 
-    def initialize(@vhost : VHost, @name : String,
-                   @exclusive : Bool = false, @auto_delete : Bool = false,
-                   @arguments : AMQP::Table = AMQP::Table.new)
+    protected def initialize(@vhost : VHost, @name : String,
+                             @exclusive : Bool = false, @auto_delete : Bool = false,
+                             @arguments : AMQP::Table = AMQP::Table.new)
       @data_dir = make_data_dir
       @metadata = ::Log::Metadata.new(nil, {queue: @name, vhost: @vhost.name})
       @log = Logger.new(Log, @metadata)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -15,6 +15,7 @@ require "../../message_store"
 require "../../unacked_message"
 require "../../deduplication"
 require "../../bool_channel"
+require "../argument_validator"
 
 module LavinMQ::AMQP
   class Queue < LavinMQ::Queue
@@ -22,6 +23,44 @@ module LavinMQ::AMQP
     include Observable(QueueEvent)
     include Stats
     include SortableJSON
+
+    def self.validate_arguments!(arguments : AMQP::Table)
+      int_zero = ArgumentValidator::IntValidator.new(min_value: 0)
+      int_one = ArgumentValidator::IntValidator.new(min_value: 1)
+      string = ArgumentValidator::StringValidator.new
+      bool = ArgumentValidator::BoolValidator.new
+      dlrk_validator = ArgumentValidator::DeadLetterRoutingKeyValidator.new
+
+      headers = {
+        "x-dead-letter-exchange":    string,
+        "x-dead-letter-routing-key": dlrk_validator,
+        "x-expires":                 int_one,
+        "x-max-length":              int_zero,
+        "x-max-length-bytes":        int_zero,
+        "x-message-ttl":             int_zero,
+        "x-overflow":                string,
+        "x-delivery-limit":          int_zero,
+        "x-consumer-timeout":        int_zero,
+        "x-single-active-consumer":  bool,
+        "x-message-deduplication":   bool,
+        "x-cache-size":              int_zero,
+        "x-cache-ttl":               int_zero,
+        "x-deduplication-header":    string,
+      }
+
+      arguments.each do |k, v|
+        if validator = headers[k]?
+          validator.validate!(k, v, arguments)
+        end
+      end
+    end
+
+    def self.create(vhost : VHost, name : String,
+                    exclusive : Bool = false, auto_delete : Bool = false,
+                    arguments : AMQP::Table = AMQP::Table.new)
+      self.validate_arguments!(arguments)
+      new vhost, name, exclusive, auto_delete, arguments
+    end
 
     @message_ttl : Int64?
     @max_length : Int64?
@@ -299,12 +338,6 @@ module LavinMQ::AMQP
     private macro parse_header(header, type)
       if value = @arguments["{{ header.id }}"]?
         value.as?({{ type }}) || raise LavinMQ::Error::PreconditionFailed.new("{{ header.id }} header not a {{ type.id }}")
-      end
-    end
-
-    private def validate_arguments
-      if @dlrk && @dlx.nil?
-        raise LavinMQ::Error::PreconditionFailed.new("x-dead-letter-exchange required if x-dead-letter-routing-key is defined")
       end
     end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -29,10 +29,11 @@ module LavinMQ::AMQP
       int_one = ArgumentValidator::IntValidator.new(min_value: 1)
       string = ArgumentValidator::StringValidator.new
       bool = ArgumentValidator::BoolValidator.new
+      dlrk = ArgumentValidator::DeadLetteringValidator.new(arguments)
 
       headers = {
         "x-dead-letter-exchange":    string,
-        "x-dead-letter-routing-key": string,
+        "x-dead-letter-routing-key": dlrk,
         "x-expires":                 int_one,
         "x-max-length":              int_zero,
         "x-max-length-bytes":        int_zero,
@@ -51,12 +52,6 @@ module LavinMQ::AMQP
         if validator = headers[k]?
           validator.validate!(k, v, arguments)
         end
-      end
-
-      if value = arguments["x-dead-letter-routing-key"]?
-        key = "x-dead-letter-routing-key"
-        validator = ArgumentValidator::DeadLetteringValidator.new
-        validator.validate!(key, value, arguments)
       end
     end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -29,11 +29,10 @@ module LavinMQ::AMQP
       int_one = ArgumentValidator::IntValidator.new(min_value: 1)
       string = ArgumentValidator::StringValidator.new
       bool = ArgumentValidator::BoolValidator.new
-      dlrk_validator = ArgumentValidator::DeadLetterRoutingKeyValidator.new
 
       headers = {
         "x-dead-letter-exchange":    string,
-        "x-dead-letter-routing-key": dlrk_validator,
+        "x-dead-letter-routing-key": string,
         "x-expires":                 int_one,
         "x-max-length":              int_zero,
         "x-max-length-bytes":        int_zero,
@@ -52,6 +51,12 @@ module LavinMQ::AMQP
         if validator = headers[k]?
           validator.validate!(k, v, arguments)
         end
+      end
+
+      if value = arguments["x-dead-letter-routing-key"]?
+        key = "x-dead-letter-routing-key"
+        validator = ArgumentValidator::DeadLetteringValidator.new
+        validator.validate!(key, value, arguments)
       end
     end
 

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -7,11 +7,10 @@ module LavinMQ::AMQP
     def self.create(vhost : VHost, name : String,
                     exclusive : Bool = false, auto_delete : Bool = false,
                     arguments : AMQP::Table = AMQP::Table.new)
-      self.validate_arguments!(arguments)
-
       if arguments.has_key?("x-max-priority")
         raise LavinMQ::Error::PreconditionFailed.new("A queue cannot be both a priority queue and a stream")
       end
+      self.validate_arguments!(arguments)
       new vhost, name, exclusive, auto_delete, arguments
     end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -8,10 +8,10 @@ module LavinMQ
       include SortableJSON
       Log = ::LavinMQ::Log.for "mqtt.session"
 
-      def initialize(@vhost : VHost,
-                     @name : String,
-                     @auto_delete = false,
-                     arguments : ::AMQ::Protocol::Table = AMQP::Table.new)
+      protected def initialize(@vhost : VHost,
+                               @name : String,
+                               @auto_delete = false,
+                               arguments : ::AMQ::Protocol::Table = AMQP::Table.new)
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
 

--- a/src/lavinmq/queue_factory.cr
+++ b/src/lavinmq/queue_factory.cr
@@ -7,13 +7,9 @@ require "./mqtt/session"
 module LavinMQ
   class QueueFactory
     def self.make(vhost : VHost, frame : AMQP::Frame)
-      if prio_queue?(frame) && stream_queue?(frame)
-        raise Error::PreconditionFailed.new("A queue cannot be both a priority queue and a stream")
-      end
       if mqtt_session?(frame)
         MQTT::Session.new(vhost, frame.queue_name, frame.auto_delete, frame.arguments)
       else
-        validate_amqp_arguments!(frame.arguments)
         if frame.durable
           make_durable(vhost, frame)
         else
@@ -24,87 +20,47 @@ module LavinMQ
 
     private def self.make_durable(vhost, frame)
       if prio_queue? frame
-        AMQP::DurablePriorityQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
+        AMQP::DurablePriorityQueue.create(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       elsif stream_queue? frame
         if frame.exclusive
           raise Error::PreconditionFailed.new("A stream cannot be exclusive")
         elsif frame.auto_delete
           raise Error::PreconditionFailed.new("A stream cannot be auto-delete")
         end
-        AMQP::Stream.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
+        AMQP::Stream.create(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       else
         warn_if_unsupported_queue_type frame
-        AMQP::DurableQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
+        AMQP::DurableQueue.create(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       end
     end
 
     private def self.make_queue(vhost, frame)
       if prio_queue? frame
-        AMQP::PriorityQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
+        AMQP::PriorityQueue.create(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       elsif stream_queue? frame
         raise Error::PreconditionFailed.new("A stream cannot be non-durable")
       else
         warn_if_unsupported_queue_type frame
-        AMQP::Queue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
+        AMQP::Queue.create(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments)
       end
     end
 
     private def self.prio_queue?(frame) : Bool
-      if value = frame.arguments["x-max-priority"]?
-        p_value = value.as?(Int) || raise Error::PreconditionFailed.new("x-max-priority must be an int")
-        0 <= p_value <= 255 || raise Error::PreconditionFailed.new("x-max-priority must be between 0 and 255")
-      else
-        false
-      end
+      frame.arguments["x-max-priority"]? != nil
     end
 
     private def self.stream_queue?(frame) : Bool
       frame.arguments["x-queue-type"]? == "stream"
     end
 
-    private def self.warn_if_unsupported_queue_type(frame)
-      if frame.arguments["x-queue-type"]?
-        Log.info { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will be changed to the default queue type" }
-      end
-    end
-
     private def self.mqtt_session?(frame) : Bool
       frame.arguments["x-queue-type"]? == "mqtt"
     end
 
-    private def self.validate_amqp_arguments!(arguments : AMQP::Table) : Nil
-      dlrk = arguments["x-dead-letter-routing-key"]?.try &.as?(String)
-      dlx = arguments["x-dead-letter-exchange"]?.try &.as?(String)
-      if dlrk && dlx.nil?
-        raise LavinMQ::Error::PreconditionFailed.new("x-dead-letter-exchange required if x-dead-letter-routing-key is defined")
+    private def self.warn_if_unsupported_queue_type(frame)
+      if frame.arguments["x-queue-type"]?
+        Log.info { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will be changed to the default queue type" }
       end
-      validate_number(arguments, "x-expires", 1)
-      validate_number(arguments, "x-max-length")
-      validate_number(arguments, "x-max-length-bytes")
-      validate_number(arguments, "x-message-ttl")
-      validate_number(arguments, "x-delivery-limit")
-      validate_number(arguments, "x-consumer-timeout")
-    end
-
-    private def self.validate_number(headers, header, min_value = 0)
-      value = headers[header]?.try &.as?(Int)
-      if min_value == 0
-        validate_positive(header, value)
-      else
-        validate_gt_zero(header, value)
-      end
-    end
-
-    private def self.validate_positive(header, value) : Nil
-      return if value.nil?
-      return if value >= 0
-      raise LavinMQ::Error::PreconditionFailed.new("#{header} has to be positive")
-    end
-
-    private def self.validate_gt_zero(header, value) : Nil
-      return if value.nil?
-      return if value > 0
-      raise LavinMQ::Error::PreconditionFailed.new("#{header} has to be larger than 0")
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR refactors queue creations and removes all(?) exceptions thrown from constructors because of invalid arguments.

The main reason for this was to get rid of a BoolChannel memory leak, but instead of doing a workaround I took the long path of refactoring more.

I'm not super happy with the code, but I think it's better than before.

It tries to move all argument validation into each queue type, instead of having some in the queue and some in the queue factory. 

### HOW can this pull request be tested?
Specs cover it, I think
