### PR TITLE
Bugfifx: lavinmqperf - correctly calculate summary

### DIFF
--- a/src/lavinmqperf/amqp/throughput.cr
+++ b/src/lavinmqperf/amqp/throughput.cr
@@ -213,9 +213,9 @@ module LavinMQPerf
           break if @stopped
           pubs_last = @pubs.get(:relaxed)
           consumes_last = @consumes.get(:relaxed)
-          start = Time.monotonic
+          report_start = Time.monotonic
           sleep 1.seconds
-          report(start, pubs_last, consumes_last) unless @quiet
+          report(report_start, pubs_last, consumes_last) unless @quiet
         end
         summary(start)
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
Currently we overwrite the `start` var every second when running lavinmqperf throughput, causing the summary to be wrong. It will always just report nr of total messages published/consumed (divided by 1) per second. This fixes that by using a separate var (`report_start`) for calculating numbers when reporting instead.

Fixes #1535 


Before: 
```
lavinmqperf amqp throughput -z 10
...
Publish rate: 990297 msgs/s Consume rate: 1010431 msgs/s
Publish rate: 989443 msgs/s Consume rate: 968065 msgs/s
Publish rate: 951777 msgs/s Consume rate: 956313 msgs/s

Summary:
Average publish rate: 9880234 msgs/s
Average consume rate: 9824295 msgs/s
```

After: 
```
lavinmqperf amqp throughput -z 10
...
Publish rate: 1003258 msgs/s Consume rate: 966396 msgs/s
Publish rate: 964459 msgs/s Consume rate: 1028311 msgs/s
Publish rate: 913957 msgs/s Consume rate: 937442 msgs/s

Summary:
Average publish rate: 983084 msgs/s
Average consume rate: 989516 msgs/s
```

### HOW can this pull request be tested?
Run `lavinmqperf amqp throughput -z 10`, verify that the summary is correct. 
