### PR TITLE
Fix: Topic exchange # wildcard now matches zero segments

### DIFF
--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -160,6 +160,15 @@ module MessageRoutingSpec
         x.unbind(q11, "#.a.#")
       end
 
+      it "# should match zero segments" do
+        q = LavinMQ::QueueFactory.make(vhost, "q_zero_segments")
+        x.bind(q, "a.*.c.#")
+        matches(x, "a.b.c").should eq(Set{q})
+        matches(x, "a.b.c.d").should eq(Set{q})
+        matches(x, "a.b.c.d.e").should eq(Set{q})
+        x.unbind(q, "a.*.c.#")
+      end
+
       it "should match double star-wildcards" do
         q12 = LavinMQ::QueueFactory.make(vhost, "q12")
         x.bind(q12, "c.*.*")

--- a/src/lavinmq/amqp/exchange/topic.cr
+++ b/src/lavinmq/amqp/exchange/topic.cr
@@ -31,10 +31,13 @@ module LavinMQ
 
         def match?(rk) : Bool
           if n = @next
+            return true if n.match?(rk)
+            return false unless rk
+
             loop do
-              return true if n.match?(rk)
               rk = rk.next
               break unless rk
+              return true if n.match?(rk)
             end
             return false
           end
@@ -47,12 +50,10 @@ module LavinMQ
         end
 
         def match?(rk) : Bool
+          return false unless rk
           if check = @next
-            if n = rk.next
-              check.match?(n)
-            else
-              false
-            end
+            n = rk.next
+            check.match?(n)
           else
             rk.next.nil?
           end
@@ -64,13 +65,11 @@ module LavinMQ
         end
 
         def match?(rk) : Bool
+          return false unless rk
           return false unless rk.value == @s
           if check = @next
-            if n = rk.next
-              check.match?(n)
-            else
-              false
-            end
+            n = rk.next
+            check.match?(n)
           else
             rk.next.nil?
           end


### PR DESCRIPTION
Fixes #1607

The `#` wildcard in topic exchange bindings was not matching zero segments, which violates AMQP specification and differs from RabbitMQ behavior.

### WHAT is this pull request doing?

This PR fixes a bug in the topic exchange routing logic where the `#` wildcard was not matching zero segments, which is required by the AMQP specification.

According to AMQP spec, `#` must match **zero or more** words (segments separated by `.`), but LavinMQ was requiring at least one segment. This caused bindings like `a.*.c.#` to incorrectly reject routing keys like `a.b.c` (where `#` should match zero segments after `c`).

**Changes:**
- Modified `HashSegment.match?` to test the zero-segment case first before attempting to consume segments
- Modified `StarSegment` and `StringSegment` to properly handle `nil` routing keys
- Added test case `"# should match zero segments"` with multiple scenarios

**Example:**
- Binding: `a.*.c.#`
- Before: `a.b.c` ❌ (incorrectly rejected)
- After: `a.b.c` ✅ (correctly accepted, matching RabbitMQ behavior)

### HOW can this pull request be tested?

Run the message routing specs:
```bash
make test SPEC=spec/message_routing_spec.cr
```

The new test case `"# should match zero segments (AMQP spec compliance)"` verifies that a binding with `#` at the end correctly matches routing keys with zero, one, and multiple trailing segments.