### PR TITLE
Fix: Register log system on config parse (startup)

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -89,7 +89,7 @@ describe LavinMQ::Config do
           [main]
           data_dir = /tmp/lavinmq-test
           log_level = debug
-          log_file = /var/log/lavinmq.log
+          log_file = /tmp/lavinmq-test.log
           stats_interval = 10000
           stats_log_size = 240
           set_timestamp = true
@@ -172,7 +172,7 @@ describe LavinMQ::Config do
       # Main section
       config.data_dir.should eq "/tmp/lavinmq-test"
       config.log_level.should eq ::Log::Severity::Debug
-      config.log_file.should eq "/var/log/lavinmq.log"
+      config.log_file.should eq "/tmp/lavinmq-test.log"
       config.stats_interval.should eq 10000
       config.stats_log_size.should eq 240
       config.set_timestamp?.should be_true

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,6 +7,10 @@ class Log
   def self.setup
     # noop, don't override during spec
   end
+
+  def self.setup(level : Severity, backend : Backend)
+    # noop, don't override during spec
+  end
 end
 
 require "spec"

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -32,6 +32,7 @@ module LavinMQ
       parse_ini(@config_file)
       parse_env()
       parse_cli(argv)
+      reload_logger
     end
 
     private def parse_config_from_cli(argv)


### PR DESCRIPTION
In #917 reload_logger was removed from Config#parse, thus logging wasn't setup properly.

When fixing this the specs broke due to `Log.capture` being unable to verify warnings since Log.setup replaced all backends now that parse actually restarted the logging, thus fixing the Log.setup(...) override in spec_helper.

Also noticed that we now try to log `/var/log/lavinmq.log` for real which in most systems isn't allowed, use `/tmp` instead.

Close #1648