### PR TITLE
CI: bump bunny to the latest commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           repository: ruby-amqp/bunny
           path: bunny
           fetch-depth: 0
-          ref: 5543c40db2567c05d614a0a24b618441aa9d199f
+          ref: 55bb3d2accc293911120ea7dc7330cf06eda41c2
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This would be https://github.com/ruby-amqp/bunny/commit/55bb3d2accc293911120ea7dc7330cf06eda41c2

The previous commit used was https://github.com/ruby-amqp/bunny/commit/5543c40db2567c05d614a0a24b618441aa9d199f

Running the bunny specs from that commit fails, because we use the latest stable Ruby, which is now Ruby 4, which no longer has the `SortedSet` (it is a gem), which the tests was failing on.