### PR TITLE
Don't render client properties for mqtt client on connetcion

### DIFF
--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -20,6 +20,8 @@ function updateConnection (all) {
       stateEl.textContent = item.state
     }
     if (all) {
+      const isAMQP = item.protocol && item.protocol.includes('AMQP')
+
       document.getElementById('conn-username').textContent = item.user
       document.getElementById('connected_at').textContent = new Date(item.connected_at).toLocaleString()
       document.getElementById('heartbeat').textContent = item.timeout + 's'
@@ -29,8 +31,11 @@ function updateConnection (all) {
       document.getElementById('tls_version').textContent = item.tls_version
       document.getElementById('cipher').textContent = item.cipher
       const cp = item.client_properties
-      document.getElementById('cp-name').textContent = cp.connection_name
-      document.getElementById('cp-capabilities').textContent = DOM.jsonToText(cp.capabilities)
+      // Show client_id for MQTT, connection_name for AMQP
+      const clientName = isAMQP ? cp.connection_name : item.client_id
+      document.getElementById('cp-name').textContent = clientName
+      document.getElementById('cp-capabilities').textContent = cp.capabilities ? DOM.jsonToText(cp.capabilities) : ''
+
       if (cp.product_version) {
         document.getElementById('cp-product').appendChild(document.createElement('span')).textContent = cp.product
         document.getElementById('cp-product').appendChild(document.createElement('br'))
@@ -53,6 +58,14 @@ function updateConnection (all) {
         infoEl.appendChild(infoLink)
       } else {
         infoEl.textContent = cp.information || ''
+      }
+
+      // Show AMQP-only elements for AMQP connections
+      if (isAMQP) {
+        document.getElementById('amqp-auth-channel').style.display = ''
+        document.getElementById('amqp-frame').style.display = ''
+        document.getElementById('client-properties').style.display = 'block'
+        document.getElementById('channels-section').style.display = 'block'
       }
     }
   })

--- a/static/js/connections.js
+++ b/static/js/connections.js
@@ -21,7 +21,11 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     connectionLink.href = HTTP.url`connection#name=${item.name}`
     connectionLink.appendChild(document.createElement('span')).textContent = item.name
     connectionLink.appendChild(document.createElement('br'))
-    connectionLink.appendChild(document.createElement('small')).textContent = item.client_properties.connection_name
+    // Show connection_name for AMQP, client_id for MQTT
+    const clientIdentifier = item.protocol && item.protocol.includes('AMQP')
+      ? item.client_properties.connection_name
+      : item.client_id
+    connectionLink.appendChild(document.createElement('small')).textContent = clientIdentifier
     Table.renderCell(tr, 0, item.vhost)
     Table.renderCell(tr, 1, connectionLink)
     Table.renderCell(tr, 2, item.user)

--- a/views/connection.ecr
+++ b/views/connection.ecr
@@ -26,25 +26,25 @@
             <th>Heartbeat</th>
             <td id="heartbeat"></td>
           </tr>
-          <tr>
+          <tr id="amqp-auth-channel" style="display: none;">
             <th>Authentication</th>
             <td id="authentication"></td>
             <th>Channel max</th>
             <td id="channel_max"></td>
           </tr>
-          <tr>
+          <tr id="amqp-frame" style="display: none;">
             <th>Frame max</th>
             <td id="frame_max"></td>
-            <th>TLS version</th>
-            <td id="tls_version"></td>
           </tr>
           <tr>
+            <th>TLS version</th>
+            <td id="tls_version"></td>
             <th>Cipher</th>
             <td id="cipher"></td>
           </tr>
         </table>
       </section>
-      <section class="card cols-6">
+      <section class="card cols-6" id="client-properties" style="display: none;">
         <h3>Client properties</h3>
         <table class="details-table">
           <tr>
@@ -73,7 +73,7 @@
         <h3>Rates</h3>
         <div class="chart-container" id="chart"></div>
       </section>
-      <section class="card">
+      <section class="card" id="channels-section" style="display: none;">
         <h3 class="has-badge">
           Channels
           <small class="tiny-badge" id="table-count"></small>


### PR DESCRIPTION


Since we do not have the same information on an MQTT connection as we do for an AMQP connection, we don't need to render the same info. 

This is a quick-fix instead of completely re-writing the views for MQTT vs AMQP

### WHAT is this pull request doing?
Fixes #1582 

### HOW can this pull request be tested?
Add AMQP and MQTT connections and make sure the views look good. 