### PR TITLE
Less scary logging if cleaning up upstream resources fails

### DIFF
--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -350,6 +350,8 @@ module LavinMQ
             ch = c.channel
             ch.queue_delete(@upstream_q)
             ch.exchange_delete(@upstream_q)
+          rescue ex : ::AMQP::Client::Error
+            @log.warn { "Failed to clean up upstream resources: #{ex.message}" }
           end
         rescue e
           @log.warn(e) { "cleanup interrupted " }


### PR DESCRIPTION
### WHAT is this pull request doing?
When an exchange link is terminated it tries to cleanup upstream resources by connecting and deleting them.

This will handle `AMQP::Client::Errors` and log them as warnings, instead of them being logged as an error with a backtrace. I don't think there is any better way of handling them.

### HOW can this pull request be tested?
Nothing to test, really. Stopping the upstream broker then terminating the upstream will probably trigger the logging.
