### PR TITLE
Remove delayed-message from policy (not working)

### DIFF
--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -43,9 +43,6 @@ module LavinMQ
         case key
         when "alternate-exchange"
           @alternate_exchange ||= value.as_s?
-        when "delayed-message"
-          @delayed ||= value.as?(Bool) == true
-          init_delayed_queue if @delayed
         when "federation-upstream"
           @vhost.upstreams.try &.link(value.as_s, self) unless internal?
         when "federation-upstream-set"


### PR DESCRIPTION
This PR removes some deadish code.

It never worked since #521 due to type validation added in controller. No way to pass a boolean which the code expects.

Also, I dont think it makes sense to make an exchange a delayed exchange via policy.

