### PR TITLE
Use correct variable to prevent channel error and reconnect

### DIFF
--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -378,7 +378,7 @@ module LavinMQ
           ch, consumer_ex = try_passive(upstream_client, ch) do |uch, passive|
             ex = uch.exchange(@upstream_q, type: "x-federation-upstream",
               args: args2, passive: passive)
-            ch.queue_bind(@upstream_q, @upstream_q, routing_key: "")
+            uch.queue_bind(@upstream_q, @upstream_q, routing_key: "")
             ex
           end
           @federated_ex.register_observer(self)


### PR DESCRIPTION
### WHAT is this pull request doing?
While debugging upstream specs I noticed an error being logged. It turned out to be the wrong variable being used.

If the upstream exchange doesn't exists the `try_passive` will yield the block again with a new channel, but `queue_bind` used the previous channel that has been closed.

Federation still worked because the link will reconnect and start over, and then the block won't be evaluated twice because the exchange exists.

### HOW can this pull request be tested?
No specs testing testing this bug, but this doesn't change any behavior so existing specs should be enough.
