### PR TITLE
Add plain-table class wout alternating row bg

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1169,6 +1169,10 @@ footer .logo {
   background-color: var(--color-table-row-even);
 }
 
+.table.plain-table tbody tr {
+  background-color: var(--color-table-row-even);
+}
+
 [id$="-error"] {
   display: none;
   margin: 10px 0;

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -19,7 +19,7 @@
         </div>
         <div id="livelog" class="livelog">
         <div id="table-error"></div>
-        <table id="table" class="table">
+        <table id="table" class="table plain-table">
           <thead>
             <tr>
               <th class="livelog-timestamp">Timestamp</th>


### PR DESCRIPTION
Add plain-table class without alternating row background color

Issue #1336

### WHAT is this pull request doing?
Adds a `plain-table` CSS class which only purpose is to override the `table` class styling for odd and even rows.

### HOW can this pull request be tested?
Manual.
