### PR TITLE
Add ECR views as dependencies for bin/lavinmq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,13 @@ all: $(BINS)
 bin/%: src/%.cr $(SOURCES) lib $(JS) $(DOCS) | bin
 	crystal build $< -o $@ $(CRYSTAL_FLAGS)
 
+bin/lavinmq: src/lavinmq.cr $(SOURCES) $(VIEW_SOURCES) $(VIEW_PARTIALS) lib $(JS) $(DOCS) | bin
+	crystal build $< -o $@ $(CRYSTAL_FLAGS)
+
 bin/%-debug: src/%.cr $(SOURCES) lib $(JS) $(DOCS) | bin
+	crystal build $< -o $@ --debug $(CRYSTAL_FLAGS)
+
+bin/lavinmq-debug: src/lavinmq.cr $(SOURCES) $(VIEW_SOURCES) $(VIEW_PARTIALS) lib $(JS) $(DOCS) | bin
 	crystal build $< -o $@ --debug $(CRYSTAL_FLAGS)
 
 bin/lavinmqctl: src/lavinmqctl.cr lib | bin


### PR DESCRIPTION
## Summary
- Views (ECR templates) are compiled into the binary but weren't listed as Makefile dependencies
- Changes to `views/*.ecr` or `views/partials/*.ecr` didn't trigger recompilation of `bin/lavinmq`

## Test plan
- [x] Modify a view file (e.g., `views/shovels.ecr`)
- [x] Run `make bin/lavinmq` and verify it recompiles