### PR TITLE
Fix invalid password hash error message

### DIFF
--- a/src/lavinmq/auth/password.cr
+++ b/src/lavinmq/auth/password.cr
@@ -59,7 +59,14 @@ module LavinMQ
             @raw_hash = raw_hash
           end
 
-          bytes = Base64.decode @raw_hash
+          begin
+            bytes = Base64.decode @raw_hash
+          rescue ex : Base64::Error
+            raise InvalidPasswordHash.new("Invalid password hash: not valid Base64 encoding (#{ex.message})")
+          end
+          if bytes.size < digest_size
+            raise InvalidPasswordHash.new("Invalid password hash: decoded size #{bytes.size} bytes is smaller than required digest size #{digest_size} bytes for #{hash_algorithm}")
+          end
           salt_size = bytes.size - digest_size
           @salt = bytes[0, salt_size]
           @hash = bytes + salt_size


### PR DESCRIPTION
Previously, posting definitions with an invalid password hash (e.g., "password_hash": "invalid_hash") resulted in an unhelpful error: "Negative count: -10"

This occurred because the password parsing code didn't validate the decoded hash size before extracting the salt, causing ArgumentError when salt_size became negative.

Added validation to catch:
- Invalid Base64 encoding in password hashes
- Decoded hash size smaller than required digest size

Now returns clear error messages:
- "Invalid password hash: not valid Base64 encoding (...)"
- "Invalid password hash: decoded size X bytes is smaller than required digest size Y bytes for <algorithm>"

Also added test coverage for:
- Invalid password hash error handling
- Exchange-to-exchange bindings in definitions upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)