### PR TITLE
Fix flaky channel api spec

### DIFF
--- a/spec/api/channels_spec.cr
+++ b/spec/api/channels_spec.cr
@@ -48,15 +48,14 @@ describe LavinMQ::HTTP::ChannelsController do
       with_http_server do |http, s|
         s.vhosts.create("my-connection")
         s.users.add_permission("guest", "my-connection", /.*/, /.*/, /.*/)
-        wg = WaitGroup.new(1)
-        2.times { spawn { with_channel(s, vhost: "my-connection") { wg.wait } } }
-
-        wait_for { s.connections.size == 2 }
-        response = http.get("/api/vhosts/my-connection/channels")
-        response.status_code.should eq 200
-        body = JSON.parse(response.body)
-        body.as_a.size.should eq 2
-        wg.done
+        with_channel(s, vhost: "my-connection") do
+          with_channel(s, vhost: "my-connection") do
+            response = http.get("/api/vhosts/my-connection/channels")
+            response.status_code.should eq 200
+            body = JSON.parse(response.body)
+            body.as_a.size.should eq 2
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### WHAT is this pull request doing?
I noticed this spec failing. I guess it happens very rarely,  but I refactored it to hopefully not fail again.

I believe that sometimes `wait_for { s.connections.size == 2 }` happened before the channels had been opened.

### HOW can this pull request be tested?
Run specs