### PR TITLE
Reset segment pos before producing metadata

### DIFF
--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -495,6 +495,7 @@ module LavinMQ
 
     private def produce_metadata(seg, mfile)
       count = 0u32
+      mfile.pos = 4
       loop do
         pos = mfile.pos
         ts = IO::ByteFormat::SystemEndian.decode(Int64, mfile.to_slice(pos, 8))


### PR DESCRIPTION
### WHAT is this pull request doing?
Make sure to reset segment position before producing metadata. The exception added in #1416 doesn't reset the position, so if the exception is raised the position is wrong when we fallback to produce new metadata for the segment.

### HOW can this pull request be tested?
Manually
