### PR TITLE
Disable vhost selection on vhost specific views

### DIFF
--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -5,7 +5,7 @@ import * as HTTP from './http.js'
 import * as Chart from './chart.js'
 import { DataSource } from './datasource.js'
 
-Helpers.disableVhostSwap()
+Helpers.disableUserMenuVhost()
 
 const channel = new URLSearchParams(window.location.hash.substring(1)).get('name')
 const channelUrl = HTTP.url`api/channels/${channel}`

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -5,7 +5,7 @@ import * as Table from './table.js'
 import * as Chart from './chart.js'
 import { UrlDataSource } from './datasource.js'
 
-Helpers.disableVhostSwap()
+Helpers.disableUserMenuVhost()
 
 const chart = Chart.render('chart', 'bytes/s')
 

--- a/static/js/consumers.js
+++ b/static/js/consumers.js
@@ -3,7 +3,7 @@ import * as HTTP from './http.js'
 import * as DOM from './dom.js'
 import * as Helpers from './helpers.js'
 
-Helpers.disableVhostSwap()
+Helpers.disableUserMenuVhost()
 
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/consumers'

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -5,7 +5,7 @@ import * as Table from './table.js'
 import * as Chart from './chart.js'
 import { UrlDataSource } from './datasource.js'
 
-Helpers.disableVhostSwap()
+Helpers.disableUserMenuVhost()
 
 const search = new URLSearchParams(window.location.hash.substring(1))
 const exchange = search.get('name')

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -172,7 +172,7 @@ function addVhostOptions (formId, options) {
   })
 }
 
-function disableVhostSwap () {
+function disableUserMenuVhost () {
   const vhostMenu = document.getElementById('userMenuVhost')
   vhostMenu.disabled = true
   vhostMenu.title = 'Current view is locked to a specific vhost'
@@ -188,5 +188,5 @@ export {
   formatJSONargument,
   autoCompleteDatalist,
   formatTimestamp,
-  disableVhostSwap
+  disableUserMenuVhost
 }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -6,7 +6,7 @@ import * as Chart from './chart.js'
 import * as Auth from './auth.js'
 import { UrlDataSource, DataSource } from './datasource.js'
 
-Helpers.disableVhostSwap()
+Helpers.disableUserMenuVhost()
 
 const search = new URLSearchParams(window.location.hash.substring(1))
 const queue = search.get('name')

--- a/static/js/unacked.js
+++ b/static/js/unacked.js
@@ -1,9 +1,9 @@
 import * as Table from './table.js'
 import { UrlDataSource } from './datasource.js'
 import * as HTTP from './http.js'
-import * as Helpers fom './helpers.js'
+import * as Helpers from './helpers.js'
 
-Helpers.disableVhostSwap()
+Helpers.disableUserMenuVhost()
 
 const search = new URLSearchParams(window.location.hash.substring(1))
 const queue = search.get('name')


### PR DESCRIPTION
### WHAT is this pull request doing?
Close https://github.com/cloudamqp/lavinmq/issues/1287

A different approach which adds a helper that disables the vhost selection for specific views.

The initial thought was as follows: 

>  we add a variable to all views which should not allow vhost switch, naming up for discussion:
> 
> `window.vhostLocked = true`
> 
> We disable the vhost selector if that variable is set and add a hover tooltip `Current view is locked to vhost x` or something similar?

https://github.com/cloudamqp/lavinmq/pull/1566#issuecomment-3674696845


But as `layout.js` is loaded before the different view specific Javascript files, the approach with setting a value to `window.vhostLocked` falls short on execution.  Another alternative is to call a function (`Helper.disableUserMenuVhost`) that disables the vhost-selector on view load in each specific view, presented in this PR.

### HOW can this pull request be tested?
Try clicking the vhost-swap selector in a vhost-locked view, should not work ✅ 
Try clicking the vhost-swap selector in a non-vhost-locked view, should work ✅ 
<img width="470" height="178" alt="image" src="https://github.com/user-attachments/assets/1dd98d69-3c16-4f5a-a9ba-9fdf82522a66" />

