### PR TITLE
Reduce etcd lease keepalive renewal interval to 1/3rd of TTL

### DIFF
--- a/src/lavinmq/etcd/lease.cr
+++ b/src/lavinmq/etcd/lease.cr
@@ -30,7 +30,7 @@ module LavinMQ
 
       private def keepalive_loop(ttl : Int32)
         loop do
-          sleep (ttl * 0.7).seconds
+          sleep (ttl / 3).seconds
           ttl = @etcd.lease_keepalive(@id)
         end
       rescue ex : Etcd::Error # only rescue etcd errors


### PR DESCRIPTION
## Summary
Reduces the etcd lease keepalive interval from 70% to 33% of TTL to align with etcd's official Go client behavior.

## Problem
LavinMQ instances sometimes experience sporadic leadership loss with "Lease expired" errors. The 70% sleep interval left only a 3-second buffer (with 10s TTL) for keepalive requests to complete, which could be insufficient for handling network latency or slow responses. 

It's not clear if the short time for keepalive requests is the issue, but this should hopefully reduce the chances of losing leadership without good reason. 

## Solution
Changed interval from `ttl * 0.7` to `ttl / 3`, matching etcd's clientv3:

```go
nextKeepAlive := time.Now().Add((time.Duration(karesp.TTL) * time.Second) / 3.0)
```

**With 10s TTL:**
- Before: 7s sleep, 3s buffer
- After: 3.3s sleep, 6.7s buffer

Reference: https://github.com/etcd-io/etcd/blob/main/client/v3/lease.go#L542

Might fix #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)