### PR TITLE
add limit to the UI for how many messages you can get at once

### DIFF
--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -217,15 +217,9 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
 document.querySelector('#getMessages').addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const count = parseInt(data.get('messages'))
-  if (count < 1 || count > 1000) {
-    window.alert('Please enter a number between 1 and 1000 messages')
-    return
-  }
-
   const url = HTTP.url`api/queues/${vhost}/${queue}/get`
   const body = {
-    count: count,
+    count: parseInt(data.get('messages')),
     ack_mode: data.get('mode'),
     encoding: data.get('encoding'),
     truncate: 50000


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a limit of 1000 to the queue page when getting messages so users don't run into issues. 
fixes #1371 

We truncate the response to max 50kB, so when getting 1000 msgs we are max handling 50MiB. This takes a second to load in. An option could be to truncate the message to the first 10kB, then it will load a bit faster. 
 
### HOW can this pull request be tested?
start up LaivnMQ, enqueue many messages and try to get 0 or more than 1000 msgs