### PR TITLE
automatically set --prerelease flag if tag includes alpha|beta|rc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,13 @@ jobs:
           fetch-depth: 0
 
       - name: Create Release
-        run: gh release create "${{ github.ref }}" --notes "$(./.github/generate-release-notes)"
+        run: |
+          VERSION="${{ github.ref_name }}"
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" =~ (alpha|beta|rc) ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "${{ github.ref }}" --notes "$(./.github/generate-release-notes)" $PRERELEASE_FLAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Automatically tag releases as pre-release if they have `alpha`, `beta` or `rc` in the name, so we don't have to remember to do that manually. 

### HOW can this pull request be tested?
Create a new release? 😨 
