### PR TITLE
 Pass version env var to deb/RPM builds for commit tracking

### DIFF
--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -13,7 +13,7 @@ RUN tar -czf ../lavinmq_${version}.orig.tar.gz -C /usr/src lavinmq_${version}
 COPY packaging/debian/ debian/
 RUN sed -i -E "s/^(lavinmq) \(.*\)/\1 \(${version}-1\)/" debian/changelog
 ARG DEB_BUILD_OPTIONS="parallel=2"
-RUN debuild -us -uc
+RUN debuild -us -uc -e=version
 
 FROM ubuntu:24.04 AS test
 COPY --from=builder /usr/src/*deb .


### PR DESCRIPTION
### WHAT is this pull request doing?
The Crystal macro in version.cr checks for `$version` env var. Since it's not set, it falls back to` git describe --tags`.. but i dont think `.git` works with the Docker image.. So the version is probably falling back to `shards version`

This PR makes the version available as an env variable during the build process so the crystal macro can access it. 
Fixes #1640 

### HOW can this pull request be tested?
Just want to try if this works when we build the deb package on PR 