### PR TITLE
Stream consumer - Flush socket only when delivery_loop would block 

### DIFF
--- a/src/lavinmq/amqp/stream/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream/stream_consumer.cr
@@ -134,6 +134,7 @@ module LavinMQ
       private def wait_for_queue_ready
         if @offset > stream_queue.last_offset && @requeued.empty?
           @log.debug { "Waiting for queue not to be empty" }
+          flush
           select
           when @new_message_available.when_true.receive
             @log.debug { "Queue is not empty - new message notification received" }


### PR DESCRIPTION
### WHAT is this pull request doing?
wait_for_queue_ready in stream_consumer should flush to socket, to match the behavior added in https://github.com/cloudamqp/lavinmq/commit/29ab3436b7ae95a4c283651d5e16be7c4ff0f108

### HOW can this pull request be tested?
.
