### PR TITLE
handle exceptions during http get and reject any unacked messages

### DIFF
--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -211,6 +211,14 @@ module LavinMQ
                     q.reject(sp, requeue)
                   end
                 end
+              rescue e : Exception
+                # Requeue all unacked messages on error
+                if unacked_sps = sps
+                  unacked_sps.each do |sp|
+                    q.reject(sp, true)
+                  end
+                end
+                raise e
               end
             end
           end


### PR DESCRIPTION
### WHAT is this pull request doing?
If an error occurs while getting multiple messages via HTTP, the messages can be unacked without being properly delivered. This changes the behavior to rescue any exception during delivery and reject the messages. 

### HOW can this pull request be tested?
Run spec
