### PR TITLE
unconditionally signal expire loop on message consume

### DIFF
--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -718,7 +718,6 @@ module LavinMQ::AMQP
     # yield the next message in the ready queue
     # returns true if a message was deliviered, false otherwise
     # if we encouncer an unrecoverable ReadError, close queue
-    # ameba:disable Metrics/CyclomaticComplexity
     private def get(no_ack : Bool, & : Envelope -> Nil) : Bool
       raise ClosedError.new if @closed
       loop do # retry if msg expired or deliver limit hit
@@ -746,8 +745,7 @@ module LavinMQ::AMQP
           # requeuing of failed delivery is up to the consumer
         end
         # Signal expire loop to recalculate wait time for next message
-        next_env = @msg_store_lock.synchronize { @msg_store.first? }
-        @message_ttl_change.try_send? nil if next_env && expire_at(next_env.message)
+        @message_ttl_change.try_send? nil
         return true
       end
       false
@@ -891,8 +889,7 @@ module LavinMQ::AMQP
       @log.info { "Purged #{delete_count} messages" }
       # Signal expire loop to recalculate wait time for next message
       if delete_count > 0
-        next_env = @msg_store_lock.synchronize { @msg_store.first? }
-        @message_ttl_change.try_send? nil if next_env && expire_at(next_env.message)
+        @message_ttl_change.try_send? nil
       end
       delete_count
     rescue ex : MessageStore::Error


### PR DESCRIPTION
### WHAT is this pull request doing?

The bugfix in #1606 impacts performance because it acquires a lock and peeks at the next message for every `get`. This addresses that by: 
- Signal expire loop unconditionally instead of checking next message's TTL first
- Remove redundant lock acquisition and message peek on every consume
- The expire loop is blocked on `@consumers_empty` when consumers are active, so `try_send?` fails immediately - no receiver listening
- When the last consumer disconnects, the expire loop does the TTL check itself when it wakes up

### Performance
Before (with original fix from #1606):
- Average publish rate: 900,347 msgs/s
- Average consume rate: 892,619 msgs/s

With this fix:
- Average publish rate: 1,021,897 msgs/s 
- Average consume rate: 968,187 msgs/s
(~10% improvement)

### HOW can this pull request be tested?
Run specs.
