### PR TITLE
Use VHost object instead of string

### DIFF
--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,7 +15,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            conns = @amqp_server.vhosts[vhost].connections.each
+            conns = vhost.connections.each
             channels = conns.flat_map(&.channels.each_value)
             page(context, channels)
           end

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -25,7 +25,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/connections" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, @amqp_server.vhosts[vhost].connections.each)
+            page(context, vhost.connections.each)
           end
         end
 

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -16,7 +16,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             user = user(context)
             refuse_unless_management(context, user, vhost)
-            itr = connections(user).each.select(&.vhost.name.==(vhost))
+            itr = connections(user).each.select(&.vhost.==(vhost))
               .flat_map do |conn|
                 conn.channels.each_value.flat_map &.consumers
               end
@@ -31,7 +31,7 @@ module LavinMQ
             consumer_tag = params["consumer_tag"]
             conn_id = params["connection"]
             ch_id = params["channel"].to_i
-            connection = connections(user).find { |conn| conn.vhost.name == vhost && conn.name == conn_id }
+            connection = connections(user).find { |conn| conn.vhost == vhost && conn.name == conn_id }
             unless connection
               context.response.status_code = 404
               break

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -40,7 +40,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
             refuse_unless_vhost_access(context, user(context), vhost)
-            VHostDefinitions.new(@amqp_server, @amqp_server.vhosts[vhost]).export(context.response)
+            VHostDefinitions.new(@amqp_server, vhost).export(context.response)
           end
         end
 
@@ -49,7 +49,7 @@ module LavinMQ
             refuse_unless_policymaker(context, user(context), vhost)
             refuse_unless_vhost_access(context, user(context), vhost)
             body = parse_body(context)
-            VHostDefinitions.new(@amqp_server, @amqp_server.vhosts[vhost]).import(body)
+            VHostDefinitions.new(@amqp_server, vhost).import(body)
           end
         end
 
@@ -60,7 +60,7 @@ module LavinMQ
             ::HTTP::FormData.parse(context.request) do |part|
               if part.name == "file"
                 body = JSON.parse(part.body)
-                VHostDefinitions.new(@amqp_server, @amqp_server.vhosts[vhost]).import(body)
+                VHostDefinitions.new(@amqp_server, vhost).import(body)
               end
             end
           end

--- a/src/lavinmq/http/controller/permissions.cr
+++ b/src/lavinmq/http/controller/permissions.cr
@@ -39,9 +39,9 @@ module LavinMQ
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params) do |vhost|
             u = user(context, params, "user")
-            perm = u.permissions[vhost]?
+            perm = u.permissions[vhost.name]?
             not_found(context) unless perm
-            u.permissions_details(vhost, perm).to_json(context.response)
+            u.permissions_details(vhost.name, perm).to_json(context.response)
           end
         end
 
@@ -56,9 +56,9 @@ module LavinMQ
             unless config && read && write
               bad_request(context, "Fields 'configure', 'read' and 'write' are required")
             end
-            is_update = @amqp_server.users[u.name].permissions[vhost]?
+            is_update = @amqp_server.users[u.name].permissions[vhost.name]?
             @amqp_server.users
-              .add_permission(u.name, vhost, Regex.new(config), Regex.new(read), Regex.new(write))
+              .add_permission(u.name, vhost.name, Regex.new(config), Regex.new(read), Regex.new(write))
             context.response.status_code = is_update ? 204 : 201
           rescue ex : ArgumentError
             bad_request(context, "Permissions must be valid Regex")
@@ -69,7 +69,7 @@ module LavinMQ
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params) do |vhost|
             u = user(context, params, "user")
-            @amqp_server.users.rm_permission(u.name, vhost)
+            @amqp_server.users.rm_permission(u.name, vhost.name)
             context.response.status_code = 204
           end
         end

--- a/src/lavinmq/http/controller/shovels.cr
+++ b/src/lavinmq/http/controller/shovels.cr
@@ -15,14 +15,14 @@ module LavinMQ
 
         get "/api/shovels/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
-            page(context, @amqp_server.vhosts[vhost].shovels.each_value)
+            page(context, vhost.shovels.each_value)
           end
         end
 
         get "/api/shovels/:vhost/:name" do |context, params|
           with_vhost(context, params) do |vhost|
             shovel_name = params["name"]
-            if shovel = @amqp_server.vhosts[vhost].shovels[shovel_name]?
+            if shovel = vhost.shovels[shovel_name]?
               shovel.to_json(context.response)
             else
               context.response.status_code = 404
@@ -33,7 +33,7 @@ module LavinMQ
         put "/api/shovels/:vhost/:name/pause" do |context, params|
           with_vhost(context, params) do |vhost|
             shovel_name = params["name"]
-            if current_shovel = @amqp_server.vhosts[vhost].shovels[shovel_name]?
+            if current_shovel = vhost.shovels[shovel_name]?
               if !current_shovel.running?
                 context.response.status_code = 422
                 next
@@ -49,7 +49,7 @@ module LavinMQ
         put "/api/shovels/:vhost/:name/resume" do |context, params|
           with_vhost(context, params) do |vhost|
             shovel_name = params["name"]
-            if current_shovel = @amqp_server.vhosts[vhost].shovels[shovel_name]?
+            if current_shovel = vhost.shovels[shovel_name]?
               if !current_shovel.paused?
                 context.response.status_code = 422
                 next


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR reduces the string passing and hash lookups in the http controllers by passing the VHost object around. `with_vhost` already did a lookup, but passed the name instead of the vhost object.

### HOW can this pull request be tested?
Run specs
