### PR TITLE
Idle fiber management for queue message expiration

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -967,4 +967,73 @@ describe LavinMQ::AMQP::Queue do
       end
     end
   end
+
+  describe "Idle fiber management" do
+    it "should not start message_expire_loop for empty queue" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("empty_q", durable: false, auto_delete: false)
+        queue = vhost.queues["empty_q"]
+        queue.message_expire_fiber_active?.should be_false
+      end
+    end
+
+    it "should not start message_expire_loop for queue with no TTL messages" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("no_ttl_test")
+          queue = s.vhosts["/"].queues["no_ttl_test"]
+
+          # Publish message without TTL
+          q.publish_confirm("test message")
+
+          # Fiber should not start
+          queue.message_expire_fiber_active?.should be_false
+        end
+      end
+    end
+
+    it "should start fiber when TTL message published and expire it" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("ttl_test", args: AMQP::Client::Arguments.new({"x-message-ttl" => 10}))
+          queue = s.vhosts["/"].queues["ttl_test"]
+
+          # Should not have fiber initially (empty queue)
+          queue.message_expire_fiber_active?.should be_false
+
+          # Publish message with TTL
+          q.publish_confirm("test message")
+
+          # Fiber should start
+          queue.message_expire_fiber_active?.should be_true
+
+          # Message should be expired
+          should_eventually(be_true) { queue.empty? }
+        end
+      end
+    end
+
+    it "should start fiber when message with per-message TTL is published" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("per_msg_ttl_test")
+          queue = s.vhosts["/"].queues["per_msg_ttl_test"]
+
+          # Should not have fiber initially
+          queue.message_expire_fiber_active?.should be_false
+
+          # Publish message with per-message TTL
+          props = AMQP::Client::Properties.new(expiration: "10")
+          ch.default_exchange.publish_confirm("test message", q.name, props: props)
+
+          # Fiber should start
+          queue.message_expire_fiber_active?.should be_true
+
+          # Message should be expired
+          should_eventually(be_true) { queue.empty? }
+        end
+      end
+    end
+  end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -1035,5 +1035,19 @@ describe LavinMQ::AMQP::Queue do
         end
       end
     end
+
+    it "should not start expire fiber while consumers are active" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("ttl_with_consumer", args: AMQP::Client::Arguments.new({"x-message-ttl" => 60_000}))
+          queue = s.vhosts["/"].queues["ttl_with_consumer"]
+          q.subscribe(no_ack: true) { }
+          should_eventually(eq 1) { queue.consumers.size }
+          q.publish_confirm("msg")
+          # rm_consumer will start the fiber once consumers disconnect; until then it stays idle
+          queue.message_expire_fiber_active?.should be_false
+        end
+      end
+    end
   end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -1049,5 +1049,32 @@ describe LavinMQ::AMQP::Queue do
         end
       end
     end
+
+    it "should start fiber when a partial purge exposes a TTL message behind a no-TTL head" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("purge_expose_ttl", args: AMQP::Client::Arguments.new(
+            {"x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "purge_expose_dlq"}
+          ))
+          dlq = ch.queue("purge_expose_dlq")
+          queue = s.vhosts["/"].queue("purge_expose_ttl")
+
+          # Head message has no TTL, so the expire fiber never starts
+          q.publish_confirm("no ttl")
+          q.publish_confirm("short ttl", props: AMQP::Client::Properties.new(expiration: "500"))
+          queue.message_expire_fiber_active?.should be_false
+
+          # Partial purge removes the no-TTL head, exposing the short-TTL message.
+          # The fiber must restart so the now-head message gets expired.
+          queue.purge(1).should eq 1
+          queue.message_expire_fiber_active?.should be_true
+
+          msg = wait_for { dlq.get(no_ack: true) }
+          msg.should_not be_nil
+          msg.not_nil!.body_io.to_s.should eq "short ttl"
+          q.get(no_ack: true).should be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -973,7 +973,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         vhost = s.vhosts["/"]
         vhost.declare_queue("empty_q", durable: false, auto_delete: false)
-        queue = vhost.queues["empty_q"]
+        queue = vhost.queue("empty_q")
         queue.message_expire_fiber_active?.should be_false
       end
     end
@@ -982,7 +982,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue("no_ttl_test")
-          queue = s.vhosts["/"].queues["no_ttl_test"]
+          queue = s.vhosts["/"].queue("no_ttl_test")
 
           # Publish message without TTL
           q.publish_confirm("test message")
@@ -997,7 +997,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue("ttl_test", args: AMQP::Client::Arguments.new({"x-message-ttl" => 10}))
-          queue = s.vhosts["/"].queues["ttl_test"]
+          queue = s.vhosts["/"].queue("ttl_test")
 
           # Should not have fiber initially (empty queue)
           queue.message_expire_fiber_active?.should be_false
@@ -1018,7 +1018,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue("per_msg_ttl_test")
-          queue = s.vhosts["/"].queues["per_msg_ttl_test"]
+          queue = s.vhosts["/"].queue("per_msg_ttl_test")
 
           # Should not have fiber initially
           queue.message_expire_fiber_active?.should be_false
@@ -1040,7 +1040,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue("ttl_with_consumer", args: AMQP::Client::Arguments.new({"x-message-ttl" => 60_000}))
-          queue = s.vhosts["/"].queues["ttl_with_consumer"]
+          queue = s.vhosts["/"].queue("ttl_with_consumer")
           q.subscribe(no_ack: true) { }
           should_eventually(eq 1) { queue.consumers.size }
           q.publish_confirm("msg")

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -85,7 +85,13 @@ module LavinMQ::AMQP
       end
     rescue ::Channel::ClosedError
     ensure
+      @message_expire_fiber_active.set(false, :release)
       @log.debug { "message_expire_loop stopped" }
+    end
+
+    # Delayed exchange queues always need their expire fiber running
+    private def should_start_expire_fiber? : Bool
+      true
     end
 
     def expire_messages

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -115,7 +115,7 @@ module LavinMQ::AMQP
       @message_expire_fiber_active.get(:relaxed)
     end
 
-    private EXPIRE_FIBER_IDLE_THRESHOLD_MS = 30_000
+    private EXPIRE_FIBER_IDLE_THRESHOLD = 30.seconds
 
     getter? internal = false
 
@@ -144,7 +144,7 @@ module LavinMQ::AMQP
         select
         when @consumers_empty.when_true.receive
           @log.debug { "Consumers empty" }
-        when timeout EXPIRE_FIBER_IDLE_THRESHOLD_MS.milliseconds
+        when timeout EXPIRE_FIBER_IDLE_THRESHOLD
           @log.debug { "Idle timeout while waiting for consumers empty, stopping fiber" }
           break
         end
@@ -152,7 +152,7 @@ module LavinMQ::AMQP
         select
         when @msg_store.empty.when_false.receive
           @log.debug { "Message store not empty" }
-        when timeout EXPIRE_FIBER_IDLE_THRESHOLD_MS.milliseconds
+        when timeout EXPIRE_FIBER_IDLE_THRESHOLD
           @log.debug { "Idle timeout while waiting for messages, stopping fiber" }
           break
         end
@@ -179,7 +179,7 @@ module LavinMQ::AMQP
             @log.debug { "Message TTL changed" }
           when @msg_store.empty.when_true.receive
             @log.debug { "Msg store is empty" }
-          when timeout EXPIRE_FIBER_IDLE_THRESHOLD_MS.milliseconds
+          when timeout EXPIRE_FIBER_IDLE_THRESHOLD
             @log.debug { "Idle timeout while no messages need expiring, stopping fiber" }
             break
           end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -108,6 +108,15 @@ module LavinMQ::AMQP
     @queue_expiration_ttl_change = ::Channel(Nil).new
     @effective_args = Array(String).new
 
+    # Idle fiber management
+    @message_expire_fiber_active = Atomic(Bool).new(false)
+
+    def message_expire_fiber_active?
+      @message_expire_fiber_active.get(:relaxed)
+    end
+
+    EXPIRE_FIBER_IDLE_THRESHOLD_MS = 30_000
+
     getter? internal = false
 
     private def queue_expire_loop
@@ -132,10 +141,22 @@ module LavinMQ::AMQP
     private def message_expire_loop
       @vhost.closed.when_false.receive?
       loop do
-        @consumers_empty.when_true.receive
-        @log.debug { "Consumers empty" }
-        @msg_store.empty.when_false.receive
-        @log.debug { "Message store not empty" }
+        select
+        when @consumers_empty.when_true.receive
+          @log.debug { "Consumers empty" }
+        when timeout EXPIRE_FIBER_IDLE_THRESHOLD_MS.milliseconds
+          @log.debug { "Idle timeout while waiting for consumers empty, stopping fiber" }
+          break
+        end
+
+        select
+        when @msg_store.empty.when_false.receive
+          @log.debug { "Message store not empty" }
+        when timeout EXPIRE_FIBER_IDLE_THRESHOLD_MS.milliseconds
+          @log.debug { "Idle timeout while waiting for messages, stopping fiber" }
+          break
+        end
+
         next unless @consumers.empty?
         if ttl = time_to_message_expiration
           @log.debug { "Next message TTL: #{ttl}" }
@@ -158,6 +179,9 @@ module LavinMQ::AMQP
             @log.debug { "Message TTL changed" }
           when @msg_store.empty.when_true.receive
             @log.debug { "Msg store is empty" }
+          when timeout EXPIRE_FIBER_IDLE_THRESHOLD_MS.milliseconds
+            @log.debug { "Idle timeout while no messages need expiring, stopping fiber" }
+            break
           end
         end
       end
@@ -166,6 +190,8 @@ module LavinMQ::AMQP
       close
       raise ex
     rescue ::Channel::ClosedError
+    ensure
+      @message_expire_fiber_active.set(false, :release)
     end
 
     getter name, arguments, vhost
@@ -211,7 +237,7 @@ module LavinMQ::AMQP
         end
         handle_arguments
         spawn queue_expire_loop, name: "Queue#queue_expire_loop #{@vhost.name}/#{@name}" if @expires
-        spawn message_expire_loop, name: "Queue#message_expire_loop #{@vhost.name}/#{@name}"
+        start_message_expire_loop if should_start_expire_fiber?
         true
       end
     end
@@ -226,9 +252,35 @@ module LavinMQ::AMQP
       end
     end
 
+    private def start_message_expire_loop
+      return if @message_expire_fiber_active.swap(true)
+      @log.debug { "Starting message expire loop" }
+      spawn message_expire_loop, name: "Queue#message_expire_loop #{@vhost.name}/#{@name}"
+    end
+
+    # Ensure the expire fiber is running if there are messages that need expiring
+    def ensure_expire_fiber
+      if !@closed && !@message_expire_fiber_active.get(:acquire)
+        start_message_expire_loop if should_start_expire_fiber?
+      end
+    end
+
+    # Check if we need the expire fiber running
+    private def should_start_expire_fiber? : Bool
+      return false if @msg_store.size == 0 # No messages to expire
+      return true if @message_ttl          # Queue-level TTL means all messages need expiring
+
+      # Check if first message has TTL (including expiration: "0" for immediate expiry)
+      @msg_store_lock.synchronize do
+        @msg_store.first?.try { |env| !env.message.ttl.nil? } || false
+      end
+    end
+
     private def reset_queue_state
       @closed = false
       @state = QueueState::Running
+      @message_expire_fiber_active.set(false, :release)
+
       # Recreate channels that were closed
       @queue_expiration_ttl_change = ::Channel(Nil).new
       @message_ttl_change = ::Channel(Nil).new
@@ -310,6 +362,7 @@ module LavinMQ::AMQP
         unless @message_ttl.try &.< value.as_i64
           @message_ttl = value.as_i64
           @message_ttl_change.try_send? nil
+          ensure_expire_fiber
           @effective_args.delete("x-message-ttl")
           return true
         end
@@ -387,6 +440,7 @@ module LavinMQ::AMQP
       @message_ttl = parse_header("x-message-ttl", Int).try &.to_i64
       @effective_args << "x-message-ttl" if @message_ttl
       @message_ttl_change.try_send? nil
+      ensure_expire_fiber if @message_ttl
       @delivery_limit = parse_header("x-delivery-limit", Int).try &.to_i64
       @effective_args << "x-delivery-limit" if @delivery_limit
       overflow = parse_header("x-overflow", String)
@@ -534,6 +588,7 @@ module LavinMQ::AMQP
         effective_arguments:          @effective_args,
         effective_policy_arguments:   effective_policy_args,
         internal:                     internal?,
+        message_expire_fiber_active:  @message_expire_fiber_active.get(:relaxed),
       }
     end
 
@@ -567,6 +622,12 @@ module LavinMQ::AMQP
       end
       @publish_count.add(1, :relaxed)
       ensure_consumers_deliver_loops if was_empty
+
+      # Record activity if message has TTL (needs expiration)
+      if @message_ttl || msg.properties.expiration
+        ensure_expire_fiber
+      end
+
       PublishResult::Ok
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -750,7 +811,7 @@ module LavinMQ::AMQP
       no_ack ? @get_no_ack_count.add(1, :relaxed) : @get_count.add(1, :relaxed)
       get(no_ack) do |env|
         yield env
-      end
+      end.tap { ensure_expire_fiber }
     end
 
     # If nil is returned it means that the delivery limit is reached
@@ -933,6 +994,8 @@ module LavinMQ::AMQP
           delete
         else
           notify_consumers_empty(true)
+          # Check if fiber needs to restart for message expiration
+          ensure_expire_fiber
         end
       end
     end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -940,6 +940,7 @@ module LavinMQ::AMQP
           end
           drop_overflow
           ensure_consumers_deliver_loops if was_empty
+          ensure_expire_fiber
         end
       else
         expire_msg(sp, :rejected)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -192,6 +192,7 @@ module LavinMQ::AMQP
     rescue ::Channel::ClosedError
     ensure
       @message_expire_fiber_active.set(false, :release)
+      ensure_expire_fiber # restart if msg arrived during teardown
     end
 
     getter name, arguments, vhost

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -1016,9 +1016,11 @@ module LavinMQ::AMQP
         delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
       end
       @log.info { "Purged #{delete_count} messages" }
-      # Signal expire loop to recalculate wait time for next message
+      # Signal expire loop to recalculate wait time for next message, and
+      # restart it if it had stopped while the (now purged) head message had no TTL
       if delete_count > 0
         @message_ttl_change.try_send? nil
+        ensure_expire_fiber
       end
       delete_count
     rescue ex : MessageStore::Error

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -268,8 +268,9 @@ module LavinMQ::AMQP
 
     # Check if we need the expire fiber running
     private def should_start_expire_fiber? : Bool
-      return false if @msg_store.size == 0 # No messages to expire
-      return true if @message_ttl          # Queue-level TTL means all messages need expiring
+      return false if @msg_store.size == 0  # No messages to expire
+      return false unless @consumers.empty? # Expire loop can't run with consumers present; rm_consumer will restart it
+      return true if @message_ttl           # Queue-level TTL means all messages need expiring
 
       # Check if first message has TTL (including expiration: "0" for immediate expiry)
       @msg_store_lock.synchronize do

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -115,7 +115,7 @@ module LavinMQ::AMQP
       @message_expire_fiber_active.get(:relaxed)
     end
 
-    EXPIRE_FIBER_IDLE_THRESHOLD_MS = 30_000
+    private EXPIRE_FIBER_IDLE_THRESHOLD_MS = 30_000
 
     getter? internal = false
 
@@ -260,7 +260,7 @@ module LavinMQ::AMQP
     end
 
     # Ensure the expire fiber is running if there are messages that need expiring
-    def ensure_expire_fiber
+    private def ensure_expire_fiber
       if !@closed && !@message_expire_fiber_active.get(:acquire)
         start_message_expire_loop if should_start_expire_fiber?
       end
@@ -590,7 +590,6 @@ module LavinMQ::AMQP
         effective_arguments:          @effective_args,
         effective_policy_arguments:   effective_policy_args,
         internal:                     internal?,
-        message_expire_fiber_active:  @message_expire_fiber_active.get(:relaxed),
       }
     end
 


### PR DESCRIPTION
## Summary

Queue `message_expire_loop` fibers are now started on demand and stop when there's nothing to expire, instead of running for the lifetime of every queue.

## When the fiber runs

- **Started** when a queue gains expirable messages — head of queue has an `expiration`, or queue-level `message-ttl` is set. Triggered on publish, `basic_get`, and TTL configuration changes.
- **Stopped** after `EXPIRE_FIBER_IDLE_THRESHOLD_MS` (30s) of waiting on any of: consumers empty, message store empty, no message at head needing expiry. Also exits cleanly on queue close via `Channel::ClosedError`.
- `DelayedExchangeQueue` always runs the fiber, since its messages are only delivered via expiration.

## Implementation

A single `Atomic(Bool)` per queue (`@message_expire_fiber_active`) tracks whether the fiber is running, with release/acquire ordering so the fiber observes a consistent view of queue state. `expiration: "0"` is treated as a valid expiration (immediate expiry).

## Performance
Idle fiber management has no measurable impact on queue churn throughput, but cuts per-queue memory use by ~20-30% at steady state. Each idle queue no longer reserves a Crystal fiber stack, which saves ~9 KB of resident memory and ~8 MB of virtual memory per queue.

  | Queues | RSS (main) | RSS (branch) | Δ RSS         | VSZ (main) | VSZ (branch) |
  |-------:|-----------:|-------------:|--------------:|-----------:|-------------:|
  |  1,000 |      43 MB |        34 MB |  -9 MB (-20%) |      16 GB |         8 GB |
  |  5,000 |     157 MB |       113 MB | -44 MB (-28%) |      79 GB |        40 GB |
  | 10,000 |     299 MB |       208 MB | -91 MB (-30%) |     157 GB |        79 GB |

### Throughput: `on-demand-expire-fibers` vs `main`

  `extras/benchmark.sh` (10s/scenario). Branch = **1 run**; main = avg of 2 runs - so treat small deltas as noise. Metric is
  **consume rate** except *Publish only* (publish rate). Δ = (branch − main) / main.

  | Scenario | Branch (msgs/s) | main (msgs/s) | Δ |
  |---|--:|--:|--:|
  | Baseline 1→1 (16 B) | 1,029,649 | 1,040,073 | −1.0% |
  | 1→1 with properties | 884,827 | 770,814 | +14.8% |
  | Publish only* | 1,858,591 | 1,982,339 | −6.2% |
  | Consume only (drain) | 1,690,995 | 1,786,710 | −5.4% |
  | Fanout 1→4 | 1,427,176 | 1,427,592 | 0.0% |
  | Large messages (100 KB) | 8,587 | 8,505 | +1.0% |
  | Prefetch 1000, ack 100 | 95,764 | 101,632 | −5.8% † |
  | Publish confirm | 33,804 | 33,875 | −0.2% ‡ |
  | Publish in tx | 9,629 | 9,834 | −2.1% ‡ |
  | Ack in tx | 870 | 865 | +0.6% |
  | Stream 1→1 | 87,231 | 92,404 | −5.6% |
  | Stream + properties | 106,872 | 122,661 | −12.9% |
  | MT fan-in 64→1 | 192,562 | 200,011 | −3.7% |
  | MT competing 1→64 | 698,741 | 698,453 | 0.0% |
  | MT symmetric 64→64 | 884,815 | 903,472 | −2.1% |
  | MT sharded 64→64 | 842,629 | 803,785 | +4.8% |
  | MT stream multi 1→64 | 1,003,001 | 941,862 | +6.5% |

  \* publish rate (no consumer).
  † high run-to-run variance, treat as noise.
  ‡ **unreliable** in `benchmark.sh` - single 10s run swings widely on all builds; ignore.

  **No regression.** Branch tracks `main` within run-to-run noise across every scenario (the −5 to −13% on drain / stream-props are within single-run variance, not a consistent signal). The +14.8% on *1→1 properties* mirrors what the deliver-loop  branch shows against the same `main` binary, so it's a shared-base/build artifact rather than an effect of this change.
  Single-run sample - rerun before drawing firm conclusions.

## Test plan

- [x] Empty queue does not start the fiber
- [x] Queue with no-TTL messages does not start the fiber
- [x] Queue-level TTL: fiber starts on publish and expires messages
- [x] Per-message TTL: fiber starts on publish and expires messages

## Related

Helps mitigate #1595 by reducing fiber count for idle queues with message TTL.