### PR TITLE
Document restart queue endpoint in OpenAPI

### DIFF
--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -254,6 +254,8 @@ paths:
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1pause"
   "/queues/{vhost}/{name}/resume":
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1resume"
+  "/queues/{vhost}/{name}/restart":
+    "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1restart"
   "/queues/{vhost}/{name}/bindings":
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1bindings"
   "/queues/{vhost}/{name}/contents":

--- a/static/docs/paths/queues.yaml
+++ b/static/docs/paths/queues.yaml
@@ -227,6 +227,47 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/queues/{vhost}/{name}/restart":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  - in: path
+    name: name
+    required: true
+    schema:
+      type: string
+      description: Name of queue.
+  put:
+    tags:
+    - queues
+    description: Restart a closed queue. This operation can only be performed on queues that are in a closed state. If the queue is still running, the operation will fail.
+    summary: Restart closed queue
+    operationId: RestartQueue
+    responses:
+      '204':
+        description: The queue was restarted successfully.
+      '400':
+        description: Bad Request. The queue was not restarted, likely because it is still running.
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
 "/queues/{vhost}/{name}/bindings":
   parameters:
   - in: path


### PR DESCRIPTION
## Summary
Documents the new `PUT /api/queues/{vhost}/{name}/restart` endpoint that was introduced in commit f35458f61589500dd881822f0016d9d4766c8b2f.

## Changes
- Added endpoint definition in `static/docs/paths/queues.yaml`
- Added path reference in `static/docs/openapi.yaml`

The endpoint allows restarting closed queues via the HTTP API:
- Returns 204 on successful restart
- Returns 400 if the queue is still running (not closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)