### PR TITLE
Fix ubuntu-24.04 build

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 export DH_VERBOSE=1
 export DEB_BUILD_OPTIONS += nostrip
+export TZ=UTC
 
 %:
 	dh $@


### PR DESCRIPTION
### WHAT is this pull request doing?
adds `export TZ=UTC` to fix the builds for Ubuntu-24.04

### HOW can this pull request be tested?
Make sure builds work
