### PR TITLE
set `fail-fast=false` for RPM workflow

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -22,6 +22,7 @@ jobs:
   build_rpm:
     name: Build RPM
     strategy:
+      fail-fast: false
       matrix:
         os: ['fedora-43', 'fedora-42', 'fedora-41', 'el-9']
     runs-on: ubuntu-latest


### PR DESCRIPTION
### WHAT is this pull request doing?
Fedora 43 builds fails because it has not been added to packagecloud dists yet. This makes sure the other RPM builds can continue even though the Fedora 43 build fails. 

### HOW can this pull request be tested?
Make sure RPM workflow works even if Fedora 43 fails. 
