### PR TITLE
only rescue `Etcd::Error` in `keepalive_loop`

### DIFF
--- a/src/lavinmq/etcd/lease.cr
+++ b/src/lavinmq/etcd/lease.cr
@@ -33,8 +33,8 @@ module LavinMQ
           sleep (ttl * 0.7).seconds
           ttl = @etcd.lease_keepalive(@id)
         end
-      rescue ex
-        Log.error(exception: ex) { "Lost leadership" } unless @lost_leadership.closed?
+      rescue ex : Etcd::Error # only rescue etcd errors
+        Log.error(exception: ex) { "Lost leadership because of #{ex.message}" } unless @lost_leadership.closed?
       ensure
         @lost_leadership.close
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
This is a step in trying to find the cause of the `Lost leadership` issues in #1486 
Don't rescue all errors in `keepalive_loop`, only `Etcd::Error`. 
Also log `ex.message` when leadership is lost. 

### HOW can this pull request be tested?
.
