### PR TITLE
chore(client.cr): use `total_seconds` instead of normal `to_s` to format into seconds

### DIFF
--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -186,13 +186,13 @@ module LavinMQ
       ensure
         cleanup
         close_socket
-        @log.info { "Connection disconnected for user=#{@user.name} duration=#{duration}" }
+        @log.info { "Connection disconnected for user=#{@user.name} duration=#{duration}s" }
       end
 
       private def duration
         ms = RoughTime.unix_ms - @connected_at
         seconds = (ms / 1000).round.to_i
-        Time::Span.new(seconds: seconds)
+        Time::Span.new(seconds: seconds).total_seconds
       end
 
       private def frame_size_ok?(frame) : Bool

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -84,13 +84,13 @@ module LavinMQ
         @broker.remove_client(self)
         @waitgroup.done
         close_socket
-        @log.info { "Connection disconnected for user=#{@user.name} duration=#{duration}" }
+        @log.info { "Connection disconnected for user=#{@user.name} duration=#{duration}s" }
       end
 
       private def duration
         ms = RoughTime.unix_ms - @connected_at
         seconds = (ms / 1000).round.to_i
-        Time::Span.new(seconds: seconds)
+        Time::Span.new(seconds: seconds).total_seconds
       end
 
       def read_and_handle_packet


### PR DESCRIPTION
### WHAT is this pull request doing?
https://github.com/cloudamqp/lavinmq/pull/1662 introduced the duration on the disconnected log but on a weird format. 

### HOW can this pull request be tested?
- Manual (`amqpcat -z`)

```bash
2026-02-06T16:47:42.138068Z  INFO lmq.amqp.client[vhost: "/", address: "127.0.0.1:54655", name: "AMQPCat 1.0.2-3-g968b65e"] Connection disconnected for user=guest duration=0.0s
```
