### PR TITLE
Add etcd tag to specs requiring etcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ lint-openapi:
 
 .PHONY: test
 test: lib
-	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(SPEC)
+	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(if $(TAGS),--tag '$(TAGS)') $(SPEC)
 
 .PHONY: format
 format:

--- a/spec/clustering/client_restart_spec.cr
+++ b/spec/clustering/client_restart_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-describe LavinMQ::Clustering::Client do
+describe LavinMQ::Clustering::Client, tags: "etcd" do
   add_etcd_around_each
 
   # Fixes #1366 - metrics_server is not closed when a follower client is closed

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 require "../../src/lavinmq/clustering/server"
 
-describe LavinMQ::Clustering::Server do
+describe LavinMQ::Clustering::Server, tags: "etcd" do
   add_etcd_around_each
 
   describe "#files_with_hash" do

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -5,7 +5,7 @@ require "../src/lavinmq/clustering/controller"
 
 alias IndexTree = LavinMQ::MQTT::TopicTree(String)
 
-describe LavinMQ::Clustering::Client do
+describe LavinMQ::Clustering::Client, tags: "etcd" do
   add_etcd_around_each
 
   it "can stream changes" do

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -4,7 +4,7 @@ require "file_utils"
 require "http/client"
 require "./spec_helper"
 
-describe LavinMQ::Etcd do
+describe LavinMQ::Etcd, tags: "etcd" do
   it "can put and get" do
     cluster = EtcdCluster.new(1)
     cluster.run do

--- a/spec/follower_proxy_during_sync_spec.cr
+++ b/spec/follower_proxy_during_sync_spec.cr
@@ -45,7 +45,7 @@ class SlowClusteringServer < LavinMQ::Clustering::Server
   end
 end
 
-describe "extract_conn_info during full_sync with syncing_followers" do
+describe "extract_conn_info during full_sync with syncing_followers", tags: "etcd" do
   add_etcd_around_each
 
   it "should handle PROXY protocol from syncing followers during full_sync" do

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -20,7 +20,7 @@ end
 
 describe LavinMQ::AMQP::PriorityQueue do
   describe "PriorityMessageStore" do
-    describe "clustering" do
+    describe "clustering", tags: "etcd" do
       add_etcd_around_each
       it "is replicated correctly" do
         with_clustering do |cluster|


### PR DESCRIPTION
## Summary
- Tag all specs that depend on etcd with `tags: "etcd"` so they can be skipped when etcd is not available
- Add `TAGS` variable to Makefile for filtering specs by tag

## Usage
```bash
# Run all tests except etcd
crystal spec --tags='~etcd'
or with all our flags:
make test TAGS='~etcd'

# Run only etcd tests
make test TAGS=etcd
```

## Test plan
- [x] Verify `make test TAGS='~etcd'` skips etcd tests
- [x] Verify `make test TAGS=etcd` runs only etcd tests