### PR TITLE
refactor: Only use `AMQP::Queue` and `AMQP::Exchange` in dead lettering

### DIFF
--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -45,7 +45,7 @@ module LavinMQ::AMQP
         def route(msg : BytesMessage, reason) # ameba:disable Metrics/CyclomaticComplexity
           # No dead letter exchange => nothing to do
           return unless dlx = (msg.dlx || dlx())
-          ex = @vhost.exchanges[dlx.to_s]? || return
+          ex = @vhost.exchanges[dlx.to_s]?.as?(AMQP::Exchange) || return
 
           dlrk = msg.dlrk || dlrk()
 
@@ -67,7 +67,7 @@ module LavinMQ::AMQP
           # cycle detection and to not create a lot of faulty stats.
           # This means that no delay, consistent hash check or such is performed
           # if the dead letter exchange has any of these features enabled.
-          queues = Set(LavinMQ::Queue).new
+          queues = Set(AMQP::Queue).new
           ex.find_queues(routing_rk, routing_headers, queues)
           return if queues.empty?
 


### PR DESCRIPTION
### WHAT is this pull request doing?
One step closer of decoupling `MQTT::Session` from `AMQP::Queue`

### HOW can this pull request be tested?
Specs still passes
