### PR TITLE
Add Prometheus metrics for mfiles

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -111,14 +111,6 @@ describe LavinMQ::HTTP::PrometheusController do
         mfile_metric = parsed_metrics.find { |m| m[:key] == "lavinmq_mfile_count" }
         mfile_metric.should_not be_nil
         mfile_metric.not_nil![:value].should be >= 0
-        {% if flag?(:linux) %}
-          mmap_metric = parsed_metrics.find { |m| m[:key] == "lavinmq_process_mmap_count" }
-          mmap_metric.should_not be_nil
-          mmap_metric.not_nil![:value].should be > 0
-          limit_metric = parsed_metrics.find { |m| m[:key] == "lavinmq_process_mmap_limit" }
-          limit_metric.should_not be_nil
-          limit_metric.not_nil![:value].should be > 0
-        {% end %}
       end
     end
   end

--- a/spec/mfile_spec.cr
+++ b/spec/mfile_spec.cr
@@ -31,4 +31,19 @@ describe MFile do
       file.delete
     end
   end
+
+  it "tracks mmap count" do
+    file = File.tempfile "mfile_spec"
+    file.print "test"
+    file.flush
+    begin
+      count_before = MFile.mmap_count
+      mfile = MFile.new file.path
+      MFile.mmap_count.should eq(count_before + 1)
+      mfile.close
+      MFile.mmap_count.should eq(count_before)
+    ensure
+      file.delete
+    end
+  end
 end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -428,9 +428,9 @@ module LavinMQ
                       type:  "gauge",
                       help:  "Number of MFile memory-mapped files"})
         {% if flag?(:linux) %}
-          if content = File.read?("/proc/self/maps")
+          if count = count_proc_maps_lines
             writer.write({name:  "process_mmap_count",
-                          value: content.count('\n').to_i64,
+                          value: count,
                           type:  "gauge",
                           help:  "Total number of virtual memory areas in the process"})
           end
@@ -630,6 +630,21 @@ module LavinMQ
             end
           end
         end
+      end
+
+      # Count lines in /proc/self/maps without allocating the entire file content.
+      # Reads in chunks and counts newlines incrementally to reduce memory usage.
+      private def count_proc_maps_lines : Int64?
+        File.open("/proc/self/maps", "r") do |file|
+          count = 0i64
+          buffer = uninitialized UInt8[4096]
+          while (bytes_read = file.read(buffer.to_slice)) > 0
+            count += buffer.to_slice[0, bytes_read].count('\n'.ord.to_u8)
+          end
+          count
+        end
+      rescue
+        nil
       end
     end
   end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -427,20 +427,6 @@ module LavinMQ
                       value: MFile.mmap_count,
                       type:  "gauge",
                       help:  "Number of MFile memory-mapped files"})
-        {% if flag?(:linux) %}
-          if count = count_proc_maps_lines
-            writer.write({name:  "process_mmap_count",
-                          value: count,
-                          type:  "gauge",
-                          help:  "Total number of virtual memory areas in the process"})
-          end
-          if max = File.read?("/proc/sys/vm/max_map_count")
-            writer.write({name:  "process_mmap_limit",
-                          value: max.to_i64,
-                          type:  "gauge",
-                          help:  "System limit for memory-mapped regions (vm.max_map_count)"})
-          end
-        {% end %}
       end
 
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,
@@ -630,21 +616,6 @@ module LavinMQ
             end
           end
         end
-      end
-
-      # Count lines in /proc/self/maps without allocating the entire file content.
-      # Reads in chunks and counts newlines incrementally to reduce memory usage.
-      private def count_proc_maps_lines : Int64?
-        File.open("/proc/self/maps", "r") do |file|
-          count = 0i64
-          buffer = uninitialized UInt8[4096]
-          while (bytes_read = file.read(buffer.to_slice)) > 0
-            count += buffer.to_slice[0, bytes_read].count('\n'.ord.to_u8)
-          end
-          count
-        end
-      rescue
-        nil
       end
     end
   end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -423,6 +423,24 @@ module LavinMQ
                         type:   "gauge",
                         help:   "Bytes that hasn't been synchronized with the follower yet"})
         end
+        writer.write({name:  "mfile_count",
+                      value: MFile.mmap_count,
+                      type:  "gauge",
+                      help:  "Number of MFile memory-mapped files"})
+        {% if flag?(:linux) %}
+          if content = File.read?("/proc/self/maps")
+            writer.write({name:  "process_mmap_count",
+                          value: content.count('\n').to_i64,
+                          type:  "gauge",
+                          help:  "Total number of virtual memory areas in the process"})
+          end
+          if max = File.read?("/proc/sys/vm/max_map_count")
+            writer.write({name:  "process_mmap_limit",
+                          value: max.to_i64,
+                          type:  "gauge",
+                          help:  "System limit for memory-mapped regions (vm.max_map_count)"})
+          end
+        {% end %}
       end
 
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,


### PR DESCRIPTION
Track open MFile instances with atomic counter and expose via Prometheus:

* `lavinmq_mfile_count` Number of MFile memory-mapped files

Documentation need to be updated once released https://lavinmq.com/documentation/prometheus