### PR TITLE
Add out-of-sync replica (OSR) tracking to clustering

### DIFF
--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -224,6 +224,7 @@ module LavinMQ
           uncompressed_bytes: @lz4.uncompressed_bytes,
           compressed_bytes:   @lz4.compressed_bytes,
           id:                 @id.to_s(36),
+          state:              @state.to_s,
         }.to_json(json)
       end
 

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -79,7 +79,7 @@ module LavinMQ
           proc_used:          Fiber.count,
           run_queue:          0,
           sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
-          followers:          @amqp_server.followers,
+          followers:          @amqp_server.all_followers,
         }
       end
 

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -182,10 +182,19 @@ Table.renderTable('followers', followersTableOpts, (tr, item, firstRender) => {
   if (firstRender) {
     Table.renderCell(tr, 0, item.id)
   }
-  Table.renderCell(tr, 1, item.remote_address)
-  Table.renderCell(tr, 2, humanizeBytes(item.sent_bytes), 'right')
-  Table.renderCell(tr, 3, humanizeBytes(item.acked_bytes), 'right')
-  Table.renderCell(tr, 4, humanizeBytes(item.sent_bytes - item.acked_bytes), 'right')
+  // Display state from follower object
+  const state = item.state || 'Unknown'
+  const statusCell = Table.renderCell(tr, 1, state === 'Syncing' ? 'Out-of-sync' : 'In-sync')
+  if (state === 'Syncing') {
+    statusCell.style.color = '#ff6b6b'
+    statusCell.style.fontWeight = 'bold'
+  } else if (state === 'Synced') {
+    statusCell.style.color = '#51cf66'
+  }
+  Table.renderCell(tr, 2, item.remote_address)
+  Table.renderCell(tr, 3, humanizeBytes(item.sent_bytes), 'right')
+  Table.renderCell(tr, 4, humanizeBytes(item.acked_bytes), 'right')
+  Table.renderCell(tr, 5, humanizeBytes(item.sent_bytes - item.acked_bytes), 'right')
 })
 
 function updateCharts (response) {
@@ -243,6 +252,7 @@ function updateCharts (response) {
     }
     Chart.update(queueChurnChart, queueChurnStats)
   }
+
   followersDataSource.update(response[0].followers)
 }
 

--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -88,6 +88,7 @@
             <thead>
               <tr>
                 <th class="left">ID</th>
+                <th class="left">Status</th>
                 <th class="left">Remote address</th>
                 <th class="right">Sent bytes</th>
                 <th class="right">Acked bytes</th>


### PR DESCRIPTION
## Summary
- Adds OSR (out-of-sync replica) tracking alongside existing ISR tracking
- Exposes follower sync state directly in API response for better cluster visibility
- Updates web UI to clearly display sync status with visual indicators

## Backend Changes
- **Clustering Server**: Track OSR in etcd at `lavinmq/osr` key, updating when followers connect, sync, or disconnect
- **Follower Serialization**: Add `state` property (`"Syncing"` or `"Synced"`) to follower JSON output
- **Nodes API**: Return `all_followers` (both synced and syncing) instead of only synced followers

## Frontend Changes
- **Nodes View**: Add "Status" column to followers table between ID and Remote address
- **Status Display**: 
  - Out-of-sync replicas shown in red and bold
  - In-sync replicas shown in green
  - Status determined directly from follower `state` property

## Technical Details
The implementation mirrors the existing ISR tracking pattern:
- OSR tracked with `@dirty_osr` flag and `update_osr` method
- State updates triggered at follower lifecycle events
- Clean API design - sync state embedded in each follower object, no separate arrays needed

## Test Plan
- [ ] Verify OSR tracking updates in etcd when followers connect
- [ ] Confirm syncing followers appear as "Out-of-sync" in web UI
- [ ] Verify followers transition to "In-sync" after full sync completes
- [ ] Check OSR updates when followers disconnect
- [ ] Test with multiple followers in various sync states

🤖 Generated with [Claude Code](https://claude.com/claude-code)