### PR TITLE
[CSS] Fix prefetch button icons

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1837,6 +1837,7 @@ pre.arguments .inactive-argument:before {
 }
 
 .btn-icon {
+  --icon-background: none;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -1850,20 +1851,20 @@ pre.arguments .inactive-argument:before {
   &:hover {
     background-color: var(--color-btn-hover-bg);
   }
+
   &::before {
-    background-repeat: no-repeat;
-    background-position: center center;
+    background: no-repeat center var(--icon-background);
     height: 12px;
     content: "";
     width: 12px;
   }
 
-  &:is(.btn-reset)::before {
-    background-image: url(img/icon-x.svg);
+  &:is(.btn-reset) {
+    --icon-background: url(img/icon-x.svg);
   }
 
-  &:is(.btn-submit)::before {
-    background-image: url(img/icon-checkbox.svg);
+  &:is(.btn-submit) {
+    --icon-background: url(img/icon-checkbox.svg);
   }
 }
 


### PR DESCRIPTION
### WHAT is this pull request doing?
The buttons allocated to reset and save the prefetch count has their icons embedded in the background of the button. 
<img width="259" height="73" alt="image" src="https://github.com/user-attachments/assets/15fa1781-41fa-4fe2-a4be-ecd1d1dadaf0" />

The structure of the `.btn-icon` class (which is only used in this context) gets an alteration to move the icon/background to the `::before` pseuedo class instead of applying it directly to the button:
<img width="557" height="254" alt="image" src="https://github.com/user-attachments/assets/bf87da39-bae6-4cd9-a5e4-57bee02ee491" />


### HOW can this pull request be tested?
:eyes: 
