### PR TITLE
Don't crash when reading metadata

### DIFF
--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -490,7 +490,7 @@ module LavinMQ
       raise ex
     rescue ex
       @log.error(exception: ex) { "Metadata file #{metafile} is incorrect" }
-      raise MetadataError.new("Metadata file #{metafile} is incorrect")
+      raise MetadataError.new("Metadata file #{metafile} is incorrect", cause: ex)
     end
 
     private def produce_metadata(seg, mfile)


### PR DESCRIPTION
### WHAT is this pull request doing?
Rescues any errors in `read_metadata_file`, re-raise a `MetadataError` and rescue that in `load_stats_from_segment` so we read data from the segment instead. Should make sure we don't crash when trying to read metadata. 

### HOW can this pull request be tested?
.
