### PR TITLE
Dont delete/clear mqtt session if new client exists

### DIFF
--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -63,8 +63,10 @@ module LavinMQ
       def remove_client(client)
         client_id = client.client_id
         if session = sessions[client_id]?
-          session.client = nil
-          sessions.delete(client_id) if session.clean_session?
+          if session.client.nil? || (session.client == client)
+            session.client = nil
+            sessions.delete(client_id) if session.clean_session?
+          end
         end
         @clients.delete client_id
         @vhost.rm_connection(client)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -8,6 +8,8 @@ module LavinMQ
       include SortableJSON
       Log = ::LavinMQ::Log.for "mqtt.session"
 
+      @client : MQTT::Client? = nil
+
       protected def initialize(@vhost : VHost,
                                @name : String,
                                @auto_delete = false,
@@ -43,6 +45,10 @@ module LavinMQ
         end
       end
 
+      def client : MQTT::Client?
+        @client
+      end
+
       def client=(client : MQTT::Client?)
         return if @closed
         @last_get_time = RoughTime.instant
@@ -59,10 +65,11 @@ module LavinMQ
         @consumers.each do |c|
           rm_consumer c
         end
-
+        @client = client
         if c = client
           add_consumer MQTT::Consumer.new(c, self)
         end
+
         @log.debug { "client set to '#{client.try &.name}'" }
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
While decoupling `MQTT::Session` from `AMQP::Queue` I noticed this. I'm not sure if this can occur today, but this adds a check to validate that the session not belongs to a new client before clearing and/or deleting it.

### HOW can this pull request be tested?
Specs still passes
