### PR TITLE
Write meta data without buffer

### DIFF
--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -330,15 +330,10 @@ module LavinMQ
       metafile = meta_file_name(wfile)
       @log.debug { "Write message segment meta file #{metafile}" }
       File.open(metafile, "w") do |f|
-        f.buffer_size = 4096
-        write_metadata(f, seg)
-        @replicator.try &.register_file(f)
+        f.sync = true
+        f.write_bytes @segment_msg_count[seg]
       end
       @replicator.try &.replace_file metafile
-    end
-
-    private def write_metadata(io, seg)
-      io.write_bytes @segment_msg_count[seg]
     end
 
     private def open_ack_file(id) : MFile


### PR DESCRIPTION
Register file after it has been written doesn't make sense, the data won't be replicated then. So only doing the replace_file now, which does the right thing.