### PR TITLE
Only include livereload.js if flag livereloadjs is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ watch-views:
 .PHONY: dev-ui
 dev-ui:
 	@trap '$(MAKE) clean-views; trap - EXIT' EXIT INT TERM; \
-   $(MAKE) bin/lavinmq CRYSTAL_FLAGS= ; \
+   $(MAKE) bin/lavinmq CRYSTAL_FLAGS=-Dlivereloadjs ; \
 	 $(MAKE) livereload & \
 	 livereload_pid=$$!; \
 	 $(MAKE) -s watch-views; \
@@ -37,7 +37,7 @@ dev-ui:
 static/views/%.html: views/%.ecr $(VIEW_PARTIALS)
 	@mkdir -p static/views
 	@TEMP_FILE=$$(mktemp) && \
-	INPUT=$< crystal run views/_render.cr > $$TEMP_FILE && \
+	INPUT=$< crystal run views/_render.cr -Dlivereloadjs > $$TEMP_FILE && \
 	mv $$TEMP_FILE $@ && \
 	echo "Rendered $< to $@"
 

--- a/views/partials/head.ecr
+++ b/views/partials/head.ecr
@@ -10,6 +10,6 @@
 <link rel="apple-touch-icon" sizes="180x180" href="img/favicon.png">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="google" content="notranslate">
-<%- {% unless flag?(:release) %} -%>
+<%- {% if flag?(:livereloadjs) %} -%>
   <script async src="http://localhost:35629/livereload.js"></script>
 <%- {% end %} -%>


### PR DESCRIPTION
### WHAT is this pull request doing?
Before this PR the livereload.js script tag was added unlessrelease flag wasn't set. This is causing annoying errors in the browser if one haven't started the livereload server.

This PR will change so the flag `livereloadjs` must be set for it to be included.

The make target `dev-ui` will set this flag, also the target for rendering html files. This should be enough for UI development.

### HOW can this pull request be tested?
Manually
