### PR TITLE
Bugfix: navigate between exchanges

### DIFF
--- a/spec/frontend/exchange.spec.js
+++ b/spec/frontend/exchange.spec.js
@@ -1,7 +1,7 @@
 import * as helpers from './helpers.js'
-import { test, expect } from './fixtures.js';
+import { test, expect } from './fixtures.js'
 
-test.describe("exchange", _ => {
+test.describe('exchange', _ => {
   const pagePath = '/exchange#vhost=%2F&name=amq.topic'
   const apiPath = 'api/exchanges/%2F/amq.topic'
 
@@ -14,11 +14,31 @@ test.describe("exchange", _ => {
   test('is refreshed automatically', async ({ page, baseURL }) => {
     await page.clock.install()
     await page.goto(pagePath)
-    for (let i=0; i<3; ++i) {
+    for (let i = 0; i < 3; ++i) {
       const apiExchangesRequest2 = helpers.waitForPathRequest(page, apiPath)
       // Move into the future and make sure we've had a second request
       await page.clock.runFor(10000)
       await expect(apiExchangesRequest2).toBeRequested()
     }
+  })
+
+  test('navigates to another exchange via binding link', async ({ page }) => {
+    await page.goto(pagePath)
+
+    // Simulate hash change to navigate to another exchange
+    const targetExchange = 'amq.direct'
+    const newHash = `#vhost=%2F&name=${targetExchange}`
+
+    // Wait for the API request to the new exchange after hash change
+    const apiNewExchangeRequest = helpers.waitForPathRequest(page, `api/exchanges/%2F/${targetExchange}`)
+
+    // Change the hash to simulate clicking an exchange binding link
+    await page.evaluate((hash) => {
+      window.location.hash = hash
+    }, newHash)
+
+    // Verify the new exchange is loaded
+    await expect(apiNewExchangeRequest).toBeRequested()
+    await expect(page).toHaveURL(new RegExp(`exchange${newHash}`))
   })
 })

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -78,12 +78,6 @@ const bindingsTable = Table.renderTable('bindings-table', tableOptions, function
 
     const destinationLink = document.createElement('a')
     destinationLink.href = HTTP.url`${item.destination_type}#vhost=${vhost}&name=${item.destination}`
-    if (item.destination_type === 'exchange') {
-      destinationLink.addEventListener('click', function (e) {
-        window.location.href = this.href
-        window.location.reload()
-      })
-    }
     destinationLink.textContent = item.destination
     const argsPre = document.createElement('pre')
     argsPre.textContent = JSON.stringify(item.arguments || {})
@@ -150,4 +144,9 @@ document.getElementById('dest-type').addEventListener('change', (e) => updateAut
 
 document.querySelector('#dataTags').addEventListener('click', e => {
   Helpers.argumentHelperJSON('publishMessage', 'properties', e)
+})
+
+// Handle navigation to another exchange via hash change
+window.addEventListener('hashchange', () => {
+  window.location.reload()
 })


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes #1402 

### HOW can this pull request be tested?

Specs and manual.

Create a exchange to exchange binding, before this patch, the link updates the hash but does not navigate. 
Do the same with this bugfix applied