### PR TITLE
 Fix OpenAPI schema for bcrypt hashing_algorithm name

### DIFF
--- a/static/docs/schemas/users.yaml
+++ b/static/docs/schemas/users.yaml
@@ -17,12 +17,17 @@ user-properties:
       - impersonator
     hashing_algorithm:
       type: string
-      description: Hashing algorithm used to generate the password hash (defaults to "SHA256" for PUT requests).
-      enum:
-      - SHA512
-      - SHA256
-      - lavinmq_bcrypt
-      - MD5
+      description: |
+        Hashing algorithm used to generate the password hash (defaults to "rabbit_password_hashing_sha256" for PUT requests).
+
+        The API accepts any value ending with 'bcrypt', 'sha256', 'sha512', or 'md5' (case-insensitive),
+        but always returns one of these normalized values:
+        - 'lavinmq_bcrypt' (for any value ending with 'bcrypt')
+        - 'rabbit_password_hashing_sha256' (for any value ending with 'sha256')
+        - 'rabbit_password_hashing_sha512' (for any value ending with 'sha512')
+        - 'rabbit_password_hashing_md5' (for any value ending with 'md5')
+
+        To avoid configuration drift in tools like Terraform, use the normalized values listed above.
     password_hash:
       type: string
       description: The password hash.


### PR DESCRIPTION
### WHAT is this pull request doing?
The OpenAPI schema listed simple algorithm names (Bcrypt, SHA256, etc.) as enum values for hashing_algorithm, but the API returns normalized values like lavinmq_bcrypt and rabbit_password_hashing_sha256. This causes Terraform to detect configuration drift when the inserted value didn't match the retrieved value.

Updated users.yaml to document the normalized values the API actually returns and explain the flexible input format it accepts. The API still accepts simplified algorithm names (case-insensitive)

### HOW can this pull request be tested?
Look at http api users endpoints. 
