### PR TITLE
Flaky etcd spec - wait a little longer for Lease::Lost

### DIFF
--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -197,12 +197,12 @@ class EtcdCluster
     end
   end
 
-  def start_process(port, i)
+  def start_process(port, node_number)
     initial_cluster = @ports.map_with_index { |p, i| "l#{i}=http://127.0.0.1:24#{p}" }.join(",")
-    FileUtils.rm_rf "/tmp/l#{i}.etcd"
+    FileUtils.rm_rf "/tmp/l#{node_number}.etcd"
     Process.new("etcd", {
-      "--name=l#{i}",
-      "--data-dir=/tmp/l#{i}.etcd",
+      "--name=l#{node_number}",
+      "--data-dir=/tmp/l#{node_number}.etcd",
       "--listen-peer-urls=http://127.0.0.1:24#{port}",
       "--listen-client-urls=http://127.0.0.1:23#{port}",
       "--advertise-client-urls=http://127.0.0.1:23#{port}",


### PR DESCRIPTION
### WHAT is this pull request doing?
In some cases (seems to depend on which etcd node we are connected to and which etcd nodes we kill) it takes slightly more than 15s for the lease to expire, resulting in a flaky spec. This should (hopefully) make the spec more robust. 

Also try to restart etcd a few times if it doesn't start correctly

Fixes #1401 

### HOW can this pull request be tested?
Run the spec `will lose leadership when loosing quorum`
