### PR TITLE
unpin crystal version so we use latest again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: 84codes/crystal:1.18.2-ubuntu-24.04
+    container: 84codes/crystal:latest-ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - run: crystal tool format --check
@@ -41,7 +41,7 @@ jobs:
     name: Lint check
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: 84codes/crystal:1.18.2-ubuntu-24.04
+    container: 84codes/crystal:latest-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -75,7 +75,7 @@ jobs:
   spec:
     name: Spec
     runs-on: ubuntu-latest
-    container: 84codes/crystal:1.18.2-ubuntu-24.04
+    container: 84codes/crystal:latest-ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Print Crystal version
@@ -114,7 +114,7 @@ jobs:
   compile:
     name: Compile LavinMQ
     runs-on: ubuntu-latest
-    container: 84codes/crystal:1.18.2-ubuntu-24.04
+    container: 84codes/crystal:latest-ubuntu-24.04
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -47,7 +47,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           build-args: |
-            build_image=84codes/crystal:1.18.2-${{ matrix.os }}
+            build_image=84codes/crystal:latest-${{ matrix.os }}
             version=${{ env.version }}
             DEB_BUILD_OPTIONS="parallel=1"
           outputs: builds

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -46,7 +46,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           build-args: |
-            build_image=84codes/crystal:1.18.2-${{ matrix.os }}
+            build_image=84codes/crystal:latest-${{ matrix.os }}
             version=${{ env.version }}
             MAKEFLAGS=-j1
           outputs: RPMS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base layer
-FROM 84codes/crystal:1.18.2-ubuntu-24.04 AS base
+FROM 84codes/crystal:latest-ubuntu-24.04 AS base
 RUN apt-get update && apt-get install -y liblz4-dev dpkg-dev
 WORKDIR /usr/src/lavinmq
 COPY shard.yml shard.lock .

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG build_image=84codes/crystal:1.18.2-ubuntu-24.04
+ARG build_image=84codes/crystal:latest-ubuntu-24.04
 
 FROM $build_image AS builder
 RUN apt-get update && apt-get install -y devscripts help2man lintian debhelper liblz4-dev

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -1,4 +1,4 @@
-ARG build_image=84codes/crystal:1.18.2-fedora-42
+ARG build_image=84codes/crystal:latest-fedora-42
 
 FROM $build_image AS builder
 # Enable CRB repository for el-9 to access help2man


### PR DESCRIPTION
### WHAT is this pull request doing?
Reverts the Crystal version pinning introduced in 301f1d50 so that main always builds with `crystal:latest`.

Main shuld use `crystal:latest`, we can pin minor versions of LavinMQ to specific crystal versions if needed (v2.6.x is pinned to 1.18.2)

### HOW can this pull request be tested?
Make sure CI runs and using the latest crystal images