### PR TITLE
Handle AMQPLAIN authentication without required keys

### DIFF
--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -101,7 +101,9 @@ module LavinMQ
         when "AMQPLAIN"
           io = ::IO::Memory.new(start_ok.response)
           tbl = AMQP::Table.from_io(io, ::IO::ByteFormat::NetworkEndian, io.bytesize.to_u32)
-          {tbl["LOGIN"].as(String), tbl["PASSWORD"].as(String)}
+          user = tbl["LOGIN"]?.as(String?) || ""
+          password = tbl["PASSWORD"]?.as(String?) || ""
+          {user, password}
         else raise "Unsupported authentication mechanism: #{start_ok.mechanism}"
         end
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -127,7 +127,7 @@ module LavinMQ
         conn_info = extract_conn_info(client)
         handle_connection(client, conn_info, protocol)
       rescue ex
-        Log.warn(exception: ex) { "Error accepting connection from #{remote_address}" }
+        Log.warn { "Error accepting connection from #{remote_address}: #{ex.message}" }
         client.close rescue nil
       end
     end


### PR DESCRIPTION
AMQPLAIN is an uncommon alternative to passing credentials in the Start frame. There the response is an AMQP Table, that should include LOGIN and PASSWORD key/values.

Noticed that amqplib client doesn't set a default username/password, and in that case don't send a LOGIN/PASSWORD at all. This handles that case and doesn't raise, but still allow empty passwords.