### PR TITLE
Fix Claude code review workflow permission prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,3 +22,4 @@ jobs:
           prompt: "/review"
           claude_args: |
             --max-turns 5
+            --allowedTools "Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
## Summary
- Add `--allowedTools` to pre-approve `gh` commands that `/review` needs
- Fixes the workflow stalling on permission prompts in CI (asking for permission to run `gh pr list`)

## Test plan
- [ ] observe the workflow runs (might need to merge and check next PR?)


🤖 Generated with [Claude Code](https://claude.com/claude-code)