### PR TITLE
Improved cluster replica tracking and management

### DIFF
--- a/spec/clustering/controller_spec.cr
+++ b/spec/clustering/controller_spec.cr
@@ -1,0 +1,52 @@
+require "../spec_helper"
+require "../../src/lavinmq/clustering/controller"
+
+describe LavinMQ::Clustering::Controller do
+  add_etcd_around_each
+
+  describe "sequential ID generation" do
+    it "assigns sequential IDs starting from 1" do
+      config = LavinMQ::Config.new
+      config.data_dir = File.tempname
+      Dir.mkdir_p config.data_dir
+      config.clustering_etcd_endpoints = "localhost:12379"
+      etcd = LavinMQ::Etcd.new("localhost:12379")
+      controller = LavinMQ::Clustering::Controller.new(config, etcd)
+      controller.id.should eq 1
+    ensure
+      FileUtils.rm_rf(config.data_dir) if config
+    end
+
+    it "skips IDs already claimed in etcd" do
+      etcd = LavinMQ::Etcd.new("localhost:12379")
+      prefix = LavinMQ::Config.instance.clustering_etcd_prefix
+      # Pre-claim IDs 1 and 2
+      etcd.put("#{prefix}/replica/1/insync", "1")
+      etcd.put("#{prefix}/replica/2/insync", "0")
+
+      config = LavinMQ::Config.new
+      config.data_dir = File.tempname
+      Dir.mkdir_p config.data_dir
+      config.clustering_etcd_endpoints = "localhost:12379"
+      controller = LavinMQ::Clustering::Controller.new(config, etcd)
+      controller.id.should eq 3
+    ensure
+      FileUtils.rm_rf(config.data_dir) if config
+    end
+
+    it "reuses ID from existing .clustering_id file" do
+      config = LavinMQ::Config.new
+      config.data_dir = File.tempname
+      Dir.mkdir_p config.data_dir
+      config.clustering_etcd_endpoints = "localhost:12379"
+      # Write a pre-existing clustering ID
+      File.write(File.join(config.data_dir, ".clustering_id"), 5.to_s(36))
+
+      etcd = LavinMQ::Etcd.new("localhost:12379")
+      controller = LavinMQ::Clustering::Controller.new(config, etcd)
+      controller.id.should eq 5
+    ensure
+      FileUtils.rm_rf(config.data_dir) if config
+    end
+  end
+end

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -4,6 +4,50 @@ require "../../src/lavinmq/clustering/server"
 describe LavinMQ::Clustering::Server, tags: "etcd" do
   add_etcd_around_each
 
+  describe "#known_replicas" do
+    it "returns replicas marked in etcd" do
+      with_datadir do |dir|
+        config = LavinMQ::Config.instance.dup.tap &.data_dir = dir
+        etcd = LavinMQ::Etcd.new("localhost:12379")
+        prefix = config.clustering_etcd_prefix
+        etcd.put("#{prefix}/replica/1/insync", "1")
+        etcd.put("#{prefix}/replica/2/insync", "0")
+        server = LavinMQ::Clustering::Server.new(config, etcd, 0)
+        replicas = server.known_replicas
+        replicas["1"].should be_true
+        replicas["2"].should be_false
+        server.close
+      end
+    end
+  end
+
+  describe "#forget_replica" do
+    it "removes a replica from etcd" do
+      with_datadir do |dir|
+        config = LavinMQ::Config.instance.dup.tap &.data_dir = dir
+        etcd = LavinMQ::Etcd.new("localhost:12379")
+        prefix = config.clustering_etcd_prefix
+        etcd.put("#{prefix}/replica/5/insync", "0")
+        server = LavinMQ::Clustering::Server.new(config, etcd, 0)
+        server.forget_replica(5).should be_true
+        etcd.get("#{prefix}/replica/5/insync").should be_nil
+        server.close
+      end
+    end
+
+    it "returns false when replica doesn't exist" do
+      with_datadir do |dir|
+        config = LavinMQ::Config.instance.dup.tap &.data_dir = dir
+        server = LavinMQ::Clustering::Server.new(
+          config,
+          LavinMQ::Etcd.new("localhost:12379"),
+          0)
+        server.forget_replica(999).should be_false
+        server.close
+      end
+    end
+  end
+
   describe "#files_with_hash" do
     describe "for MFile" do
       it "should use mfile buffer when calculating hash" do

--- a/spec/follower_proxy_during_sync_spec.cr
+++ b/spec/follower_proxy_during_sync_spec.cr
@@ -45,7 +45,7 @@ class SlowClusteringServer < LavinMQ::Clustering::Server
   end
 end
 
-describe "extract_conn_info during full_sync with syncing_followers", tags: "etcd" do
+describe "extract_conn_info during full_sync with followers" do
   add_etcd_around_each
 
   it "should handle PROXY protocol from syncing followers during full_sync" do

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -149,7 +149,8 @@ class LavinMQ::Clustering::Controller
     if isr = @etcd.get(old_key)
       legacy_isr_exists = true
       if isr.split(",").map(&.to_i(36)).includes?(@id)
-        Log.info { "In sync via legacy ISR key" }
+        Log.info { "In sync via legacy ISR key, migrating to new format" }
+        @etcd.put(new_key, "1")
         return
       end
     end

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -31,7 +31,6 @@ class LavinMQ::Clustering::Controller
     wait_to_be_insync
     @etcd.election_campaign("#{@config.clustering_etcd_prefix}/leader", @advertised_uri, lease: @id) # blocks until becoming leader
     @is_leader.set(true)
-    @etcd.del("#{@config.clustering_etcd_prefix}/isr") # delete legacy ISR key (used up until v2.6.x)
     execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
     @repli_client.try &.close
     # TODO: make sure we still are in the ISR set

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -13,14 +13,14 @@ module LavinMQ
       end
       Log = LavinMQ::Log.for "clustering.follower"
 
-      @acked_bytes = 0_i64
-      @sent_bytes = 0_i64
       @actions = Channel(Action).new(Config.instance.clustering_max_unsynced_actions)
       @running = WaitGroup.new
       @state = State::Syncing
       getter id = -1
       getter remote_address
       getter state
+      getter acked_bytes = 0_i64
+      getter sent_bytes = 0_i64
 
       def initialize(@socket : TCPSocket, @data_dir : String, @file_index : FileIndex)
         @socket.sync = true # Use buffering in lz4

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -11,6 +11,7 @@ module LavinMQ
       abstract def followers : Array(Follower)
       abstract def syncing_followers : Array(Follower)
       abstract def all_followers : Array(Follower)
+      abstract def known_replicas : Hash(String, Bool)
       abstract def close
       abstract def listen(server : TCPServer)
       abstract def clear

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -16,6 +16,7 @@ module LavinMQ
       abstract def listen(server : TCPServer)
       abstract def clear
       abstract def password : String
+      abstract def forget_replica(id : Int32) : Bool
     end
   end
 end

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -17,6 +17,7 @@ module LavinMQ
       abstract def clear
       abstract def password : String
       abstract def forget_replica(id : Int32) : Bool
+      abstract def id : Int32
     end
   end
 end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -233,12 +233,16 @@ module LavinMQ
         key = "#{@config.clustering_etcd_prefix}/replica/#{id.to_s(36)}/insync"
         @etcd.put(key, "1")
         Log.debug { "Marked replica #{id.to_s(36)} as in-sync" }
+      rescue ex : Etcd::Error
+        Log.error { "Failed to mark replica #{id.to_s(36)} as in-sync: #{ex.message}" }
       end
 
       private def mark_out_of_sync(id : Int32)
         key = "#{@config.clustering_etcd_prefix}/replica/#{id.to_s(36)}/insync"
         @etcd.put(key, "0")
         Log.debug { "Marked replica #{id.to_s(36)} as out-of-sync" }
+      rescue ex : Etcd::Error
+        Log.error { "Failed to mark replica #{id.to_s(36)} as out-of-sync: #{ex.message}" }
       end
 
       # Removes a replica from etcd, returns true if the replica was found and deleted

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -200,15 +200,16 @@ module LavinMQ
             @followers.delete(stale_follower)
             stale_follower.close
           end
+          @disconnected_followers.delete(follower.id)
           @followers << follower # Starts in Syncing state
         end
-        follower.full_sync # sync the bulk
-        @lock.synchronize do
-          follower.full_sync    # sync the last
-          follower.mark_synced! # Change state to Synced
-          mark_insync(follower.id)
-        end
         begin
+          follower.full_sync # sync the bulk
+          @lock.synchronize do
+            follower.full_sync    # sync the last
+            follower.mark_synced! # Change state to Synced
+            mark_insync(follower.id)
+          end
           follower.action_loop
         ensure
           @lock.synchronize do

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -32,7 +32,7 @@ module LavinMQ
       @password : String
       @files = Hash(String, MFile?).new
       @disconnected_followers = Array(Int32).new
-      @id : Int32
+      getter id : Int32
       @config : Config
 
       def initialize(config : Config, @etcd : Etcd, @id : Int32)

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -241,6 +241,18 @@ module LavinMQ
         Log.debug { "Marked replica #{id.to_s(36)} as out-of-sync" }
       end
 
+      # Removes a replica from etcd, returns true if the replica was found and deleted
+      def forget_replica(id : Int32) : Bool
+        key = "#{@config.clustering_etcd_prefix}/replica/#{id.to_s(36)}/insync"
+        deleted = @etcd.del(key)
+        if deleted > 0
+          Log.info { "Forgot replica #{id.to_s(36)}" }
+          true
+        else
+          false
+        end
+      end
+
       def close
         @listeners.each &.close
         @lock.synchronize do

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -52,18 +52,16 @@ module LavinMQ
       end
     end
 
-    def get_prefix(key) : Hash(String, String)
+    def get_prefix(key) : Array(Tuple(String, String))
       range_end = key.to_slice.dup
       range_end.update(-1) { |v| v + 1 }
       json = post("/v3/kv/range", %({"key":"#{Base64.strict_encode key}","range_end":"#{Base64.strict_encode range_end}"}))
-      kvs = json["kvs"].as_a
-      h = Hash(String, String).new(initial_capacity: kvs.size)
-      kvs.each do |kv|
-        key = Base64.decode_string kv["key"].as_s
-        value = Base64.decode_string kv["value"].as_s
-        h[key] = value
+      kvs = json["kvs"]?.try(&.as_a) || return [] of Tuple(String, String)
+      kvs.map do |kv|
+        k = Base64.decode_string kv["key"].as_s
+        v = Base64.decode_string kv["value"].as_s
+        {k, v}
       end
-      h
     end
 
     def put(key, value) : String?

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -79,7 +79,8 @@ module LavinMQ
           proc_used:          Fiber.count,
           run_queue:          0,
           sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
-          followers:          merged_replicas,
+          followers:          @amqp_server.followers,
+          merged_replicas:    merged_replicas,
         }
       end
 
@@ -110,21 +111,6 @@ module LavinMQ
               remote_address: nil,
               sent_bytes:     nil,
               acked_bytes:    nil,
-            }
-          end
-        end
-
-        # Add any connected followers not yet in etcd (shouldn't happen but be safe)
-        connected.each do |follower|
-          id = follower.id.to_s(36)
-          unless known.has_key?(id)
-            result << {
-              id:             id,
-              role:           "follower",
-              insync:         false,
-              remote_address: follower.remote_address.to_s,
-              sent_bytes:     follower.sent_bytes,
-              acked_bytes:    follower.acked_bytes,
             }
           end
         end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -69,6 +69,10 @@ module LavinMQ
       @replicator.try(&.all_followers) || Array(Clustering::Follower).new
     end
 
+    def known_replicas
+      @replicator.try(&.known_replicas) || Hash(String, Bool).new
+    end
+
     def amqp_url
       addr = @listeners
         .select { |_, v| v.amqp? }

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -77,6 +77,10 @@ module LavinMQ
       @replicator.try(&.forget_replica(id)) || false
     end
 
+    def leader_id : Int32?
+      @replicator.try(&.id)
+    end
+
     def amqp_url
       addr = @listeners
         .select { |_, v| v.amqp? }

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -73,6 +73,10 @@ module LavinMQ
       @replicator.try(&.known_replicas) || Hash(String, Bool).new
     end
 
+    def forget_replica(id : Int32) : Bool
+      @replicator.try(&.forget_replica(id)) || false
+    end
+
     def amqp_url
       addr = @listeners
         .select { |_, v| v.amqp? }

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -52,6 +52,7 @@ class LavinMQCtl
     {"delete_shovel", "Delete a shovel", "<name>"},
     {"list_federations", "Lists federation upstreams", ""},
     {"delete_federation", "Delete a federation upstream", "<name>"},
+    {"forget_cluster_node", "Remove a disconnected node from the cluster", "<id>"},
 
   }
 
@@ -279,6 +280,7 @@ class LavinMQCtl
     when "list_federations"      then list_federations
     when "add_federation"        then add_federation
     when "delete_federation"     then delete_federation
+    when "forget_cluster_node"   then forget_cluster_node
     when "stop_app"
     when "start_app"
     else
@@ -799,6 +801,13 @@ class LavinMQCtl
       }
       output cluster_status_obj
     end
+  end
+
+  private def forget_cluster_node
+    id = ARGV.shift?
+    abort @banner unless id
+    resp = http.delete "/api/nodes/#{URI.encode_www_form(id)}", @headers
+    handle_response(resp, 204)
   end
 
   private def set_vhost_limits

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -182,16 +182,17 @@ Table.renderTable('followers', followersTableOpts, (tr, item, firstRender) => {
   if (firstRender) {
     Table.renderCell(tr, 0, item.id)
   }
+  const isLeader = item.role === 'leader'
   const connected = item.remote_address !== null
-  Table.renderCell(tr, 1, connected ? '✓' : '✗', 'center')
+  Table.renderCell(tr, 1, isLeader ? 'Leader' : (connected ? '✓' : '✗'), 'center')
   Table.renderCell(tr, 2, item.insync ? '✓' : '✗', 'center')
   Table.renderCell(tr, 3, item.remote_address || '-')
   Table.renderCell(tr, 4, connected ? humanizeBytes(item.sent_bytes) : '-', 'right')
   Table.renderCell(tr, 5, connected ? humanizeBytes(item.acked_bytes) : '-', 'right')
   Table.renderCell(tr, 6, connected ? humanizeBytes(item.sent_bytes - item.acked_bytes) : '-', 'right')
-  if (!connected) {
+  if (!connected && !isLeader) {
     const btn = document.createElement('button')
-    btn.className = 'button-danger'
+    btn.className = 'btn btn-red'
     btn.textContent = 'Forget'
     btn.onclick = () => {
       if (window.confirm(`Are you sure you want to forget replica ${item.id}?`)) {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -189,6 +189,21 @@ Table.renderTable('followers', followersTableOpts, (tr, item, firstRender) => {
   Table.renderCell(tr, 4, connected ? humanizeBytes(item.sent_bytes) : '-', 'right')
   Table.renderCell(tr, 5, connected ? humanizeBytes(item.acked_bytes) : '-', 'right')
   Table.renderCell(tr, 6, connected ? humanizeBytes(item.sent_bytes - item.acked_bytes) : '-', 'right')
+  if (!connected) {
+    const btn = document.createElement('button')
+    btn.className = 'button-danger'
+    btn.textContent = 'Forget'
+    btn.onclick = () => {
+      if (window.confirm(`Are you sure you want to forget replica ${item.id}?`)) {
+        HTTP.request('DELETE', `api/nodes/${item.id}`).then(() => {
+          update(updateCharts)
+        })
+      }
+    }
+    Table.renderCell(tr, 7, btn)
+  } else {
+    Table.renderCell(tr, 7, '')
+  }
 })
 
 function updateCharts (response) {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -182,10 +182,13 @@ Table.renderTable('followers', followersTableOpts, (tr, item, firstRender) => {
   if (firstRender) {
     Table.renderCell(tr, 0, item.id)
   }
-  Table.renderCell(tr, 1, item.remote_address)
-  Table.renderCell(tr, 2, humanizeBytes(item.sent_bytes), 'right')
-  Table.renderCell(tr, 3, humanizeBytes(item.acked_bytes), 'right')
-  Table.renderCell(tr, 4, humanizeBytes(item.sent_bytes - item.acked_bytes), 'right')
+  const connected = item.remote_address !== null
+  Table.renderCell(tr, 1, connected ? '✓' : '✗', 'center')
+  Table.renderCell(tr, 2, item.insync ? '✓' : '✗', 'center')
+  Table.renderCell(tr, 3, item.remote_address || '-')
+  Table.renderCell(tr, 4, connected ? humanizeBytes(item.sent_bytes) : '-', 'right')
+  Table.renderCell(tr, 5, connected ? humanizeBytes(item.acked_bytes) : '-', 'right')
+  Table.renderCell(tr, 6, connected ? humanizeBytes(item.sent_bytes - item.acked_bytes) : '-', 'right')
 })
 
 function updateCharts (response) {

--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -94,6 +94,7 @@
                 <th class="right">Sent bytes</th>
                 <th class="right">Acked bytes</th>
                 <th class="right">Lag</th>
+                <th></th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -88,6 +88,8 @@
             <thead>
               <tr>
                 <th class="left">ID</th>
+                <th class="center">Connected</th>
+                <th class="center">In-sync</th>
                 <th class="left">Remote address</th>
                 <th class="right">Sent bytes</th>
                 <th class="right">Acked bytes</th>


### PR DESCRIPTION
## Summary

- Track replicas using individual etcd keys instead of comma-separated ISR list
- Show all known replicas in Nodes page with Connected/In-sync status columns  
- Add ability to forget disconnected replicas via UI and CLI
- Generate sequential cluster node IDs using atomic etcd transactions

## Changes

### Use individual etcd keys for ISR tracking
Instead of maintaining a comma-separated list at a single "isr" key, each replica now has its own key at `{prefix}/replica/{id}/insync` with value "1" for in-sync and "0" for out-of-sync.

### Show all known replicas in nodes page
- Add `known_replicas` method to Clustering::Server that queries etcd
- Merge etcd replicas with connected followers in NodesController
- Add Connected and In-sync columns to followers table
- Show leader role in replicas table, sorted first

### Add forget button for disconnected replicas
- Allow removing disconnected replicas via Nodes page UI or `DELETE /api/nodes/:id`
- Prevent forgetting leader node
- Add `lavinmqctl forget_cluster_node <id>` CLI command

### Generate sequential cluster node IDs
- New nodes get sequential IDs (1, 2, 3, ...) instead of random IDs
- Uses atomic etcd transactions to ensure IDs don't collide
- Handles manually created nodes by checking for existing replica keys

## Test plan
- [x] Start a 3-node cluster and verify nodes get IDs 1, 2, 3
- [x] Verify Nodes page shows all replicas with correct Connected/In-sync status
- [x] Stop a follower and verify it shows as disconnected
- [x] Use Forget button to remove disconnected replica
- [x] Verify `lavinmqctl forget_cluster_node` works
- [x] Restart forgotten node and verify it gets a new sequential ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)