### PR TITLE
Improve Log.capture test reliability

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -428,12 +428,12 @@ describe LavinMQ::Config do
         default_password = +pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+
       CONFIG
       end
-      Log.capture(level: :info) do |logs|
+      logs = Log.capture(level: :info) do
         config = LavinMQ::Config.new
         argv = ["-c", config_file.path]
         config.parse(argv)
-        logs.check(:warn, /is deprecated/)
       end
+      logs.check(:warn, /is deprecated/)
     end
 
     it "should log warning for cli options" do
@@ -442,12 +442,12 @@ describe LavinMQ::Config do
         [main]
       CONFIG
       end
-      Log.capture(level: :info) do |logs|
+      logs = Log.capture(level: :info) do
         config = LavinMQ::Config.new
         argv = ["-c", config_file.path, "--default-password", "8Yw8kj5HkhfRxQ/3kbTAO/nmgqGpkvMsGDbUWXA6+jTF3JP3"]
         config.parse(argv)
-        logs.check(:warn, /is deprecated/)
       end
+      logs.check(:warn, /is deprecated/)
     end
 
     it "should forward ini option values to the new property" do


### PR DESCRIPTION
Move log assertions outside the capture block so they are always verified after the action completes, regardless of success or failure.