### PR TITLE
Group prometheus metrics per metric with type and help 

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -197,6 +197,21 @@ describe LavinMQ::HTTP::PrometheusController do
         # But values should appear for each queue (3 queues)
         value_count = lines.count(&.starts_with?("lavinmq_detailed_queue_messages_ready{"))
         value_count.should eq 3
+
+        # Verify grouping: TYPE and HELP should immediately precede the values
+        # Find TYPE line index, HELP should be next, then values should follow
+        type_idx = lines.index(&.includes?("# TYPE lavinmq_detailed_queue_messages_ready"))
+        help_idx = lines.index(&.includes?("# HELP lavinmq_detailed_queue_messages_ready"))
+        first_value_idx = lines.index(&.starts_with?("lavinmq_detailed_queue_messages_ready{"))
+
+        type_idx.should_not be_nil
+        help_idx.should_not be_nil
+        first_value_idx.should_not be_nil
+
+        # HELP should come right after TYPE
+        help_idx.should eq(type_idx.not_nil! + 1)
+        # First value should come right after HELP
+        first_value_idx.should eq(help_idx.not_nil! + 1)
       end
     end
   end


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes #1045 

It resolves the issue of outputting multiple `# TYPE` and `# HELP` but it also adds more loops in the controller as it has to go over all the queue per metric type. 
No checks has been made on how much these extra loops will cost and also, maybe there is a better way? 

### HOW can this pull request be tested?

Specs 

Can also be tested manually by creating two queue, publish some messages in to one of them and then check output from `curl -s http://localhost:15692/metrics/detailed?family=queue_coarse_metrics` 