### PR TITLE
Fix: Display error when binding to non-existent exchange/queue

### DIFF
--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -109,6 +109,12 @@ document.querySelector('#addBinding').addEventListener('submit', function (evt) 
       bindingsTable.reload()
       evt.target.reset()
     })
+    .catch(e => {
+      if (e.status === 404) {
+        const type = t === 'q' ? 'Queue' : 'Exchange'
+        DOM.toast(`${type} '${d}' does not exist and needs to be created first.`, 'error')
+      }
+    })
 })
 
 document.querySelector('#publishMessage').addEventListener('submit', function (evt) {

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -192,6 +192,11 @@ document.querySelector('#addBinding').addEventListener('submit', function (evt) 
       evt.target.reset()
       DOM.toast('Exchange ' + e + ' bound to queue')
     })
+    .catch(err => {
+      if (err.status === 404) {
+        DOM.toast(`Exchange '${e}' does not exist and needs to be created first.`, 'error')
+      }
+    })
 })
 
 document.querySelector('#publishMessage').addEventListener('submit', function (evt) {


### PR DESCRIPTION
### WHAT is this pull request doing?

When attempting to bind to a non-existent exchange or queue in the UI, a 404 error was logged to the console but no user-facing error message was shown.

Added catch handlers in exchange.js and queue.js to display a toast notification informing the user that the target exchange/queue does not exist and needs to be created first.

<img width="1613" height="1208" alt="Screenshot 2025-11-03 at 16 18 15" src="https://github.com/user-attachments/assets/445dd56c-bb4e-4690-8556-b68f542f1c1f" />

Fixes #1426

### HOW can this pull request be tested?

Tested locally.