### PR TITLE
Crystal 1.18.0 compatibility

### DIFF
--- a/src/stdlib/web_socket.cr
+++ b/src/stdlib/web_socket.cr
@@ -1,0 +1,8 @@
+require "http/web_socket"
+
+class HTTP::WebSocket
+  def send(message : Bytes) : Nil
+    check_open
+    @ws.send(message)
+  end
+end


### PR DESCRIPTION
`HTTP::WebSocket#send(message : Bytes)` was missing, this adds it back.