### PR TITLE
WIP: DecoupleMQTT::Session` from `AMQP::Queue`

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -107,15 +107,15 @@ describe LavinMQ::HTTP::Server do
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         ex = s.vhosts["/"].exchanges["import_x1"]
-        qs = Set(LavinMQ::Queue).new
-        es = Set(LavinMQ::Exchange).new
+        qs = Set(LavinMQ::AMQP::Queue).new
+        es = Set(LavinMQ::AMQP::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
         res << s.vhosts["/"].exchanges["import_x1"]
         res << s.vhosts["/"].exchanges["import_x2"]
         es.should eq res
-        qs = Set(LavinMQ::Queue).new
-        es = Set(LavinMQ::Exchange).new
+        qs = Set(LavinMQ::AMQP::Queue).new
+        es = Set(LavinMQ::AMQP::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
         res << s.vhosts["/"].queues["import_q1"]
@@ -499,15 +499,15 @@ describe LavinMQ::HTTP::Server do
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
         ex = s.vhosts["/"].exchanges["import_x1"]
-        qs = Set(LavinMQ::Queue).new
-        es = Set(LavinMQ::Exchange).new
+        qs = Set(LavinMQ::AMQP::Queue).new
+        es = Set(LavinMQ::AMQP::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
         res << s.vhosts["/"].exchanges["import_x1"]
         res << s.vhosts["/"].exchanges["import_x2"]
         es.should eq res
-        qs = Set(LavinMQ::Queue).new
-        es = Set(LavinMQ::Exchange).new
+        qs = Set(LavinMQ::AMQP::Queue).new
+        es = Set(LavinMQ::AMQP::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
         res << s.vhosts["/"].queues["import_q1"]

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -130,8 +130,9 @@ describe LavinMQ::HTTP::QueuesController do
             2.times { q.publish "m1" }
             q.subscribe(no_ack: false) { }
 
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 2 }
-            s.vhosts["/"].queues["unacked_q"].basic_get_unacked.size.should eq 0
+            unacked_q = s.vhosts["/"].queues["unacked_q"].should be_a(LavinMQ::AMQP::Queue)
+            wait_for { unacked_q.unacked_count == 2 }
+            unacked_q.basic_get_unacked.size.should eq 0
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -187,7 +188,8 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
 
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues["unacked_q"].basic_get_unacked.size == 1 }
+            unacked_q = s.vhosts["/"].queues["unacked_q"].should be_a(LavinMQ::AMQP::Queue)
+            wait_for { unacked_q.basic_get_unacked.size == 1 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -143,7 +143,7 @@ describe "Delayed Message Exchange" do
         # the message published with 6000ms should be published. Also, the new message
         # with 1500ms should be published
         sleep 2.seconds
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::Queue)
         queue.message_count.should eq 3
         sleep 3.seconds # total 10, the 9000ms message should have been published
         queue.message_count.should eq 4

--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -1,10 +1,10 @@
 require "./spec_helper"
 
 module MessageRoutingSpec
-  def self.matches(exchange : LavinMQ::Exchange, routing_key, headers = nil) : Set(LavinMQ::Destination)
+  def self.matches(exchange : LavinMQ::AMQP::Exchange, routing_key, headers = nil) : Set(LavinMQ::Destination)
     s = Set(LavinMQ::Destination).new
-    qs = Set(LavinMQ::Queue).new
-    es = Set(LavinMQ::Exchange).new
+    qs = Set(LavinMQ::AMQP::Queue).new
+    es = Set(LavinMQ::AMQP::Exchange).new
     exchange.find_queues(routing_key, headers, qs, es)
     qs.each { |q| s << q }
     s
@@ -56,57 +56,57 @@ module MessageRoutingSpec
       end
 
       it "matches prefixed star-wildcard" do
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q1, "*.test")
         matches(x, "rk2.test").should eq(Set{q1})
         x.unbind(q1, "*.test")
       end
 
       it "matches exact rk" do
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q1, "rk1")
         matches(x, "rk1", nil).should eq(Set{q1})
         x.unbind(q1, "rk1")
       end
 
       it "matches star-wildcards" do
-        q2 = LavinMQ::QueueFactory.make(vhost, "q2")
+        q2 = LavinMQ::QueueFactory.make(vhost, "q2").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q2, "*")
         matches(x, "rk2").should eq(Set{q2})
         x.unbind(q2, "*")
       end
 
       it "matches star-wildcards but not too much" do
-        q22 = LavinMQ::QueueFactory.make(vhost, "q22")
+        q22 = LavinMQ::QueueFactory.make(vhost, "q22").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q22, "*")
         matches(x, "rk2.a").should be_empty
         x.unbind(q22, "*")
       end
 
       it "should not match with too many star-wildcards" do
-        q3 = LavinMQ::QueueFactory.make(vhost, "q3")
+        q3 = LavinMQ::QueueFactory.make(vhost, "q3").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q3, "a.*")
         matches(x, "b.c").should be_empty
         x.unbind(q3, "a.*")
       end
 
       it "should match star-wildcards in the middle" do
-        q4 = LavinMQ::QueueFactory.make(vhost, "q4")
+        q4 = LavinMQ::QueueFactory.make(vhost, "q4").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q4, "c.*.d")
         matches(x, "c.a.d").should eq(Set{q4})
         x.unbind(q4, "c.*.d")
       end
 
       it "should match catch-all" do
-        q5 = LavinMQ::QueueFactory.make(vhost, "q5")
+        q5 = LavinMQ::QueueFactory.make(vhost, "q5").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q5, "d.#")
         matches(x, "d.a.d").should eq(Set{q5})
         x.unbind(q5, "d.#")
       end
 
       it "should match multiple bindings" do
-        q6 = LavinMQ::QueueFactory.make(vhost, "q6")
-        q7 = LavinMQ::QueueFactory.make(vhost, "q7")
+        q6 = LavinMQ::QueueFactory.make(vhost, "q6").should be_a(LavinMQ::AMQP::Queue)
+        q7 = LavinMQ::QueueFactory.make(vhost, "q7").should be_a(LavinMQ::AMQP::Queue)
         ex = LavinMQ::AMQP::TopicExchange.new(vhost, "t55", false, false, true)
         ex.bind(q6, "rk")
         ex.bind(q7, "rk")
@@ -116,7 +116,7 @@ module MessageRoutingSpec
       end
 
       it "should not get index out of bound when matching routing keys" do
-        q8 = LavinMQ::QueueFactory.make(vhost, "q63")
+        q8 = LavinMQ::QueueFactory.make(vhost, "q63").should be_a(LavinMQ::AMQP::Queue)
         ex = LavinMQ::AMQP::TopicExchange.new(vhost, "t63", false, false, true)
         ex.bind(q8, "rk63.rk63")
         matches(ex, "rk63").should be_empty
@@ -124,7 +124,7 @@ module MessageRoutingSpec
       end
 
       it "# should consider what's comes after" do
-        q9 = LavinMQ::QueueFactory.make(vhost, "q9")
+        q9 = LavinMQ::QueueFactory.make(vhost, "q9").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q9, "#.a")
         matches(x, "a.a.b").should be_empty
         matches(x, "a.a.a").should eq(Set{q9})
@@ -132,21 +132,21 @@ module MessageRoutingSpec
       end
 
       it "# should consider what's comes after" do
-        q9 = LavinMQ::QueueFactory.make(vhost, "q9")
+        q9 = LavinMQ::QueueFactory.make(vhost, "q9").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q9, "#.a.a.a")
         matches(x, "a.a.b.a.a").should be_empty
         matches(x, "a.a.a.a").should eq(Set{q9})
         x.unbind(q9, "#.a.a.a")
       end
       it "# should consider what's comes after" do
-        q9 = LavinMQ::QueueFactory.make(vhost, "q9")
+        q9 = LavinMQ::QueueFactory.make(vhost, "q9").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q9, "#.a.b.c")
         matches(x, "a.a.a.a.b.c").should eq(Set{q9})
         x.unbind(q9, "#.a.b.c")
       end
 
       it "# can be followed by *" do
-        q0 = LavinMQ::QueueFactory.make(vhost, "q0")
+        q0 = LavinMQ::QueueFactory.make(vhost, "q0").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q0, "#.*.d")
         matches(x, "a.d.a").should be_empty
         matches(x, "a.a.d").should eq(Set{q0})
@@ -154,14 +154,14 @@ module MessageRoutingSpec
       end
 
       it "can handle multiple #" do
-        q11 = LavinMQ::QueueFactory.make(vhost, "q11")
+        q11 = LavinMQ::QueueFactory.make(vhost, "q11").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q11, "#.a.#")
         matches(x, "b.b.a.b.b").should eq(Set{q11})
         x.unbind(q11, "#.a.#")
       end
 
       it "# should match zero segments" do
-        q = LavinMQ::QueueFactory.make(vhost, "q_zero_segments")
+        q = LavinMQ::QueueFactory.make(vhost, "q_zero_segments").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q, "a.*.c.#")
         matches(x, "a.b.c").should eq(Set{q})
         matches(x, "a.b.c.d").should eq(Set{q})
@@ -170,28 +170,28 @@ module MessageRoutingSpec
       end
 
       it "should match double star-wildcards" do
-        q12 = LavinMQ::QueueFactory.make(vhost, "q12")
+        q12 = LavinMQ::QueueFactory.make(vhost, "q12").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q12, "c.*.*")
         matches(x, "c.a.d").should eq(Set{q12})
         x.unbind(q12, "c.*.*")
       end
 
       it "should not match single star on multiple segments" do
-        q = LavinMQ::QueueFactory.make(vhost, "q123")
+        q = LavinMQ::QueueFactory.make(vhost, "q123").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q, "c.*")
         matches(x, "c.a.d").should be_empty
         x.unbind(q, "c.*")
       end
 
       it "should match triple star-wildcards" do
-        q13 = LavinMQ::QueueFactory.make(vhost, "q13")
+        q13 = LavinMQ::QueueFactory.make(vhost, "q13").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q13, "c.*.*.*")
         matches(x, "c.a.d.e").should eq(Set{q13})
         x.unbind(q13, "c.*.*.*")
       end
 
       it "can differentiate a.b.c from a.b" do
-        q = LavinMQ::QueueFactory.make(vhost, "")
+        q = LavinMQ::QueueFactory.make(vhost, "").should be_a(LavinMQ::AMQP::Queue)
         x.bind(q, "a.b.c")
         matches(x, "a.b.c").should eq(Set{q})
         matches(x, "a.b").should be_empty
@@ -250,7 +250,7 @@ module MessageRoutingSpec
 
       describe "unbind" do
         it "shouldn't care about argument order" do
-          q = LavinMQ::QueueFactory.make(vhost, "q")
+          q = LavinMQ::QueueFactory.make(vhost, "q").should be_a(LavinMQ::AMQP::Queue)
           args1 = {"foo": "bar", "f00": "baz"}
           args2 = {"f00": "baz", "foo": "bar"}
           x.bind(q, "", LavinMQ::AMQP::Table.new args1)
@@ -258,7 +258,7 @@ module MessageRoutingSpec
         end
 
         it "shouldn't care about argument order with many bindings" do
-          q = LavinMQ::QueueFactory.make(vhost, "q")
+          q = LavinMQ::QueueFactory.make(vhost, "q").should be_a(LavinMQ::AMQP::Queue)
           args1 = {"foo": "bar", "f00": "baz"}
           args2 = {"f00": "baz", "foo": "bar"}
           x.bind(q, "", LavinMQ::AMQP::Table.new args1)
@@ -271,13 +271,13 @@ module MessageRoutingSpec
 
       describe "match all" do
         it "should match if same args" do
-          q6 = LavinMQ::QueueFactory.make(vhost, "q6")
+          q6 = LavinMQ::QueueFactory.make(vhost, "q6").should be_a(LavinMQ::AMQP::Queue)
           x.bind(q6, "", hdrs_all)
           matches(x, "", hdrs_all).should eq(Set{q6})
         end
 
         it "should not match if not all args are the same" do
-          q7 = LavinMQ::QueueFactory.make(vhost, "q7")
+          q7 = LavinMQ::QueueFactory.make(vhost, "q7").should be_a(LavinMQ::AMQP::Queue)
           x.bind(q7, "", hdrs_all)
           msg_hdrs = hdrs_all.clone
           msg_hdrs.delete "x-match"
@@ -286,7 +286,7 @@ module MessageRoutingSpec
         end
 
         it "should not match if args are missing" do
-          q = LavinMQ::QueueFactory.make(vhost, "q")
+          q = LavinMQ::QueueFactory.make(vhost, "q").should be_a(LavinMQ::AMQP::Queue)
           bind_hdrs = hdrs_all.clone.merge!({
             "missing": "header",
           })
@@ -297,7 +297,7 @@ module MessageRoutingSpec
 
       describe "match any" do
         it "should match if any args are the same" do
-          q8 = LavinMQ::QueueFactory.make(vhost, "q8")
+          q8 = LavinMQ::QueueFactory.make(vhost, "q8").should be_a(LavinMQ::AMQP::Queue)
           x.bind(q8, "", hdrs_any)
           msg_hdrs = hdrs_any.clone
           msg_hdrs.delete "x-match"
@@ -306,7 +306,7 @@ module MessageRoutingSpec
         end
 
         it "should not match if no args are the same" do
-          q9 = LavinMQ::QueueFactory.make(vhost, "q9")
+          q9 = LavinMQ::QueueFactory.make(vhost, "q9").should be_a(LavinMQ::AMQP::Queue)
           x.bind(q9, "", hdrs_any)
           msg_hdrs = hdrs_any.clone
           msg_hdrs.delete "x-match"
@@ -316,7 +316,7 @@ module MessageRoutingSpec
         end
 
         it "should match nestled amq-protocol tables" do
-          q10 = LavinMQ::QueueFactory.make(vhost, "q10")
+          q10 = LavinMQ::QueueFactory.make(vhost, "q10").should be_a(LavinMQ::AMQP::Queue)
           bind_hdrs = LavinMQ::AMQP::Table.new({
             "x-match" => "any",
             "tbl"     => LavinMQ::AMQP::Table.new({"foo": "bar"}),
@@ -329,7 +329,7 @@ module MessageRoutingSpec
       end
 
       it "should handle multiple bindings" do
-        q10 = LavinMQ::QueueFactory.make(vhost, "q10")
+        q10 = LavinMQ::QueueFactory.make(vhost, "q10").should be_a(LavinMQ::AMQP::Queue)
         hdrs1 = LavinMQ::AMQP::Table.new({"x-match" => "any", "org" => "84codes", "user" => "test"})
         hdrs2 = LavinMQ::AMQP::Table.new({"x-match" => "all", "org" => "google", "user" => "test"})
 
@@ -342,7 +342,7 @@ module MessageRoutingSpec
       end
 
       it "should handle all Field types" do
-        q11 = LavinMQ::QueueFactory.make(vhost, "q11")
+        q11 = LavinMQ::QueueFactory.make(vhost, "q11").should be_a(LavinMQ::AMQP::Queue)
         hsh = {"k" => "v"} of String => LavinMQ::AMQP::Field
         arrf = [1] of LavinMQ::AMQP::Field
         arru = [1_u8] of LavinMQ::AMQP::Field
@@ -358,7 +358,7 @@ module MessageRoutingSpec
       end
 
       it "should handle unbind" do
-        q12 = LavinMQ::QueueFactory.make(vhost, "q12")
+        q12 = LavinMQ::QueueFactory.make(vhost, "q12").should be_a(LavinMQ::AMQP::Queue)
         hdrs1 = LavinMQ::AMQP::Table.new({
           "x-match" => "any", "org" => "84codes", "user" => "test",
         })
@@ -372,7 +372,7 @@ module MessageRoutingSpec
 
       describe "match empty" do
         it "should match if both args and headers are empty" do
-          q13 = LavinMQ::QueueFactory.make(vhost, "q13")
+          q13 = LavinMQ::QueueFactory.make(vhost, "q13").should be_a(LavinMQ::AMQP::Queue)
           x.bind(q13, "", nil)
           matches(x, "", nil).size.should eq 1
         end
@@ -384,8 +384,8 @@ module MessageRoutingSpec
     it "should handle CC in header" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
-        q2 = LavinMQ::QueueFactory.make(vhost, "q2")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
+        q2 = LavinMQ::QueueFactory.make(vhost, "q2").should be_a(LavinMQ::AMQP::Queue)
         x = LavinMQ::AMQP::DirectExchange.new(vhost, "")
         x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
         x.bind(q2, "q2", LavinMQ::AMQP::Table.new)
@@ -397,15 +397,15 @@ module MessageRoutingSpec
     it "should raise if CC header isn't array" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
-        q2 = LavinMQ::QueueFactory.make(vhost, "q2")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
+        q2 = LavinMQ::QueueFactory.make(vhost, "q2").should be_a(LavinMQ::AMQP::Queue)
         x = LavinMQ::AMQP::DirectExchange.new(vhost, "")
         x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
         x.bind(q2, "q2", LavinMQ::AMQP::Table.new)
         headers = LavinMQ::AMQP::Table.new
         headers["CC"] = "q2"
         expect_raises(LavinMQ::Error::PreconditionFailed) do
-          x.find_queues("q1", headers, Set(LavinMQ::Queue).new)
+          x.find_queues("q1", headers, Set(LavinMQ::AMQP::Queue).new)
         end
       end
     end
@@ -413,8 +413,8 @@ module MessageRoutingSpec
     it "should handle BCC in header" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
-        q2 = LavinMQ::QueueFactory.make(vhost, "q2")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
+        q2 = LavinMQ::QueueFactory.make(vhost, "q2").should be_a(LavinMQ::AMQP::Queue)
         x = LavinMQ::AMQP::DirectExchange.new(vhost, "")
         x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
         x.bind(q2, "q2", LavinMQ::AMQP::Table.new)
@@ -427,15 +427,15 @@ module MessageRoutingSpec
     it "should raise if BCC header isn't array" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
-        q2 = LavinMQ::QueueFactory.make(vhost, "q2")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
+        q2 = LavinMQ::QueueFactory.make(vhost, "q2").should be_a(LavinMQ::AMQP::Queue)
         x = LavinMQ::AMQP::DirectExchange.new(vhost, "")
         x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
         x.bind(q2, "q2", LavinMQ::AMQP::Table.new)
         headers = LavinMQ::AMQP::Table.new
         headers["BCC"] = "q2"
         expect_raises(LavinMQ::Error::PreconditionFailed) do
-          x.find_queues("q1", headers, Set(LavinMQ::Queue).new)
+          x.find_queues("q1", headers, Set(LavinMQ::AMQP::Queue).new)
         end
       end
     end
@@ -443,9 +443,9 @@ module MessageRoutingSpec
     it "should read both CC and BCC" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
-        q2 = LavinMQ::QueueFactory.make(vhost, "q2")
-        q3 = LavinMQ::QueueFactory.make(vhost, "q3")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
+        q2 = LavinMQ::QueueFactory.make(vhost, "q2").should be_a(LavinMQ::AMQP::Queue)
+        q3 = LavinMQ::QueueFactory.make(vhost, "q3").should be_a(LavinMQ::AMQP::Queue)
         x = LavinMQ::AMQP::DirectExchange.new(vhost, "")
         x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
         x.bind(q2, "q2", LavinMQ::AMQP::Table.new)
@@ -462,8 +462,9 @@ module MessageRoutingSpec
     it "should only allow Session to bind" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")
-        q1 = LavinMQ::QueueFactory.make(vhost, "q1")
+        q1 = LavinMQ::QueueFactory.make(vhost, "q1").should be_a(LavinMQ::AMQP::Queue)
         s1 = LavinMQ::QueueFactory.make(vhost, "q1", arguments: LavinMQ::AMQP::Table.new({"x-queue-type": "mqtt"}))
+        s1 = s1.should be_a(LavinMQ::MQTT::Session)
         index = LavinMQ::MQTT::TopicTree(String).new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
         x = LavinMQ::MQTT::Exchange.new(vhost, "", store)

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -314,7 +314,8 @@ module MqttSpecs
               disconnect(io)
             end
             sleep 100.milliseconds
-            server.vhosts["/"].queues["mqtt.client_id"].consumers.should be_empty
+            session = server.vhosts["/"].queues["mqtt.client_id"].should be_a(LavinMQ::MQTT::Session)
+            session.client.should be_nil
           end
         end
       end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -41,6 +41,29 @@ module MqttSpecs
           end
         end
 
+        it "no session present when reconnecting a non-clean session with a clean session after server restart [MQTT-3.1.2-6]" do
+          with_server(clean_dir: false) do |server|
+            with_client_io(server) do |io|
+              connect(io, clean_session: false)
+
+              # LavinMQ won't save sessions without subscriptions
+              subscribe(io,
+                topic_filters: [subtopic("a/topic", 0u8)],
+                packet_id: 1u16
+              )
+              disconnect(io)
+            end
+          end
+          with_server(clean_dir: true) do |server|
+            with_client_io(server) do |io|
+              connack = connect(io, clean_session: true)
+              connack.should be_a(MQTT::Protocol::Connack)
+              connack = connack.as(MQTT::Protocol::Connack)
+              connack.session_present?.should be_false
+            end
+          end
+        end
+
         it "no session present when reconnecting a clean session with a non-clean session [MQTT-3.1.2-6]" do
           with_server do |server|
             with_client_io(server) do |io|
@@ -89,6 +112,27 @@ module MqttSpecs
               )
               disconnect(io)
             end
+            with_client_io(server) do |io|
+              connack = connect(io, clean_session: false)
+              connack.should be_a(MQTT::Protocol::Connack)
+              connack = connack.as(MQTT::Protocol::Connack)
+              connack.session_present?.should be_true
+            end
+          end
+        end
+
+        it "session present when reconnecting a non-clean session after server restart [MQTT-3.1.2-4]" do
+          with_server(clean_dir: false) do |server|
+            with_client_io(server) do |io|
+              connect(io, clean_session: false)
+              subscribe(io,
+                topic_filters: [subtopic("a/topic", 0u8)],
+                packet_id: 1u16
+              )
+              disconnect(io)
+            end
+          end
+          with_server(clean_dir: true) do |server|
             with_client_io(server) do |io|
               connack = connect(io, clean_session: false)
               connack.should be_a(MQTT::Protocol::Connack)

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -133,32 +133,32 @@ module MqttSpecs
     # subscribes won't ruing the session in anyway
     it "should not ruin session when subcribing again" do
       with_server do |server|
-        with_client_io(server) do |io|
-          connect(io, client_id: "sub", clean_session: false)
+        with_client_io(server) do |sub|
+          connect(sub, client_id: "sub", clean_session: false)
           # QoS1 important so message must be acked
           topic_filters = mk_topic_filters({"a/b", 1})
-          subscribe(io, topic_filters: topic_filters)
+          subscribe(sub, topic_filters: topic_filters)
 
           # Now publish a message
-          with_client_io(server) do |io|
-            connect(io, client_id: "pub")
-            publish(io, topic: "a/b", payload: "a".to_slice, qos: 1u8)
-            disconnect(io)
+          with_client_io(server) do |pub|
+            connect(pub, client_id: "pub")
+            publish(pub, topic: "a/b", payload: "a".to_slice, qos: 1u8)
+            disconnect(pub)
           end
 
           # Before ack, do another subscribe
-          pkt = read_packet(io).should be_a(MQTT::Protocol::Publish)
+          pkt = read_packet(sub).should be_a(MQTT::Protocol::Publish)
           topic_filters = mk_topic_filters({"c/d", 1})
-          resp = subscribe(io, topic_filters: topic_filters)
+          subscribe(sub, topic_filters: topic_filters)
 
           # This should be succesful
-          puback(io, packet_id: pkt.packet_id)
+          puback(sub, packet_id: pkt.packet_id)
 
           # Pingpong to "sync" with server. Since we're waiting for "pong"
           # we know that the server will handle the puback.
-          pingpong(io)
+          pingpong(sub)
 
-          disconnect(io)
+          disconnect(sub)
         end
       end
     end

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -26,8 +26,7 @@ module MqttSpecs
             ack.should be_nil
 
             msg = read_packet(sub_io)
-            msg.should be_a(MQTT::Protocol::Publish)
-            msg = msg.as(MQTT::Protocol::Publish)
+            msg = msg.should be_a(MQTT::Protocol::Publish)
             msg.payload.should eq payload
             msg.packet_id.should be_nil # QoS=0
           end
@@ -100,8 +99,7 @@ module MqttSpecs
 
           topic_filters = mk_topic_filters({"a/b", 0})
           suback = subscribe(io, topic_filters: topic_filters)
-          suback.should be_a(MQTT::Protocol::SubAck)
-          suback = suback.as(MQTT::Protocol::SubAck)
+          suback = suback.should be_a(MQTT::Protocol::SubAck)
           # Verify that we subscribed as qos0
           suback.return_codes.first.should eq(MQTT::Protocol::SubAck::ReturnCode::QoS0)
 
@@ -115,8 +113,7 @@ module MqttSpecs
           # Now do a second subscribe with another qos and do the same verification
           topic_filters = mk_topic_filters({"a/b", 1})
           suback = subscribe(io, topic_filters: topic_filters)
-          suback.should be_a(MQTT::Protocol::SubAck)
-          suback = suback.as(MQTT::Protocol::SubAck)
+          suback = suback.should be_a(MQTT::Protocol::SubAck)
           # Verify that we subscribed as qos1
           suback.return_codes.should eq([MQTT::Protocol::SubAck::ReturnCode::QoS1])
 

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -130,7 +130,8 @@ module MqttSpecs
     end
 
     # LavinMQ creates the session (queue) on subscribe. Make sure multiple
-    # subscribes won't ruing the session in anyway
+    # subscribes won't ruin the session in any way. This is to make sure an
+    # unreported bug won't reoccur (unacked was clear).
     it "should not ruin session when subcribing again" do
       with_server do |server|
         with_client_io(server) do |sub|

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -81,7 +81,7 @@ describe LavinMQ::Federation::Upstream do
 
         with_channel(s) do |ch|
           ch.queue("federated_q")
-          link = upstream.link(vhost_downstream.queues["federated_q"])
+          link = upstream.link(vhost_downstream.queues["federated_q"].should be_a(LavinMQ::AMQP::Queue))
           link.name.should eq "federated_q"
           wait_for { link.state.running? }
           vhost_upstream.queues.has_key?("federated_q").should be_true
@@ -99,7 +99,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
@@ -118,7 +118,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x = UpstreamSpecHelpers.setup_qs(ch).first
           x.publish_confirm "federate me", "federation_q1"
-          link = upstream.link(vhost.queues["federation_q2"])
+          link = upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           wait_for { link.state.running? }
           vhost.queues["federation_q1"].message_count.should eq 1
           vhost.queues["federation_q2"].message_count.should eq 0
@@ -137,7 +137,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
@@ -157,7 +157,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
@@ -210,7 +210,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           q2.subscribe do |msg|
             msgs << msg
           end
@@ -241,7 +241,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1", props: AMQP::Client::Properties.new(content_type: "application/json")
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           msgs = [] of AMQP::Client::DeliverMessage
           q2.subscribe { |msg| msgs << msg }
           wait_for { msgs.size == 1 }
@@ -281,8 +281,8 @@ describe LavinMQ::Federation::Upstream do
           msgs.should be_receiving "msg1"
           wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
         end
-
-        wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].consumers.empty? }
+        ds_queue = s.vhosts[ds_vhost.name].queues[ds_queue_name].should be_a(LavinMQ::AMQP::Queue)
+        wait_for { ds_queue.consumers.empty? }
 
         # publish another message
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|
@@ -379,8 +379,8 @@ describe LavinMQ::Federation::Upstream do
             vhost.declare_queue("q2", true, false)
 
             upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", nil, nil)
-            link1 = upstream.link(vhost.queues["q1"])
-            link2 = upstream.link(vhost.queues["q2"])
+            link1 = upstream.link(vhost.queues["q1"].should be_a(LavinMQ::AMQP::Queue))
+            link2 = upstream.link(vhost.queues["q2"].should be_a(LavinMQ::AMQP::Queue))
 
             link1.@upstream_q.should eq "q1"
             link2.@upstream_q.should eq "q2"
@@ -553,7 +553,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish "foo", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queues["federation_q2"].should be_a(LavinMQ::AMQP::Queue))
           msgs = [] of AMQP::Client::DeliverMessage
           wg = WaitGroup.new(1)
           q2.subscribe do |msg|
@@ -581,8 +581,8 @@ describe LavinMQ::Federation::Upstream do
         vhost3.declare_queue("q3", durable: true, auto_delete: false)
 
         vhost1.queues["q1"]
-        q2 = vhost2.queues["q2"]
-        q3 = vhost3.queues["q3"]
+        q2 = vhost2.queues["q2"].should be_a(LavinMQ::AMQP::Queue)
+        q3 = vhost3.queues["q3"].should be_a(LavinMQ::AMQP::Queue)
 
         url = URI.parse(s.amqp_url)
 

--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -67,7 +67,7 @@ module LavinMQ::AMQP
           # cycle detection and to not create a lot of faulty stats.
           # This means that no delay, consistent hash check or such is performed
           # if the dead letter exchange has any of these features enabled.
-          queues = Set(LavinMQ::Queue).new
+          queues = Set(AMQP::Queue).new
           ex.find_queues(routing_rk, routing_headers, queues)
           return if queues.empty?
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -661,10 +661,10 @@ module LavinMQ
         q.exclusive? && !@exclusive_queues.includes?(q)
       end
 
-      private def declare_queue(frame)
+      private def declare_queue(frame) # ameba:disable Metrics/CyclomaticComplexity
         if !frame.queue_name.empty? && !NameValidator.valid_entity_name?(frame.queue_name)
           send_precondition_failed(frame, "Queue name isn't valid")
-        elsif q = @vhost.queues[frame.queue_name]? # .as?(AMQP::Queue)
+        elsif q = @vhost.queues[frame.queue_name]?
           if q = q.as?(AMQP::Queue)
             redeclare_queue(frame, q)
           else

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -22,7 +22,7 @@ module LavinMQ
       @unacked = Atomic(UInt32).new(0_u32)
       getter has_capacity : BoolChannel
 
-      def initialize(@channel : AMQP::Channel, @queue : Queue, frame : AMQP::Frame::Basic::Consume)
+      def initialize(@channel : AMQP::Channel, @queue : AMQP::Queue, frame : AMQP::Frame::Basic::Consume)
         @tag = frame.consumer_tag
         @no_ack = frame.no_ack
         @exclusive = frame.exclusive

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -3,7 +3,6 @@ require "../../logger"
 require "../../segment_position"
 require "../../policy"
 require "../../observable"
-require "../../stats"
 require "../../sortable_json"
 require "../../client/channel/consumer"
 require "../../message"
@@ -17,13 +16,14 @@ require "../../deduplication"
 require "../../bool_channel"
 require "../argument_target"
 require "../argument"
+require "../../queue_stats"
 
 module LavinMQ::AMQP
   class Queue < LavinMQ::Queue
     include PolicyTarget
     include Observable(QueueEvent)
-    include Stats
     include SortableJSON
+    include QueueStats
 
     include ArgumentTarget
     include Argument::DeadLettering
@@ -66,16 +66,6 @@ module LavinMQ::AMQP
     @message_ttl_change = ::Channel(Nil).new
 
     getter basic_get_unacked = Deque(UnackedMessage).new
-    @unacked_count = Atomic(UInt32).new(0u32)
-    @unacked_bytesize = Atomic(UInt64).new(0u64)
-
-    def unacked_count
-      @unacked_count.get(:relaxed)
-    end
-
-    def unacked_bytesize
-      @unacked_bytesize.get(:relaxed)
-    end
 
     @msg_store_lock = Mutex.new(:reentrant)
     @msg_store : MessageStore
@@ -147,11 +137,6 @@ module LavinMQ::AMQP
     rescue ::Channel::ClosedError
     end
 
-    # Creates @[x]_count and @[x]_rate and @[y]_log
-    rate_stats(
-      {"ack", "deliver", "deliver_no_ack", "deliver_get", "confirm", "get", "get_no_ack", "publish", "redeliver", "reject", "return_unroutable", "dedup"},
-      {"message_count", "unacked_count"})
-
     getter name, arguments, vhost, consumers
     getter? auto_delete, exclusive
     getter policy : Policy?
@@ -216,8 +201,7 @@ module LavinMQ::AMQP
       @consumers_empty = BoolChannel.new(true)
       @single_active_consumer_change = ::Channel(Client::Channel::Consumer).new
       @deliver_loop_wg = WaitGroup.new
-      @unacked_count.set(0u32, :relaxed)
-      @unacked_bytesize.set(0u64, :relaxed)
+      reset_queue_stats
     end
 
     # own method so that it can be overriden in other queue implementations
@@ -466,9 +450,7 @@ module LavinMQ::AMQP
     end
 
     def details_tuple
-      unacked_count = unacked_count()
-      unacked_bytesize = unacked_bytesize()
-      unacked_avg_bytes = unacked_count.zero? ? 0u64 : unacked_bytesize//unacked_count
+      stats = queue_stats_details
       {
         name:                         @name,
         durable:                      durable?,
@@ -477,19 +459,19 @@ module LavinMQ::AMQP
         arguments:                    @arguments,
         consumers:                    @consumers.size,
         vhost:                        @vhost.name,
-        messages:                     @msg_store.size + unacked_count,
-        total_bytes:                  @msg_store.bytesize + unacked_bytesize,
-        messages_persistent:          durable? ? @msg_store.size + unacked_count : 0,
+        messages:                     @msg_store.size + stats[:messages_unacknowledged],
+        total_bytes:                  @msg_store.bytesize + stats[:message_bytes_unacknowledged],
+        messages_persistent:          durable? ? @msg_store.size + stats[:messages_unacknowledged] : 0,
         ready:                        @msg_store.size, # Deprecated, to be removed in next major version
         messages_ready:               @msg_store.size,
         ready_bytes:                  @msg_store.bytesize, # Deprecated, to be removed in next major version
         message_bytes_ready:          @msg_store.bytesize,
         ready_avg_bytes:              @msg_store.avg_bytesize,
-        unacked:                      unacked_count, # Deprecated, to be removed in next major version
-        messages_unacknowledged:      unacked_count,
-        unacked_bytes:                unacked_bytesize, # Deprecated, to be removed in next major version
-        message_bytes_unacknowledged: unacked_bytesize,
-        unacked_avg_bytes:            unacked_avg_bytes,
+        unacked:                      stats[:unacked], # Deprecated, to be removed in next major version
+        messages_unacknowledged:      stats[:messages_unacknowledged],
+        unacked_bytes:                stats[:unacked_bytes], # Deprecated, to be removed in next major version
+        message_bytes_unacknowledged: stats[:message_bytes_unacknowledged],
+        unacked_avg_bytes:            stats[:unacked_avg_bytes],
         operator_policy:              @operator_policy.try &.name,
         policy:                       @policy.try &.name,
         exclusive_consumer_tag:       @exclusive ? @consumers.first?.try(&.tag) : nil,

--- a/src/lavinmq/bool_channel.cr
+++ b/src/lavinmq/bool_channel.cr
@@ -48,7 +48,7 @@ class BoolChannel
   end
 
   def value
-    @value.get
+    @value.get(:acquire)
   end
 
   def set(value : Bool)

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -195,7 +195,7 @@ module LavinMQ
 
         @consumer_available = Channel(Nil).new
 
-        def initialize(@upstream : Upstream, @federated_q : Queue, @upstream_q : String)
+        def initialize(@upstream : Upstream, @federated_q : AMQP::Queue, @upstream_q : String)
           super(@upstream)
           @metadata = @metadata.extend({link: @federated_q.name})
 

--- a/src/lavinmq/http/controller/bindings.cr
+++ b/src/lavinmq/http/controller/bindings.cr
@@ -35,7 +35,7 @@ module LavinMQ
             itr = Iterator(BindingDetails).chain({e.bindings_details.select { |db| db.destination == q }})
             if e.name.empty?
               binding_key = BindingKey.new(q.name)
-              default_binding = BindingDetails.new("", q.vhost.name, binding_key, q)
+              default_binding = BindingDetails.new("", vhost.name, binding_key, q)
               itr = {default_binding}.each.chain(itr)
             end
             page(context, itr)

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -289,7 +289,7 @@ module LavinMQ
                 next if q.exclusive?
                 {
                   "name":        q.name,
-                  "vhost":       q.vhost.name,
+                  "vhost":       v.name,
                   "durable":     q.durable?,
                   "auto_delete": q.auto_delete?,
                   "arguments":   q.arguments,

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -286,7 +286,7 @@ module LavinMQ
           json.array do
             vhosts.each_value do |v|
               v.queues.each_value do |q|
-                next if q.exclusive?
+                next if q.as?(AMQP::Queue).try &.exclusive?
                 {
                   "name":        q.name,
                   "vhost":       v.name,

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -135,7 +135,7 @@ module LavinMQ
               IO::Memory.new("test"))
             ok = vhost.publish(msg)
             env = nil
-            vhost.queues["aliveness-test"].basic_get(true) { |e| env = e }
+            vhost.queues["aliveness-test"].as(LavinMQ::AMQP::Queue).basic_get(true) { |e| env = e }
             ok = ok && env && String.new(env.message.body) == "test"
             {status: ok ? "ok" : "failed"}.to_json(context.response)
           end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -497,7 +497,7 @@ module LavinMQ
 
       private def detailed_queue_consumer_count(vhosts, writer)
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues.each_value.select(LavinMQ::AMQP::Queue).each do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write({name:   "detailed_queue_consumers",
                           value:  q.consumers.size,

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -62,7 +62,7 @@ module LavinMQ
 
       def remove_client(client)
         client_id = client.client_id
-        if (session = sessions[client_id]?)
+        if session = sessions[client_id]?
           if session.client.nil? || (session.client == client)
             session.client = nil
             sessions.delete(client_id) if session.clean_session?

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -62,9 +62,11 @@ module LavinMQ
 
       def remove_client(client)
         client_id = client.client_id
-        if session = sessions[client_id]?
-          session.client = nil
-          sessions.delete(client_id) if session.clean_session?
+        if (session = sessions[client_id]?)
+          if session.client.nil? || (session.client == client)
+            session.client = nil
+            sessions.delete(client_id) if session.clean_session?
+          end
         end
         @clients.delete client_id
         @vhost.rm_connection(client)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -94,12 +94,6 @@ module LavinMQ
         end
       end
 
-      private def add_consumer(consumer : Client::Channel::Consumer)
-      end
-
-      private def rm_consumer(consumer : Client::Channel::Consumer)
-      end
-
       def details_tuple
         stats = queue_stats_details
         {

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -8,6 +8,8 @@ module LavinMQ
       include SortableJSON
       Log = ::LavinMQ::Log.for "mqtt.session"
 
+      @client : MQTT::Client? = nil
+
       protected def initialize(@vhost : VHost,
                                @name : String,
                                @auto_delete = false,
@@ -43,6 +45,10 @@ module LavinMQ
         end
       end
 
+      def client : MQTT::Client?
+        @client
+      end
+
       def client=(client : MQTT::Client?)
         return if @closed
         @last_get_time = RoughTime.instant
@@ -59,10 +65,11 @@ module LavinMQ
         @consumers.each do |c|
           rm_consumer c
         end
-
+        @client = client
         if c = client
           add_consumer MQTT::Consumer.new(c, self)
         end
+
         @log.debug { "client set to '#{client.try &.name}'" }
       end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -1,48 +1,146 @@
 require "../amqp/queue/queue"
 require "../error"
+require "../queue_stats"
 require "./consts"
 
 module LavinMQ
   module MQTT
-    class Session < LavinMQ::AMQP::Queue
+    class ClosedError < Error; end
+
+    class Session < LavinMQ::Queue
+      include PolicyTarget
+      include QueueStats
       include SortableJSON
-      Log = ::LavinMQ::Log.for "mqtt.session"
+
+      EMPTY_ARGUMENTS = AMQP::Table.new
+      Log             = ::LavinMQ::Log.for "mqtt.session"
+
+      getter name
+      getter arguments : AMQP::Table = EMPTY_ARGUMENTS
+      getter vhost
+      getter? internal = false
+      getter? exclusive = false
+      getter? auto_delete
+      getter? closed = false
+      getter? deleted = false
+      getter state = QueueState::Running
+
+      @msg_store : MessageStore
+      @msg_store_lock = Mutex.new(:reentrant)
+      @has_client = BoolChannel.new(false)
 
       @client : MQTT::Client? = nil
 
       protected def initialize(@vhost : VHost,
                                @name : String,
-                               @auto_delete = false,
-                               arguments : ::AMQ::Protocol::Table = AMQP::Table.new)
+                               @auto_delete = false)
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
-
-        super(@vhost, @name, false, @auto_delete, arguments)
-
+        @metadata = ::Log::Metadata.new(nil, {session: @name, vhost: @vhost.name})
+        data_dir = make_data_dir
+        @msg_store = init_msg_store(data_dir)
         @log = Logger.new(Log, @metadata)
         spawn deliver_loop, name: "Session#deliver_loop"
+      end
+
+      private def init_msg_store(data_dir)
+        replicator = durable? ? @vhost.@replicator : nil
+        MessageStore.new(data_dir, replicator, durable?, metadata: @metadata)
+      end
+
+      private def make_data_dir : String
+        data_dir = if durable?
+                     File.join(@vhost.data_dir, Digest::SHA1.hexdigest @name)
+                   else
+                     File.join(@vhost.data_dir, "transient", Digest::SHA1.hexdigest @name)
+                   end
+        if Dir.exists? data_dir
+          # delete left over files from transient queues
+          unless durable?
+            FileUtils.rm_r data_dir
+            Dir.mkdir_p data_dir
+          end
+        else
+          Dir.mkdir_p data_dir
+        end
+        data_dir
+      end
+
+      def clear_policy_arguments
+      end
+
+      # Return true if applied
+      def apply_policy_argument(key : String, value : JSON::Any) : Bool
+        false
       end
 
       def clean_session?
         @auto_delete
       end
 
+      def empty? : Bool
+        @msg_store.empty?
+      end
+
       private def deliver_loop
         i = 0
         loop do
-          break if @closed
+          break if closed?
           next @msg_store.empty.when_false.receive? if @msg_store.empty?
-          next @consumers_empty.when_false.receive? if @consumers.empty?
-          consumer = @consumers.first.as(MQTT::Consumer)
-          get_packet do |pub_packet|
-            consumer.deliver(pub_packet)
+          next @has_client.when_true.receive? unless @has_client.value
+          if client = @client
+            get_packet do |pub_packet|
+              client.send(pub_packet)
+            end
           end
           Fiber.yield if (i &+= 1) % 32768 == 0
         rescue ex
           @log.error(exception: ex) { "Failed to deliver message in deliver_loop" }
-          @consumers.each &.close
+          @client.try &.close
           self.client = nil
         end
+      end
+
+      private def add_consumer(consumer : Client::Channel::Consumer)
+      end
+
+      private def rm_consumer(consumer : Client::Channel::Consumer)
+      end
+
+      def details_tuple
+        stats = queue_stats_details
+        {
+          name:        @name,
+          durable:     @auto_delete == false,
+          exclusive:   exclusive?,
+          auto_delete: @auto_delete,
+          # arguments:                    {},
+          consumers:                    @client.nil? ? 0 : 1,
+          vhost:                        @vhost.name,
+          messages:                     @msg_store.size + stats[:messages_unacknowledged],
+          total_bytes:                  @msg_store.bytesize + stats[:message_bytes_unacknowledged],
+          messages_persistent:          durable? ? @msg_store.size + stats[:messages_unacknowledged] : 0,
+          ready:                        @msg_store.size, # Deprecated, to be removed in next major version
+          messages_ready:               @msg_store.size,
+          ready_bytes:                  @msg_store.bytesize, # Deprecated, to be removed in next major version
+          message_bytes_ready:          @msg_store.bytesize,
+          ready_avg_bytes:              @msg_store.avg_bytesize,
+          unacked:                      stats[:unacked], # Deprecated, to be removed in next major version
+          messages_unacknowledged:      stats[:messages_unacknowledged],
+          unacked_bytes:                stats[:unacked_bytes], # Deprecated, to be removed in next major version
+          message_bytes_unacknowledged: stats[:message_bytes_unacknowledged],
+          unacked_avg_bytes:            stats[:unacked_avg_bytes],
+          operator_policy:              @operator_policy.try &.name,
+          policy:                       @policy.try &.name,
+          exclusive_consumer_tag:       nil,
+          single_active_consumer_tag:   nil,
+          state:                        @state,
+          effective_policy_definition:  nil, # Policy.merge_definitions(@policy, @operator_policy),
+          message_stats:                current_stats_details,
+          effective_arguments:          nil,
+          effective_policy_arguments:   nil,
+          internal:                     internal?,
+        }
       end
 
       def client : MQTT::Client?
@@ -50,7 +148,7 @@ module LavinMQ
       end
 
       def client=(client : MQTT::Client?)
-        return if @closed
+        return if closed?
         @last_get_time = RoughTime.instant
 
         unless clean_session?
@@ -62,12 +160,10 @@ module LavinMQ
         end
         @unacked.clear
 
-        @consumers.each do |c|
-          rm_consumer c
-        end
-        @client = client
-        if c = client
-          add_consumer MQTT::Consumer.new(c, self)
+        if @client = client
+          @has_client.set(true)
+        else
+          @has_client.set(false)
         end
 
         @log.debug { "client set to '#{client.try &.name}'" }
@@ -75,6 +171,20 @@ module LavinMQ
 
       def durable?
         !clean_session?
+      end
+
+      def match?(frame)
+        durable? == frame.durable &&
+          @exclusive == frame.exclusive &&
+          @auto_delete == frame.auto_delete &&
+          frame.arguments.empty?
+      end
+
+      def match?(durable, exclusive, auto_delete, arguments)
+        durable? == durable &&
+          @exclusive == exclusive &&
+          @auto_delete == auto_delete &&
+          arguments.empty?
       end
 
       def subscribe(tf, qos)
@@ -94,13 +204,39 @@ module LavinMQ
       end
 
       def publish(msg : Message) : Bool
+        return false if @deleted || @state.closed?
         # Do not enqueue messages with QoS 0 if there are no consumers subscribed to the session
-        return true if msg.properties.delivery_mode == 0 && @consumers.empty?
-        super
+        return true if msg.properties.delivery_mode == 0 && @client.nil?
+        @msg_store_lock.synchronize do
+          @msg_store.push(msg)
+        end
+        @publish_count.add(1, :relaxed)
+        true
+      rescue ex : MessageStore::Error
+        @log.error(ex) { "Queue closed due to error" }
+        close
+        raise ex
+      end
+
+      def delete : Bool
+        return false if @deleted
+        @deleted = true
+        close
+        @state = QueueState::Deleted
+        @msg_store_lock.synchronize do
+          @msg_store.delete
+        end
+        @vhost.delete_queue(@name)
+        @log.info { "(messages=#{message_count}) Deleted" }
+        true
       end
 
       private def find_binding(rk)
         bindings.find { |b| b.binding_key.routing_key == rk }
+      end
+
+      def bindings
+        @vhost.queue_bindings(self)
       end
 
       private def unbind(rk, arguments)
@@ -108,7 +244,7 @@ module LavinMQ
       end
 
       private def get_packet(& : MQTT::Publish -> Nil) : Bool
-        raise ClosedError.new if @closed
+        raise ClosedError.new if closed?
         loop do
           env = @msg_store_lock.synchronize { @msg_store.shift? } || break
           sp = env.segment_position
@@ -147,6 +283,32 @@ module LavinMQ
         raise ClosedError.new(cause: ex)
       end
 
+      def close : Bool
+        return false if @closed
+        @closed = true
+        @state = QueueState::Closed
+        @client.try &.close("session closed")
+        @msg_store_lock.synchronize do
+          @msg_store.close
+        end
+        Fiber.yield
+        @log.debug { "Closed" }
+        true
+      end
+
+      def message_count
+        @msg_store.size.to_u32
+      end
+
+      protected def delete_message(sp : SegmentPosition) : Nil
+        {% unless flag?(:release) %}
+          @log.debug { "Deleting: #{sp}" }
+        {% end %}
+        @msg_store_lock.synchronize do
+          @msg_store.delete(sp)
+        end
+      end
+
       def build_packet(env, packet_id) : MQTT::Publish
         msg = env.message
         retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
@@ -163,37 +325,16 @@ module LavinMQ
         )
       end
 
-      private def apply_policy_argument(key : String, value : JSON::Any) : Bool
-        @log.debug { "Applying policy #{key}: #{value}" }
-        case key
-        when "max-length"
-          unless @max_length.try &.< value.as_i64
-            @max_length = value.as_i64
-            drop_overflow
-            return true
-          end
-        when "max-length-bytes"
-          unless @max_length_bytes.try &.< value.as_i64
-            @max_length_bytes = value.as_i64
-            drop_overflow
-            return true
-          end
-        when "overflow"
-          @reject_on_overflow ||= value.as_s == "reject-publish"
-          return true
-        end
-        false
-      end
-
-      def after_policy_applied
-        drop_overflow
-      end
-
       def ack(packet : MQTT::PubAck) : Nil
+        return if @deleted
         id = packet.packet_id
         sp = @unacked[id]
         @unacked.delete id
-        super sp
+        @log.debug { "Acking #{sp}" }
+        @ack_count.add(1, :relaxed)
+        @unacked_count.sub(1, :relaxed)
+        @unacked_bytesize.sub(sp.bytesize, :relaxed)
+        delete_message(sp)
       rescue
         raise ::IO::Error.new("Could not acknowledge package with id: #{id}")
       end
@@ -218,6 +359,46 @@ module LavinMQ
       private def handle_arguments
         super
         @effective_args << "x-queue-type"
+      end
+
+      def purge(max_count : Int = UInt32::MAX) : UInt32
+        if unacked_count == 0 && max_count >= message_count
+          # If there's no unacked and we're purging all messages, we can purge faster by deleting files
+          delete_count = message_count
+          @msg_store_lock.synchronize { @msg_store.purge_all }
+        else
+          delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
+        end
+        @log.info { "Purged #{delete_count} messages" }
+        delete_count
+      rescue ex : MessageStore::Error
+        @log.error(ex) { "Queue closed due to error" }
+        close
+        raise ex
+      end
+
+      def basic_get(no_ack, force = false, & : Envelope -> Nil) : Bool
+        raise "Not supported"
+      end
+
+      def ack(sp : SegmentPosition) : Nil
+        raise "Not supported"
+      end
+
+      def reject(sp : SegmentPosition, requeue : Bool)
+        raise "Not supported"
+      end
+
+      def pause!
+        raise "Not supported"
+      end
+
+      def resume!
+        raise "Not supported"
+      end
+
+      def restart!
+        raise "Not supported"
       end
     end
   end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -149,6 +149,8 @@ module LavinMQ
 
       def client=(client : MQTT::Client?)
         return if closed?
+        # We're done if we hold the same client already
+        return if !client.nil? && (@client == client)
         @last_get_time = RoughTime.instant
 
         unless clean_session?
@@ -160,13 +162,13 @@ module LavinMQ
         end
         @unacked.clear
 
+        @log.debug { "client set to '#{client.try &.name}'" }
+
         if @client = client
           @has_client.set(true)
         else
           @has_client.set(false)
         end
-
-        @log.debug { "client set to '#{client.try &.name}'" }
       end
 
       def durable?

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -12,11 +12,11 @@ module LavinMQ
       include QueueStats
       include SortableJSON
 
-      EMPTY_ARGUMENTS = AMQP::Table.new({"x-queue-type": "mqtt"})
-      Log             = ::LavinMQ::Log.for "mqtt.session"
+      ARGUMENTS = AMQP::Table.new({"x-queue-type": "mqtt"})
+      Log       = ::LavinMQ::Log.for "mqtt.session"
 
       getter name
-      getter arguments : AMQP::Table = EMPTY_ARGUMENTS
+      getter arguments : AMQP::Table = ARGUMENTS
       getter vhost
       getter? internal = false
       getter? exclusive = false

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -12,7 +12,7 @@ module LavinMQ
       include QueueStats
       include SortableJSON
 
-      EMPTY_ARGUMENTS = AMQP::Table.new
+      EMPTY_ARGUMENTS = AMQP::Table.new({"x-queue-type": "mqtt"})
       Log             = ::LavinMQ::Log.for "mqtt.session"
 
       getter name

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -19,11 +19,12 @@ module LavinMQ
       end
 
       def declare(client : Client)
-        self[client.client_id]? || begin
+        session = self[client.client_id]? || begin
           @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, AMQP::Table.new({"x-queue-type": "mqtt"}))
-          self[client.client_id].client = client
           self[client.client_id]
         end
+        session.client = client
+        session
       end
 
       def delete(client_id : String)

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -20,7 +20,7 @@ module LavinMQ
 
       def declare(client : Client)
         session = self[client.client_id]? || begin
-          @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, AMQP::Table.new({"x-queue-type": "mqtt"}))
+          @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, Session::ARGUMENTS)
           self[client.client_id]
         end
         if session.client != client

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -23,7 +23,9 @@ module LavinMQ
           @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, AMQP::Table.new({"x-queue-type": "mqtt"}))
           self[client.client_id]
         end
-        session.client = client
+        if session.client != client
+          session.client = client
+        end
         session
       end
 

--- a/src/lavinmq/queue_factory.cr
+++ b/src/lavinmq/queue_factory.cr
@@ -69,12 +69,12 @@ module LavinMQ
       )
     end
 
-    def self.to_frame(queue : MQTT::Session) : AMQP::Frame::Queue::Declare
+    def self.to_frame(session : MQTT::Session) : AMQP::Frame::Queue::Declare
       AMQP::Frame::Queue::Declare.new(
-        0_u16, 0_u16, queue.name, false,
-        queue.durable?, false,
-        queue.auto_delete?, false,
-        queue.arguments
+        0_u16, 0_u16, session.name, false,
+        session.durable?, false,
+        session.clean_session?, false,
+        session.arguments
       )
     end
 

--- a/src/lavinmq/queue_factory.cr
+++ b/src/lavinmq/queue_factory.cr
@@ -74,7 +74,7 @@ module LavinMQ
         0_u16, 0_u16, queue.name, false,
         queue.durable?, false,
         queue.auto_delete?, false,
-        ::AMQ::Protocol::Table.new({"x-queue-type": "mqtt"})
+        queue.arguments
       )
     end
 

--- a/src/lavinmq/queue_factory.cr
+++ b/src/lavinmq/queue_factory.cr
@@ -8,7 +8,7 @@ module LavinMQ
   class QueueFactory
     def self.make(vhost : VHost, frame : AMQP::Frame)
       if mqtt_session?(frame)
-        MQTT::Session.new(vhost, frame.queue_name, frame.auto_delete, frame.arguments)
+        MQTT::Session.new(vhost, frame.queue_name, frame.auto_delete) # , frame.arguments)
       else
         if frame.durable
           make_durable(vhost, frame)
@@ -59,6 +59,27 @@ module LavinMQ
       if frame.arguments["x-queue-type"]?
         Log.info { "The queue type #{frame.arguments["x-queue-type"]} is not supported by LavinMQ and will be changed to the default queue type" }
       end
+    end
+
+    def self.to_frame(queue : AMQP::Queue) : AMQP::Frame::Queue::Declare
+      AMQP::Frame::Queue::Declare.new(
+        0_u16, 0_u16, queue.name, false,
+        queue.durable?, queue.exclusive?,
+        queue.auto_delete?, false, queue.arguments
+      )
+    end
+
+    def self.to_frame(queue : MQTT::Session) : AMQP::Frame::Queue::Declare
+      AMQP::Frame::Queue::Declare.new(
+        0_u16, 0_u16, queue.name, false,
+        queue.durable?, false,
+        queue.auto_delete?, false,
+        ::AMQ::Protocol::Table.new({"x-queue-type": "mqtt"})
+      )
+    end
+
+    def self.to_frame(queue : LavinMQ::Queue) : AMQP::Frame::Queue::Declare
+      raise "Unsupported queue type: #{queue.class}"
     end
   end
 end

--- a/src/lavinmq/queue_stats.cr
+++ b/src/lavinmq/queue_stats.cr
@@ -1,6 +1,6 @@
 require "./stats"
 
-module LavinMQ::AMQP
+module LavinMQ
   module QueueStats
     include Stats
 

--- a/src/lavinmq/queue_stats.cr
+++ b/src/lavinmq/queue_stats.cr
@@ -1,0 +1,43 @@
+require "./stats"
+
+module LavinMQ::AMQP
+  module QueueStats
+    include Stats
+
+    macro included
+      @unacked_count = Atomic(UInt32).new(0u32)
+      @unacked_bytesize = Atomic(UInt64).new(0u64)
+
+      rate_stats(
+        {"ack", "deliver", "deliver_no_ack", "deliver_get", "confirm", "get", "get_no_ack", "publish", "redeliver", "reject", "return_unroutable", "dedup"},
+        {"message_count", "unacked_count"})
+    end
+
+    def unacked_count
+      @unacked_count.get(:relaxed)
+    end
+
+    def unacked_bytesize
+      @unacked_bytesize.get(:relaxed)
+    end
+
+    def queue_stats_details
+      unacked_count = unacked_count()
+      unacked_bytesize = unacked_bytesize()
+      unacked_avg_bytes = unacked_count.zero? ? 0u64 : unacked_bytesize//unacked_count
+
+      {
+        unacked:                      unacked_count,
+        messages_unacknowledged:      unacked_count,
+        unacked_bytes:                unacked_bytesize,
+        message_bytes_unacknowledged: unacked_bytesize,
+        unacked_avg_bytes:            unacked_avg_bytes,
+      }
+    end
+
+    private def reset_queue_stats
+      @unacked_count.set(0u32, :relaxed)
+      @unacked_bytesize.set(0u64, :relaxed)
+    end
+  end
+end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -124,7 +124,7 @@ module LavinMQ
     # The position of the msg.body_io should be at the start of the body
     # When this method finishes, the position will be the same, start of the body
     def publish(msg : Message, immediate = false,
-                visited = Set(LavinMQ::Exchange).new, found_queues = Set(LavinMQ::Queue).new) : Bool
+                visited = Set(LavinMQ::AMQP::Exchange).new, found_queues = Set(LavinMQ::AMQP::Queue).new) : Bool
       ex = @exchanges[msg.exchange_name]? || return false
       ex.publish(msg, immediate, found_queues, visited)
     ensure
@@ -262,7 +262,7 @@ module LavinMQ
           store_definition(f) if !loading && f.durable && !f.exclusive
           event_tick(EventType::QueueDeclared) unless loading
         when AMQP::Frame::Queue::Delete
-          if q = @queues.delete(f.queue_name)
+          if q = @queues.delete(f.queue_name).as?(AMQP::Queue)
             @exchanges.each_value do |ex|
               ex.bindings_details.each do |binding|
                 next unless binding.destination == q
@@ -278,13 +278,27 @@ module LavinMQ
         when AMQP::Frame::Queue::Bind
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || return false
-          return false unless x.bind(q, f.routing_key, f.arguments)
-          store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
+          case q
+          in AMQP::Queue
+            return false unless x.bind(q, f.routing_key, f.arguments)
+            store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
+          in MQTT::Session
+            return false unless x.as(MQTT::Exchange).bind(q, f.routing_key, f.arguments)
+          in LavinMQ::Queue
+            return false
+          end
         when AMQP::Frame::Queue::Unbind
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || return false
-          return false unless x.unbind(q, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
+          case q
+          in AMQP::Queue
+            return false unless x.unbind(q, f.routing_key, f.arguments)
+            store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
+          in MQTT::Session
+            return false unless x.as(MQTT::Exchange).unbind(q, f.routing_key, f.arguments)
+          in LavinMQ::Queue
+            return false
+          end
         else raise "Cannot apply frame #{f.class} in vhost #{@name}"
         end
         true
@@ -586,9 +600,7 @@ module LavinMQ
           io.write_bytes f
         end
         @queues.each_value.select(&.durable?).each do |q|
-          f = AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, q.name, false, q.durable?, q.exclusive?,
-            q.auto_delete?, false, q.arguments)
-          io.write_bytes f
+          io.write_bytes QueueFactory.to_frame(q)
         end
         @exchanges.each_value.select(&.durable?).each do |e|
           e.bindings_details.each do |binding|


### PR DESCRIPTION
### WHAT is this pull request doing?
This is an attempt to get rid of the inheritance between `MQTT::Session` and `AMQP::Queue`. 

This should be split into multiple PRs.

Addresses #957 

### HOW can this pull request be tested?
Specs? Manual steps? Please fill me in.
