### PR TITLE
Fix: Apply stream max-length and max-length-bytes from policy

### DIFF
--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -46,25 +46,36 @@ module LavinMQ::AMQP
     end
 
     private def apply_policy_argument(key : String, value : JSON::Any) : Bool
-      if key == "max-age"
-        result = false
+      case key
+      when "max-age"
         if max_age_policy = parse_max_age(value.as_s?)
           if current_max = stream_msg_store.max_age
-            if current_max > max_age_policy
-              stream_msg_store.max_age = max_age_policy
-              @effective_args.delete("x-max-age")
-              result = true
-            end
-          else
-            stream_msg_store.max_age = max_age_policy
-            @effective_args.delete("x-max-age")
-            result = true
+            return false unless current_max > max_age_policy
           end
+          stream_msg_store.max_age = max_age_policy
+          @effective_args.delete("x-max-age")
+          stream_msg_store.drop_overflow
+          return true
         end
-        stream_msg_store.max_length = @max_length
-        stream_msg_store.max_length_bytes = @max_length_bytes
-        stream_msg_store.drop_overflow
-        result
+        false
+      when "max-length"
+        unless @max_length.try &.< value.as_i64
+          @max_length = value.as_i64
+          stream_msg_store.max_length = @max_length
+          @effective_args.delete("x-max-length")
+          stream_msg_store.drop_overflow
+          return true
+        end
+        false
+      when "max-length-bytes"
+        unless @max_length_bytes.try &.< value.as_i64
+          @max_length_bytes = value.as_i64
+          stream_msg_store.max_length_bytes = @max_length_bytes
+          @effective_args.delete("x-max-length-bytes")
+          stream_msg_store.drop_overflow
+          return true
+        end
+        false
       else
         super(key, value)
       end
@@ -179,6 +190,7 @@ module LavinMQ::AMQP
         stream_msg_store.max_age = max_age
         @effective_args << "x-max-age"
       end
+      # Propagate limits set by super to stream_msg_store
       stream_msg_store.max_length = @max_length
       stream_msg_store.max_length_bytes = @max_length_bytes
       stream_msg_store.drop_overflow


### PR DESCRIPTION
After the refactor in b66052e29fab94f704d6e909f13fde66f372917c, Stream relied on the parent Queue class to handle max-length policies. However, Queue calls drop_overflow which was a no-op in Stream, so limits were never synced to StreamMessageStore and cleanup never triggered.

Handle all three policy types (`max-age`, `max-length`, `max-length-bytes`) directly in Stream, syncing to StreamMessageStore immediately.

Tested this PR on a 2.6.1 instance that got hit by this bug (disk filled up), now it it works as expected.

<img width="593" height="352" alt="Screenshot 2026-01-20 at 10 12 18" src="https://github.com/user-attachments/assets/ed44a72b-887c-4185-888d-42c5cb8ebdb6" />

Fixes #1613