### PR TITLE
Don't log `NaNs left` in clustering sync

### DIFF
--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -145,7 +145,7 @@ module LavinMQ
           total_requested_bytes -= file_size
           total_time_taken = (Time.monotonic - start).total_seconds
           bps = (sent_bytes / total_time_taken).round.to_u64
-          time_left = (total_requested_bytes / bps).round(1)
+          time_left = bps > 0 ? (total_requested_bytes / bps).round(1) : 0
           Log.info { "Uploaded #{filename} in #{bps.humanize_bytes}/s" }
           Log.info { "#{total_requested_bytes.humanize_bytes} left, expected #{time_left}s left" }
           Fiber.yield


### PR DESCRIPTION
### WHAT is this pull request doing?
Avoids division by zero if `bps == 0`, and instead just sets `time_left = 0` when calculating time left to sync.

Logs could be like this before: 
`0B left, expected NaNs left`

Now they will be: 
`0B left, expected 0s left`

Fixes #1396 

### HOW can this pull request be tested?
.
