### PR TITLE
Log `info` instead of `warning` on passive declare

### DIFF
--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -510,7 +510,6 @@ module LavinMQ
         close_channel(frame, ChannelReplyCode::NOT_FOUND, text)
       end
 
-
       def send_resource_locked(frame, text)
         @log.warn { "Resource locked channel=#{frame.channel} reason=\"#{text}\"" }
         close_channel(frame, ChannelReplyCode::RESOURCE_LOCKED, text)


### PR DESCRIPTION
### WHAT is this pull request doing?
This adds `send_passive_not_found` that logs at `info` level instead of `warn` level (as in `send_not_found`). I went for adding a new method  instead of adding an if statement to `send_not_found`. This way we don't need to check `frame.passive` twice. 

Fixes #1375 

### HOW can this pull request be tested?
declare a queue or exchange passively and observe that there are no warning logs, instead there are info logs. 
