### PR TITLE
Run a fiber for each vhost to check user expiration

### DIFF
--- a/spec/oauth_spec.cr
+++ b/spec/oauth_spec.cr
@@ -488,42 +488,19 @@ describe LavinMQ::Auth::OAuthUser do
     end
   end
 
-  describe "#on_expiration" do
-    it "calls callback immediately when token is already expired" do
+  describe "#token_lifetime" do
+    it "returns zero for expired tokens" do
       permissions = {"/" => {config: /.*/, read: /.*/, write: /.*/}}
-      # Create user with already expired token
       user = OAuthUserHelper.create_user(RoughTime.utc - 1.hour, permissions)
 
-      callback_called = false
-      user.on_expiration do
-        callback_called = true
-      end
-
-      # Give fiber a moment to trigger the timeout and call callback
-      sleep 1000.milliseconds
-
-      # Callback should be called since timeout triggers immediately for expired tokens
-      callback_called.should be_true
+      user.token_lifetime.should eq(0.seconds)
     end
 
-    it "stops fiber when user is closed" do
+    it "returns positive duration for valid tokens" do
       permissions = {"/" => {config: /.*/, read: /.*/, write: /.*/}}
-      # Create user with token that expires in the future
       user = OAuthUserHelper.create_user(RoughTime.utc + 1.hour, permissions)
 
-      callback_called = false
-      user.on_expiration do
-        callback_called = true
-      end
-
-      # Close the user (which closes the channel)
-      user.cleanup
-
-      # Give fiber a moment to detect closed channel and exit
-      sleep 1000.milliseconds
-
-      # Callback should not be called since user was closed before expiration
-      callback_called.should be_false
+      user.token_lifetime.should be > 0.seconds
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?

Instead of one fiber per OAuthUser we run one fiber per vhost that checks for expiration of users. 
Even if fibers are cheap they are not free so connecting a lot of users using oauth would increase memory but this resolves it by just running one fiber per user and checks if any user has expired. 

### HOW can this pull request be tested?

.... 