### PR TITLE
Track publish events for HTTP endpoints

### DIFF
--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -147,7 +147,6 @@ module LavinMQ
             Log.debug { "Post to exchange=#{e.name} on vhost=#{e.vhost.name} with routing_key=#{routing_key} payload_encoding=#{payload_encoding} properties=#{properties} size=#{size}" }
             ok = e.vhost.publish(msg)
             e.vhost.event_tick(EventType::ClientPublish)
-            e.vhost.add_recv_bytes(size)
             {routed: ok}.to_json(context.response)
           end
         end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -7,7 +7,7 @@ module LavinMQ
     class MainController < Controller
       include StatsHelpers
 
-      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject", "recv_oct", "send_oct"}
+      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject"}
       EXCHANGE_TYPES = {
         {name: "direct", human: "Direct"},
         {name: "fanout", human: "Fanout"},

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -7,7 +7,7 @@ module LavinMQ
     class MainController < Controller
       include StatsHelpers
 
-      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject"}
+      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject", "recv_oct", "send_oct"}
       EXCHANGE_TYPES = {
         {name: "direct", human: "Direct"},
         {name: "fanout", human: "Fanout"},

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -191,10 +191,8 @@ module LavinMQ
                 get_count.times do
                   q.basic_get(false, true) do |env|
                     sps << env.segment_position
-                    # Track vhost-level metrics for HTTP API consumption
                     event_type = ack ? EventType::ClientGet : EventType::ClientGetNoAck
                     vhost.event_tick(event_type)
-                    vhost.add_send_bytes(env.message.bodysize.to_u64)
                     j.object do
                       payload_encoding = "string"
                       j.field("payload_bytes", env.message.bodysize)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -23,7 +23,7 @@ module LavinMQ
 
     rate_stats({"channel_closed", "channel_created", "connection_closed", "connection_created",
                 "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
-                "redeliver", "reject", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
+                "redeliver", "reject", "consumer_added", "consumer_removed"})
 
     getter name, exchanges, queues, data_dir, operator_policies, policies, parameters, shovels,
       direct_reply_consumers, connections, dir, users
@@ -701,14 +701,6 @@ module LavinMQ
         @deliver_no_ack_count.add(1, :relaxed)
         @deliver_get_count.add(1, :relaxed)
       end
-    end
-
-    def add_recv_bytes(bytes : UInt64) : Nil
-      @recv_oct_count.add(bytes, :relaxed)
-    end
-
-    def add_send_bytes(bytes : UInt64) : Nil
-      @send_oct_count.add(bytes, :relaxed)
     end
 
     def sync : Nil


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes vhost-level message rate stats not updating when publishing or consuming messages via the HTTP API, by adding event_tick calls for these operations. 

Fixes #1677

### HOW can this pull request be tested?

see #1677 