### PR TITLE
Regression: Fix INI option names that don't match property names

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -111,9 +111,9 @@ describe LavinMQ::Config do
           default_user = admin
           default_user_only_loopback = false
           data_dir_lock = false
-          tls_cert_path = /etc/lavinmq/cert.pem
+          tls_cert = /etc/lavinmq/cert.pem
           tls_ciphers = ECDHE-RSA-AES256-GCM-SHA384
-          tls_key_path = /etc/lavinmq/key.pem
+          tls_key = /etc/lavinmq/key.pem
           tls_min_version = 1.3
           tls_keylog_file = /tmp/keylog.txt
           metrics_http_bind = 0.0.0.0
@@ -137,10 +137,10 @@ describe LavinMQ::Config do
           port = 1884
           tls_port = 8884
           unix_path = /tmp/mqtt.sock
-          mqtt_permission_check_enabled = true
-          mqtt_max_packet_size = 536870910
+          permission_check_enabled = true
+          max_packet_size = 536870910
           max_inflight_messages = 100
-          default_mqtt_vhost = /mqtt
+          default_vhost = /mqtt
 
           [mgmt]
           bind = 0.0.0.0
@@ -160,6 +160,9 @@ describe LavinMQ::Config do
           etcd_endpoints = localhost:2380,localhost:2381
           etcd_prefix = test-lavinmq
           max_unsynced_actions = 16384
+          advertised_uri = lavinmq://localhost:5680
+          on_leader_elected = echo "Leader elected"
+          on_leader_lost = echo "Leader lost"
         CONFIG
       end
       config = LavinMQ::Config.new
@@ -239,6 +242,9 @@ describe LavinMQ::Config do
       config.clustering_etcd_endpoints.should eq "localhost:2380,localhost:2381"
       config.clustering_etcd_prefix.should eq "test-lavinmq"
       config.clustering_max_unsynced_actions.should eq 16384
+      config.clustering_advertised_uri.should eq "lavinmq://localhost:5680"
+      config.clustering_on_leader_elected.should eq "echo \"Leader elected\""
+      config.clustering_on_leader_lost.should eq "echo \"Leader lost\""
     ensure
       # Reset log level to default for other specs
       Log.setup(:fatal)

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -92,7 +92,7 @@ module LavinMQ
       property https_port = 15671
 
       @[CliOpt("", "--cert FILE", "TLS certificate (including chain)", section: "tls")]
-      @[IniOpt(section: "main")]
+      @[IniOpt(ini_name: tls_cert, section: "main")]
       @[EnvOpt("LAVINMQ_TLS_CERT_PATH")]
       property tls_cert_path = ""
 
@@ -102,7 +102,7 @@ module LavinMQ
       property tls_ciphers = ""
 
       @[CliOpt("", "--key FILE", "Private key for the TLS certificate", section: "tls")]
-      @[IniOpt(section: "main")]
+      @[IniOpt(ini_name: tls_key, section: "main")]
       @[EnvOpt("LAVINMQ_TLS_KEY_PATH")]
       property tls_key_path = ""
 
@@ -122,18 +122,18 @@ module LavinMQ
       @[CliOpt("", "--metrics-http-port=PORT", "HTTP port that prometheus will listen to (default: 15692)")]
       property metrics_http_port = 15692
 
-      @[IniOpt(section: "mqtt")]
+      @[IniOpt(ini_name: permission_check_enabled, section: "mqtt")]
       property? mqtt_permission_check_enabled : Bool = false
 
-      @[IniOpt(section: "clustering")]
+      @[IniOpt(ini_name: on_leader_elected, section: "clustering")]
       @[CliOpt("", "--clustering-on-leader-elected=COMMAND", "Shell command to execute when elected leader", section: "clustering")]
       property clustering_on_leader_elected = "" # shell command to execute when elected leader
 
-      @[IniOpt(section: "clustering")]
+      @[IniOpt(ini_name: on_leader_lost, section: "clustering")]
       @[CliOpt("", "--clustering-on-leader-lost=COMMAND", "Shell command to execute when losing leadership", section: "clustering")]
       property clustering_on_leader_lost = "" # shell command to execute when losing leadership
 
-      @[IniOpt(section: "mqtt")]
+      @[IniOpt(ini_name: max_packet_size, section: "mqtt")]
       property mqtt_max_packet_size = 268_435_455_u32 # bytes
 
       @[IniOpt(section: "mgmt")]
@@ -172,7 +172,7 @@ module LavinMQ
       @[IniOpt(section: "mqtt")]
       property max_inflight_messages : UInt16 = UInt16::MAX # mqtt messages
 
-      @[IniOpt(section: "mqtt")]
+      @[IniOpt(ini_name: default_vhost, section: "mqtt")]
       property default_mqtt_vhost = "/"
 
       @[IniOpt(section: "main", transform: ->tcp_keepalive?(String))]
@@ -260,7 +260,7 @@ module LavinMQ
       property? clustering = false
 
       @[CliOpt("", "--clustering-advertised-uri=URI", "Advertised URI for the clustering server", section: "clustering")]
-      @[IniOpt(section: "clustering")]
+      @[IniOpt(ini_name: advertised_uri, section: "clustering")]
       @[EnvOpt("LAVINMQ_CLUSTERING_ADVERTISED_URI")]
       property clustering_advertised_uri : String? = nil
 


### PR DESCRIPTION
### WHAT is this pull request doing?
After the config rewrite in 5ae8bf7d, several INI options stopped working because the property names don't match the INI key names that were used before. Add `ini_name` overrides for:

- tls_cert/tls_key in [main] section
- default_vhost, permission_check_enabled, max_packet_size in [mqtt] section
- advertised_uri, on_leader_elected, on_leader_lost in [clustering] section

### HOW can this pull request be tested?
Run spec
