### PR TITLE
use set_blocking instead of constructor

### DIFF
--- a/src/lavinmq/mfile.cr
+++ b/src/lavinmq/mfile.cr
@@ -168,7 +168,8 @@ class MFile < IO
   def copy_to(output : IO, size = @size) : Int64
     if unmapped? # don't remap unmapped files
       raise ClosedError.new if @fd < 0
-      io = IO::FileDescriptor.new(@fd, blocking: true, close_on_finalize: false)
+      io = IO::FileDescriptor.new(@fd, close_on_finalize: false)
+      IO::FileDescriptor.set_blocking(@fd, true)
       io.rewind
       IO.copy(io, output, size) == size || raise IO::EOFError.new
     else


### PR DESCRIPTION
### WHAT is this pull request doing?
Crystal 1.18.0 deprecation. 
Fixes build warning.

This is for 2.4.x!

### HOW can this pull request be tested?
Make sure builds & spec run
