### PR TITLE
Faster GHA macos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
   spec_osx:
     name: Spec OS X
-    runs-on: macos-14
+    runs-on: macos-latest-xlarge
     timeout-minutes: 10
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Newer macOS version, and bigger machine that's hopefully faster and
less flaky.

If CI is green, then maybe this helps. :)