### PR TITLE
Bugfix: Unable to consume from priority queues

### DIFF
--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -163,8 +163,10 @@ module LavinMQ::AMQP
       def shift?(consumer = nil) : Envelope?
         raise ClosedError.new if @closed
         @stores.reverse_each do |s|
-          envelope = s.shift?(consumer)
-          return envelope unless envelope.nil?
+          if envelope = s.shift?(consumer)
+            @empty.set true if size.zero?
+            return envelope
+          end
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes a bug where consumers where unable to consume from priority queues because they where stuck waiting on `empty?` to be false. It would never be false though, because it needs to look at all priority message stores. This adds an override `empty?` method that looks at all stores. 

Fixes #1439 

### HOW can this pull request be tested?
Manual.
