### PR TITLE
Prevent MFile leakage

### DIFF
--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -192,6 +192,9 @@ module LavinMQ
         @sent_bytes += lag_size
         @actions.send action
         lag_size
+      rescue ex : Channel::ClosedError
+        action.done
+        raise ex
       end
 
       def close

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -236,9 +236,10 @@ module LavinMQ
         @lock.synchronize do
           update_isr if @dirty_isr
           @followers.each do |f|
-            next unless f.synced?
+            next if f.syncing? # Performing a full sync
             yield f
           rescue Channel::ClosedError
+            Log.info { "Follower disconnected address=#{f.remote_address} id=#{f.id.to_s(36)}" }
             Fiber.yield # Allow other fiber to run to remove the follower from array
           end
         end

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -244,6 +244,7 @@ module LavinMQ
         replicator.delete_file(file.path, wg)
         spawn(name: "wait for file deletion is replicated") do
           wg.wait
+        ensure
           file.close
         end
       else


### PR DESCRIPTION
We noticed that deleted mmap's in replicated cluster aren't unmapped. This is an attempt to fix that. If a follower disconnects it's `@actions` channels is closed, which prevents the action from being enqueued, it raises a ClosedChannel exception, but the WaitGroup is already increased, but won't be decreased again in `Follower#close` as it's not in the `@actions` channel.