### PR TITLE
Add proxy protocol trusted sources verification

### DIFF
--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -16,7 +16,7 @@ bind = ::
 ;port = 5672
 ;tls_port = 5671
 ;tcp_proxy_protocol = 0
-;proxy_protocol_trusted_sources = 10.0.0.1, 10.0.0.2
+;proxy_protocol_trusted_sources = 10.0.0.1, 192.168.0.0/24, 2001:db8::/32
 
 [mqtt]
 bind = ::

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -15,6 +15,8 @@ bind = ::
 bind = ::
 ;port = 5672
 ;tls_port = 5671
+;tcp_proxy_protocol = 0
+;proxy_protocol_trusted_sources = 10.0.0.1, 10.0.0.2
 
 [mqtt]
 bind = ::

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -15,7 +15,7 @@ bind = ::
 bind = ::
 ;port = 5672
 ;tls_port = 5671
-;tcp_proxy_protocol = 0
+;tcp_proxy_protocol = false
 ;proxy_protocol_trusted_sources = 10.0.0.1, 192.168.0.0/24, 2001:db8::/32
 
 [mqtt]

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -206,7 +206,7 @@ describe LavinMQ::Config do
       config.amqp_port.should eq 5673
       config.amqps_port.should eq 5674
       config.unix_path.should eq "/tmp/lavinmq.sock"
-      config.tcp_proxy_protocol.should be_true
+      config.tcp_proxy_protocol?.should be_true
       config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
       config.heartbeat.should eq 600
       config.frame_max.should eq 262144
@@ -573,7 +573,7 @@ describe LavinMQ::Config do
         config = LavinMQ::Config.new
         argv = ["-c", config_file.path]
         config.parse(argv)
-        config.tcp_proxy_protocol.should eq {{expected}}
+        config.tcp_proxy_protocol?.should eq {{expected}}
       end
     {% end %}
   end

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -124,8 +124,8 @@ describe LavinMQ::Config do
           port = 5673
           tls_port = 5674
           unix_path = /tmp/lavinmq.sock
-          unix_proxy_protocol = 2
           tcp_proxy_protocol = 1
+          proxy_protocol_trusted_sources = 10.0.0.1
           heartbeat = 600
           frame_max = 262144
           channel_max = 4096
@@ -206,8 +206,8 @@ describe LavinMQ::Config do
       config.amqp_port.should eq 5673
       config.amqps_port.should eq 5674
       config.unix_path.should eq "/tmp/lavinmq.sock"
-      config.unix_proxy_protocol.should eq 2
-      config.tcp_proxy_protocol.should eq 1
+      config.tcp_proxy_protocol.should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
       config.heartbeat.should eq 600
       config.frame_max.should eq 262144
       config.channel_max.should eq 4096
@@ -559,5 +559,22 @@ describe LavinMQ::Config do
     config.amqp_bind.should eq "0.0.0.0"
     config.http_bind.should eq "0.0.0.0"
     config.mqtt_bind.should eq "0.0.0.0"
+  end
+
+  describe "tcp_proxy_protocol" do
+    {% for value, expected in {"1": true, "yes": true, "2": true, "-1": false, "no": false, "false": false, "0": false} %}
+      it "sets tcp_proxy_protocol to {{expected}} when value is {{value}}" do
+        config_file = File.tempfile do |file|
+          file.print <<-CONFIG
+                [amqp]
+                tcp_proxy_protocol = {{value}}
+              CONFIG
+        end
+        config = LavinMQ::Config.new
+        argv = ["-c", config_file.path]
+        config.parse(argv)
+        config.tcp_proxy_protocol.should eq {{expected}}
+      end
+    {% end %}
   end
 end

--- a/spec/ip_matcher_spec.cr
+++ b/spec/ip_matcher_spec.cr
@@ -1,0 +1,277 @@
+require "./spec_helper"
+
+describe LavinMQ::IPMatcher do
+  describe ".parse and #matches?" do
+    describe "IPv4 exact IP matching" do
+      it "matches exact IPv4 address" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.1")
+        matcher.matches?("192.168.1.1").should be_true
+      end
+
+      it "doesn't match different IPv4 address" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.1")
+        matcher.matches?("192.168.1.2").should be_false
+        matcher.matches?("192.168.2.1").should be_false
+        matcher.matches?("10.0.0.1").should be_false
+      end
+
+      it "handles loopback address" do
+        matcher = LavinMQ::IPMatcher.parse("127.0.0.1")
+        matcher.matches?("127.0.0.1").should be_true
+        matcher.matches?("127.0.0.2").should be_false
+      end
+    end
+
+    describe "IPv6 exact IP matching" do
+      it "matches exact IPv6 address" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1")
+        matcher.matches?("2001:db8::1").should be_true
+      end
+
+      it "doesn't match different IPv6 address" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1")
+        matcher.matches?("2001:db8::2").should be_false
+        matcher.matches?("2001:db9::1").should be_false
+      end
+
+      it "handles IPv6 loopback" do
+        matcher = LavinMQ::IPMatcher.parse("::1")
+        matcher.matches?("::1").should be_true
+        matcher.matches?("::2").should be_false
+      end
+
+      it "exact match requires same string representation" do
+        # Exact IPs use string comparison for performance
+        # Different representations of the same IPv6 address won't match
+        matcher = LavinMQ::IPMatcher.parse("2001:0db8:0000:0000:0000:0000:0000:0001")
+        matcher.matches?("2001:0db8:0000:0000:0000:0000:0000:0001").should be_true
+        matcher.matches?("2001:db8::1").should be_false
+
+        # If you need to match different representations, use CIDR /128
+        cidr_matcher = LavinMQ::IPMatcher.parse("2001:db8::1/128")
+        cidr_matcher.matches?("2001:db8::1").should be_true
+      end
+    end
+
+    describe "IPv4 CIDR matching" do
+      it "matches IP in /24 range" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.0/24")
+        matcher.matches?("192.168.1.0").should be_true
+        matcher.matches?("192.168.1.1").should be_true
+        matcher.matches?("192.168.1.50").should be_true
+        matcher.matches?("192.168.1.255").should be_true
+      end
+
+      it "doesn't match IP outside /24 range" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.0/24")
+        matcher.matches?("192.168.0.255").should be_false
+        matcher.matches?("192.168.2.0").should be_false
+        matcher.matches?("192.169.1.1").should be_false
+        matcher.matches?("10.0.0.1").should be_false
+      end
+
+      it "matches IP in /16 range" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.0.0/16")
+        matcher.matches?("192.168.0.0").should be_true
+        matcher.matches?("192.168.1.1").should be_true
+        matcher.matches?("192.168.255.255").should be_true
+      end
+
+      it "doesn't match IP outside /16 range" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.0.0/16")
+        matcher.matches?("192.167.255.255").should be_false
+        matcher.matches?("192.169.0.0").should be_false
+        matcher.matches?("10.0.0.1").should be_false
+      end
+
+      it "matches IP in /8 range" do
+        matcher = LavinMQ::IPMatcher.parse("10.0.0.0/8")
+        matcher.matches?("10.0.0.0").should be_true
+        matcher.matches?("10.1.2.3").should be_true
+        matcher.matches?("10.255.255.255").should be_true
+      end
+
+      it "doesn't match IP outside /8 range" do
+        matcher = LavinMQ::IPMatcher.parse("10.0.0.0/8")
+        matcher.matches?("9.255.255.255").should be_false
+        matcher.matches?("11.0.0.0").should be_false
+        matcher.matches?("192.168.1.1").should be_false
+      end
+
+      it "matches IP in /32 range (single host)" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.100/32")
+        matcher.matches?("192.168.1.100").should be_true
+        matcher.matches?("192.168.1.99").should be_false
+        matcher.matches?("192.168.1.101").should be_false
+      end
+
+      it "matches IP in /0 range (all IPs)" do
+        matcher = LavinMQ::IPMatcher.parse("0.0.0.0/0")
+        matcher.matches?("0.0.0.0").should be_true
+        matcher.matches?("192.168.1.1").should be_true
+        matcher.matches?("255.255.255.255").should be_true
+      end
+
+      it "handles /25 CIDR" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.0/25")
+        matcher.matches?("192.168.1.0").should be_true
+        matcher.matches?("192.168.1.127").should be_true
+        matcher.matches?("192.168.1.128").should be_false
+        matcher.matches?("192.168.1.255").should be_false
+      end
+
+      it "handles /12 CIDR (AWS VPC default)" do
+        matcher = LavinMQ::IPMatcher.parse("172.16.0.0/12")
+        matcher.matches?("172.16.0.0").should be_true
+        matcher.matches?("172.31.255.255").should be_true
+        matcher.matches?("172.15.255.255").should be_false
+        matcher.matches?("172.32.0.0").should be_false
+      end
+
+      it "normalizes network address" do
+        # Even if network address isn't properly masked, it should work
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.50/24")
+        matcher.matches?("192.168.1.1").should be_true
+        matcher.matches?("192.168.1.255").should be_true
+      end
+    end
+
+    describe "IPv6 CIDR matching" do
+      it "matches IP in /64 range" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/64")
+        matcher.matches?("2001:db8::1").should be_true
+        matcher.matches?("2001:db8::ffff").should be_true
+        matcher.matches?("2001:db8:0:0:ffff:ffff:ffff:ffff").should be_true
+      end
+
+      it "doesn't match IP outside /64 range" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/64")
+        matcher.matches?("2001:db8:0:1::1").should be_false
+        matcher.matches?("2001:db9::1").should be_false
+        matcher.matches?("2001:db7:ffff:ffff:ffff:ffff:ffff:ffff").should be_false
+      end
+
+      it "matches IP in /32 range" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/32")
+        matcher.matches?("2001:db8::1").should be_true
+        matcher.matches?("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff").should be_true
+      end
+
+      it "doesn't match IP outside /32 range" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/32")
+        matcher.matches?("2001:db7:ffff:ffff:ffff:ffff:ffff:ffff").should be_false
+        matcher.matches?("2001:db9::1").should be_false
+      end
+
+      it "matches IP in /128 range (single host)" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1/128")
+        matcher.matches?("2001:db8::1").should be_true
+        matcher.matches?("2001:db8::2").should be_false
+      end
+
+      it "matches IP in /0 range (all IPs)" do
+        matcher = LavinMQ::IPMatcher.parse("::/0")
+        matcher.matches?("::").should be_true
+        matcher.matches?("2001:db8::1").should be_true
+        matcher.matches?("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").should be_true
+      end
+
+      it "handles link-local /10 range" do
+        matcher = LavinMQ::IPMatcher.parse("fe80::/10")
+        matcher.matches?("fe80::1").should be_true
+        matcher.matches?("fe80::ffff:ffff:ffff:ffff").should be_true
+        matcher.matches?("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff").should be_true
+        matcher.matches?("fec0::1").should be_false
+      end
+    end
+
+    describe "error handling" do
+      it "raises on invalid IPv4 address" do
+        expect_raises(ArgumentError, /Invalid IP address/) do
+          LavinMQ::IPMatcher.parse("256.0.0.1")
+        end
+
+        expect_raises(ArgumentError, /Invalid IP address/) do
+          LavinMQ::IPMatcher.parse("not-an-ip")
+        end
+      end
+
+      it "raises on invalid IPv6 address" do
+        expect_raises(ArgumentError, /Invalid IP address/) do
+          LavinMQ::IPMatcher.parse("gggg::1")
+        end
+      end
+
+      it "raises on invalid CIDR notation" do
+        expect_raises(ArgumentError, /Invalid CIDR/) do
+          LavinMQ::IPMatcher.parse("192.168.1.0//24")
+        end
+
+        expect_raises(ArgumentError, /Invalid CIDR/) do
+          LavinMQ::IPMatcher.parse("192.168.1.0/")
+        end
+      end
+
+      it "raises on invalid CIDR prefix" do
+        expect_raises(ArgumentError, /Invalid CIDR prefix/) do
+          LavinMQ::IPMatcher.parse("192.168.1.0/abc")
+        end
+      end
+
+      it "raises on IPv4 prefix > 32" do
+        expect_raises(ArgumentError, /IPv4 prefix must be 0-32/) do
+          LavinMQ::IPMatcher.parse("192.168.1.0/33")
+        end
+
+        expect_raises(ArgumentError, /IPv4 prefix must be 0-32/) do
+          LavinMQ::IPMatcher.parse("10.0.0.0/255")
+        end
+      end
+
+      it "raises on IPv6 prefix > 128" do
+        expect_raises(ArgumentError, /IPv6 prefix must be 0-128/) do
+          LavinMQ::IPMatcher.parse("2001:db8::/129")
+        end
+
+        expect_raises(ArgumentError, /IPv6 prefix must be 0-128/) do
+          LavinMQ::IPMatcher.parse("::1/255")
+        end
+      end
+
+      it "raises on CIDR with invalid IP" do
+        expect_raises(ArgumentError, /Invalid IP address in CIDR/) do
+          LavinMQ::IPMatcher.parse("not-an-ip/24")
+        end
+      end
+    end
+
+    describe "edge cases" do
+      it "handles whitespace in IP" do
+        matcher = LavinMQ::IPMatcher.parse("  192.168.1.1  ")
+        matcher.matches?("192.168.1.1").should be_true
+      end
+
+      it "handles whitespace in CIDR" do
+        matcher = LavinMQ::IPMatcher.parse("  192.168.1.0  /  24  ")
+        matcher.matches?("192.168.1.50").should be_true
+      end
+
+      it "doesn't match IPv6 address against IPv4 CIDR" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.0/24")
+        matcher.matches?("2001:db8::1").should be_false
+      end
+
+      it "doesn't match IPv4 address against IPv6 CIDR" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/32")
+        matcher.matches?("192.168.1.1").should be_false
+      end
+
+      it "CIDR notation can match different IPv6 representations" do
+        # CIDR notation uses byte comparison and can match different representations
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1/128")
+        matcher.matches?("2001:0db8:0000:0000:0000:0000:0000:0001").should be_true
+        matcher.matches?("2001:db8::1").should be_true
+      end
+    end
+  end
+end

--- a/spec/ip_matcher_spec.cr
+++ b/spec/ip_matcher_spec.cr
@@ -40,16 +40,25 @@ describe LavinMQ::IPMatcher do
         matcher.matches?("::2").should be_false
       end
 
-      it "exact match requires same string representation" do
-        # Exact IPs use string comparison for performance
-        # Different representations of the same IPv6 address won't match
-        matcher = LavinMQ::IPMatcher.parse("2001:0db8:0000:0000:0000:0000:0000:0001")
-        matcher.matches?("2001:0db8:0000:0000:0000:0000:0000:0001").should be_true
-        matcher.matches?("2001:db8::1").should be_false
+      it "matches equivalent IPv6 representations of loopback" do
+        matcher = LavinMQ::IPMatcher.parse("::1")
+        matcher.matches?("0:0:0:0:0:0:0:1").should be_true
+        matcher.matches?("0000:0000:0000:0000:0000:0000:0000:0001").should be_true
+      end
 
-        # If you need to match different representations, use CIDR /128
-        cidr_matcher = LavinMQ::IPMatcher.parse("2001:db8::1/128")
-        cidr_matcher.matches?("2001:db8::1").should be_true
+      it "matches expanded form against zero-compressed form" do
+        matcher = LavinMQ::IPMatcher.parse("2001:0db8:0000:0000:0000:0000:0000:0001")
+        matcher.matches?("2001:db8::1").should be_true
+      end
+
+      it "matches zero-compressed form against expanded form" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1")
+        matcher.matches?("2001:0db8:0000:0000:0000:0000:0000:0001").should be_true
+      end
+
+      it "matches mixed-case hex digits" do
+        matcher = LavinMQ::IPMatcher.parse("2001:DB8::1")
+        matcher.matches?("2001:db8::1").should be_true
       end
     end
 
@@ -239,7 +248,7 @@ describe LavinMQ::IPMatcher do
       end
 
       it "raises on CIDR with invalid IP" do
-        expect_raises(ArgumentError, /Invalid IP address in CIDR/) do
+        expect_raises(ArgumentError, /Invalid IP address/) do
           LavinMQ::IPMatcher.parse("not-an-ip/24")
         end
       end
@@ -267,10 +276,70 @@ describe LavinMQ::IPMatcher do
       end
 
       it "CIDR notation can match different IPv6 representations" do
-        # CIDR notation uses byte comparison and can match different representations
         matcher = LavinMQ::IPMatcher.parse("2001:db8::1/128")
         matcher.matches?("2001:0db8:0000:0000:0000:0000:0000:0001").should be_true
         matcher.matches?("2001:db8::1").should be_true
+      end
+    end
+
+    describe "negative matches" do
+      it "IPv4 off-by-one in last octet" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.0.1")
+        matcher.matches?("192.168.0.2").should be_false
+        matcher.matches?("192.168.0.0").should be_false
+      end
+
+      it "IPv4 off-by-one at /24 boundary" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.0/24")
+        matcher.matches?("192.168.0.255").should be_false
+        matcher.matches?("192.168.2.0").should be_false
+      end
+
+      it "IPv6 off-by-one in last group" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1")
+        matcher.matches?("2001:db8::2").should be_false
+        matcher.matches?("2001:db8::0").should be_false
+      end
+
+      it "IPv6 lookalike with different magnitude doesn't match" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::1")
+        matcher.matches?("2001:db8::10").should be_false
+        matcher.matches?("2001:db8::100").should be_false
+        matcher.matches?("2001:db8:1::").should be_false
+      end
+
+      it "IPv6 /127 boundary" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/127")
+        matcher.matches?("2001:db8::").should be_true
+        matcher.matches?("2001:db8::1").should be_true
+        matcher.matches?("2001:db8::2").should be_false
+      end
+
+      it "IPv6 /126 boundary" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8::/126")
+        matcher.matches?("2001:db8::3").should be_true
+        matcher.matches?("2001:db8::4").should be_false
+      end
+
+      it "IPv6 /64 doesn't bleed into adjacent /64" do
+        matcher = LavinMQ::IPMatcher.parse("2001:db8:0:1::/64")
+        matcher.matches?("2001:db8:0:0:ffff:ffff:ffff:ffff").should be_false
+        matcher.matches?("2001:db8:0:2::").should be_false
+      end
+
+      it "IPv4 matcher rejects IPv4-mapped IPv6" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.1")
+        matcher.matches?("::ffff:192.168.1.1").should be_false
+      end
+
+      it "IPv4 CIDR rejects IPv4-mapped IPv6" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.0/24")
+        matcher.matches?("::ffff:192.168.1.50").should be_false
+      end
+
+      it "IPv6 matcher rejects raw IPv4" do
+        matcher = LavinMQ::IPMatcher.parse("::ffff:192.168.1.1")
+        matcher.matches?("192.168.1.1").should be_false
       end
     end
   end

--- a/spec/proxy_protocol_spec.cr
+++ b/spec/proxy_protocol_spec.cr
@@ -152,7 +152,7 @@ describe "ProxyProtocol" do
   describe "trusted sources" do
     it "parses individual IPv4 addresses" do
       config = LavinMQ::Config.new
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("192.168.1.1, 10.0.0.1")
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list("192.168.1.1, 10.0.0.1")
 
       config.proxy_protocol_trusted_sources.size.should eq 2
       config.proxy_protocol_trusted_sources[0].matches?("192.168.1.1").should be_true
@@ -161,7 +161,7 @@ describe "ProxyProtocol" do
 
     it "parses IPv4 CIDR notation" do
       config = LavinMQ::Config.new
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("192.168.0.0/24")
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list("192.168.0.0/24")
 
       config.proxy_protocol_trusted_sources.size.should eq 1
       config.proxy_protocol_trusted_sources[0].matches?("192.168.0.1").should be_true
@@ -171,7 +171,7 @@ describe "ProxyProtocol" do
 
     it "parses IPv6 CIDR notation" do
       config = LavinMQ::Config.new
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("2001:db8::/32")
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list("2001:db8::/32")
 
       config.proxy_protocol_trusted_sources.size.should eq 1
       config.proxy_protocol_trusted_sources[0].matches?("2001:db8::1").should be_true
@@ -181,7 +181,7 @@ describe "ProxyProtocol" do
 
     it "parses mixed IPs and CIDR notation" do
       config = LavinMQ::Config.new
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources(
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list(
         "10.0.0.1, 192.168.0.0/24, 2001:db8::/32, ::1")
 
       config.proxy_protocol_trusted_sources.size.should eq 4
@@ -206,7 +206,7 @@ describe "ProxyProtocol" do
     it "handles invalid entries gracefully" do
       config = LavinMQ::Config.new
       # This should print warnings to STDERR but not fail
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources(
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list(
         "10.0.0.1, invalid-ip, 192.168.0.0/24, 300.0.0.1")
 
       # Only valid entries should be parsed
@@ -217,7 +217,7 @@ describe "ProxyProtocol" do
 
     it "handles whitespace correctly" do
       config = LavinMQ::Config.new
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources(
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list(
         "  10.0.0.1  ,  192.168.0.0/24  ")
 
       config.proxy_protocol_trusted_sources.size.should eq 2
@@ -227,7 +227,7 @@ describe "ProxyProtocol" do
 
     it "returns empty array for empty config" do
       config = LavinMQ::Config.new
-      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("")
+      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list("")
 
       config.proxy_protocol_trusted_sources.size.should eq 0
     end

--- a/spec/proxy_protocol_spec.cr
+++ b/spec/proxy_protocol_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "./spec_helper"
 require "../src/lavinmq/proxy_protocol"
 
 describe "ProxyProtocol" do
@@ -85,6 +85,90 @@ describe "ProxyProtocol" do
         0x7f, 0x00, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01,
         0x92, 0x30, 0x16, 0x27
       ).to_slice
+    end
+  end
+
+  describe "trusted sources" do
+    it "parses individual IPv4 addresses" do
+      config = LavinMQ::Config.new
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("192.168.1.1, 10.0.0.1")
+
+      config.proxy_protocol_trusted_sources.size.should eq 2
+      config.proxy_protocol_trusted_sources[0].matches?("192.168.1.1").should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("192.168.1.2").should be_false
+    end
+
+    it "parses IPv4 CIDR notation" do
+      config = LavinMQ::Config.new
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("192.168.0.0/24")
+
+      config.proxy_protocol_trusted_sources.size.should eq 1
+      config.proxy_protocol_trusted_sources[0].matches?("192.168.0.1").should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("192.168.0.255").should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("192.168.1.1").should be_false
+    end
+
+    it "parses IPv6 CIDR notation" do
+      config = LavinMQ::Config.new
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("2001:db8::/32")
+
+      config.proxy_protocol_trusted_sources.size.should eq 1
+      config.proxy_protocol_trusted_sources[0].matches?("2001:db8::1").should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff").should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("2001:db9::1").should be_false
+    end
+
+    it "parses mixed IPs and CIDR notation" do
+      config = LavinMQ::Config.new
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources(
+        "10.0.0.1, 192.168.0.0/24, 2001:db8::/32, ::1")
+
+      config.proxy_protocol_trusted_sources.size.should eq 4
+
+      # Exact IPv4
+      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
+      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.2").should be_false
+
+      # IPv4 CIDR
+      config.proxy_protocol_trusted_sources[1].matches?("192.168.0.50").should be_true
+      config.proxy_protocol_trusted_sources[1].matches?("192.168.1.50").should be_false
+
+      # IPv6 CIDR
+      config.proxy_protocol_trusted_sources[2].matches?("2001:db8::100").should be_true
+      config.proxy_protocol_trusted_sources[2].matches?("2001:db9::1").should be_false
+
+      # Exact IPv6
+      config.proxy_protocol_trusted_sources[3].matches?("::1").should be_true
+      config.proxy_protocol_trusted_sources[3].matches?("::2").should be_false
+    end
+
+    it "handles invalid entries gracefully" do
+      config = LavinMQ::Config.new
+      # This should print warnings to STDERR but not fail
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources(
+        "10.0.0.1, invalid-ip, 192.168.0.0/24, 300.0.0.1")
+
+      # Only valid entries should be parsed
+      config.proxy_protocol_trusted_sources.size.should eq 2
+      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
+      config.proxy_protocol_trusted_sources[1].matches?("192.168.0.50").should be_true
+    end
+
+    it "handles whitespace correctly" do
+      config = LavinMQ::Config.new
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources(
+        "  10.0.0.1  ,  192.168.0.0/24  ")
+
+      config.proxy_protocol_trusted_sources.size.should eq 2
+      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
+      config.proxy_protocol_trusted_sources[1].matches?("192.168.0.50").should be_true
+    end
+
+    it "returns empty array for empty config" do
+      config = LavinMQ::Config.new
+      config.proxy_protocol_trusted_sources = config.parse_trusted_sources("")
+
+      config.proxy_protocol_trusted_sources.size.should eq 0
     end
   end
 end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -8,7 +8,6 @@ require "./in_memory_backend"
 require "./auth/password"
 require "./sni_config"
 require "./config/options"
-require "./ip_matcher"
 
 module LavinMQ
   class Config

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -8,6 +8,7 @@ require "./in_memory_backend"
 require "./auth/password"
 require "./sni_config"
 require "./config/options"
+require "./ip_matcher"
 
 module LavinMQ
   class Config

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -78,22 +78,8 @@ module LavinMQ
       @[IniOpt(section: "amqp", transform: ->(v : String) { true?(v) || v.to_u8? == 2 })]
       property? tcp_proxy_protocol = false
 
-      @[IniOpt(section: "amqp", transform: ->(v : String) { parse_trusted_sources(v) })]
+      @[IniOpt(section: "amqp", transform: ->IPMatcher.parse_list(String))]
       property proxy_protocol_trusted_sources = Array(IPMatcher).new
-
-      def parse_trusted_sources(sources : String) : Array(IPMatcher)
-        sources.split(',')
-          .map(&.strip)
-          .reject(&.empty?)
-          .compact_map do |source|
-            begin
-              IPMatcher.parse(source)
-            rescue ex : Socket::Error | ArgumentError
-              STDERR.puts "WARNING: Invalid IP/CIDR in proxy_protocol_trusted_sources: #{source} - #{ex.message}"
-              nil
-            end
-          end
-      end
 
       @[CliOpt("", "--http-bind=BIND", "IP address that the HTTP server will listen on (default: 127.0.0.1)", section: "bindings")]
       @[IniOpt(ini_name: bind, section: "mgmt")]

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -76,7 +76,7 @@ module LavinMQ
       property mqtt_unix_path = ""
 
       @[IniOpt(section: "amqp", transform: ->(v : String) { true?(v) || v.to_u8? == 2 })]
-      property tcp_proxy_protocol = false
+      property? tcp_proxy_protocol = false
 
       @[IniOpt(section: "amqp", transform: ->(v : String) { parse_trusted_sources(v) })]
       property proxy_protocol_trusted_sources = Array(IPMatcher).new

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -1,6 +1,7 @@
 require "log"
 require "../auth/password"
 require "../amqp/exchange/consistent_hash_algorithm"
+require "../ip_matcher"
 
 module LavinMQ
   class Config
@@ -74,11 +75,25 @@ module LavinMQ
       @[IniOpt(ini_name: unix_path, section: "mqtt")]
       property mqtt_unix_path = ""
 
-      @[IniOpt(section: "amqp", transform: ->(v : String) { true?(v) ? 1u8 : v.to_u8? || 0u8 })]
-      property unix_proxy_protocol = 1_u8 # PROXY protocol version on unix domain socket connections
+      @[IniOpt(section: "amqp", transform: ->(v : String) { true?(v) || v.to_u8? == 2 })]
+      property tcp_proxy_protocol = false
 
-      @[IniOpt(section: "amqp", transform: ->(v : String) { true?(v) ? 1u8 : v.to_u8? || 0u8 })]
-      property tcp_proxy_protocol = 0_u8 # PROXY protocol version on amqp tcp connections
+      @[IniOpt(section: "amqp", transform: ->(v : String) { parse_trusted_sources(v) })]
+      property proxy_protocol_trusted_sources = Array(IPMatcher).new
+
+      def parse_trusted_sources(sources : String) : Array(IPMatcher)
+        sources.split(',')
+          .map(&.strip)
+          .reject(&.empty?)
+          .compact_map do |source|
+            begin
+              IPMatcher.parse(source)
+            rescue ex : Socket::Error | ArgumentError
+              STDERR.puts "WARNING: Invalid IP/CIDR in proxy_protocol_trusted_sources: #{source} - #{ex.message}"
+              nil
+            end
+          end
+      end
 
       @[CliOpt("", "--http-bind=BIND", "IP address that the HTTP server will listen on (default: 127.0.0.1)", section: "bindings")]
       @[IniOpt(ini_name: bind, section: "mgmt")]

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -27,6 +27,21 @@ module LavinMQ
       end
     end
 
+    # Parse a comma-separated list of IP addresses or CIDR ranges from config
+    def self.parse_list(sources : String) : Array(IPMatcher)
+      sources.split(',')
+        .map(&.strip)
+        .reject(&.empty?)
+        .compact_map do |source|
+          begin
+            parse(source)
+          rescue ex : Socket::Error | ArgumentError
+            STDERR.puts "WARNING: Invalid IP/CIDR: #{source} - #{ex.message}"
+            nil
+          end
+        end
+    end
+
     # Check if an IP address matches this matcher
     def matches?(address : String) : Bool
       case @type

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -1,0 +1,158 @@
+require "socket"
+
+module LavinMQ
+  # Matches IP addresses against either exact IPs or CIDR ranges
+  struct IPMatcher
+    enum Type
+      ExactIPv4
+      ExactIPv6
+      CIDRv4
+      CIDRv6
+    end
+
+    @type : Type
+    @address_string : String
+    @network : Bytes? # Only used for CIDR
+    @mask : Bytes?    # Only used for CIDR
+
+    def initialize(@type : Type, @address_string : String, @network : Bytes? = nil, @mask : Bytes? = nil)
+    end
+
+    # Parse from config string: "192.168.0.0/24" or "10.0.0.1"
+    def self.parse(source : String) : IPMatcher
+      if source.includes?('/')
+        parse_cidr(source)
+      else
+        parse_exact_ip(source)
+      end
+    end
+
+    # Check if an IP address matches this matcher
+    def matches?(address : String) : Bool
+      case @type
+      when Type::ExactIPv4, Type::ExactIPv6
+        @address_string == address
+      when Type::CIDRv4
+        network = @network
+        mask = @mask
+        return false unless network && mask
+        if target = ip_to_bytes_v4(address)
+          matches_cidr?(target, network, mask)
+        else
+          false
+        end
+      when Type::CIDRv6
+        network = @network
+        mask = @mask
+        return false unless network && mask
+        if target = ip_to_bytes_v6(address)
+          matches_cidr?(target, network, mask)
+        else
+          false
+        end
+      else
+        false
+      end
+    end
+
+    private def self.parse_cidr(source : String) : IPMatcher
+      parts = source.split('/', 2)
+      raise ArgumentError.new("Invalid CIDR notation: #{source}") if parts.size != 2
+
+      ip_str = parts[0].strip
+      prefix_str = parts[1].strip
+      prefix = prefix_str.to_u8?
+      raise ArgumentError.new("Invalid CIDR prefix: #{prefix_str}") unless prefix
+
+      # Try IPv4 first
+      if fields = Socket::IPAddress.parse_v4_fields?(ip_str)
+        raise ArgumentError.new("IPv4 prefix must be 0-32, got #{prefix}") if prefix > 32
+        network = Bytes.new(4) { |i| fields[i] }
+        mask = calculate_mask(prefix, 4)
+        # Apply mask to network address to normalize it
+        network.size.times { |i| network[i] &= mask[i] }
+        return new(Type::CIDRv4, source, network, mask)
+      end
+
+      # Try IPv6
+      if fields = Socket::IPAddress.parse_v6_fields?(ip_str)
+        raise ArgumentError.new("IPv6 prefix must be 0-128, got #{prefix}") if prefix > 128
+        network = v6_fields_to_bytes(fields)
+        mask = calculate_mask(prefix, 16)
+        # Apply mask to network address to normalize it
+        network.size.times { |i| network[i] &= mask[i] }
+        return new(Type::CIDRv6, source, network, mask)
+      end
+
+      raise ArgumentError.new("Invalid IP address in CIDR: #{ip_str}")
+    end
+
+    private def self.parse_exact_ip(source : String) : IPMatcher
+      source = source.strip
+
+      # Try IPv4 - just validate
+      if Socket::IPAddress.parse_v4_fields?(source)
+        return new(Type::ExactIPv4, source)
+      end
+
+      # Try IPv6 - just validate
+      if Socket::IPAddress.parse_v6_fields?(source)
+        return new(Type::ExactIPv6, source)
+      end
+
+      raise ArgumentError.new("Invalid IP address: #{source}")
+    end
+
+    # Calculate netmask from prefix length
+    private def self.calculate_mask(prefix : UInt8, total_bytes : Int32) : Bytes
+      mask = Bytes.new(total_bytes, 0_u8)
+      full_bytes = prefix // 8
+      remaining_bits = prefix % 8
+
+      # Set full bytes to 0xFF
+      full_bytes.times { |i| mask[i] = 0xFF_u8 }
+
+      # Set partial byte if any remaining bits
+      if remaining_bits > 0 && full_bytes < total_bytes
+        mask[full_bytes] = (0xFF_u8 << (8 - remaining_bits))
+      end
+
+      mask
+    end
+
+    # Convert IPv4 address string to bytes
+    private def ip_to_bytes_v4(address : String) : Bytes?
+      if fields = Socket::IPAddress.parse_v4_fields?(address)
+        Bytes.new(4) { |i| fields[i] }
+      end
+    end
+
+    # Convert IPv6 address string to bytes
+    private def ip_to_bytes_v6(address : String) : Bytes?
+      if fields = Socket::IPAddress.parse_v6_fields?(address)
+        IPMatcher.v6_fields_to_bytes(fields)
+      end
+    end
+
+    # Convert IPv6 fields array to bytes (shared helper)
+    protected def self.v6_fields_to_bytes(fields : StaticArray(UInt16, 8)) : Bytes
+      bytes = Bytes.new(16)
+      fields.each_with_index do |field, i|
+        bytes[i * 2] = (field >> 8).to_u8
+        bytes[i * 2 + 1] = (field & 0xFF).to_u8
+      end
+      bytes
+    end
+
+    # Check if target IP matches CIDR range using bitwise AND
+    private def matches_cidr?(target : Bytes, network : Bytes, mask : Bytes) : Bool
+      return false unless target.size == network.size == mask.size
+
+      target.size.times do |i|
+        return false if (target[i] & mask[i]) != (network[i] & mask[i])
+      end
+
+      true
+    end
+  end
+end

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -4,27 +4,50 @@ module LavinMQ
   # Matches IP addresses against either exact IPs or CIDR ranges
   struct IPMatcher
     enum Type
-      ExactIPv4
-      ExactIPv6
-      CIDRv4
-      CIDRv6
+      IPv4
+      IPv6
     end
 
     @type : Type
-    @address_string : String
-    @network : Bytes? # Only used for CIDR
-    @mask : Bytes?    # Only used for CIDR
+    @network : Bytes
+    @mask : Bytes
 
-    def initialize(@type : Type, @address_string : String, @network : Bytes? = nil, @mask : Bytes? = nil)
+    def initialize(@type : Type, @network : Bytes, @mask : Bytes)
     end
 
-    # Parse from config string: "192.168.0.0/24" or "10.0.0.1"
+    # Parse from config string: "192.168.0.0/24", "10.0.0.1", "2001:db8::1/128", or "2001:db8::1"
     def self.parse(source : String) : IPMatcher
+      source = source.strip
       if source.includes?('/')
-        parse_cidr(source)
+        parts = source.split('/', 2)
+        ip_str = parts[0].strip
+        prefix_str = parts[1].strip
+        prefix = prefix_str.to_u8?
+        raise ArgumentError.new("Invalid CIDR prefix: #{prefix_str}") unless prefix
       else
-        parse_exact_ip(source)
+        ip_str = source
+        prefix = nil
       end
+
+      if fields = Socket::IPAddress.parse_v4_fields?(ip_str)
+        p = prefix || 32_u8
+        raise ArgumentError.new("IPv4 prefix must be 0-32, got #{p}") if p > 32
+        network = Bytes.new(4) { |i| fields[i] }
+        mask = calculate_mask(p, 4)
+        network.size.times { |i| network[i] &= mask[i] }
+        return new(Type::IPv4, network, mask)
+      end
+
+      if fields = Socket::IPAddress.parse_v6_fields?(ip_str)
+        p = prefix || 128_u8
+        raise ArgumentError.new("IPv6 prefix must be 0-128, got #{p}") if p > 128
+        network = v6_fields_to_bytes(fields)
+        mask = calculate_mask(p, 16)
+        network.size.times { |i| network[i] &= mask[i] }
+        return new(Type::IPv6, network, mask)
+      end
+
+      raise ArgumentError.new("Invalid IP address: #{ip_str}")
     end
 
     # Parse a comma-separated list of IP addresses or CIDR ranges from config
@@ -36,7 +59,7 @@ module LavinMQ
           begin
             parse(source)
           rescue ex : Socket::Error | ArgumentError
-            STDERR.puts "WARNING: Invalid IP/CIDR: #{source} - #{ex.message}"
+            Log.error(exception: ex) { "Invalid IP/CIDR: #{source}" }
             nil
           end
         end
@@ -44,78 +67,12 @@ module LavinMQ
 
     # Check if an IP address matches this matcher
     def matches?(address : String) : Bool
-      case @type
-      when Type::ExactIPv4, Type::ExactIPv6
-        @address_string == address
-      when Type::CIDRv4
-        network = @network
-        mask = @mask
-        return false unless network && mask
-        if target = ip_to_bytes_v4(address)
-          matches_cidr?(target, network, mask)
-        else
-          false
-        end
-      when Type::CIDRv6
-        network = @network
-        mask = @mask
-        return false unless network && mask
-        if target = ip_to_bytes_v6(address)
-          matches_cidr?(target, network, mask)
-        else
-          false
-        end
-      else
-        false
-      end
-    end
-
-    private def self.parse_cidr(source : String) : IPMatcher
-      parts = source.split('/', 2)
-      raise ArgumentError.new("Invalid CIDR notation: #{source}") if parts.size != 2
-
-      ip_str = parts[0].strip
-      prefix_str = parts[1].strip
-      prefix = prefix_str.to_u8?
-      raise ArgumentError.new("Invalid CIDR prefix: #{prefix_str}") unless prefix
-
-      # Try IPv4 first
-      if fields = Socket::IPAddress.parse_v4_fields?(ip_str)
-        raise ArgumentError.new("IPv4 prefix must be 0-32, got #{prefix}") if prefix > 32
-        network = Bytes.new(4) { |i| fields[i] }
-        mask = calculate_mask(prefix, 4)
-        # Apply mask to network address to normalize it
-        network.size.times { |i| network[i] &= mask[i] }
-        return new(Type::CIDRv4, source, network, mask)
-      end
-
-      # Try IPv6
-      if fields = Socket::IPAddress.parse_v6_fields?(ip_str)
-        raise ArgumentError.new("IPv6 prefix must be 0-128, got #{prefix}") if prefix > 128
-        network = v6_fields_to_bytes(fields)
-        mask = calculate_mask(prefix, 16)
-        # Apply mask to network address to normalize it
-        network.size.times { |i| network[i] &= mask[i] }
-        return new(Type::CIDRv6, source, network, mask)
-      end
-
-      raise ArgumentError.new("Invalid IP address in CIDR: #{ip_str}")
-    end
-
-    private def self.parse_exact_ip(source : String) : IPMatcher
-      source = source.strip
-
-      # Try IPv4 - just validate
-      if Socket::IPAddress.parse_v4_fields?(source)
-        return new(Type::ExactIPv4, source)
-      end
-
-      # Try IPv6 - just validate
-      if Socket::IPAddress.parse_v6_fields?(source)
-        return new(Type::ExactIPv6, source)
-      end
-
-      raise ArgumentError.new("Invalid IP address: #{source}")
+      target = case @type
+               in Type::IPv4 then ip_to_bytes_v4(address)
+               in Type::IPv6 then ip_to_bytes_v6(address)
+               end
+      return false unless target
+      matches?(target, @network, @mask)
     end
 
     # Calculate netmask from prefix length
@@ -159,8 +116,7 @@ module LavinMQ
       bytes
     end
 
-    # Check if target IP matches CIDR range using bitwise AND
-    private def matches_cidr?(target : Bytes, network : Bytes, mask : Bytes) : Bool
+    private def matches?(target : Bytes, network : Bytes, mask : Bytes) : Bool
       return false unless target.size == network.size == mask.size
 
       target.size.times do |i|

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -14,6 +14,17 @@ module LavinMQ
 
     class UnsupportedTLVType < Error; end
 
+    def self.parse(io : IO) : ConnectionInfo?
+      peeked = io.peek
+      if peeked.size >= 5 && peeked[0, 5] == "PROXY".to_slice
+        ProxyProtocol::V1.parse(io)
+      elsif peeked.size >= 12 && peeked[0, 12] == ProxyProtocol::V2::Signature.to_slice
+        ProxyProtocol::V2.parse(io)
+      else
+        nil
+      end
+    end
+
     struct V1
       # Examples:
       # PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -156,7 +156,7 @@ module LavinMQ
       remote_address = client.remote_address
       parsed_proxy = ProxyProtocol.parse(client)
 
-      if @config.tcp_proxy_protocol
+      if @config.tcp_proxy_protocol?
         if trusted_proxy_source?(remote_address.address)
           return parsed_proxy if parsed_proxy
         else
@@ -167,7 +167,7 @@ module LavinMQ
           return parsed_proxy if parsed_proxy
         end
       end
-      return ConnectionInfo.new(remote_address, client.local_address)
+      ConnectionInfo.new(remote_address, client.local_address)
     end
 
     private def trusted_proxy_source?(address : String) : Bool

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -47,6 +47,7 @@ module LavinMQ
     @listeners = Hash(Socket::Server, Protocol).new # Socket => protocol
     @connection_factories = Hash(Protocol, ConnectionFactory).new
     @replicator : Clustering::Replicator?
+    @trusted_proxy_sources : Array(String)
     Log = LavinMQ::Log.for "server"
 
     def initialize(@config : Config, @replicator = nil)
@@ -60,6 +61,10 @@ module LavinMQ
       @mqtt_brokers = MQTT::Brokers.new(@vhosts, @replicator)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator)
       @authenticator = Auth::Chain.create(@config, @users)
+      @trusted_proxy_sources = @config.proxy_protocol_trusted_sources.split(',').map(&.strip).reject(&.empty?)
+      if @config.tcp_proxy_protocol > 0 && @trusted_proxy_sources.empty?
+        Log.warn { "PROXY protocol enabled without trusted sources configured - accepting from all sources" }
+      end
       @connection_factories = {
         Protocol::AMQP => AMQP::ConnectionFactory.new(@authenticator, @vhosts),
         Protocol::MQTT => MQTT::ConnectionFactory.new(@authenticator, @mqtt_brokers, @config),
@@ -152,23 +157,39 @@ module LavinMQ
     private def extract_conn_info(client) : ConnectionInfo
       remote_address = client.remote_address
       case @config.tcp_proxy_protocol
-      when 1 then ProxyProtocol::V1.parse(client)
-      when 2 then ProxyProtocol::V2.parse(client)
+      when 1, 2
+        if trusted_proxy_source?(remote_address.address)
+          parse_proxy_protocol(client, @config.tcp_proxy_protocol)
+        else
+          Log.warn { "PROXY protocol from untrusted source #{remote_address}, ignoring header" }
+          ConnectionInfo.new(remote_address, client.local_address)
+        end
       else
-        # Allow proxy connection from followers
+        # Accept PROXY protocol from verified cluster followers
         if @config.clustering? &&
            client.peek[0, 5]? == "PROXY".to_slice &&
            all_followers.any? { |f| f.remote_address.address == remote_address.address }
-          # Expect PROXY protocol header if remote address is a follower
           ProxyProtocol::V1.parse(client)
         elsif @config.clustering? &&
               client.peek[0, 8]? == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
               all_followers.any? { |f| f.remote_address.address == remote_address.address }
-          # Expect PROXY protocol header if remote address is a follower
           ProxyProtocol::V2.parse(client)
         else
           ConnectionInfo.new(remote_address, client.local_address)
         end
+      end
+    end
+
+    private def trusted_proxy_source?(address : String) : Bool
+      return true if @trusted_proxy_sources.empty?
+      @trusted_proxy_sources.includes?(address)
+    end
+
+    private def parse_proxy_protocol(client, version : UInt8) : ConnectionInfo
+      case version
+      when 1 then ProxyProtocol::V1.parse(client)
+      when 2 then ProxyProtocol::V2.parse(client)
+      else        raise "Invalid proxy protocol version: #{version}"
       end
     end
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -47,7 +47,6 @@ module LavinMQ
     @listeners = Hash(Socket::Server, Protocol).new # Socket => protocol
     @connection_factories = Hash(Protocol, ConnectionFactory).new
     @replicator : Clustering::Replicator?
-    @trusted_proxy_sources : Array(String)
     Log = LavinMQ::Log.for "server"
 
     def initialize(@config : Config, @replicator = nil)
@@ -61,8 +60,7 @@ module LavinMQ
       @mqtt_brokers = MQTT::Brokers.new(@vhosts, @replicator)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator)
       @authenticator = Auth::Chain.create(@config, @users)
-      @trusted_proxy_sources = @config.proxy_protocol_trusted_sources.split(',').map(&.strip).reject(&.empty?)
-      if @config.tcp_proxy_protocol > 0 && @trusted_proxy_sources.empty?
+      if @config.tcp_proxy_protocol > 0 && @config.proxy_protocol_trusted_sources.empty?
         Log.warn { "PROXY protocol enabled without trusted sources configured - accepting from all sources" }
       end
       @connection_factories = {
@@ -181,8 +179,8 @@ module LavinMQ
     end
 
     private def trusted_proxy_source?(address : String) : Bool
-      return true if @trusted_proxy_sources.empty?
-      @trusted_proxy_sources.includes?(address)
+      return true if @config.proxy_protocol_trusted_sources.empty?
+      @config.proxy_protocol_trusted_sources.any?(&.matches?(address))
     end
 
     private def parse_proxy_protocol(client, version : UInt8) : ConnectionInfo

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -60,7 +60,7 @@ module LavinMQ
       @mqtt_brokers = MQTT::Brokers.new(@vhosts, @replicator)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator)
       @authenticator = Auth::Chain.create(@config, @users)
-      if @config.tcp_proxy_protocol > 0 && @config.proxy_protocol_trusted_sources.empty?
+      if @config.tcp_proxy_protocol? && @config.proxy_protocol_trusted_sources.empty?
         Log.warn { "PROXY protocol enabled without trusted sources configured - accepting from all sources" }
       end
       @connection_factories = {
@@ -154,41 +154,25 @@ module LavinMQ
 
     private def extract_conn_info(client) : ConnectionInfo
       remote_address = client.remote_address
-      case @config.tcp_proxy_protocol
-      when 1, 2
+      parsed_proxy = ProxyProtocol.parse(client)
+
+      if @config.tcp_proxy_protocol
         if trusted_proxy_source?(remote_address.address)
-          parse_proxy_protocol(client, @config.tcp_proxy_protocol)
+          return parsed_proxy if parsed_proxy
         else
-          Log.warn { "PROXY protocol from untrusted source #{remote_address}, ignoring header" }
-          ConnectionInfo.new(remote_address, client.local_address)
+          Log.warn { "PROXY protocol from untrusted source #{remote_address}, ignoring header" } if parsed_proxy
         end
       else
-        # Accept PROXY protocol from verified cluster followers
-        if @config.clustering? &&
-           client.peek[0, 5]? == "PROXY".to_slice &&
-           all_followers.any? { |f| f.remote_address.address == remote_address.address }
-          ProxyProtocol::V1.parse(client)
-        elsif @config.clustering? &&
-              client.peek[0, 8]? == ProxyProtocol::V2::Signature.to_slice[0, 8] &&
-              all_followers.any? { |f| f.remote_address.address == remote_address.address }
-          ProxyProtocol::V2.parse(client)
-        else
-          ConnectionInfo.new(remote_address, client.local_address)
+        if @config.clustering? && all_followers.any? { |f| f.remote_address.address == remote_address.address }
+          return parsed_proxy if parsed_proxy
         end
       end
+      return ConnectionInfo.new(remote_address, client.local_address)
     end
 
     private def trusted_proxy_source?(address : String) : Bool
       return true if @config.proxy_protocol_trusted_sources.empty?
       @config.proxy_protocol_trusted_sources.any?(&.matches?(address))
-    end
-
-    private def parse_proxy_protocol(client, version : UInt8) : ConnectionInfo
-      case version
-      when 1 then ProxyProtocol::V1.parse(client)
-      when 2 then ProxyProtocol::V2.parse(client)
-      else        raise "Invalid proxy protocol version: #{version}"
-      end
     end
 
     def listen(s : UNIXServer, protocol : Protocol)
@@ -209,12 +193,11 @@ module LavinMQ
       spawn(name: "Accept UNIX socket") do
         remote_address = client.remote_address
         set_buffer_size(client)
-        conn_info =
-          case @config.unix_proxy_protocol
-          when 1 then ProxyProtocol::V1.parse(client)
-          when 2 then ProxyProtocol::V2.parse(client)
-          else        ConnectionInfo.local # TODO: use unix socket address, don't fake local
-          end
+        if conn_info = ProxyProtocol.parse(client)
+          # PROXY protocol over unix socket
+        else
+          conn_info = ConnectionInfo.local # TODO: use unix socket address, don't fake local
+        end
         handle_connection(client, conn_info, protocol)
       rescue ex
         Log.warn(exception: ex) { "Error accepting connection from #{remote_address}" }

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -154,9 +154,9 @@ module LavinMQ
 
     private def extract_conn_info(client) : ConnectionInfo
       remote_address = client.remote_address
-      parsed_proxy = ProxyProtocol.parse(client)
 
       if @config.tcp_proxy_protocol?
+        parsed_proxy = ProxyProtocol.parse(client)
         if trusted_proxy_source?(remote_address.address)
           return parsed_proxy if parsed_proxy
         else
@@ -164,6 +164,7 @@ module LavinMQ
         end
       else
         if @config.clustering? && all_followers.any? { |f| f.remote_address.address == remote_address.address }
+          parsed_proxy = ProxyProtocol.parse(client)
           return parsed_proxy if parsed_proxy
         end
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -172,6 +172,7 @@ module LavinMQ
     end
 
     private def trusted_proxy_source?(address : String) : Bool
+      # If no trusted sources are configured, accept from all sources for backward compatibility
       return true if @config.proxy_protocol_trusted_sources.empty?
       @config.proxy_protocol_trusted_sources.any?(&.matches?(address))
     end


### PR DESCRIPTION
  ## Summary
 - Add `proxy_protocol_trusted_sources` config option supporting individual IPs and CIDR notation (e.g., `10.0.0.1, 192.168.0.0/24, 2001:db8::/32`)
  - Change `tcp_proxy_protocol` from version number (`0`/`1`/`2`) to boolean - protocol version is now auto-detected
  - Only parse PROXY protocol headers from trusted sources or cluster followers
  - Connections from untrusted sources sending PROXY headers will fail (protocol mismatch)
  - Remove `unix_proxy_protocol` config option - unix sockets now always auto-detect proxy protocol if present
  - Add warning at startup if proxy protocol is enabled without trusted sources configured

  ## "Breaking" Changes

  - `tcp_proxy_protocol` now accepts boolean values (`true`/`false`/`yes`/`no`) or `1`/`2` (both treated as enabled).     
  Setting `0` disables it.
  - `unix_proxy_protocol` config option is removed. Unix sockets always accept proxy protocol headers if present.

  ## Configuration

  ```ini
  [amqp]
  tcp_proxy_protocol = true
  proxy_protocol_trusted_sources = 10.0.0.1, 192.168.0.0/24, 2001:db8::/32
```
  If proxy_protocol_trusted_sources is empty and tcp_proxy_protocol is enabled, proxy headers are accepted from all  sources (with a warning logged).

  ## Security

  This follows the HAProxy proxy protocol specification recommendation to verify that proxy protocol traffic comes from trusted load balancers, preventing IP spoofing from untrusted clients.