### PR TITLE
Don't use --error-on-warnings on release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build lavinmq
-        run: make -j bin/lavinmq bin/lavinmqctl DOCS= CRYSTAL_FLAGS=-Dbake_static
+        run: make -j bin/lavinmq bin/lavinmqctl DOCS= CRYSTAL_FLAGS="--error-on-warnings -Dbake_static"
 
       - name: Print build info
         run: bin/lavinmq --build-info

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VIEW_PARTIALS := $(wildcard views/partials/*.ecr)
 JS := static/js/lib/chunks/helpers.segment.js static/js/lib/chart.js static/js/lib/luxon.js static/js/lib/chartjs-adapter-luxon.esm.js static/js/lib/elements-8.2.0.js static/js/lib/elements-8.2.0.css $(wildcard static/js/*.js)
 LDFLAGS := $(shell (dpkg-buildflags --get LDFLAGS || rpm -E "%{build_ldflags}" || echo "-pie") 2>/dev/null)
 CRYSTAL_FLAGS := --release
-override CRYSTAL_FLAGS += --stats --error-on-warnings -Dpreview_mt -Dexecution_context --link-flags="$(LDFLAGS)"
+override CRYSTAL_FLAGS += --stats -Dpreview_mt -Dexecution_context --link-flags="$(LDFLAGS)"
 .DELETE_ON_ERROR:
 
 .DEFAULT_GOAL := all


### PR DESCRIPTION
It completely stops a build that "just" has warnings, we do want it in CI though.

Related to #1616