### PR TITLE
automatically turn to draft once changes have been requested

### DIFF
--- a/.github/workflows/draft-on-changes-requested.yml
+++ b/.github/workflows/draft-on-changes-requested.yml
@@ -1,0 +1,19 @@
+name: Mark PR as draft on changes requested
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  mark-as-draft:
+    name: Convert PR to draft
+    runs-on: ubuntu-latest
+    if: github.event.review.state == 'changes_requested'
+    steps:
+      - name: Convert PR to draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr ready --undo "${PR_NUMBER}" --repo "${REPO}"


### PR DESCRIPTION
### WHAT is this pull request doing?
This adds a workflow that would automatically make a PR into a draft once a reviewer has requested changes. This could help us keep order amongst the pull requests that are ready/not ready for merge

This requires reviewers to be conscious of this when reviewing and only request changes if they are certain there needs to be a change to the code. 

 This is just a suggestion, would like your thoughts
