### PR TITLE
Remove NoopServer and make replicator nullable throughout codebase

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -88,7 +88,7 @@ describe LavinMQ::Clustering::Client do
       wait_for { replicator.followers.first?.try &.lag_in_bytes == 0 }
       cluster.stop
 
-      follower_retain_store = LavinMQ::MQTT::RetainStore.new("#{cluster.follower_config.data_dir}/retain_store", LavinMQ::Clustering::NoopServer.new)
+      follower_retain_store = LavinMQ::MQTT::RetainStore.new("#{cluster.follower_config.data_dir}/retain_store", nil)
       a = Array(String).new(2)
       b = Array(String).new(2)
       follower_retain_store.each("#") do |topic, body_io, body_bytesize|

--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -471,7 +471,7 @@ module MessageRoutingSpec
         q1 = LavinMQ::QueueFactory.make(vhost, "q1")
         s1 = LavinMQ::QueueFactory.make(vhost, "q1", arguments: LavinMQ::AMQP::Table.new({"x-queue-type": "mqtt"}))
         index = LavinMQ::MQTT::TopicTree(String).new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         x = LavinMQ::MQTT::Exchange.new(vhost, "", store)
         x.bind(s1, "s1", LavinMQ::AMQP::Table.new)
         expect_raises(LavinMQ::Exchange::AccessRefused) do

--- a/spec/mqtt/integrations/retain_store_spec.cr
+++ b/spec/mqtt/integrations/retain_store_spec.cr
@@ -13,7 +13,7 @@ module MqttSpecs
     describe "retain" do
       it "adds to index and writes msg file" do
         index = IndexTree.new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         props = LavinMQ::AMQP::Properties.new
         msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
         store.retain("a", msg.body_io, msg.bodysize)
@@ -29,7 +29,7 @@ module MqttSpecs
 
       it "empty body deletes" do
         index = IndexTree.new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         props = LavinMQ::AMQP::Properties.new
         msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
 
@@ -48,7 +48,7 @@ module MqttSpecs
     describe "each" do
       it "can be called multiple times" do
         index = IndexTree.new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         props = LavinMQ::AMQP::Properties.new
         msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
         store.retain("a", msg.body_io, msg.bodysize)
@@ -65,7 +65,7 @@ module MqttSpecs
 
       it "calls block with correct arguments" do
         index = IndexTree.new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         props = LavinMQ::AMQP::Properties.new
         msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
         store.retain("a", msg.body_io, msg.bodysize)
@@ -88,7 +88,7 @@ module MqttSpecs
 
       it "handles multiple subscriptions" do
         index = IndexTree.new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         props = LavinMQ::AMQP::Properties.new
         msg1 = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
         msg2 = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
@@ -120,7 +120,7 @@ module MqttSpecs
     describe "restore_index" do
       it "restores the index from a file" do
         index = IndexTree.new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         props = LavinMQ::AMQP::Properties.new
         msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
 
@@ -128,7 +128,7 @@ module MqttSpecs
         store.close
 
         new_index = IndexTree.new
-        LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, new_index)
+        LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, new_index)
 
         new_index.size.should eq(1)
         new_index.@leafs.has_key?("a").should be_true
@@ -137,7 +137,7 @@ module MqttSpecs
 
     it "survives a restart" do
       index = IndexTree.new
-      store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+      store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
       props = LavinMQ::AMQP::Properties.new
       msg = LavinMQ::Message.new(100, "test", "topic", props, 4, IO::Memory.new("body"))
 
@@ -146,7 +146,7 @@ module MqttSpecs
 
       # Reopen
       index = IndexTree.new
-      store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", LavinMQ::Clustering::NoopServer.new, index)
+      store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
       store.each("topic") do |topic, body_io, body_bytesize|
         body = Bytes.new(body_bytesize)
         body_io.read(body)

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -39,7 +39,7 @@ module MqttHelpers
   def with_server(clean_dir = true, & : LavinMQ::Server -> Nil)
     mqtt_server = TCPServer.new("localhost", 0)
     amqp_server = TCPServer.new("localhost", 0)
-    s = LavinMQ::Server.new(LavinMQ::Config.instance, LavinMQ::Clustering::NoopServer.new)
+    s = LavinMQ::Server.new(LavinMQ::Config.instance, nil)
     begin
       spawn(name: "amqp tcp listen") { s.listen(amqp_server, LavinMQ::Server::Protocol::AMQP) }
       spawn(name: "mqtt tcp listen") { s.listen(mqtt_server, LavinMQ::Server::Protocol::MQTT) }

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -93,7 +93,7 @@ def wait_for(timeout = 5.seconds, file = __FILE__, line = __LINE__, &)
   fail "Execution expired", file: file, line: line
 end
 
-def with_amqp_server(tls = false, replicator = LavinMQ::Clustering::NoopServer.new,
+def with_amqp_server(tls = false, replicator = nil,
                      config = LavinMQ::Config.instance,
                      file = __FILE__, line = __LINE__, & : LavinMQ::Server -> Nil)
   LavinMQ::Config.instance = init_config(config)

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -12,7 +12,7 @@ module LavinMQ
         DIRECT_USER == name
       end
 
-      def initialize(@data_dir : String, @replicator : Clustering::Replicator)
+      def initialize(@data_dir : String, @replicator : Clustering::Replicator?)
         @users = Hash(String, User).new
         load!
       end
@@ -113,7 +113,7 @@ module LavinMQ
             Array(User).from_json(f) do |user|
               @users[user.name] = user
             end
-            @replicator.register_file f
+            @replicator.try &.register_file f
           end
         else
           Log.debug { "Loading default users" }
@@ -144,7 +144,7 @@ module LavinMQ
         tmpfile = "#{path}.tmp"
         File.open(tmpfile, "w") { |f| to_pretty_json(f); f.fsync }
         File.rename tmpfile, path
-        @replicator.replace_file path
+        @replicator.try &.replace_file path
       end
     end
   end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -248,49 +248,5 @@ module LavinMQ
         path[@data_dir.bytesize + 1..]
       end
     end
-
-    class NoopServer
-      include Replicator
-
-      def register_file(file : File)
-      end
-
-      def register_file(mfile : MFile)
-      end
-
-      def replace_file(path : String) # only non mfiles are ever replaced
-      end
-
-      def append(path : String, obj)
-      end
-
-      def delete_file(path : String, wg : WaitGroup)
-      end
-
-      def followers : Array(Follower)
-        Array(Follower).new(0)
-      end
-
-      def syncing_followers : Array(Follower)
-        Array(Follower).new(0)
-      end
-
-      def all_followers : Array(Follower)
-        Array(Follower).new(0)
-      end
-
-      def close
-      end
-
-      def listen(server : TCPServer)
-      end
-
-      def clear
-      end
-
-      def password : String
-        ""
-      end
-    end
   end
 end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -33,6 +33,7 @@ module LavinMQ
     @first_shutdown_attempt = true
     @data_dir_lock : DataDirLock?
     @closed = false
+    @replicator : Clustering::Server?
 
     def initialize(@config : Config)
       print_environment_info
@@ -53,7 +54,6 @@ module LavinMQ
         @runner = controller = Clustering::Controller.new(@config, etcd)
         @replicator = Clustering::Server.new(@config, etcd, controller.id)
       else
-        @replicator = Clustering::NoopServer.new
         @runner = StandaloneRunner.new
       end
 
@@ -80,7 +80,7 @@ module LavinMQ
       @runner.run do
         start
       end
-      @replicator.close
+      @replicator.try &.close
       @data_dir_lock.try &.release
     end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -22,7 +22,7 @@ module LavinMQ
       # - Handling the retain store
       # - Interfacing with the virtual host (vhost) and the exchange to route messages
       # The `Broker` class helps keep the MQTT client concise and focused on the protocol.
-      def initialize(@vhost : VHost, @replicator : Clustering::Replicator)
+      def initialize(@vhost : VHost, @replicator : Clustering::Replicator?)
         @sessions = Sessions.new(@vhost)
         @clients = Hash(String, Client).new
         @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @replicator)

--- a/src/lavinmq/mqtt/brokers.cr
+++ b/src/lavinmq/mqtt/brokers.cr
@@ -8,7 +8,7 @@ module LavinMQ
     class Brokers
       include Observer(VHostStore::Event)
 
-      def initialize(@vhosts : VHostStore, @replicator : Clustering::Replicator)
+      def initialize(@vhosts : VHostStore, @replicator : Clustering::Replicator?)
         @brokers = Hash(String, Broker).new(initial_capacity: @vhosts.size)
         @vhosts.each do |(name, vhost)|
           @brokers[name] = Broker.new(vhost, @replicator)

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -8,7 +8,7 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "parameter_store"
 
-    def initialize(@data_dir : String, @file_name : String, @replicator : Clustering::Replicator, vhost : String? = nil)
+    def initialize(@data_dir : String, @file_name : String, @replicator : Clustering::Replicator?, vhost : String? = nil)
       metadata = vhost ? ::Log::Metadata.build({vhost: vhost}) : ::Log::Metadata.empty
       @log = Logger.new(Log, metadata)
       @parameters = Hash(ParameterId?, T).new
@@ -64,7 +64,7 @@ module LavinMQ
       tmpfile = "#{path}.tmp"
       File.open(tmpfile, "w") { |f| self.to_pretty_json(f) }
       File.rename tmpfile, path
-      @replicator.replace_file path
+      @replicator.try &.replace_file path
     end
 
     private def load!
@@ -72,7 +72,7 @@ module LavinMQ
       if File.exists?(path)
         File.open(path) do |f|
           Array(T).from_json(f).each { |p| create(p, save: false) }
-          @replicator.register_file f
+          @replicator.try &.register_file f
         end
       end
       @log.debug { "#{size} items loaded from #{@file_name}" }

--- a/src/lavinmq/schema.cr
+++ b/src/lavinmq/schema.cr
@@ -21,7 +21,7 @@ module LavinMQ
       else
         raise UnsupportedSchemaVersion.new(v, data_dir)
       end
-      replicator.replace_file(File.join(data_dir, "schema_version"))
+      replicator.try &.replace_file(File.join(data_dir, "schema_version"))
     end
 
     private def self.version(data_dir) : Int32?

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -44,7 +44,7 @@ module LavinMQ
     @definitions_deletes = 0
     Log = LavinMQ::Log.for "vhost"
 
-    def initialize(@name : String, @server_data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator, @description = "", @tags = Array(String).new(0))
+    def initialize(@name : String, @server_data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @description = "", @tags = Array(String).new(0))
       @log = Logger.new(Log, vhost: @name)
       @dir = Digest::SHA1.hexdigest(@name)
       @data_dir = File.join(@server_data_dir, @dir)
@@ -52,7 +52,7 @@ module LavinMQ
       FileUtils.rm_rf File.join(@data_dir, "transient")
       @definitions_file_path = File.join(@data_dir, "definitions.amqp")
       @definitions_file = File.open(@definitions_file_path, "a+")
-      @replicator.register_file(@definitions_file)
+      @replicator.try &.register_file(@definitions_file)
       File.write(File.join(@data_dir, ".vhost"), @name)
       load_limits
       @operator_policies = ParameterStore(OperatorPolicy).new(@data_dir, "operator_policies.json", @replicator, vhost: @name)
@@ -602,7 +602,7 @@ module LavinMQ
         end
         io.fsync
         File.rename io.path, @definitions_file_path
-        @replicator.replace_file @definitions_file_path
+        @replicator.try &.replace_file @definitions_file_path
         @definitions_file.close
         @definitions_file = io
       end
@@ -612,7 +612,7 @@ module LavinMQ
       @log.debug { "Storing definition: #{frame.inspect}" }
       bytes = frame.to_slice
       @definitions_file.write bytes
-      @replicator.append @definitions_file_path, bytes
+      @replicator.try &.append @definitions_file_path, bytes
       @definitions_file.fsync
       if dirty
         if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions


### PR DESCRIPTION
- Remove NoopServer class from Clustering::Server
- Make @replicator nullable (Clustering::Replicator?) in:
  - Server, Launcher, VHost, VHostStore
  - ParameterStore, UserStore
  - MQTT Broker, Brokers, and RetainStore
  - Schema migration
- Update all replicator method calls to use .try(&.method)
- Update specs to use nil instead of NoopServer.new

This simplifies the codebase by removing the no-op implementation and allowing replicator to be nil when clustering is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
