### PR TITLE
Thread-safe multi-threaded execution with Sync wrappers

### DIFF
--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -65,7 +65,7 @@ describe LavinMQ::HTTP::BindingsController do
         response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
         response.status_code.should eq 201
         response.headers["Location"].should eq "bindings_q1/rk"
-        s.vhosts["/"].exchanges_byname("be1").bindings_details.first.routing_key.should eq "rk"
+        s.vhosts["/"].exchange("be1").bindings_details.first.routing_key.should eq "rk"
       end
     end
 
@@ -127,7 +127,7 @@ describe LavinMQ::HTTP::BindingsController do
         props = binding[0]["properties_key"].as_s
         response = http.delete("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
         response.status_code.should eq 204
-        s.vhosts["/"].exchanges_byname("be1").bindings_details.empty?.should be_true
+        s.vhosts["/"].exchange("be1").bindings_details.empty?.should be_true
       end
     end
   end

--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -65,7 +65,7 @@ describe LavinMQ::HTTP::BindingsController do
         response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
         response.status_code.should eq 201
         response.headers["Location"].should eq "bindings_q1/rk"
-        s.vhosts["/"].exchanges["be1"].bindings_details.first.routing_key.should eq "rk"
+        s.vhosts["/"].exchanges_byname("be1").bindings_details.first.routing_key.should eq "rk"
       end
     end
 
@@ -127,7 +127,7 @@ describe LavinMQ::HTTP::BindingsController do
         props = binding[0]["properties_key"].as_s
         response = http.delete("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
         response.status_code.should eq 204
-        s.vhosts["/"].exchanges["be1"].bindings_details.empty?.should be_true
+        s.vhosts["/"].exchanges_byname("be1").bindings_details.empty?.should be_true
       end
     end
   end

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -68,7 +68,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "queues": [{ "name": "import_q1", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].queues.has_key?("import_q1").should be_true
+        s.vhosts["/"].queues_has_key?("import_q1").should be_true
       end
     end
 
@@ -77,7 +77,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "exchanges": [{ "name": "import_x1", "type": "direct", "vhost": "/", "durable": true, "internal": false, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].exchanges.has_key?("import_x1").should be_true
+        s.vhosts["/"].exchanges_has_key?("import_x1").should be_true
       end
     end
 
@@ -106,19 +106,19 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        ex = s.vhosts["/"].exchanges["import_x1"]
+        ex = s.vhosts["/"].exchanges_byname("import_x1")
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
-        res << s.vhosts["/"].exchanges["import_x1"]
-        res << s.vhosts["/"].exchanges["import_x2"]
+        res << s.vhosts["/"].exchanges_byname("import_x1")
+        res << s.vhosts["/"].exchanges_byname("import_x2")
         es.should eq res
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
-        res << s.vhosts["/"].queues["import_q1"]
+        res << s.vhosts["/"].queues_byname("import_q1")
         qs.should eq res
       end
     end
@@ -460,7 +460,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "queues": [{ "name": "import_q1", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].queues.has_key?("import_q1").should be_true
+        s.vhosts["/"].queues_has_key?("import_q1").should be_true
       end
     end
 
@@ -469,7 +469,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "exchanges": [{ "name": "import_x1", "type": "direct", "vhost": "/", "durable": true, "internal": false, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].exchanges.has_key?("import_x1").should be_true
+        s.vhosts["/"].exchanges_has_key?("import_x1").should be_true
       end
     end
 
@@ -498,19 +498,19 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        ex = s.vhosts["/"].exchanges["import_x1"]
+        ex = s.vhosts["/"].exchanges_byname("import_x1")
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
-        res << s.vhosts["/"].exchanges["import_x1"]
-        res << s.vhosts["/"].exchanges["import_x2"]
+        res << s.vhosts["/"].exchanges_byname("import_x1")
+        res << s.vhosts["/"].exchanges_byname("import_x2")
         es.should eq res
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
-        res << s.vhosts["/"].queues["import_q1"]
+        res << s.vhosts["/"].queues_byname("import_q1")
         qs.should eq res
       end
     end
@@ -568,7 +568,7 @@ describe LavinMQ::HTTP::Server do
           body = %({ "queues": [{ "name": "import_q1", "vhost": "new", "durable": true, "auto_delete": false, "arguments": {} }] })
           response = http.post("/api/definitions/new", headers: headers, body: body)
           response.status_code.should eq 200
-          s.vhosts["new"].queues.has_key?("import_q1").should be_true
+          s.vhosts["new"].queues_has_key?("import_q1").should be_true
         end
       end
 
@@ -695,7 +695,7 @@ describe LavinMQ::HTTP::Server do
       args = {"x-delayed-message", false, false, false, LavinMQ::AMQP::Table.new({"x-delayed-type": "direct"})}
       vhost.declare_exchange "test", *args
       http.get("/api/definitions")
-      vhost.exchanges["test"].match?(*args).should be_true
+      vhost.exchanges_byname("test").match?(*args).should be_true
     end
   end
 

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -106,19 +106,19 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        ex = s.vhosts["/"].exchanges_byname("import_x1")
+        ex = s.vhosts["/"].exchange("import_x1")
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
-        res << s.vhosts["/"].exchanges_byname("import_x1")
-        res << s.vhosts["/"].exchanges_byname("import_x2")
+        res << s.vhosts["/"].exchange("import_x1")
+        res << s.vhosts["/"].exchange("import_x2")
         es.should eq res
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
-        res << s.vhosts["/"].queues_byname("import_q1")
+        res << s.vhosts["/"].queue("import_q1")
         qs.should eq res
       end
     end
@@ -498,19 +498,19 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        ex = s.vhosts["/"].exchanges_byname("import_x1")
+        ex = s.vhosts["/"].exchange("import_x1")
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
-        res << s.vhosts["/"].exchanges_byname("import_x1")
-        res << s.vhosts["/"].exchanges_byname("import_x2")
+        res << s.vhosts["/"].exchange("import_x1")
+        res << s.vhosts["/"].exchange("import_x2")
         es.should eq res
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
-        res << s.vhosts["/"].queues_byname("import_q1")
+        res << s.vhosts["/"].queue("import_q1")
         qs.should eq res
       end
     end
@@ -695,7 +695,7 @@ describe LavinMQ::HTTP::Server do
       args = {"x-delayed-message", false, false, false, LavinMQ::AMQP::Table.new({"x-delayed-type": "direct"})}
       vhost.declare_exchange "test", *args
       http.get("/api/definitions")
-      vhost.exchanges_byname("test").match?(*args).should be_true
+      vhost.exchange("test").match?(*args).should be_true
     end
   end
 

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -68,7 +68,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "queues": [{ "name": "import_q1", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].queues_has_key?("import_q1").should be_true
+        s.vhosts["/"].queue_exists?("import_q1").should be_true
       end
     end
 
@@ -77,7 +77,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "exchanges": [{ "name": "import_x1", "type": "direct", "vhost": "/", "durable": true, "internal": false, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].exchanges_has_key?("import_x1").should be_true
+        s.vhosts["/"].exchange_exists?("import_x1").should be_true
       end
     end
 
@@ -460,7 +460,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "queues": [{ "name": "import_q1", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].queues_has_key?("import_q1").should be_true
+        s.vhosts["/"].queue_exists?("import_q1").should be_true
       end
     end
 
@@ -469,7 +469,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "exchanges": [{ "name": "import_x1", "type": "direct", "vhost": "/", "durable": true, "internal": false, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].exchanges_has_key?("import_x1").should be_true
+        s.vhosts["/"].exchange_exists?("import_x1").should be_true
       end
     end
 
@@ -568,7 +568,7 @@ describe LavinMQ::HTTP::Server do
           body = %({ "queues": [{ "name": "import_q1", "vhost": "new", "durable": true, "auto_delete": false, "arguments": {} }] })
           response = http.post("/api/definitions/new", headers: headers, body: body)
           response.status_code.should eq 200
-          s.vhosts["new"].queues_has_key?("import_q1").should be_true
+          s.vhosts["new"].queue_exists?("import_q1").should be_true
         end
       end
 

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -258,7 +258,7 @@ describe LavinMQ::HTTP::ExchangesController do
         response.status_code.should eq 200
         body = JSON.parse(response.body)
         body["routed"].as_bool.should be_true
-        s.vhosts["/"].queues["q1p"].message_count.should eq 1
+        s.vhosts["/"].queues_byname("q1p").message_count.should eq 1
       end
     end
 

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -258,7 +258,7 @@ describe LavinMQ::HTTP::ExchangesController do
         response.status_code.should eq 200
         body = JSON.parse(response.body)
         body["routed"].as_bool.should be_true
-        s.vhosts["/"].queues_byname("q1p").message_count.should eq 1
+        s.vhosts["/"].queue("q1p").message_count.should eq 1
       end
     end
 

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -252,7 +252,7 @@ describe LavinMQ::HTTP::Server do
             100.times { x.publish("msg", q.name) }
           end
         end
-        wait_for { vhost.exchanges["b-exchange"].details_tuple["message_stats"]["publish_in_details"]["rate"] > 0 }
+        wait_for { vhost.exchanges_byname("b-exchange").details_tuple["message_stats"]["publish_in_details"]["rate"] > 0 }
         response = http.get("/api/exchanges?page=1&sort=message_stats.publish_in_details.rate&sort_reverse=false")
         response.status_code.should eq 200
         items = JSON.parse(response.body).as_h["items"].as_a

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -252,7 +252,7 @@ describe LavinMQ::HTTP::Server do
             100.times { x.publish("msg", q.name) }
           end
         end
-        wait_for { vhost.exchanges_byname("b-exchange").details_tuple["message_stats"]["publish_in_details"]["rate"] > 0 }
+        wait_for { vhost.exchange("b-exchange").details_tuple["message_stats"]["publish_in_details"]["rate"] > 0 }
         response = http.get("/api/exchanges?page=1&sort=message_stats.publish_in_details.rate&sort_reverse=false")
         response.status_code.should eq 200
         items = JSON.parse(response.body).as_h["items"].as_a

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -130,8 +130,8 @@ describe LavinMQ::HTTP::QueuesController do
             2.times { q.publish "m1" }
             q.subscribe(no_ack: false) { }
 
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 2 }
-            s.vhosts["/"].queues["unacked_q"].basic_get_unacked.size.should eq 0
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 2 }
+            s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked.size.should eq 0
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -149,7 +149,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) do |msg|
               msg.ack
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
 
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
@@ -168,7 +168,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) do |msg|
               msg.reject
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
 
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
@@ -187,7 +187,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
 
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues["unacked_q"].basic_get_unacked.size == 1 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked.size == 1 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -203,10 +203,10 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
             ch.prefetch(1)
             if msg = q.get(no_ack: false)
-              wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 1 }
+              wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 1 }
               msg.ack
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -223,10 +223,10 @@ describe LavinMQ::HTTP::QueuesController do
 
             ch.prefetch(1)
             if msg = q.get(no_ack: false)
-              wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 1 }
+              wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 1 }
               msg.reject
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -243,9 +243,9 @@ describe LavinMQ::HTTP::QueuesController do
 
             ch.prefetch(1)
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 1 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 1 }
           end
-          wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+          wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
           response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
           response.status_code.should eq 200
           body = JSON.parse(response.body)
@@ -382,7 +382,7 @@ describe LavinMQ::HTTP::QueuesController do
           keys = ["payload_bytes", "redelivered", "exchange", "routing_key", "message_count",
                   "properties", "payload", "payload_encoding"]
           body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
-          s.vhosts["/"].queues["q3"].message_count.should be > 0
+          s.vhosts["/"].queues_byname("q3").message_count.should be > 0
         end
       end
     end
@@ -392,7 +392,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues["q4"]
+          q4 = s.vhosts["/"].queues_byname("q4")
           q.publish "m1"
           wait_for { q4.message_count == 1 }
           body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
@@ -409,7 +409,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues["q4"]
+          q4 = s.vhosts["/"].queues_byname("q4")
           mem_io = IO::Memory.new
           Compress::Deflate::Writer.open(mem_io, Compress::Deflate::BEST_SPEED) { |deflate| deflate.print("m1") }
           encoded_msg = mem_io.to_s
@@ -430,7 +430,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues["q4"]
+          q4 = s.vhosts["/"].queues_byname("q4")
           message_count = 100
           message_count.times { q.publish "m1" * 100000 } # Larger messages to slow down JSON serialization
           wait_for { q4.message_count == message_count }
@@ -556,7 +556,7 @@ describe LavinMQ::HTTP::QueuesController do
         with_channel(s) do |ch|
           ch.queue("confqueue")
 
-          q = s.vhosts["/"].queues["confqueue"]
+          q = s.vhosts["/"].queues_byname("confqueue")
           q.pause!
 
           response = http.get("/api/queues/%2f/confqueue")
@@ -600,7 +600,7 @@ describe LavinMQ::HTTP::QueuesController do
           queue_name = "restart_queue"
           ch.queue(queue_name)
 
-          q = s.vhosts["/"].queues[queue_name]
+          q = s.vhosts["/"].queues_byname(queue_name)
           q.close
 
           response = http.get("/api/queues/%2f/#{queue_name}")
@@ -625,7 +625,7 @@ describe LavinMQ::HTTP::QueuesController do
           queue_name = "restart_queue"
           ch.queue(queue_name)
 
-          s.vhosts["/"].queues[queue_name]
+          s.vhosts["/"].queues_byname(queue_name)
           response = http.put("/api/queues/%2f/#{queue_name}/restart")
           response.status_code.should eq 400
 

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -130,8 +130,8 @@ describe LavinMQ::HTTP::QueuesController do
             2.times { q.publish "m1" }
             q.subscribe(no_ack: false) { }
 
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 2 }
-            s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked_each.size.should eq 0
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 2 }
+            s.vhosts["/"].queue("unacked_q").basic_get_unacked_each.size.should eq 0
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -149,7 +149,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) do |msg|
               msg.ack
             end
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
 
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
@@ -168,7 +168,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) do |msg|
               msg.reject
             end
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
 
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
@@ -187,7 +187,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
 
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked_each.size == 1 }
+            wait_for { s.vhosts["/"].queue("unacked_q").basic_get_unacked_each.size == 1 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -203,10 +203,10 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
             ch.prefetch(1)
             if msg = q.get(no_ack: false)
-              wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 1 }
+              wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 1 }
               msg.ack
             end
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -223,10 +223,10 @@ describe LavinMQ::HTTP::QueuesController do
 
             ch.prefetch(1)
             if msg = q.get(no_ack: false)
-              wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 1 }
+              wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 1 }
               msg.reject
             end
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -243,9 +243,9 @@ describe LavinMQ::HTTP::QueuesController do
 
             ch.prefetch(1)
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 1 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 1 }
           end
-          wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 0 }
+          wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
           response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
           response.status_code.should eq 200
           body = JSON.parse(response.body)
@@ -382,7 +382,7 @@ describe LavinMQ::HTTP::QueuesController do
           keys = ["payload_bytes", "redelivered", "exchange", "routing_key", "message_count",
                   "properties", "payload", "payload_encoding"]
           body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
-          s.vhosts["/"].queues_byname("q3").message_count.should be > 0
+          s.vhosts["/"].queue("q3").message_count.should be > 0
         end
       end
     end
@@ -392,7 +392,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues_byname("q4")
+          q4 = s.vhosts["/"].queue("q4")
           q.publish "m1"
           wait_for { q4.message_count == 1 }
           body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
@@ -409,7 +409,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues_byname("q4")
+          q4 = s.vhosts["/"].queue("q4")
           mem_io = IO::Memory.new
           Compress::Deflate::Writer.open(mem_io, Compress::Deflate::BEST_SPEED) { |deflate| deflate.print("m1") }
           encoded_msg = mem_io.to_s
@@ -430,7 +430,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues_byname("q4")
+          q4 = s.vhosts["/"].queue("q4")
           message_count = 100
           message_count.times { q.publish "m1" * 100000 } # Larger messages to slow down JSON serialization
           wait_for { q4.message_count == message_count }
@@ -556,7 +556,7 @@ describe LavinMQ::HTTP::QueuesController do
         with_channel(s) do |ch|
           ch.queue("confqueue")
 
-          q = s.vhosts["/"].queues_byname("confqueue")
+          q = s.vhosts["/"].queue("confqueue")
           q.pause!
 
           response = http.get("/api/queues/%2f/confqueue")
@@ -600,7 +600,7 @@ describe LavinMQ::HTTP::QueuesController do
           queue_name = "restart_queue"
           ch.queue(queue_name)
 
-          q = s.vhosts["/"].queues_byname(queue_name)
+          q = s.vhosts["/"].queue(queue_name)
           q.close
 
           response = http.get("/api/queues/%2f/#{queue_name}")
@@ -625,7 +625,7 @@ describe LavinMQ::HTTP::QueuesController do
           queue_name = "restart_queue"
           ch.queue(queue_name)
 
-          s.vhosts["/"].queues_byname(queue_name)
+          s.vhosts["/"].queue(queue_name)
           response = http.put("/api/queues/%2f/#{queue_name}/restart")
           response.status_code.should eq 400
 

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -131,7 +131,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) { }
 
             wait_for { s.vhosts["/"].queues_byname("unacked_q").unacked_count == 2 }
-            s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked.size.should eq 0
+            s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked_each.size.should eq 0
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -187,7 +187,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
 
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked.size == 1 }
+            wait_for { s.vhosts["/"].queues_byname("unacked_q").basic_get_unacked_each.size == 1 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -20,7 +20,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
 
       server = LavinMQ::Server.new(cluster.follower_config)
       begin
-        q = server.vhosts["/"].queues["repli"].as(LavinMQ::AMQP::DurableQueue)
+        q = server.vhosts["/"].queues_byname("repli").as(LavinMQ::AMQP::DurableQueue)
         q.message_count.should eq 1
         q.basic_get(true) do |env|
           String.new(env.message.body).to_s.should eq "hello world"

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -20,7 +20,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
 
       server = LavinMQ::Server.new(cluster.follower_config)
       begin
-        q = server.vhosts["/"].queues_byname("repli").as(LavinMQ::AMQP::DurableQueue)
+        q = server.vhosts["/"].queue("repli").as(LavinMQ::AMQP::DurableQueue)
         q.message_count.should eq 1
         q.basic_get(true) do |env|
           String.new(env.message.body).to_s.should eq "hello world"

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -103,7 +103,7 @@ describe LavinMQ::Server do
         conn = AMQP::Client.new(port: amqp_port(s), channel_max: 0).connect
         conn.channel
         conn.channel
-        s.connections.first.channels.size.should eq 2
+        s.connections.first.channels_size.should eq 2
         s.connections.first.as(LavinMQ::AMQP::Client).channel_max.should eq 0
       end
     end

--- a/spec/consistent_hash_exchange_spec.cr
+++ b/spec/consistent_hash_exchange_spec.cr
@@ -9,8 +9,8 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         vhost = s.vhosts["/"]
         vhost.declare_exchange "con-hash", "x-consistent-hash", durable: true, auto_delete: false
         vhost.declare_queue "my-queue", durable: true, auto_delete: false
-        exchange = vhost.exchanges_byname("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
-        queue = vhost.queues_byname("my-queue").as(LavinMQ::AMQP::Queue)
+        exchange = vhost.exchange("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
+        queue = vhost.queue("my-queue").as(LavinMQ::AMQP::Queue)
         expect_raises(LavinMQ::Error::PreconditionFailed) do
           exchange.bind(queue, "non-numeric", nil)
         end
@@ -25,8 +25,8 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         vhost = s.vhosts["/"]
         vhost.declare_exchange "con-hash", "x-consistent-hash", durable: true, auto_delete: false
         vhost.declare_queue "my-queue", durable: true, auto_delete: false
-        exchange = vhost.exchanges_byname("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
-        queue = vhost.queues_byname("my-queue").as(LavinMQ::AMQP::Queue)
+        exchange = vhost.exchange("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
+        queue = vhost.queue("my-queue").as(LavinMQ::AMQP::Queue)
         expect_raises(LavinMQ::Error::PreconditionFailed) do
           exchange.unbind(queue, "non-numeric", nil)
         end
@@ -257,7 +257,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "jump"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq JumpConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -267,7 +267,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "ring"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -277,7 +277,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           LavinMQ::Config.instance.default_consistent_hash_algorithm.should eq LavinMQ::ConsistentHashAlgorithm::Ring
           ch.exchange(x_name, "x-consistent-hash")
-          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -288,7 +288,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
           LavinMQ::Config.instance.default_consistent_hash_algorithm.should eq LavinMQ::ConsistentHashAlgorithm::Ring
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "juump"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end

--- a/spec/consistent_hash_exchange_spec.cr
+++ b/spec/consistent_hash_exchange_spec.cr
@@ -9,8 +9,8 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         vhost = s.vhosts["/"]
         vhost.declare_exchange "con-hash", "x-consistent-hash", durable: true, auto_delete: false
         vhost.declare_queue "my-queue", durable: true, auto_delete: false
-        exchange = vhost.exchanges["con-hash"].should be_a(LavinMQ::AMQP::ConsistentHashExchange)
-        queue = vhost.queues["my-queue"].as(LavinMQ::AMQP::Queue)
+        exchange = vhost.exchanges_byname("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
+        queue = vhost.queues_byname("my-queue").as(LavinMQ::AMQP::Queue)
         expect_raises(LavinMQ::Error::PreconditionFailed) do
           exchange.bind(queue, "non-numeric", nil)
         end
@@ -25,8 +25,8 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         vhost = s.vhosts["/"]
         vhost.declare_exchange "con-hash", "x-consistent-hash", durable: true, auto_delete: false
         vhost.declare_queue "my-queue", durable: true, auto_delete: false
-        exchange = vhost.exchanges["con-hash"].should be_a(LavinMQ::AMQP::ConsistentHashExchange)
-        queue = vhost.queues["my-queue"].as(LavinMQ::AMQP::Queue)
+        exchange = vhost.exchanges_byname("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
+        queue = vhost.queues_byname("my-queue").as(LavinMQ::AMQP::Queue)
         expect_raises(LavinMQ::Error::PreconditionFailed) do
           exchange.unbind(queue, "non-numeric", nil)
         end
@@ -257,7 +257,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "jump"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq JumpConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -267,7 +267,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "ring"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -277,7 +277,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           LavinMQ::Config.instance.default_consistent_hash_algorithm.should eq LavinMQ::ConsistentHashAlgorithm::Ring
           ch.exchange(x_name, "x-consistent-hash")
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -288,7 +288,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
           LavinMQ::Config.instance.default_consistent_hash_algorithm.should eq LavinMQ::ConsistentHashAlgorithm::Ring
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "juump"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end

--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -183,7 +183,7 @@ describe LavinMQ::Deduplication::Deduper do
             "x-deduplication-header" => "msg1",
           })
 
-          exchange = s.vhosts["/"].exchanges["delayed_ex"].should be_a(LavinMQ::AMQP::Exchange)
+          exchange = s.vhosts["/"].exchanges_byname("delayed_ex").should be_a(LavinMQ::AMQP::Exchange)
           delay_q = exchange.@delayed_queue.should be_a(LavinMQ::AMQP::DelayedExchangeQueue)
 
           # Publish a message and verify it has been delayed and not thrown away

--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -183,7 +183,7 @@ describe LavinMQ::Deduplication::Deduper do
             "x-deduplication-header" => "msg1",
           })
 
-          exchange = s.vhosts["/"].exchanges_byname("delayed_ex").should be_a(LavinMQ::AMQP::Exchange)
+          exchange = s.vhosts["/"].exchange("delayed_ex").should be_a(LavinMQ::AMQP::Exchange)
           delay_q = exchange.@delayed_queue.should be_a(LavinMQ::AMQP::DelayedExchangeQueue)
 
           # Publish a message and verify it has been delayed and not thrown away

--- a/spec/definitions_frame_size_spec.cr
+++ b/spec/definitions_frame_size_spec.cr
@@ -16,9 +16,8 @@ describe LavinMQ::VHost do
       )
     )
     with_amqp_server do |s|
-      exchanges = s.vhosts["test"].exchanges
-      src_x = exchanges["source.exchange"]
-      dst_x = exchanges["destination.exchange"]
+      src_x = s.vhosts["test"].exchanges_byname("source.exchange")
+      dst_x = s.vhosts["test"].exchanges_byname("destination.exchange")
       src_x.bindings_details.to_a.should_not be_empty
       dst_x.bindings_details.to_a.should_not be_empty
     end

--- a/spec/definitions_frame_size_spec.cr
+++ b/spec/definitions_frame_size_spec.cr
@@ -16,8 +16,8 @@ describe LavinMQ::VHost do
       )
     )
     with_amqp_server do |s|
-      src_x = s.vhosts["test"].exchanges_byname("source.exchange")
-      dst_x = s.vhosts["test"].exchanges_byname("destination.exchange")
+      src_x = s.vhosts["test"].exchange("source.exchange")
+      dst_x = s.vhosts["test"].exchange("destination.exchange")
       src_x.bindings_details.to_a.should_not be_empty
       dst_x.bindings_details.to_a.should_not be_empty
     end

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -16,7 +16,7 @@ describe "Delayed Message Exchange" do
 
         with_channel(s) do |ch|
           ch.exchange(x_name, "topic", args: x_args)
-          q = s.vhosts["/"].queues_byname?(legacy_q_name)
+          q = s.vhosts["/"].queue?(legacy_q_name)
           q.should_not be_nil
         end
       end
@@ -26,7 +26,7 @@ describe "Delayed Message Exchange" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.exchange(x_name, "topic", args: x_args)
-          q = s.vhosts["/"].queues_byname?(delay_q_name)
+          q = s.vhosts["/"].queue?(delay_q_name)
           q.should_not be_nil
           dlx_exchange = q.not_nil!.arguments["x-dead-letter-exchange"]?.try &.as?(String)
           dlx_exchange.should eq x_name
@@ -41,7 +41,7 @@ describe "Delayed Message Exchange" do
           ch.exchange(x_name, "topic", args: x_args)
           ch.exchange("", delay_q_name, args: x_args)
           ch.basic_publish_confirm "test", exchange: "", routing_key: delay_q_name
-          s.vhosts["/"].queues_byname(delay_q_name).message_count.should eq 0
+          s.vhosts["/"].queue(delay_q_name).message_count.should eq 0
         end
       end
     end
@@ -52,12 +52,12 @@ describe "Delayed Message Exchange" do
         with_channel(s) do |ch|
           ex = ch.exchange(x_name, "topic", args: x_args)
           ex.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-          s.vhosts["/"].queues_byname(delay_q_name).message_count.should eq 1
+          s.vhosts["/"].queue(delay_q_name).message_count.should eq 1
         end
         s.restart
-        s.vhosts["/"].queues_byname(delay_q_name).message_count.should eq 1
+        s.vhosts["/"].queue(delay_q_name).message_count.should eq 1
         sleep 1.second
-        wait_for { s.vhosts["/"].queues_byname(delay_q_name).message_count == 0 }
+        wait_for { s.vhosts["/"].queue(delay_q_name).message_count == 0 }
       end
     end
   end
@@ -71,7 +71,7 @@ describe "Delayed Message Exchange" do
         q.bind(x.name, "#")
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues_byname(q_name)
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
@@ -89,7 +89,7 @@ describe "Delayed Message Exchange" do
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "test message 1", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         x.publish "test message 2", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues_byname(q_name)
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 2 }
         queue.message_count.should eq 2
@@ -109,7 +109,7 @@ describe "Delayed Message Exchange" do
         x.publish "delay-long", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "delay-short", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues_byname(q_name)
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count >= 1 }
         q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-short")
@@ -143,7 +143,7 @@ describe "Delayed Message Exchange" do
         # the message published with 6000ms should be published. Also, the new message
         # with 1500ms should be published
         sleep 2.seconds
-        queue = s.vhosts["/"].queues_byname(q_name)
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 3
         sleep 3.seconds # total 10, the 9000ms message should have been published
         queue.message_count.should eq 4
@@ -166,7 +166,7 @@ describe "Delayed Message Exchange" do
         q.bind(x.name, "rk")
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 5})
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues_byname(q_name)
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for(200.milliseconds) { queue.message_count == 1 }
         queue.message_count.should eq 1
@@ -207,7 +207,7 @@ describe "Delayed Message Exchange" do
         x = ch.exchange(x_name, "topic", args: x_args)
         q = ch.queue(q_name)
         q.bind(x.name, "#")
-        ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::Exchange)
+        ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::Exchange)
 
         delayed_q = ex.@delayed_queue.should_not be_nil
 
@@ -242,7 +242,7 @@ describe "Delayed Message Exchange" do
       with_channel(s) do |ch|
         ch.exchange(x_name, "topic", args: x_args)
         # The internal delayed queue should exist
-        internal_queue = s.vhosts["/"].queues_byname?(delay_q_name)
+        internal_queue = s.vhosts["/"].queue?(delay_q_name)
         internal_queue.should_not be_nil
 
         # Attempting to bind the delayed exchange to its internal queue should raise an error
@@ -266,12 +266,12 @@ describe "Delayed Message Exchange" do
         x.publish "test message", "test.routing.key"
 
         # Message should reach the bound queue, not create a loop
-        queue = s.vhosts["/"].queues_byname(q_name)
+        queue = s.vhosts["/"].queue(q_name)
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
 
         # Internal delayed queue should remain empty
-        internal_queue = s.vhosts["/"].queues_byname(delay_q_name)
+        internal_queue = s.vhosts["/"].queue(delay_q_name)
         internal_queue.message_count.should eq 0
       end
     end

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -16,7 +16,7 @@ describe "Delayed Message Exchange" do
 
         with_channel(s) do |ch|
           ch.exchange(x_name, "topic", args: x_args)
-          q = s.vhosts["/"].queues[legacy_q_name]?
+          q = s.vhosts["/"].queues_byname?(legacy_q_name)
           q.should_not be_nil
         end
       end
@@ -26,7 +26,7 @@ describe "Delayed Message Exchange" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.exchange(x_name, "topic", args: x_args)
-          q = s.vhosts["/"].queues[delay_q_name]?
+          q = s.vhosts["/"].queues_byname?(delay_q_name)
           q.should_not be_nil
           dlx_exchange = q.not_nil!.arguments["x-dead-letter-exchange"]?.try &.as?(String)
           dlx_exchange.should eq x_name
@@ -41,7 +41,7 @@ describe "Delayed Message Exchange" do
           ch.exchange(x_name, "topic", args: x_args)
           ch.exchange("", delay_q_name, args: x_args)
           ch.basic_publish_confirm "test", exchange: "", routing_key: delay_q_name
-          s.vhosts["/"].queues[delay_q_name].message_count.should eq 0
+          s.vhosts["/"].queues_byname(delay_q_name).message_count.should eq 0
         end
       end
     end
@@ -52,12 +52,12 @@ describe "Delayed Message Exchange" do
         with_channel(s) do |ch|
           ex = ch.exchange(x_name, "topic", args: x_args)
           ex.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-          s.vhosts["/"].queues[delay_q_name].message_count.should eq 1
+          s.vhosts["/"].queues_byname(delay_q_name).message_count.should eq 1
         end
         s.restart
-        s.vhosts["/"].queues[delay_q_name].message_count.should eq 1
+        s.vhosts["/"].queues_byname(delay_q_name).message_count.should eq 1
         sleep 1.second
-        wait_for { s.vhosts["/"].queues[delay_q_name].message_count == 0 }
+        wait_for { s.vhosts["/"].queues_byname(delay_q_name).message_count == 0 }
       end
     end
   end
@@ -71,7 +71,7 @@ describe "Delayed Message Exchange" do
         q.bind(x.name, "#")
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues_byname(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
@@ -89,7 +89,7 @@ describe "Delayed Message Exchange" do
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "test message 1", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         x.publish "test message 2", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues_byname(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 2 }
         queue.message_count.should eq 2
@@ -109,7 +109,7 @@ describe "Delayed Message Exchange" do
         x.publish "delay-long", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "delay-short", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues_byname(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count >= 1 }
         q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-short")
@@ -143,7 +143,7 @@ describe "Delayed Message Exchange" do
         # the message published with 6000ms should be published. Also, the new message
         # with 1500ms should be published
         sleep 2.seconds
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues_byname(q_name)
         queue.message_count.should eq 3
         sleep 3.seconds # total 10, the 9000ms message should have been published
         queue.message_count.should eq 4
@@ -166,7 +166,7 @@ describe "Delayed Message Exchange" do
         q.bind(x.name, "rk")
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 5})
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues_byname(q_name)
         queue.message_count.should eq 0
         wait_for(200.milliseconds) { queue.message_count == 1 }
         queue.message_count.should eq 1
@@ -207,7 +207,7 @@ describe "Delayed Message Exchange" do
         x = ch.exchange(x_name, "topic", args: x_args)
         q = ch.queue(q_name)
         q.bind(x.name, "#")
-        ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::Exchange)
+        ex = s.vhosts["/"].exchanges_byname(x_name).as(LavinMQ::AMQP::Exchange)
 
         delayed_q = ex.@delayed_queue.should_not be_nil
 
@@ -242,7 +242,7 @@ describe "Delayed Message Exchange" do
       with_channel(s) do |ch|
         ch.exchange(x_name, "topic", args: x_args)
         # The internal delayed queue should exist
-        internal_queue = s.vhosts["/"].queues[delay_q_name]?
+        internal_queue = s.vhosts["/"].queues_byname?(delay_q_name)
         internal_queue.should_not be_nil
 
         # Attempting to bind the delayed exchange to its internal queue should raise an error
@@ -266,12 +266,12 @@ describe "Delayed Message Exchange" do
         x.publish "test message", "test.routing.key"
 
         # Message should reach the bound queue, not create a loop
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queues_byname(q_name)
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
 
         # Internal delayed queue should remain empty
-        internal_queue = s.vhosts["/"].queues[delay_q_name]
+        internal_queue = s.vhosts["/"].queues_byname(delay_q_name)
         internal_queue.message_count.should eq 0
       end
     end

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -16,8 +16,8 @@ describe LavinMQ::Exchange do
               x = ch.exchange("test", exchange_type)
               q = ch.queue("q")
               q.bind(x.name, routing_key, args: LavinMQ::AMQP::Table.new({"x-foo": "bar"}))
-              ex = s.vhosts["/"].exchanges_byname("test")
-              q = s.vhosts["/"].queues_byname("q")
+              ex = s.vhosts["/"].exchange("test")
+              q = s.vhosts["/"].queue("q")
               bd = ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
               bd.binding_key.arguments.should eq LavinMQ::AMQP::Table.new({"x-foo": "bar"})
             end
@@ -31,8 +31,8 @@ describe LavinMQ::Exchange do
               ch_q = ch.queue("q")
               bd_args = LavinMQ::AMQP::Table.new({"x-foo": "bar"})
               ch_q.bind(x.name, routing_key, args: bd_args)
-              ex = s.vhosts["/"].exchanges_byname("test")
-              q = s.vhosts["/"].queues_byname("q")
+              ex = s.vhosts["/"].exchange("test")
+              q = s.vhosts["/"].queue("q")
               ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
               ch_q.unbind(x.name, routing_key)
               ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
@@ -86,7 +86,7 @@ describe LavinMQ::Exchange do
           x_args = AMQP::Client::Arguments.new
           x = ch.exchange(x_name, "topic", args: x_args)
           x.publish_confirm "test message 1", "none"
-          s.vhosts["/"].exchanges_byname(x_name).unroutable_count.should eq 1
+          s.vhosts["/"].exchange(x_name).unroutable_count.should eq 1
         end
       end
     end
@@ -100,7 +100,7 @@ describe LavinMQ::Exchange do
           q.bind(x.name, q.name)
           x.publish_confirm "test message 1", "none"
           x.publish_confirm "test message 2", q.name
-          s.vhosts["/"].exchanges_byname(x_name).unroutable_count.should eq 1
+          s.vhosts["/"].exchange(x_name).unroutable_count.should eq 1
         end
       end
     end
@@ -142,7 +142,7 @@ describe LavinMQ::Exchange do
           expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
             ch.exchange("test2", "x-delayed-message", args: illegal_dmx_args)
           end
-          s.vhosts["/"].exchanges_byname?("test2").should be_nil
+          s.vhosts["/"].exchange?("test2").should be_nil
         end
       end
     end
@@ -174,8 +174,8 @@ describe LavinMQ::Exchange do
         with_channel(s) do |ch|
           ch.exchange("e1", "topic", auto_delete: true)
           ch.exchange("e2", "topic", auto_delete: true)
-          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_false
-          s.vhosts["/"].exchanges_byname("e2").in_use?.should be_false
+          s.vhosts["/"].exchange("e1").in_use?.should be_false
+          s.vhosts["/"].exchange("e2").in_use?.should be_false
         end
       end
     end
@@ -185,7 +185,7 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic", auto_delete: true)
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges_byname("e2").in_use?.should be_true
+          s.vhosts["/"].exchange("e2").in_use?.should be_true
         end
       end
     end
@@ -195,7 +195,7 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic", auto_delete: true)
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_true
+          s.vhosts["/"].exchange("e1").in_use?.should be_true
         end
       end
     end
@@ -206,9 +206,9 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic")
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_true
+          s.vhosts["/"].exchange("e1").in_use?.should be_true
           x2.unbind(x1.name, "#")
-          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_false
+          s.vhosts["/"].exchange("e1").in_use?.should be_false
         end
       end
     end
@@ -222,7 +222,7 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchanges_byname("test")
+          ex = s.vhosts["/"].exchange("test")
           q = s.vhosts["/"].queues_each_value.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
@@ -251,7 +251,7 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchanges_byname("test")
+          ex = s.vhosts["/"].exchange("test")
           q = s.vhosts["/"].queues_each_value.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
@@ -310,7 +310,7 @@ describe LavinMQ::Exchange do
             definition = {"federation-upstream" => JSON::Any.new("upstream")}
             downstream_vhost.add_policy("fed", "^fed", "exchanges", definition, 1i8)
             downstream_vhost.declare_exchange("fed.internal", "topic", durable: true, auto_delete: false, internal: true)
-            wait_for(100.milliseconds) { downstream_vhost.exchanges_byname("fed.internal").policy.try &.name == "fed" }
+            wait_for(100.milliseconds) { downstream_vhost.exchange("fed.internal").policy.try &.name == "fed" }
             downstream_vhost.upstreams["upstream"]?.try(&.links.empty?).should be_true
           end
         end

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -280,10 +280,10 @@ describe LavinMQ::Exchange do
             downstream_vhost.upstreams.create_upstream("upstream", config)
             definition = {"federation-upstream" => JSON::Any.new("upstream")}
             downstream_vhost.add_policy("fed", "^amq.topic", "exchanges", definition, 1i8)
-            wait_for(100.milliseconds) { downstream_vhost.upstreams.@upstreams["upstream"]?.try &.links.present? }
+            wait_for(100.milliseconds) { downstream_vhost.upstreams["upstream"]?.try &.links.present? }
 
             downstream_vhost.delete_policy("fed")
-            wait_for(100.milliseconds) { downstream_vhost.upstreams.@upstreams["upstream"]?.try &.links.empty? }
+            wait_for(100.milliseconds) { downstream_vhost.upstreams["upstream"]?.try &.links.empty? }
           end
         end
       end
@@ -297,7 +297,7 @@ describe LavinMQ::Exchange do
           downstream_vhost.upstreams.create_upstream("upstream", config)
           definition = {"federation-upstream" => JSON::Any.new("upstream")}
           downstream_vhost.add_policy("fed", "^amq.topic", "exchanges", definition, 1i8)
-          wait_for(100.milliseconds) { downstream_vhost.upstreams.@upstreams["upstream"]?.try &.links.present? }
+          wait_for(100.milliseconds) { downstream_vhost.upstreams["upstream"]?.try &.links.present? }
         end
       end
 
@@ -311,7 +311,7 @@ describe LavinMQ::Exchange do
             downstream_vhost.add_policy("fed", "^fed", "exchanges", definition, 1i8)
             downstream_vhost.declare_exchange("fed.internal", "topic", durable: true, auto_delete: false, internal: true)
             wait_for(100.milliseconds) { downstream_vhost.exchanges_byname("fed.internal").policy.try &.name == "fed" }
-            downstream_vhost.upstreams.@upstreams["upstream"].links.empty?.should be_true
+            downstream_vhost.upstreams["upstream"]?.try(&.links.empty?).should be_true
           end
         end
       end

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -16,8 +16,8 @@ describe LavinMQ::Exchange do
               x = ch.exchange("test", exchange_type)
               q = ch.queue("q")
               q.bind(x.name, routing_key, args: LavinMQ::AMQP::Table.new({"x-foo": "bar"}))
-              ex = s.vhosts["/"].exchanges["test"]
-              q = s.vhosts["/"].queues["q"]
+              ex = s.vhosts["/"].exchanges_byname("test")
+              q = s.vhosts["/"].queues_byname("q")
               bd = ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
               bd.binding_key.arguments.should eq LavinMQ::AMQP::Table.new({"x-foo": "bar"})
             end
@@ -31,8 +31,8 @@ describe LavinMQ::Exchange do
               ch_q = ch.queue("q")
               bd_args = LavinMQ::AMQP::Table.new({"x-foo": "bar"})
               ch_q.bind(x.name, routing_key, args: bd_args)
-              ex = s.vhosts["/"].exchanges["test"]
-              q = s.vhosts["/"].queues["q"]
+              ex = s.vhosts["/"].exchanges_byname("test")
+              q = s.vhosts["/"].queues_byname("q")
               ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
               ch_q.unbind(x.name, routing_key)
               ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
@@ -86,7 +86,7 @@ describe LavinMQ::Exchange do
           x_args = AMQP::Client::Arguments.new
           x = ch.exchange(x_name, "topic", args: x_args)
           x.publish_confirm "test message 1", "none"
-          s.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+          s.vhosts["/"].exchanges_byname(x_name).unroutable_count.should eq 1
         end
       end
     end
@@ -100,7 +100,7 @@ describe LavinMQ::Exchange do
           q.bind(x.name, q.name)
           x.publish_confirm "test message 1", "none"
           x.publish_confirm "test message 2", q.name
-          s.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+          s.vhosts["/"].exchanges_byname(x_name).unroutable_count.should eq 1
         end
       end
     end
@@ -142,7 +142,7 @@ describe LavinMQ::Exchange do
           expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
             ch.exchange("test2", "x-delayed-message", args: illegal_dmx_args)
           end
-          s.vhosts["/"].exchanges["test2"]?.should be_nil
+          s.vhosts["/"].exchanges_byname?("test2").should be_nil
         end
       end
     end
@@ -174,8 +174,8 @@ describe LavinMQ::Exchange do
         with_channel(s) do |ch|
           ch.exchange("e1", "topic", auto_delete: true)
           ch.exchange("e2", "topic", auto_delete: true)
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_false
-          s.vhosts["/"].exchanges["e2"].in_use?.should be_false
+          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_false
+          s.vhosts["/"].exchanges_byname("e2").in_use?.should be_false
         end
       end
     end
@@ -185,7 +185,7 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic", auto_delete: true)
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges["e2"].in_use?.should be_true
+          s.vhosts["/"].exchanges_byname("e2").in_use?.should be_true
         end
       end
     end
@@ -195,7 +195,7 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic", auto_delete: true)
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_true
+          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_true
         end
       end
     end
@@ -206,9 +206,9 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic")
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_true
+          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_true
           x2.unbind(x1.name, "#")
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_false
+          s.vhosts["/"].exchanges_byname("e1").in_use?.should be_false
         end
       end
     end
@@ -222,8 +222,8 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchanges["test"]
-          q = s.vhosts["/"].queues.first_value
+          ex = s.vhosts["/"].exchanges_byname("test")
+          q = s.vhosts["/"].queues_each_value.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
@@ -251,8 +251,8 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchanges["test"]
-          q = s.vhosts["/"].queues.first_value
+          ex = s.vhosts["/"].exchanges_byname("test")
+          q = s.vhosts["/"].queues_each_value.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))
@@ -310,7 +310,7 @@ describe LavinMQ::Exchange do
             definition = {"federation-upstream" => JSON::Any.new("upstream")}
             downstream_vhost.add_policy("fed", "^fed", "exchanges", definition, 1i8)
             downstream_vhost.declare_exchange("fed.internal", "topic", durable: true, auto_delete: false, internal: true)
-            wait_for(100.milliseconds) { downstream_vhost.exchanges["fed.internal"].policy.try &.name == "fed" }
+            wait_for(100.milliseconds) { downstream_vhost.exchanges_byname("fed.internal").policy.try &.name == "fed" }
             downstream_vhost.upstreams.@upstreams["upstream"].links.empty?.should be_true
           end
         end

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -108,7 +108,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.queues_has_key?("new_queue").should be_true
+        vhost.queue_exists?("new_queue").should be_true
 
         result = run_lavinmqctl(http.addr.to_s, ["delete_queue", "new_queue"])
         result[:exit].should eq(0)
@@ -197,7 +197,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.exchanges_has_key?("test_exchange").should be_true
+        vhost.exchange_exists?("test_exchange").should be_true
 
         result = run_lavinmqctl(http.addr.to_s, ["delete_exchange", "test_exchange"])
         result[:exit].should eq(0)
@@ -210,7 +210,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.exchanges_has_key?("test_durable_exchange").should be_true
+        vhost.exchange_exists?("test_durable_exchange").should be_true
       end
     end
 
@@ -220,7 +220,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.queues_has_key?("test_durable_queue").should be_true
+        vhost.queue_exists?("test_durable_queue").should be_true
       end
     end
 

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -108,7 +108,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.queues.has_key?("new_queue").should be_true
+        vhost.queues_has_key?("new_queue").should be_true
 
         result = run_lavinmqctl(http.addr.to_s, ["delete_queue", "new_queue"])
         result[:exit].should eq(0)
@@ -197,7 +197,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.exchanges.has_key?("test_exchange").should be_true
+        vhost.exchanges_has_key?("test_exchange").should be_true
 
         result = run_lavinmqctl(http.addr.to_s, ["delete_exchange", "test_exchange"])
         result[:exit].should eq(0)
@@ -210,7 +210,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.exchanges.has_key?("test_durable_exchange").should be_true
+        vhost.exchanges_has_key?("test_durable_exchange").should be_true
       end
     end
 
@@ -220,7 +220,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.queues.has_key?("test_durable_queue").should be_true
+        vhost.queues_has_key?("test_durable_queue").should be_true
       end
     end
 

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -314,7 +314,7 @@ module MqttSpecs
               disconnect(io)
             end
             sleep 100.milliseconds
-            server.vhosts["/"].queues_byname("mqtt.client_id").consumers.should be_empty
+            server.vhosts["/"].queues_byname("mqtt.client_id").consumers_empty?.should be_true
           end
         end
       end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -314,7 +314,7 @@ module MqttSpecs
               disconnect(io)
             end
             sleep 100.milliseconds
-            server.vhosts["/"].queues_byname("mqtt.client_id").consumers_empty?.should be_true
+            server.vhosts["/"].queue("mqtt.client_id").consumers_empty?.should be_true
           end
         end
       end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -171,7 +171,7 @@ module MqttSpecs
           with_server do |server|
             with_client_io(server) do |io|
               connect(io, client_id: "", clean_session: true)
-              server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
+              server.vhosts["/"].connections_each.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
             end
           end
         end
@@ -314,7 +314,7 @@ module MqttSpecs
               disconnect(io)
             end
             sleep 100.milliseconds
-            server.vhosts["/"].queues["mqtt.client_id"].consumers.should be_empty
+            server.vhosts["/"].queues_byname("mqtt.client_id").consumers.should be_empty
           end
         end
       end

--- a/spec/mqtt/multi_vhost_spec.cr
+++ b/spec/mqtt/multi_vhost_spec.cr
@@ -7,7 +7,7 @@ module MqttSpecs
       it "should create mqtt exchange when vhost is created" do
         with_amqp_server do |server|
           server.vhosts.create("new")
-          server.vhosts["new"].exchanges[LavinMQ::MQTT::EXCHANGE]?.should_not be_nil
+          server.vhosts["new"].exchanges_byname?(LavinMQ::MQTT::EXCHANGE).should_not be_nil
         end
       end
 

--- a/spec/mqtt/multi_vhost_spec.cr
+++ b/spec/mqtt/multi_vhost_spec.cr
@@ -7,7 +7,7 @@ module MqttSpecs
       it "should create mqtt exchange when vhost is created" do
         with_amqp_server do |server|
           server.vhosts.create("new")
-          server.vhosts["new"].exchanges_byname?(LavinMQ::MQTT::EXCHANGE).should_not be_nil
+          server.vhosts["new"].exchange?(LavinMQ::MQTT::EXCHANGE).should_not be_nil
         end
       end
 

--- a/spec/mqtt/permissions_spec.cr
+++ b/spec/mqtt/permissions_spec.cr
@@ -64,7 +64,7 @@ module MqttSpecs
 
           with_client_io(server) do |subscriber_io|
             connect(subscriber_io, username: "guest", password: "guest".to_slice)
-            initial_publish_count = server.@mqtt_brokers.@brokers["/"].@exchange.@publish_in_count.get
+            initial_publish_count = server.@mqtt_brokers.[]?("/").not_nil!.@exchange.@publish_in_count.get
 
             # Create a client with no write permissions and a will message
             will_socket = nil
@@ -76,7 +76,7 @@ module MqttSpecs
             end
 
             sleep 0.1.seconds
-            final_publish_count = server.@mqtt_brokers.@brokers["/"].@exchange.@publish_in_count.get
+            final_publish_count = server.@mqtt_brokers.[]?("/").not_nil!.@exchange.@publish_in_count.get
             final_publish_count.should eq(initial_publish_count)
           end
         end

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -10,8 +10,10 @@ module MqttHelpers
   end
 
   def with_client_socket(server)
-    listener = server.listeners.find(&.[:protocol].mqtt?)
-    tcp_listener = listener.as(NamedTuple(ip_address: String, protocol: LavinMQ::Server::Protocol, port: Int32))
+    tcp_listener = wait_for {
+      server.listeners.find(&.[:protocol].mqtt?)
+        .as?(NamedTuple(ip_address: String, protocol: LavinMQ::Server::Protocol, port: Int32))
+    }
 
     socket = TCPSocket.new(
       tcp_listener[:ip_address],

--- a/spec/msg_segment_meta_files_spec.cr
+++ b/spec/msg_segment_meta_files_spec.cr
@@ -7,7 +7,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("meta_test")
-          queue = vhost.queues_byname("meta_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("meta_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create a large message to fill segments faster
           segment_size = LavinMQ::Config.instance.segment_size
@@ -43,7 +43,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("stream_meta_test", args: AMQP::Client::Arguments.new({"x-queue-type" => "stream"}))
-          queue = vhost.queues_byname("stream_meta_test").as(LavinMQ::AMQP::Stream)
+          queue = vhost.queue("stream_meta_test").as(LavinMQ::AMQP::Stream)
 
           # Publish enough messages to trigger new segment creation
           segment_size = LavinMQ::Config.instance.segment_size
@@ -85,7 +85,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("metadata_load_test")
-          queue = vhost.queues_byname("metadata_load_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("metadata_load_test").as(LavinMQ::AMQP::DurableQueue)
 
           large_message = "x" * (LavinMQ::Config.instance.segment_size // 4) # message is 1/4 of segment size
           5.times { q.publish_confirm large_message }
@@ -118,7 +118,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("fallback_test")
-          queue = vhost.queues_byname("fallback_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("fallback_test").as(LavinMQ::AMQP::DurableQueue)
 
           25.times { |i| q.publish_confirm "message #{i}" }
           msg_dir = queue.@msg_store.@msg_dir
@@ -141,7 +141,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("delete_test")
-          queue = vhost.queues_byname("delete_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("delete_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Fill multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -179,7 +179,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("purge_test")
-          queue = vhost.queues_byname("purge_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("purge_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Fill segments enough to create multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -212,7 +212,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("cleanup_test")
-          queue = vhost.queues_byname("cleanup_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("cleanup_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create enough messages to span multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -255,7 +255,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("count_test")
-          queue = vhost.queues_byname("count_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("count_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create enough messages to fill multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -286,7 +286,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("init_test")
-          queue = vhost.queues_byname("init_test").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("init_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Publish messages
           large_message = "x" * (LavinMQ::Config.instance.segment_size // 4) # message is 1/4 of segment size

--- a/spec/msg_segment_meta_files_spec.cr
+++ b/spec/msg_segment_meta_files_spec.cr
@@ -7,7 +7,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("meta_test")
-          queue = vhost.queues["meta_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("meta_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create a large message to fill segments faster
           segment_size = LavinMQ::Config.instance.segment_size
@@ -43,7 +43,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("stream_meta_test", args: AMQP::Client::Arguments.new({"x-queue-type" => "stream"}))
-          queue = vhost.queues["stream_meta_test"].as(LavinMQ::AMQP::Stream)
+          queue = vhost.queues_byname("stream_meta_test").as(LavinMQ::AMQP::Stream)
 
           # Publish enough messages to trigger new segment creation
           segment_size = LavinMQ::Config.instance.segment_size
@@ -85,7 +85,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("metadata_load_test")
-          queue = vhost.queues["metadata_load_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("metadata_load_test").as(LavinMQ::AMQP::DurableQueue)
 
           large_message = "x" * (LavinMQ::Config.instance.segment_size // 4) # message is 1/4 of segment size
           5.times { q.publish_confirm large_message }
@@ -118,7 +118,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("fallback_test")
-          queue = vhost.queues["fallback_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("fallback_test").as(LavinMQ::AMQP::DurableQueue)
 
           25.times { |i| q.publish_confirm "message #{i}" }
           msg_dir = queue.@msg_store.@msg_dir
@@ -141,7 +141,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("delete_test")
-          queue = vhost.queues["delete_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("delete_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Fill multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -179,7 +179,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("purge_test")
-          queue = vhost.queues["purge_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("purge_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Fill segments enough to create multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -212,7 +212,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("cleanup_test")
-          queue = vhost.queues["cleanup_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("cleanup_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create enough messages to span multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -255,7 +255,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("count_test")
-          queue = vhost.queues["count_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("count_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create enough messages to fill multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -286,7 +286,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("init_test")
-          queue = vhost.queues["init_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("init_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Publish messages
           large_message = "x" * (LavinMQ::Config.instance.segment_size // 4) # message is 1/4 of segment size

--- a/spec/observable_spec.cr
+++ b/spec/observable_spec.cr
@@ -40,7 +40,7 @@ module ObservableSpec
           observable.register_observer(obs1 = Observer(FooEvent).new { |_, _| nil })
           observable.register_observer(obs2 = Observer(FooEvent).new { |_, _| nil })
 
-          observable.@__t_observers.should eq Set{obs1, obs2}
+          observable.@__t_observers.get.should eq Set{obs1, obs2}
         end
       end
 
@@ -52,7 +52,7 @@ module ObservableSpec
           observable.register_observer(obs2 = Observer(FooEvent).new { |_, _| nil })
           observable.unregister_observer(obs1)
 
-          observable.@__t_observers.should eq Set{obs2}
+          observable.@__t_observers.get.should eq Set{obs2}
         end
       end
 

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -42,7 +42,7 @@ describe LavinMQ::AMQP::PriorityQueue do
 
           server = LavinMQ::Server.new(cluster.follower_config)
           begin
-            q = server.vhosts["/"].queues_byname("repli").as(LavinMQ::AMQP::DurablePriorityQueue)
+            q = server.vhosts["/"].queue("repli").as(LavinMQ::AMQP::DurablePriorityQueue)
             q.message_count.should eq 1
             q.basic_get(true) do |env|
               env.message.properties.priority.should eq 1

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -42,7 +42,7 @@ describe LavinMQ::AMQP::PriorityQueue do
 
           server = LavinMQ::Server.new(cluster.follower_config)
           begin
-            q = server.vhosts["/"].queues["repli"].as(LavinMQ::AMQP::DurablePriorityQueue)
+            q = server.vhosts["/"].queues_byname("repli").as(LavinMQ::AMQP::DurablePriorityQueue)
             q.message_count.should eq 1
             q.basic_get(true) do |env|
               env.message.properties.priority.should eq 1

--- a/spec/queue_dead_lettering_spec.cr
+++ b/spec/queue_dead_lettering_spec.cr
@@ -278,7 +278,7 @@ module DeadLetteringSpec
 
       it "should only dead letter on nack multiple with requeue=false when basic get" do
         with_dead_lettering_setup do |q, dlq, _, s|
-          queue = s.vhosts["/"].queues["q"].should be_a LavinMQ::AMQP::Queue
+          queue = s.vhosts["/"].queues_byname("q").should be_a LavinMQ::AMQP::Queue
 
           publish_n(3, q)
 

--- a/spec/queue_dead_lettering_spec.cr
+++ b/spec/queue_dead_lettering_spec.cr
@@ -278,7 +278,7 @@ module DeadLetteringSpec
 
       it "should only dead letter on nack multiple with requeue=false when basic get" do
         with_dead_lettering_setup do |q, dlq, _, s|
-          queue = s.vhosts["/"].queues_byname("q").should be_a LavinMQ::AMQP::Queue
+          queue = s.vhosts["/"].queue("q").should be_a LavinMQ::AMQP::Queue
 
           publish_n(3, q)
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -8,7 +8,7 @@ def with_queue(&)
   with_amqp_server do |s|
     vhost = s.vhosts["/"]
     vhost.declare_queue("q", durable: true, auto_delete: false)
-    q = vhost.queues_byname("q")
+    q = vhost.queue("q")
     yield q
   ensure
     q.try &.delete
@@ -20,7 +20,7 @@ describe LavinMQ::AMQP::Queue do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         q = ch.queue("qexpires", args: AMQP::Client::Arguments.new({"x-expires" => 100}))
-        queue = s.vhosts["/"].queues_byname("qexpires")
+        queue = s.vhosts["/"].queue("qexpires")
         tag = q.subscribe { }
         sleep 110.milliseconds
         queue.closed?.should be_false
@@ -141,7 +141,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].queues_byname(q.name)
+          iq = s.vhosts["/"].queue(q.name)
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -155,12 +155,12 @@ describe LavinMQ::AMQP::Queue do
         s.vhosts.create("/")
         v = s.vhosts["/"].not_nil!
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues_byname("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
-        s.vhosts["/"].queues_byname("q").pause!
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        s.vhosts["/"].queue("q").pause!
         File.exists?(File.join(data_dir, "paused")).should be_true
         s.restart
-        s.vhosts["/"].queues_byname("q").state.paused?.should be_true
-        s.vhosts["/"].queues_byname("q").resume!
+        s.vhosts["/"].queue("q").state.paused?.should be_true
+        s.vhosts["/"].queue("q").resume!
         File.exists?(File.join(data_dir, "paused")).should be_false
       end
     end
@@ -170,11 +170,11 @@ describe LavinMQ::AMQP::Queue do
         s.vhosts.create("/")
         v = s.vhosts["/"].not_nil!
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues_byname("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         File.touch(File.join(data_dir, ".paused"))
         s.restart
         File.exists?(File.join(data_dir, "paused")).should be_true
-        s.vhosts["/"].queues_byname("q").state.paused?.should be_true
+        s.vhosts["/"].queue("q").state.paused?.should be_true
       end
     end
 
@@ -188,7 +188,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].queues_byname(q.name)
+          iq = s.vhosts["/"].queue(q.name)
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -221,7 +221,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].queues_byname(q.name)
+          iq = s.vhosts["/"].queue(q.name)
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -253,7 +253,7 @@ describe LavinMQ::AMQP::Queue do
         tag = "consumer-to-be-canceled"
         with_channel(s) do |ch|
           q = ch.queue(q_name)
-          queue = s.vhosts["/"].queues_byname(q_name).as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
           q.publish_confirm "m1"
 
           # Should get canceled
@@ -266,7 +266,7 @@ describe LavinMQ::AMQP::Queue do
         end
 
         # Queue is closed, delete to prevent spec failure because of closed queue
-        s.vhosts["/"].queues_byname(q_name).try &.delete
+        s.vhosts["/"].queue(q_name).try &.delete
       end
     end
   end
@@ -277,7 +277,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues_byname(q_name).as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Publish a message
           q.publish_confirm "test message"
@@ -302,7 +302,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues_byname(q_name).as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
           q.publish_confirm "test message"
           queue.message_count.should eq 1
 
@@ -335,7 +335,7 @@ describe LavinMQ::AMQP::Queue do
           q = ch.queue(q_name, durable: true, args: AMQP::Client::Arguments.new(
             {"x-message-ttl" => 500, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "dlq"}
           ))
-          queue = s.vhosts["/"].queues_byname(q_name).as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Publish a message
           q.publish_confirm "test message"
@@ -358,7 +358,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.queue(q_name, durable: true, args: AMQP::Client::Arguments.new({"x-expires" => 100}))
-          queue = s.vhosts["/"].queues_byname(q_name).as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Close the queue
           queue.close
@@ -376,7 +376,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues_byname(q_name).as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Try to restart without closing
           queue.restart!.should be_false
@@ -399,7 +399,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message 3", q.name
           x.publish_confirm "test message 4", q.name
 
-          internal_queue = s.vhosts["/"].queues_byname(q.name)
+          internal_queue = s.vhosts["/"].queue(q.name)
           internal_queue.message_count.should eq 4
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents")
@@ -421,7 +421,7 @@ describe LavinMQ::AMQP::Queue do
           end
 
           vhost = s.vhosts["/"]
-          internal_queue = vhost.queues_byname(q.name)
+          internal_queue = vhost.queue(q.name)
           internal_queue.message_count.should eq 10
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents?count=5")
@@ -441,7 +441,7 @@ describe LavinMQ::AMQP::Queue do
 
         msg = q.get(no_ack: false)
         msg.should_not be_nil
-        sq = s.vhosts["/"].queues_byname(q.name)
+        sq = s.vhosts["/"].queue(q.name)
         sq.unacked_count.should eq 1
         msg.not_nil!.ack
         sleep 10.milliseconds
@@ -461,7 +461,7 @@ describe LavinMQ::AMQP::Queue do
           done.send msg
         end
         msg = done.receive
-        sq = s.vhosts["/"].queues_byname(q.name)
+        sq = s.vhosts["/"].queue(q.name)
         sq.unacked_count.should eq 1
         msg.ack
         sleep 10.milliseconds
@@ -475,7 +475,7 @@ describe LavinMQ::AMQP::Queue do
       with_channel(s) do |ch|
         ch.queue "transient", durable: false
       end
-      data_dir = s.vhosts["/"].queues_byname("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+      data_dir = s.vhosts["/"].queue("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
       s.stop
       Dir.exists?(data_dir).should be_false
     end
@@ -486,7 +486,7 @@ describe LavinMQ::AMQP::Queue do
       with_channel(s) do |ch|
         ch.queue "transient", durable: false
       end
-      data_dir = s.vhosts["/"].queues_byname("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+      data_dir = s.vhosts["/"].queue("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
       Dir.exists?(data_dir).should be_true
       File.exists?("#{data_dir}/msgs.0000000001").should be_false
     end
@@ -498,7 +498,7 @@ describe LavinMQ::AMQP::Queue do
       with_channel(s) do |ch|
         q = ch.queue "transient", durable: false
         q.publish_confirm "foobar"
-        data_dir = s.vhosts["/"].queues_byname("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         FileUtils.cp_r data_dir, "#{s.vhosts["/"].data_dir}.copy"
       end
       s.stop
@@ -518,7 +518,7 @@ describe LavinMQ::AMQP::Queue do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         q = ch.queue("q", auto_delete: true)
-        data_dir = s.vhosts["/"].queues_byname("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         sub = q.subscribe(no_ack: true) { |_| }
         Dir.exists?(data_dir).should be_true
         q.unsubscribe(sub)
@@ -641,7 +641,7 @@ describe LavinMQ::AMQP::Queue do
         s.vhosts["/"].declare_queue("expire_test_queue", true, false, AMQP::Client::Arguments.new({
           "x-message-ttl" => 600,
         }))
-        queue = s.vhosts["/"].queues_byname("expire_test_queue").as(LavinMQ::AMQP::DurableQueue)
+        queue = s.vhosts["/"].queue("expire_test_queue").as(LavinMQ::AMQP::DurableQueue)
 
         10_000.times do
           queue.publish(LavinMQ::Message.new("ex", "rk", "body" * 250, AMQ::Protocol::Properties.new))
@@ -691,7 +691,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue
-          sq = s.vhosts["/"].queues_byname(q.name).should be_a LavinMQ::AMQP::Queue
+          sq = s.vhosts["/"].queue(q.name).should be_a LavinMQ::AMQP::Queue
 
           q.publish_confirm "a"
           q.publish_confirm "b"
@@ -733,7 +733,7 @@ describe LavinMQ::AMQP::Queue do
         with_amqp_server do |s|
           q = s.vhosts["/"].try do |vhost|
             vhost.declare_queue("q", durable: true, auto_delete: false, arguments: AMQP::Client::Arguments.new(args))
-            vhost.queues_byname("q")
+            vhost.queue("q")
           end
 
           effective_arguments = q.details_tuple[:effective_arguments]
@@ -753,7 +753,7 @@ describe LavinMQ::AMQP::Queue do
         with_amqp_server do |s|
           q = s.vhosts["/"].try do |vhost|
             vhost.declare_queue("q", durable: true, auto_delete: false, arguments: AMQP::Client::Arguments.new(args))
-            vhost.queues_byname("q")
+            vhost.queue("q")
           end
 
           effective_arguments = q.details_tuple[:effective_arguments]
@@ -789,7 +789,7 @@ describe LavinMQ::AMQP::Queue do
         with_amqp_server do |s|
           q = s.vhosts["/"].try do |vhost|
             vhost.declare_queue("q", durable: true, auto_delete: false, arguments: AMQP::Client::Arguments.new(args))
-            vhost.queues_byname("q")
+            vhost.queue("q")
           end
           definition = JSON.parse(policy_args.to_json).as_h
           policy = LavinMQ::Policy.new("p1", "/", %r{"."}, LavinMQ::Policy::Target::All, definition, 1i8)

--- a/spec/random_spec.cr
+++ b/spec/random_spec.cr
@@ -26,8 +26,8 @@ describe LavinMQ do
           count.should eq 0
 
           Fiber.yield
-          Server.vhosts["/"].queues[qname].@ready.size.should eq 2
-          Server.vhosts["/"].queues[qname].@unacked.size.should eq 0
+          Server.vhosts["/"].queues_byname(qname).@ready.size.should eq 2
+          Server.vhosts["/"].queues_byname(qname).@unacked.size.should eq 0
         end
       end
     end

--- a/spec/random_spec.cr
+++ b/spec/random_spec.cr
@@ -26,8 +26,8 @@ describe LavinMQ do
           count.should eq 0
 
           Fiber.yield
-          Server.vhosts["/"].queues_byname(qname).@ready.size.should eq 2
-          Server.vhosts["/"].queues_byname(qname).@unacked.size.should eq 0
+          Server.vhosts["/"].queue(qname).@ready.size.should eq 2
+          Server.vhosts["/"].queue(qname).@unacked.size.should eq 0
         end
       end
     end

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -40,7 +40,7 @@ describe LavinMQ::SchemaVersion do
       with_amqp_server do |s|
         v = s.vhosts["/"]
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues_byname("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         path = File.join(data_dir, "msgs.0000000002")
         MFile.open(path, LavinMQ::Config.instance.segment_size) do |file|
           file.resize(LavinMQ::Config.instance.segment_size)

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -40,7 +40,7 @@ describe LavinMQ::SchemaVersion do
       with_amqp_server do |s|
         v = s.vhosts["/"]
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queues_byname("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         path = File.join(data_dir, "msgs.0000000002")
         MFile.open(path, LavinMQ::Config.instance.segment_size) do |file|
           file.resize(LavinMQ::Config.instance.segment_size)

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -232,7 +232,7 @@ describe LavinMQ::Server do
         q.publish_confirm ttl_msg
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(ttl_msg)
-        s.vhosts["/"].queues_byname(q.name).empty?.should be_true
+        s.vhosts["/"].queue(q.name).empty?.should be_true
         q.publish_confirm ttl_msg
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(ttl_msg)
@@ -250,7 +250,7 @@ describe LavinMQ::Server do
         msg.reject(requeue: true)
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(r_msg)
-        s.vhosts["/"].queues_byname(q.name).empty?.should be_true
+        s.vhosts["/"].queue(q.name).empty?.should be_true
       end
     end
   end
@@ -278,7 +278,7 @@ describe LavinMQ::Server do
         tag = q.subscribe(no_ack: false) { |_| done.send nil }
         done.receive
         q.unsubscribe(tag)
-        s.vhosts["/"].queues_byname("msg_q").empty?.should be_true
+        s.vhosts["/"].queue("msg_q").empty?.should be_true
       end
     end
   end
@@ -651,7 +651,7 @@ describe LavinMQ::Server do
         definitions = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
         s.vhosts["/"].add_policy("test", "^mlq$", "queues", definitions, 10_i8)
         sleep 10.milliseconds
-        s.vhosts["/"].queues_byname("mlq").message_count.should eq 1
+        s.vhosts["/"].queue("mlq").message_count.should eq 1
       end
     end
   end
@@ -980,7 +980,7 @@ describe LavinMQ::Server do
         msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
         msg.reject(requeue: true)
         Fiber.yield
-        s.vhosts["/"].queues_byname("delivery_limit").empty?.should be_true
+        s.vhosts["/"].queue("delivery_limit").empty?.should be_true
       end
     end
   end
@@ -1116,8 +1116,8 @@ describe LavinMQ::Server do
         count.should eq 0
 
         Fiber.yield
-        s.vhosts["/"].queues_byname(qname).message_count.should eq 1
-        s.vhosts["/"].queues_byname(qname).unacked_count.should eq 0
+        s.vhosts["/"].queue(qname).message_count.should eq 1
+        s.vhosts["/"].queue(qname).unacked_count.should eq 0
       end
     end
   end

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -823,7 +823,7 @@ describe LavinMQ::Server do
         ch.queue("test", args: args)
         sleep 5.milliseconds
         Fiber.yield
-        s.vhosts["/"].queues.has_key?("test").should be_false
+        s.vhosts["/"].queues_has_key?("test").should be_false
       end
     end
   end
@@ -837,7 +837,7 @@ describe LavinMQ::Server do
         q.subscribe(no_ack: true) { |_| }
         sleep 50.milliseconds
         Fiber.yield
-        s.vhosts["/"].queues.has_key?("test").should be_true
+        s.vhosts["/"].queues_has_key?("test").should be_true
       end
     end
   end

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -232,7 +232,7 @@ describe LavinMQ::Server do
         q.publish_confirm ttl_msg
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(ttl_msg)
-        s.vhosts["/"].queues[q.name].empty?.should be_true
+        s.vhosts["/"].queues_byname(q.name).empty?.should be_true
         q.publish_confirm ttl_msg
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(ttl_msg)
@@ -250,7 +250,7 @@ describe LavinMQ::Server do
         msg.reject(requeue: true)
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(r_msg)
-        s.vhosts["/"].queues[q.name].empty?.should be_true
+        s.vhosts["/"].queues_byname(q.name).empty?.should be_true
       end
     end
   end
@@ -278,7 +278,7 @@ describe LavinMQ::Server do
         tag = q.subscribe(no_ack: false) { |_| done.send nil }
         done.receive
         q.unsubscribe(tag)
-        s.vhosts["/"].queues["msg_q"].empty?.should be_true
+        s.vhosts["/"].queues_byname("msg_q").empty?.should be_true
       end
     end
   end
@@ -651,7 +651,7 @@ describe LavinMQ::Server do
         definitions = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
         s.vhosts["/"].add_policy("test", "^mlq$", "queues", definitions, 10_i8)
         sleep 10.milliseconds
-        s.vhosts["/"].queues["mlq"].message_count.should eq 1
+        s.vhosts["/"].queues_byname("mlq").message_count.should eq 1
       end
     end
   end
@@ -980,7 +980,7 @@ describe LavinMQ::Server do
         msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
         msg.reject(requeue: true)
         Fiber.yield
-        s.vhosts["/"].queues["delivery_limit"].empty?.should be_true
+        s.vhosts["/"].queues_byname("delivery_limit").empty?.should be_true
       end
     end
   end
@@ -1116,8 +1116,8 @@ describe LavinMQ::Server do
         count.should eq 0
 
         Fiber.yield
-        s.vhosts["/"].queues[qname].message_count.should eq 1
-        s.vhosts["/"].queues[qname].unacked_count.should eq 0
+        s.vhosts["/"].queues_byname(qname).message_count.should eq 1
+        s.vhosts["/"].queues_byname(qname).unacked_count.should eq 0
       end
     end
   end

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -823,7 +823,7 @@ describe LavinMQ::Server do
         ch.queue("test", args: args)
         sleep 5.milliseconds
         Fiber.yield
-        s.vhosts["/"].queues_has_key?("test").should be_false
+        s.vhosts["/"].queue_exists?("test").should be_false
       end
     end
   end
@@ -837,7 +837,7 @@ describe LavinMQ::Server do
         q.subscribe(no_ack: true) { |_| }
         sleep 50.milliseconds
         Fiber.yield
-        s.vhosts["/"].queues_has_key?("test").should be_true
+        s.vhosts["/"].queue_exists?("test").should be_true
       end
     end
   end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -26,10 +26,10 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues["source"].publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
           expect_raises(AMQP::Client::Connection::ClosedException) do
             source.each do
-              s.vhosts["/"].connections.each &.close("spec")
+              s.vhosts["/"].connections_each &.close("spec")
             end
           end
           source.started?.should be_false
@@ -49,7 +49,7 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues["source"].publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
           wg = WaitGroup.new(1)
           spawn { source.each { wg.done } }
           wg.wait
@@ -79,7 +79,7 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues["source"].publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
           wg = WaitGroup.new(1)
           spawn { source.each { wg.done } }
           wg.wait
@@ -110,12 +110,12 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues["source"].publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
           wg = WaitGroup.new(1)
           spawn { source.each { |m| source.ack(m.delivery_tag) && wg.done } }
           wg.wait
           sleep 1.millisecond
-          s.vhosts["/"].queues["source"].unacked_count.should eq 0
+          s.vhosts["/"].queues_byname("source").unacked_count.should eq 0
           source.stop
         end
       end
@@ -259,7 +259,7 @@ describe LavinMQ::Shovel do
           spawn shovel.run
           wait_for { shovel.running? }
           sleep 0.1.seconds # Give time for message to be shoveled
-          s.vhosts["/"].queues["ap_q1"].message_count.should eq 0
+          s.vhosts["/"].queues_byname("ap_q1").message_count.should eq 0
           q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
         end
       end
@@ -288,8 +288,8 @@ describe LavinMQ::Shovel do
           x, q2 = ShovelSpecHelpers.setup_qs ch, "na_"
           x.publish_confirm "shovel me", "na_q1"
           spawn { shovel.run }
-          wait_for { s.vhosts["/"].queues["na_q1"].message_count.zero? }
-          wait_for { !s.vhosts["/"].queues["na_q2"].message_count.zero? }
+          wait_for { s.vhosts["/"].queues_byname("na_q1").message_count.zero? }
+          wait_for { !s.vhosts["/"].queues_byname("na_q2").message_count.zero? }
           q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
         end
       end
@@ -317,12 +317,12 @@ describe LavinMQ::Shovel do
           100.times do
             x.publish_confirm "shovel me", "prefetch_q1"
           end
-          wait_for { s.vhosts["/"].queues["prefetch_q1"].message_count == 100 }
+          wait_for { s.vhosts["/"].queues_byname("prefetch_q1").message_count == 100 }
           shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch_shovel", vhost)
           shovel.run
           wait_for { shovel.terminated? }
-          s.vhosts["/"].queues["prefetch_q1"].message_count.should eq 0
-          s.vhosts["/"].queues["prefetch_q2"].message_count.should eq 100
+          s.vhosts["/"].queues_byname("prefetch_q1").message_count.should eq 0
+          s.vhosts["/"].queues_byname("prefetch_q2").message_count.should eq 100
         end
       end
     end
@@ -449,14 +449,14 @@ describe LavinMQ::Shovel do
           x.publish_confirm "shovel me 2", "prefetch2_q1"
           x.publish_confirm "shovel me 2", "prefetch2_q1"
           # Wait until four messages has been published to destination...
-          wait_for { s.vhosts["/"].queues["prefetch2_q2"].message_count == 4 }
+          wait_for { s.vhosts["/"].queues_byname("prefetch2_q2").message_count == 4 }
           # ... but only three has been acked (because batching)
-          wait_for { s.vhosts["/"].queues["prefetch2_q1"].unacked_count == 1 }
+          wait_for { s.vhosts["/"].queues_byname("prefetch2_q1").unacked_count == 1 }
           # Now when we terminate the shovel it should ack the last message(s)
           shovel.terminate
-          wait_for { s.vhosts["/"].queues["prefetch2_q1"].unacked_count == 0 }
-          s.vhosts["/"].queues["prefetch2_q2"].message_count.should eq 4
-          s.vhosts["/"].queues["prefetch2_q1"].message_count.should eq 0
+          wait_for { s.vhosts["/"].queues_byname("prefetch2_q1").unacked_count == 0 }
+          s.vhosts["/"].queues_byname("prefetch2_q2").message_count.should eq 4
+          s.vhosts["/"].queues_byname("prefetch2_q1").message_count.should eq 0
         end
       end
     end
@@ -512,7 +512,7 @@ describe LavinMQ::Shovel do
           10.times do
             x.publish_confirm "shovel me", "c_q1"
           end
-          wait_for { s.vhosts["/"].queues["c_q2"].message_count == 10 }
+          wait_for { s.vhosts["/"].queues_byname("c_q2").message_count == 10 }
           shovel.details_tuple[:message_count].should eq 10
         end
         shovel.state.to_s.should eq "Running"
@@ -624,7 +624,7 @@ describe LavinMQ::Shovel do
           q1.publish_confirm "shovel me 1", "#{queue_name}q1"
           q1.publish_confirm "shovel me 2", "#{queue_name}q1"
           spawn { shovel.run }
-          wait_for { s.vhosts["/"].queues["#{queue_name}q2"].message_count == 2 }
+          wait_for { s.vhosts["/"].queues_byname("#{queue_name}q2").message_count == 2 }
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
           shovel.pause
@@ -636,7 +636,7 @@ describe LavinMQ::Shovel do
 
           spawn shovel.resume
           wait_for { shovel.running? } # Ensure it gets back to Running state
-          wait_for { s.vhosts["/"].queues["#{queue_name}q2"].message_count == 2 }
+          wait_for { s.vhosts["/"].queues_byname("#{queue_name}q2").message_count == 2 }
           shovel.terminate
           wait_for { shovel.terminated? }
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 3"
@@ -672,7 +672,7 @@ describe LavinMQ::Shovel do
           shovel.pause
           wait_for { shovel.paused? }
 
-          vhost.queues["#{queue_name}q1"].message_count.should be > 0
+          vhost.queues_byname("#{queue_name}q1").message_count.should be > 0
           shovel = vhost.shovels[queue_name]
           spawn shovel.resume
           wait_for { shovel.running? } # Ensure it gets back to Running state

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -26,7 +26,7 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queue("source").publish(LavinMQ::Message.new("", "", ""))
           expect_raises(AMQP::Client::Connection::ClosedException) do
             source.each do
               s.vhosts["/"].connections_each &.close("spec")
@@ -49,7 +49,7 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queue("source").publish(LavinMQ::Message.new("", "", ""))
           wg = WaitGroup.new(1)
           spawn { source.each { wg.done } }
           wg.wait
@@ -79,7 +79,7 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queue("source").publish(LavinMQ::Message.new("", "", ""))
           wg = WaitGroup.new(1)
           spawn { source.each { wg.done } }
           wg.wait
@@ -110,12 +110,12 @@ describe LavinMQ::Shovel do
 
           source.start
 
-          s.vhosts["/"].queues_byname("source").publish(LavinMQ::Message.new("", "", ""))
+          s.vhosts["/"].queue("source").publish(LavinMQ::Message.new("", "", ""))
           wg = WaitGroup.new(1)
           spawn { source.each { |m| source.ack(m.delivery_tag) && wg.done } }
           wg.wait
           sleep 1.millisecond
-          s.vhosts["/"].queues_byname("source").unacked_count.should eq 0
+          s.vhosts["/"].queue("source").unacked_count.should eq 0
           source.stop
         end
       end
@@ -259,7 +259,7 @@ describe LavinMQ::Shovel do
           spawn shovel.run
           wait_for { shovel.running? }
           sleep 0.1.seconds # Give time for message to be shoveled
-          s.vhosts["/"].queues_byname("ap_q1").message_count.should eq 0
+          s.vhosts["/"].queue("ap_q1").message_count.should eq 0
           q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
         end
       end
@@ -288,8 +288,8 @@ describe LavinMQ::Shovel do
           x, q2 = ShovelSpecHelpers.setup_qs ch, "na_"
           x.publish_confirm "shovel me", "na_q1"
           spawn { shovel.run }
-          wait_for { s.vhosts["/"].queues_byname("na_q1").message_count.zero? }
-          wait_for { !s.vhosts["/"].queues_byname("na_q2").message_count.zero? }
+          wait_for { s.vhosts["/"].queue("na_q1").message_count.zero? }
+          wait_for { !s.vhosts["/"].queue("na_q2").message_count.zero? }
           q2.get(no_ack: false).try(&.body_io.to_s).should eq "shovel me"
         end
       end
@@ -317,12 +317,12 @@ describe LavinMQ::Shovel do
           100.times do
             x.publish_confirm "shovel me", "prefetch_q1"
           end
-          wait_for { s.vhosts["/"].queues_byname("prefetch_q1").message_count == 100 }
+          wait_for { s.vhosts["/"].queue("prefetch_q1").message_count == 100 }
           shovel = LavinMQ::Shovel::Runner.new(source, dest, "prefetch_shovel", vhost)
           shovel.run
           wait_for { shovel.terminated? }
-          s.vhosts["/"].queues_byname("prefetch_q1").message_count.should eq 0
-          s.vhosts["/"].queues_byname("prefetch_q2").message_count.should eq 100
+          s.vhosts["/"].queue("prefetch_q1").message_count.should eq 0
+          s.vhosts["/"].queue("prefetch_q2").message_count.should eq 100
         end
       end
     end
@@ -449,14 +449,14 @@ describe LavinMQ::Shovel do
           x.publish_confirm "shovel me 2", "prefetch2_q1"
           x.publish_confirm "shovel me 2", "prefetch2_q1"
           # Wait until four messages has been published to destination...
-          wait_for { s.vhosts["/"].queues_byname("prefetch2_q2").message_count == 4 }
+          wait_for { s.vhosts["/"].queue("prefetch2_q2").message_count == 4 }
           # ... but only three has been acked (because batching)
-          wait_for { s.vhosts["/"].queues_byname("prefetch2_q1").unacked_count == 1 }
+          wait_for { s.vhosts["/"].queue("prefetch2_q1").unacked_count == 1 }
           # Now when we terminate the shovel it should ack the last message(s)
           shovel.terminate
-          wait_for { s.vhosts["/"].queues_byname("prefetch2_q1").unacked_count == 0 }
-          s.vhosts["/"].queues_byname("prefetch2_q2").message_count.should eq 4
-          s.vhosts["/"].queues_byname("prefetch2_q1").message_count.should eq 0
+          wait_for { s.vhosts["/"].queue("prefetch2_q1").unacked_count == 0 }
+          s.vhosts["/"].queue("prefetch2_q2").message_count.should eq 4
+          s.vhosts["/"].queue("prefetch2_q1").message_count.should eq 0
         end
       end
     end
@@ -512,7 +512,7 @@ describe LavinMQ::Shovel do
           10.times do
             x.publish_confirm "shovel me", "c_q1"
           end
-          wait_for { s.vhosts["/"].queues_byname("c_q2").message_count == 10 }
+          wait_for { s.vhosts["/"].queue("c_q2").message_count == 10 }
           shovel.details_tuple[:message_count].should eq 10
         end
         shovel.state.to_s.should eq "Running"
@@ -624,7 +624,7 @@ describe LavinMQ::Shovel do
           q1.publish_confirm "shovel me 1", "#{queue_name}q1"
           q1.publish_confirm "shovel me 2", "#{queue_name}q1"
           spawn { shovel.run }
-          wait_for { s.vhosts["/"].queues_byname("#{queue_name}q2").message_count == 2 }
+          wait_for { s.vhosts["/"].queue("#{queue_name}q2").message_count == 2 }
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 1"
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
           shovel.pause
@@ -636,7 +636,7 @@ describe LavinMQ::Shovel do
 
           spawn shovel.resume
           wait_for { shovel.running? } # Ensure it gets back to Running state
-          wait_for { s.vhosts["/"].queues_byname("#{queue_name}q2").message_count == 2 }
+          wait_for { s.vhosts["/"].queue("#{queue_name}q2").message_count == 2 }
           shovel.terminate
           wait_for { shovel.terminated? }
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 3"
@@ -672,7 +672,7 @@ describe LavinMQ::Shovel do
           shovel.pause
           wait_for { shovel.paused? }
 
-          vhost.queues_byname("#{queue_name}q1").message_count.should be > 0
+          vhost.queue("#{queue_name}q1").message_count.should be > 0
           shovel = vhost.shovels[queue_name]
           spawn shovel.resume
           wait_for { shovel.running? } # Ensure it gets back to Running state

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -124,7 +124,7 @@ def with_amqp_server(tls = false, replicator = nil,
     # everything has been cleaned up after a `with_channel` inside the `with_amqp_server`.
     closed_queues = 3.times do
       Fiber.yield
-      queues = s.vhosts.flat_map { |_, vhost| vhost.queues.values.select &.closed? }
+      queues = s.vhosts.flat_map { |_, vhost| vhost.queues_each_value.select(&.closed?).to_a }
       break if queues.empty?
       queues
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -54,13 +54,6 @@ end
 
 def with_channel(s : LavinMQ::Server, file = __FILE__, line = __LINE__, **args, &)
   name = "lavinmq-spec-#{file}:#{line}"
-  s.@listeners
-    .select { |k, v| k.is_a?(TCPServer) && v.amqp? }
-    .keys
-    .select(TCPServer)
-    .first
-    .local_address
-    .port
   args = {port: amqp_port(s), name: name}.merge(args)
   conn = AMQP::Client.new(**args).connect
   ch = conn.channel
@@ -70,7 +63,7 @@ ensure
 end
 
 def amqp_port(s)
-  s.@listeners.keys.select(TCPServer).first.local_address.port
+  wait_for { s.@listeners.keys.select(TCPServer).first? }.local_address.port
 end
 
 def should_eventually(expectation, timeout = 5.seconds, file = __FILE__, line = __LINE__, &)

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -14,7 +14,7 @@ describe LavinMQ::AMQP::DurableQueue do
       config = LavinMQ::Config.new.tap &.data_dir = "/tmp/lavinmq-spec-index-v2"
       server = LavinMQ::Server.new(config)
       begin
-        q = server.vhosts["/"].queues_byname("queue").as(LavinMQ::AMQP::DurableQueue)
+        q = server.vhosts["/"].queue("queue").as(LavinMQ::AMQP::DurableQueue)
         q.basic_get(true) do |env|
           String.new(env.message.body).to_s.should eq "message"
         end.should be_true
@@ -31,7 +31,7 @@ describe LavinMQ::AMQP::DurableQueue do
           vhost = s.vhosts.create("corrupt_vhost")
           with_channel(s, vhost: vhost.name) do |ch|
             q = ch.queue("corrupt_q")
-            queue = vhost.queues_byname("corrupt_q").as(LavinMQ::AMQP::DurableQueue)
+            queue = vhost.queue("corrupt_q").as(LavinMQ::AMQP::DurableQueue)
             q.publish_confirm "test message"
 
             sleep 10.milliseconds
@@ -48,7 +48,7 @@ describe LavinMQ::AMQP::DurableQueue do
             should_eventually(be_true) { queue.state.closed? }
           end
 
-          vhost.queues_byname?("corrupt_q").try &.delete
+          vhost.queue?("corrupt_q").try &.delete
         end
       end
     end
@@ -59,7 +59,7 @@ describe LavinMQ::AMQP::DurableQueue do
         enq_path = ""
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("corrupt_q2")
-          queue = vhost.queues_byname("corrupt_q2").as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("corrupt_q2").as(LavinMQ::AMQP::DurableQueue)
           enq_path = queue.@msg_store.@segments.last_value.path
           2.times do |i|
             q.publish_confirm "test message #{i}"
@@ -84,7 +84,7 @@ describe LavinMQ::AMQP::DurableQueue do
       with_channel(s) do |ch|
         q = ch.queue("corruption_test", durable: true)
         q.publish_confirm "Hello world"
-        queue = s.vhosts["/"].queues_byname("corruption_test").as(LavinMQ::AMQP::DurableQueue)
+        queue = s.vhosts["/"].queue("corruption_test").as(LavinMQ::AMQP::DurableQueue)
         enq_path = queue.@msg_store.@segments.last_value.path
       end
       s.stop
@@ -97,7 +97,7 @@ describe LavinMQ::AMQP::DurableQueue do
         q.publish_confirm "Hello world"
       end
       s.restart
-      queue = s.vhosts["/"].queues_byname("corruption_test").as(LavinMQ::AMQP::DurableQueue)
+      queue = s.vhosts["/"].queue("corruption_test").as(LavinMQ::AMQP::DurableQueue)
       queue.message_count.should eq 2
     end
   end
@@ -108,7 +108,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(queue_name)
-        queue = vhost.queues_byname(queue_name).as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queue(queue_name).as(LavinMQ::AMQP::DurableQueue)
         mfile = queue.@msg_store.@segments.first_value
 
         # fill up one segment
@@ -140,7 +140,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(queue_name)
-        queue = vhost.queues_byname(queue_name).as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queue(queue_name).as(LavinMQ::AMQP::DurableQueue)
         mfile = queue.@msg_store.@segments.first_value
 
         # fill up one segment
@@ -179,7 +179,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(rk, durable: true)
-        queue = vhost.queues_byname(rk).as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queue(rk).as(LavinMQ::AMQP::DurableQueue)
         q.publish_confirm "a"
         store = LavinMQ::MessageStore.new(queue.@msg_store.@msg_dir, nil)
 

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -14,7 +14,7 @@ describe LavinMQ::AMQP::DurableQueue do
       config = LavinMQ::Config.new.tap &.data_dir = "/tmp/lavinmq-spec-index-v2"
       server = LavinMQ::Server.new(config)
       begin
-        q = server.vhosts["/"].queues["queue"].as(LavinMQ::AMQP::DurableQueue)
+        q = server.vhosts["/"].queues_byname("queue").as(LavinMQ::AMQP::DurableQueue)
         q.basic_get(true) do |env|
           String.new(env.message.body).to_s.should eq "message"
         end.should be_true
@@ -31,7 +31,7 @@ describe LavinMQ::AMQP::DurableQueue do
           vhost = s.vhosts.create("corrupt_vhost")
           with_channel(s, vhost: vhost.name) do |ch|
             q = ch.queue("corrupt_q")
-            queue = vhost.queues["corrupt_q"].as(LavinMQ::AMQP::DurableQueue)
+            queue = vhost.queues_byname("corrupt_q").as(LavinMQ::AMQP::DurableQueue)
             q.publish_confirm "test message"
 
             sleep 10.milliseconds
@@ -48,7 +48,7 @@ describe LavinMQ::AMQP::DurableQueue do
             should_eventually(be_true) { queue.state.closed? }
           end
 
-          vhost.queues["corrupt_q"].try &.delete
+          vhost.queues_byname?("corrupt_q").try &.delete
         end
       end
     end
@@ -59,7 +59,7 @@ describe LavinMQ::AMQP::DurableQueue do
         enq_path = ""
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("corrupt_q2")
-          queue = vhost.queues["corrupt_q2"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queues_byname("corrupt_q2").as(LavinMQ::AMQP::DurableQueue)
           enq_path = queue.@msg_store.@segments.last_value.path
           2.times do |i|
             q.publish_confirm "test message #{i}"
@@ -84,7 +84,7 @@ describe LavinMQ::AMQP::DurableQueue do
       with_channel(s) do |ch|
         q = ch.queue("corruption_test", durable: true)
         q.publish_confirm "Hello world"
-        queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::AMQP::DurableQueue)
+        queue = s.vhosts["/"].queues_byname("corruption_test").as(LavinMQ::AMQP::DurableQueue)
         enq_path = queue.@msg_store.@segments.last_value.path
       end
       s.stop
@@ -97,7 +97,7 @@ describe LavinMQ::AMQP::DurableQueue do
         q.publish_confirm "Hello world"
       end
       s.restart
-      queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::AMQP::DurableQueue)
+      queue = s.vhosts["/"].queues_byname("corruption_test").as(LavinMQ::AMQP::DurableQueue)
       queue.message_count.should eq 2
     end
   end
@@ -108,7 +108,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(queue_name)
-        queue = vhost.queues[queue_name].as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queues_byname(queue_name).as(LavinMQ::AMQP::DurableQueue)
         mfile = queue.@msg_store.@segments.first_value
 
         # fill up one segment
@@ -140,7 +140,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(queue_name)
-        queue = vhost.queues[queue_name].as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queues_byname(queue_name).as(LavinMQ::AMQP::DurableQueue)
         mfile = queue.@msg_store.@segments.first_value
 
         # fill up one segment
@@ -179,7 +179,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(rk, durable: true)
-        queue = vhost.queues[rk].as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queues_byname(rk).as(LavinMQ::AMQP::DurableQueue)
         q.publish_confirm "a"
         store = LavinMQ::MessageStore.new(queue.@msg_store.@msg_dir, nil)
 
@@ -201,8 +201,8 @@ describe LavinMQ::VHost do
   pending "GC segments" do
     with_amqp_server do |s|
       vhost = s.vhosts["/"]
-      vhost.queues.each_value &.delete
-      vhost.queues.clear
+      vhost.queues_each_value &.delete
+      # TODO: need queues_clear for tests
 
       msg_size = 5120
       overhead = 21

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -329,7 +329,7 @@ describe LavinMQ::AMQP::Stream do
           q = ch.queue("stream-max-length", args: AMQP::Client::Arguments.new(args))
           data = Bytes.new(LavinMQ::Config.instance.segment_size)
           3.times { q.publish_confirm data }
-          dir = s.vhosts["/"].queues["stream-max-length"].as(LavinMQ::AMQP::Stream).@data_dir
+          dir = s.vhosts["/"].queues_byname("stream-max-length").as(LavinMQ::AMQP::Stream).@data_dir
           File.exists?(File.join(dir, "msgs.0000000001")).should be_false
           File.exists?(File.join(dir, "meta.0000000001")).should be_false
           q.message_count.should eq 1
@@ -689,7 +689,7 @@ describe LavinMQ::AMQP::Stream do
           ch.prefetch 1
           args = {"x-queue-type": "stream"}
           q = ch.queue(queue_name, args: AMQP::Client::Arguments.new(args))
-          stream = s.vhosts["/"].queues[queue_name].as(LavinMQ::AMQP::Stream)
+          stream = s.vhosts["/"].queues_byname(queue_name).as(LavinMQ::AMQP::Stream)
           q.publish_confirm "test message"
           stream.message_count.should eq 1
 
@@ -728,7 +728,7 @@ describe LavinMQ::AMQP::Stream do
         msg = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
         StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 1
 
-        stream = s.vhosts["/"].queues[queue_name].as(LavinMQ::AMQP::Stream)
+        stream = s.vhosts["/"].queues_byname(queue_name).as(LavinMQ::AMQP::Stream)
         stream.close
         stream.closed?.should be_true
         stream.restart!

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -329,7 +329,7 @@ describe LavinMQ::AMQP::Stream do
           q = ch.queue("stream-max-length", args: AMQP::Client::Arguments.new(args))
           data = Bytes.new(LavinMQ::Config.instance.segment_size)
           3.times { q.publish_confirm data }
-          dir = s.vhosts["/"].queues_byname("stream-max-length").as(LavinMQ::AMQP::Stream).@data_dir
+          dir = s.vhosts["/"].queue("stream-max-length").as(LavinMQ::AMQP::Stream).@data_dir
           File.exists?(File.join(dir, "msgs.0000000001")).should be_false
           File.exists?(File.join(dir, "meta.0000000001")).should be_false
           q.message_count.should eq 1
@@ -689,7 +689,7 @@ describe LavinMQ::AMQP::Stream do
           ch.prefetch 1
           args = {"x-queue-type": "stream"}
           q = ch.queue(queue_name, args: AMQP::Client::Arguments.new(args))
-          stream = s.vhosts["/"].queues_byname(queue_name).as(LavinMQ::AMQP::Stream)
+          stream = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Stream)
           q.publish_confirm "test message"
           stream.message_count.should eq 1
 
@@ -728,7 +728,7 @@ describe LavinMQ::AMQP::Stream do
         msg = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
         StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 1
 
-        stream = s.vhosts["/"].queues_byname(queue_name).as(LavinMQ::AMQP::Stream)
+        stream = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Stream)
         stream.close
         stream.closed?.should be_true
         stream.restart!

--- a/spec/stream_reader_spec.cr
+++ b/spec/stream_reader_spec.cr
@@ -15,7 +15,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}", q.name)
         end
 
-        iq = s.vhosts["/"].queues_byname(q.name).as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queue(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader 5
 
         count = 0
@@ -40,7 +40,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}" * 100, q.name)
         end
 
-        iq = s.vhosts["/"].queues_byname(q.name).as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queue(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader 0
 
         count = 0

--- a/spec/stream_reader_spec.cr
+++ b/spec/stream_reader_spec.cr
@@ -15,7 +15,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}", q.name)
         end
 
-        iq = s.vhosts["/"].queues[q.name].as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queues_byname(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader 5
 
         count = 0
@@ -40,7 +40,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}" * 100, q.name)
         end
 
-        iq = s.vhosts["/"].queues[q.name].as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queues_byname(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader 0
 
         count = 0

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -84,7 +84,7 @@ describe LavinMQ::Federation::Upstream do
           link = upstream.link(vhost_downstream.queue("federated_q"))
           link.name.should eq "federated_q"
           wait_for { link.state.running? }
-          vhost_upstream.queues_has_key?("federated_q").should be_true
+          vhost_upstream.queue_exists?("federated_q").should be_true
         end
       ensure
         upstream.try &.close
@@ -517,11 +517,11 @@ describe LavinMQ::Federation::Upstream do
           downstream_ex = ch.exchange("downstream_ex", "topic")
           link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
-          upstream_vhost.queues_has_key?(federation_name).should eq true
-          upstream_vhost.exchanges_has_key?(federation_name).should eq true
+          upstream_vhost.queue_exists?(federation_name).should eq true
+          upstream_vhost.exchange_exists?(federation_name).should eq true
           link.terminate
-          upstream_vhost.queues_has_key?(federation_name).should eq false
-          upstream_vhost.exchanges_has_key?(federation_name).should eq false
+          upstream_vhost.queue_exists?(federation_name).should eq false
+          upstream_vhost.exchange_exists?(federation_name).should eq false
         end
       end
     end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -61,7 +61,7 @@ module UpstreamSpecHelpers
       url.path = vhost_prev.name
       upstream = LavinMQ::Federation::Upstream.new(vhost, "ef from #{vhost_prev.name}", url.to_s, exchange: nil, queue: nil, max_hops: max_hops)
       upstreams << upstream
-      link = upstream.link(vhost.exchanges_byname("fe"))
+      link = upstream.link(vhost.exchange("fe"))
       wait_for { link.state.running? }
       vhost_prev = vhost
     end
@@ -81,7 +81,7 @@ describe LavinMQ::Federation::Upstream do
 
         with_channel(s) do |ch|
           ch.queue("federated_q")
-          link = upstream.link(vhost_downstream.queues_byname("federated_q"))
+          link = upstream.link(vhost_downstream.queue("federated_q"))
           link.name.should eq "federated_q"
           wait_for { link.state.running? }
           vhost_upstream.queues_has_key?("federated_q").should be_true
@@ -99,11 +99,11 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues_byname("federation_q2"))
+          upstream.link(vhost.queue("federation_q2"))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
-          vhost.queues_byname("federation_q1").message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -118,10 +118,10 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x = UpstreamSpecHelpers.setup_qs(ch).first
           x.publish_confirm "federate me", "federation_q1"
-          link = upstream.link(vhost.queues_byname("federation_q2"))
+          link = upstream.link(vhost.queue("federation_q2"))
           wait_for { link.state.running? }
-          vhost.queues_byname("federation_q1").message_count.should eq 1
-          vhost.queues_byname("federation_q2").message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 1
+          vhost.queue("federation_q2").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -137,11 +137,11 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues_byname("federation_q2"))
+          upstream.link(vhost.queue("federation_q2"))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
-          vhost.queues_byname("federation_q1").message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -157,11 +157,11 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues_byname("federation_q2"))
+          upstream.link(vhost.queue("federation_q2"))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
-          vhost.queues_byname("federation_q1").message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -182,7 +182,7 @@ describe LavinMQ::Federation::Upstream do
         downstream_vhost.declare_exchange("downstream_ex", "topic", true, false)
         downstream_vhost.declare_queue("downstream_q", true, false)
 
-        wait_for { downstream_vhost.queues_byname("downstream_q").policy.try(&.name) == "FE" }
+        wait_for { downstream_vhost.queue("downstream_q").policy.try(&.name) == "FE" }
         wait_for { upstream.links.first?.try &.state.running? }
 
         # Disconnect the federation link
@@ -210,7 +210,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues_byname("federation_q2"))
+          upstream.link(vhost.queue("federation_q2"))
           q2.subscribe do |msg|
             msgs << msg
           end
@@ -226,7 +226,7 @@ describe LavinMQ::Federation::Upstream do
           end
           wait_for { msgs.size == 2 }
           msgs.size.should eq 2
-          wait_for { vhost.queues_byname("federation_q1").message_count == 0 }
+          wait_for { vhost.queue("federation_q1").message_count == 0 }
         end
       ensure
         upstream.try &.close
@@ -241,7 +241,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1", props: AMQP::Client::Properties.new(content_type: "application/json")
-          upstream.link(vhost.queues_byname("federation_q2"))
+          upstream.link(vhost.queue("federation_q2"))
           msgs = [] of AMQP::Client::DeliverMessage
           q2.subscribe { |msg| msgs << msg }
           wait_for { msgs.size == 1 }
@@ -271,7 +271,7 @@ describe LavinMQ::Federation::Upstream do
         # consume 1 message
         with_channel(s, vhost: ds_vhost.name) do |downstream_ch|
           downstream_q = downstream_ch.queue(ds_queue_name)
-          wait_for { ds_vhost.queues_byname(ds_queue_name).policy.try(&.name) == "FE" }
+          wait_for { ds_vhost.queue(ds_queue_name).policy.try(&.name) == "FE" }
           wait_for { upstream.links.first?.try &.state.running? }
 
           msgs = Channel(String).new
@@ -279,10 +279,10 @@ describe LavinMQ::Federation::Upstream do
             msgs.send msg.body_io.to_s
           end
           msgs.should be_receiving "msg1"
-          wait_for { s.vhosts[ds_vhost.name].queues_byname(ds_queue_name).message_count == 0 }
+          wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).message_count == 0 }
         end
 
-        wait_for { s.vhosts[ds_vhost.name].queues_byname(ds_queue_name).consumers_empty? }
+        wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).consumers_empty? }
 
         # publish another message
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|
@@ -312,12 +312,12 @@ describe LavinMQ::Federation::Upstream do
         message_count = 2
 
         ds_vhost.declare_queue(ds_queue_name, true, false)
-        ds_queue = ds_vhost.queues_byname(ds_queue_name).as(LavinMQ::AMQP::Queue)
+        ds_queue = ds_vhost.queue(ds_queue_name).as(LavinMQ::AMQP::Queue)
 
         link = wait_for { upstream.links.first? }
         loop { link.@state_changed.receive.try &.running? && break }
 
-        us_queue = us_vhost.queues_byname(us_queue_name).as(LavinMQ::AMQP::Queue)
+        us_queue = us_vhost.queue(us_queue_name).as(LavinMQ::AMQP::Queue)
 
         # publish 2 messages to upstream queue
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|
@@ -379,8 +379,8 @@ describe LavinMQ::Federation::Upstream do
             vhost.declare_queue("q2", true, false)
 
             upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", nil, nil)
-            link1 = upstream.link(vhost.queues_byname("q1"))
-            link2 = upstream.link(vhost.queues_byname("q2"))
+            link1 = upstream.link(vhost.queue("q1"))
+            link2 = upstream.link(vhost.queue("q2"))
 
             link1.@upstream_q.should eq "q1"
             link2.@upstream_q.should eq "q2"
@@ -402,7 +402,7 @@ describe LavinMQ::Federation::Upstream do
           downstream_ex = ch.exchange("downstream_ex", "topic")
           downstream_q = ch.queue("downstream_q")
           downstream_q.bind(downstream_ex.name, "#")
-          link = upstream.link(vhost.exchanges_byname(downstream_ex.name))
+          link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
           upstream_ex = ch.exchange("upstream_ex", "topic", passive: true)
           upstream_ex.publish "federate me", "rk"
@@ -426,7 +426,7 @@ describe LavinMQ::Federation::Upstream do
           with_channel(s, vhost: "downstream") do |downstream_ch|
             upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
             downstream_ch.exchange("downstream_ex", "topic")
-            wait_for { downstream_vhost.exchanges_byname("downstream_ex").policy.try(&.name) == "FE" }
+            wait_for { downstream_vhost.exchange("downstream_ex").policy.try(&.name) == "FE" }
             # Assert setup is correct
             wait_for { upstream.links.first?.try &.state.running? }
             downstream_q = downstream_ch.queue("downstream_q")
@@ -475,7 +475,7 @@ describe LavinMQ::Federation::Upstream do
             # When state is running everything should be setup in the upstream
             wait_for { link.state.running? }
 
-            us_queue = upstream_vhost.queues_byname(link.@upstream_q).should be_a LavinMQ::AMQP::Queue
+            us_queue = upstream_vhost.queue(link.@upstream_q).should be_a LavinMQ::AMQP::Queue
             us_queue.consumers_empty.when_true.receive
 
             upstream_ex.publish_confirm "msg1", "rk1"
@@ -515,7 +515,7 @@ describe LavinMQ::Federation::Upstream do
 
         with_channel(s) do |ch|
           downstream_ex = ch.exchange("downstream_ex", "topic")
-          link = upstream.link(vhost.exchanges_byname(downstream_ex.name))
+          link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
           upstream_vhost.queues_has_key?(federation_name).should eq true
           upstream_vhost.exchanges_has_key?(federation_name).should eq true
@@ -535,7 +535,7 @@ describe LavinMQ::Federation::Upstream do
           vhost.declare_exchange("ex1", "topic", true, false)
 
           upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", {{v}})
-          link1 = upstream.link(vhost.exchanges_byname("ex1"))
+          link1 = upstream.link(vhost.exchange("ex1"))
 
           link1.@upstream_exchange.should eq "ex1"
         end
@@ -553,7 +553,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish "foo", "federation_q1"
-          upstream.link(vhost.queues_byname("federation_q2"))
+          upstream.link(vhost.queue("federation_q2"))
           msgs = [] of AMQP::Client::DeliverMessage
           wg = WaitGroup.new(1)
           q2.subscribe do |msg|
@@ -580,9 +580,9 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_queue("q2", durable: true, auto_delete: false)
         vhost3.declare_queue("q3", durable: true, auto_delete: false)
 
-        vhost1.queues_byname("q1")
-        q2 = vhost2.queues_byname("q2")
-        q3 = vhost3.queues_byname("q3")
+        vhost1.queue("q1")
+        q2 = vhost2.queue("q2")
+        q3 = vhost3.queue("q3")
 
         url = URI.parse(s.amqp_url)
 
@@ -642,7 +642,7 @@ describe LavinMQ::Federation::Upstream do
           UpstreamSpecHelpers.start_link(upstream)
           wait_for { upstream.links.first?.try &.state.running? }
 
-          upstream_ex = upstream_vhost.exchanges_byname("upstream_ex").as(LavinMQ::AMQP::Exchange)
+          upstream_ex = upstream_vhost.exchange("upstream_ex").as(LavinMQ::AMQP::Exchange)
           upstream_ex.bindings_details.size.should eq queues.size
 
           10.times do |i|
@@ -667,8 +667,8 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_exchange("downstream_ex", "topic", durable: true, auto_delete: false)
         vhost2.declare_queue("downstream_q", durable: true, auto_delete: false)
 
-        downstream_ex = vhost2.exchanges_byname("downstream_ex")
-        downstream_q = vhost2.queues_byname("downstream_q")
+        downstream_ex = vhost2.exchange("downstream_ex")
+        downstream_q = vhost2.queue("downstream_q")
         downstream_ex.bind(downstream_q, "#")
 
         url = URI.parse(s.amqp_url)
@@ -710,13 +710,13 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_exchange("ex2", "topic", durable: true, auto_delete: false)
         vhost3.declare_exchange("ex3", "topic", durable: true, auto_delete: false)
 
-        ex1 = vhost1.exchanges_byname("ex1")
-        ex2 = vhost2.exchanges_byname("ex2")
-        ex3 = vhost3.exchanges_byname("ex3")
+        ex1 = vhost1.exchange("ex1")
+        ex2 = vhost2.exchange("ex2")
+        ex3 = vhost3.exchange("ex3")
 
         vhost3.declare_queue("q3", durable: true, auto_delete: false)
-        downstream_q = vhost3.queues_byname("q3")
-        downstream_ex = vhost3.exchanges_byname("ex3")
+        downstream_q = vhost3.queue("q3")
+        downstream_ex = vhost3.exchange("ex3")
 
         url = URI.parse(s.amqp_url)
 
@@ -769,11 +769,11 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_exchange("downstream_ex", "topic", durable: true, auto_delete: false)
         vhost2.declare_queue("downstream_q", durable: true, auto_delete: false)
 
-        downstream_ex = vhost2.exchanges_byname("downstream_ex")
-        downstream_q = vhost2.queues_byname("downstream_q")
+        downstream_ex = vhost2.exchange("downstream_ex")
+        downstream_q = vhost2.queue("downstream_q")
         downstream_ex.bind(downstream_q, "federation.link.rk")
 
-        upstream_ex = vhost1.exchanges_byname("upstream_ex")
+        upstream_ex = vhost1.exchange("upstream_ex")
 
         url = URI.parse(s.amqp_url)
         url.path = vhost1.name
@@ -798,9 +798,9 @@ describe LavinMQ::Federation::Upstream do
         with_http_server do |_http, s|
           UpstreamSpecHelpers.with_fe_chain(s, chain_length: 10) do
             downstream_vhost = s.vhosts["v10"]
-            downstream_ex = downstream_vhost.exchanges_byname("fe")
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues_byname("q")
+            q = downstream_vhost.queue("q")
             # This binding should be propagated all the way to "fe" in "v1"
             # For each hop x-bound-from should be extended with one new entry
             downstream_ex.bind(q, "spec.routing.key")
@@ -808,7 +808,7 @@ describe LavinMQ::Federation::Upstream do
             # Verify bindings on exchange "fe" from vhost v1 to
             # vhost v9.
             1.to(9) do |i|
-              fe = s.vhosts["v#{i}"].exchanges_byname("fe")
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 1
               fe_bk = fe.bindings_details.first.binding_key
               args = fe_bk.arguments.should_not be_nil
@@ -839,9 +839,9 @@ describe LavinMQ::Federation::Upstream do
             us.max_hops = 1
 
             downstream_vhost = s.vhosts["v10"]
-            downstream_ex = downstream_vhost.exchanges_byname("fe")
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues_byname("q")
+            q = downstream_vhost.queue("q")
             # This binding should only be propagated to "fe" in "v4", because
             # max_hops on v5 is 1.
             downstream_ex.bind(q, "spec.routing.key")
@@ -849,14 +849,14 @@ describe LavinMQ::Federation::Upstream do
             # Verify bindings on exchange "fe" from vhost v1 to
             # vhost v4.
             1.to(3) do |i|
-              fe = s.vhosts["v#{i}"].exchanges_byname("fe")
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 0
             end
 
             # Verify bindings on exchange "fe" from vhost v4 to
             # vhost v9.
             4.to(9) do |i|
-              fe = s.vhosts["v#{i}"].exchanges_byname("fe")
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 1
               fe_bk = fe.bindings_details.first.binding_key
               args = fe_bk.arguments.should_not be_nil
@@ -886,9 +886,9 @@ describe LavinMQ::Federation::Upstream do
             us.max_hops = 3
 
             downstream_vhost = s.vhosts["v10"]
-            downstream_ex = downstream_vhost.exchanges_byname("fe")
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues_byname("q")
+            q = downstream_vhost.queue("q")
             # This binding should only be propagated to "fe" in "v4", because
             # max_hops on v5 is 1.
             downstream_ex.bind(q, "spec.routing.key")
@@ -896,14 +896,14 @@ describe LavinMQ::Federation::Upstream do
             # Verify bindings on exchange "fe" from vhost v1 to
             # vhost v6.
             1.to(6) do |i|
-              fe = s.vhosts["v#{i}"].exchanges_byname("fe")
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 0
             end
 
             # Verify bindings on exchange "fe" from vhost v7 to
             # vhost v9.
             7.to(9) do |i|
-              fe = s.vhosts["v#{i}"].exchanges_byname("fe")
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq(1), "FE in vhost v#{i} should have one binding"
               fe_bk = fe.bindings_details.first.binding_key
               args = fe_bk.arguments.should_not be_nil
@@ -926,9 +926,9 @@ describe LavinMQ::Federation::Upstream do
         with_http_server do |_http, s|
           UpstreamSpecHelpers.with_fe_chain(s, chain_length: 3) do
             downstream_vhost = s.vhosts["v3"]
-            downstream_ex = downstream_vhost.exchanges_byname("fe")
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues_byname("q")
+            q = downstream_vhost.queue("q")
             downstream_ex.bind(q, "spec.routing.key")
 
             with_channel(s, vhost: "v1") do |ch|
@@ -945,9 +945,9 @@ describe LavinMQ::Federation::Upstream do
               ch.exchange("fe", "topic").publish_confirm "foo", "spec.routing.key", props: props
             end
 
-            v1fe = s.vhosts["v1"].exchanges_byname("fe")
-            v2fe = s.vhosts["v2"].exchanges_byname("fe")
-            v3fe = s.vhosts["v3"].exchanges_byname("fe")
+            v1fe = s.vhosts["v1"].exchange("fe")
+            v2fe = s.vhosts["v2"].exchange("fe")
+            v3fe = s.vhosts["v3"].exchange("fe")
 
             # We have no good synchronization point, so we yield a few times (instead of sleep)
             # to make sure the message has been processed all the way

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -282,7 +282,7 @@ describe LavinMQ::Federation::Upstream do
           wait_for { s.vhosts[ds_vhost.name].queues_byname(ds_queue_name).message_count == 0 }
         end
 
-        wait_for { s.vhosts[ds_vhost.name].queues_byname(ds_queue_name).consumers.empty? }
+        wait_for { s.vhosts[ds_vhost.name].queues_byname(ds_queue_name).consumers_empty? }
 
         # publish another message
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -30,7 +30,7 @@ describe LavinMQ::VHost do
       v = s.vhosts["test"].not_nil!
       v.declare_exchange("e", "direct", true, false)
       s.restart
-      s.vhosts["test"].exchanges["e"].should_not be_nil
+      s.vhosts["test"].exchanges_byname("e").should_not be_nil
     end
   end
 
@@ -59,7 +59,7 @@ describe LavinMQ::VHost do
       v = s.vhosts["test"].not_nil!
       v.declare_queue("q", true, false)
       s.restart
-      s.vhosts["test"].queues["q"].should_not be_nil
+      s.vhosts["test"].queues_byname("q").should_not be_nil
     end
   end
 
@@ -71,7 +71,7 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.restart
-      s.vhosts["test"].exchanges["e"].bindings_details.first.destination.name.should eq "q"
+      s.vhosts["test"].exchanges_byname("e").bindings_details.first.destination.name.should eq "q"
     end
   end
 

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -30,7 +30,7 @@ describe LavinMQ::VHost do
       v = s.vhosts["test"].not_nil!
       v.declare_exchange("e", "direct", true, false)
       s.restart
-      s.vhosts["test"].exchanges_byname("e").should_not be_nil
+      s.vhosts["test"].exchange("e").should_not be_nil
     end
   end
 
@@ -59,7 +59,7 @@ describe LavinMQ::VHost do
       v = s.vhosts["test"].not_nil!
       v.declare_queue("q", true, false)
       s.restart
-      s.vhosts["test"].queues_byname("q").should_not be_nil
+      s.vhosts["test"].queue("q").should_not be_nil
     end
   end
 
@@ -71,7 +71,7 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.restart
-      s.vhosts["test"].exchanges_byname("e").bindings_details.first.destination.name.should eq "q"
+      s.vhosts["test"].exchange("e").bindings_details.first.destination.name.should eq "q"
     end
   end
 

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -26,7 +26,7 @@ describe LavinMQ::VHost do
     it "should not delete stats when connection is closed" do
       with_amqp_server do |s|
         vhost = s.vhosts["/"]
-        wait_for { s.connections.sum(&.channels.size).zero? }
+        wait_for { s.connections.sum(&.channels_size).zero? }
 
         s.update_stats_rates
         initial_channels_created = vhost.channel_created_count

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -58,7 +58,7 @@ describe LavinMQ::VHost do
           vhost.connection_closed_count.should eq(initial_connections_closed)
         end
 
-        wait_for { vhost.@connections.empty? }
+        wait_for { vhost.connections_size == 0 }
 
         s.update_stats_rates
         vhost.connection_created_count.should eq(initial_connections_created + 1)

--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -45,7 +45,7 @@ module LavinMQ::AMQP
         def route(msg : BytesMessage, reason) # ameba:disable Metrics/CyclomaticComplexity
           # No dead letter exchange => nothing to do
           return unless dlx = (msg.dlx || dlx())
-          ex = @vhost.exchanges_byname?(dlx.to_s) || return
+          ex = @vhost.exchange?(dlx.to_s) || return
 
           dlrk = msg.dlrk || dlrk()
 

--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -45,7 +45,7 @@ module LavinMQ::AMQP
         def route(msg : BytesMessage, reason) # ameba:disable Metrics/CyclomaticComplexity
           # No dead letter exchange => nothing to do
           return unless dlx = (msg.dlx || dlx())
-          ex = @vhost.exchanges[dlx.to_s]? || return
+          ex = @vhost.exchanges_byname?(dlx.to_s) || return
 
           dlrk = msg.dlrk || dlrk()
 

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -111,7 +111,7 @@ module LavinMQ
           return
         end
         raise LavinMQ::Error::UnexpectedFrame.new(frame) if @next_publish_exchange_name
-        if ex = @client.vhost.exchanges[frame.exchange]?
+        if ex = @client.vhost.exchanges_byname?(frame.exchange)
           if !ex.internal?
             @next_publish_exchange_name = frame.exchange
             @next_publish_routing_key = frame.routing_key
@@ -300,7 +300,7 @@ module LavinMQ
       private def direct_reply?(msg) : Bool
         return false unless msg.routing_key.starts_with? "amq.direct.reply-to."
         consumer_tag = msg.routing_key[20..]
-        if ch = @client.vhost.direct_reply_consumers[consumer_tag]?
+        if ch = @client.vhost.direct_reply_consumer?(consumer_tag)
           confirm do
             deliver = AMQP::Frame::Basic::Deliver.new(ch.id, consumer_tag,
               1_u64, false,
@@ -363,11 +363,11 @@ module LavinMQ
           end
           @log.debug { "Saving direct reply consumer #{frame.consumer_tag}" }
           @direct_reply_consumer = frame.consumer_tag
-          @client.vhost.direct_reply_consumers[frame.consumer_tag] = self
+          @client.vhost.direct_reply_consumer_set(frame.consumer_tag, self)
           unless frame.no_wait
             send AMQP::Frame::Basic::ConsumeOk.new(frame.channel, frame.consumer_tag)
           end
-        elsif q = @client.vhost.queues[frame.queue]?
+        elsif q = @client.vhost.queues_byname?(frame.queue)
           if @client.queue_exclusive_to_other_client?(q)
             @client.send_resource_locked(frame, "Exclusive queue")
             return
@@ -393,7 +393,7 @@ module LavinMQ
       end
 
       def basic_get(frame)
-        if q = @client.vhost.queues.fetch(frame.queue, nil)
+        if q = @client.vhost.queues_fetch(frame.queue, nil)
           if @client.queue_exclusive_to_other_client?(q)
             @client.send_resource_locked(frame, "Exclusive queue")
           elsif q.has_exclusive_consumer?
@@ -656,7 +656,7 @@ module LavinMQ
         end
         @consumers.clear
         if drc = @direct_reply_consumer
-          @client.vhost.direct_reply_consumers.delete(drc)
+          @client.vhost.direct_reply_consumer_delete(drc)
         end
         @unack_lock.synchronize do
           @unacked.each do |unack|
@@ -729,7 +729,7 @@ module LavinMQ
           c.close
         elsif @direct_reply_consumer == frame.consumer_tag
           @direct_reply_consumer = nil
-          @client.vhost.direct_reply_consumers.delete(frame.consumer_tag)
+          @client.vhost.direct_reply_consumer_delete(frame.consumer_tag)
         end
         unless frame.no_wait
           send AMQP::Frame::Basic::CancelOk.new(frame.channel, frame.consumer_tag)

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -413,7 +413,7 @@ module LavinMQ
             ok = q.basic_get(frame.no_ack) do |env|
               delivery_tag = next_delivery_tag(q, env.segment_position, frame.no_ack, nil)
               unless frame.no_ack # track unacked messages
-                q.basic_get_unacked << UnackedMessage.new(self, delivery_tag, RoughTime.instant)
+                q.basic_get_unacked_push(UnackedMessage.new(self, delivery_tag, RoughTime.instant))
               end
               get_ok = AMQP::Frame::Basic::GetOk.new(frame.channel, delivery_tag,
                 env.redelivered, env.message.exchange_name,
@@ -509,7 +509,7 @@ module LavinMQ
           c.ack(unack.sp)
         end
         unack.queue.ack(unack.sp)
-        unack.queue.basic_get_unacked.reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
+        unack.queue.basic_get_unacked_reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
         @client.vhost.event_tick(EventType::ClientAck)
         @ack_count.add(1, :relaxed)
       end
@@ -588,7 +588,7 @@ module LavinMQ
           c.reject(unack.sp, requeue)
         end
         unack.queue.reject(unack.sp, requeue)
-        unack.queue.basic_get_unacked.reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
+        unack.queue.basic_get_unacked_reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
         @reject_count.add(1, :relaxed)
         @client.vhost.event_tick(EventType::ClientReject)
       end
@@ -662,7 +662,7 @@ module LavinMQ
           @unacked.each do |unack|
             @log.debug { "Requeing unacked msg #{unack.sp}" }
             unack.queue.reject(unack.sp, true)
-            unack.queue.basic_get_unacked.reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
+            unack.queue.basic_get_unacked_reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
           end
           @unacked.clear
         end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -393,7 +393,7 @@ module LavinMQ
       end
 
       def basic_get(frame)
-        if q = @client.vhost.queues_fetch(frame.queue, nil)
+        if q = @client.vhost.queue?(frame.queue)
           if @client.queue_exclusive_to_other_client?(q)
             @client.send_resource_locked(frame, "Exclusive queue")
           elsif q.has_exclusive_consumer?

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -111,7 +111,7 @@ module LavinMQ
           return
         end
         raise LavinMQ::Error::UnexpectedFrame.new(frame) if @next_publish_exchange_name
-        if ex = @client.vhost.exchanges_byname?(frame.exchange)
+        if ex = @client.vhost.exchange?(frame.exchange)
           if !ex.internal?
             @next_publish_exchange_name = frame.exchange
             @next_publish_routing_key = frame.routing_key
@@ -367,7 +367,7 @@ module LavinMQ
           unless frame.no_wait
             send AMQP::Frame::Basic::ConsumeOk.new(frame.channel, frame.consumer_tag)
           end
-        elsif q = @client.vhost.queues_byname?(frame.queue)
+        elsif q = @client.vhost.queue?(frame.queue)
           if @client.queue_exclusive_to_other_client?(q)
             @client.send_resource_locked(frame, "Exclusive queue")
             return

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -424,10 +424,10 @@ module LavinMQ
         when AMQP::Frame::Channel::Open
           open_channel(frame)
         when AMQP::Frame::Channel::Close
-          @channels.lock { |chs| chs.delete(frame.channel) }.try &.close
+          @channels.lock(&.delete(frame.channel)).try &.close
           send AMQP::Frame::Channel::CloseOk.new(frame.channel), true
         when AMQP::Frame::Channel::CloseOk
-          @channels.lock { |chs| chs.delete(frame.channel) }.try &.close
+          @channels.lock(&.delete(frame.channel)).try &.close
         when AMQP::Frame::Channel::Flow
           with_channel frame, &.flow(frame.active)
         when AMQP::Frame::Channel::FlowOk
@@ -555,7 +555,7 @@ module LavinMQ
         else
           send AMQP::Frame::Channel::Close.new(frame.channel, code.value, text, 0, 0)
         end
-        @channels.lock { |chs| chs.delete(frame.channel) }.try &.close
+        @channels.lock(&.delete(frame.channel)).try &.close
       end
 
       def close_connection(frame : AMQ::Protocol::Frame?, code : ConnectionReplyCode, text)
@@ -609,7 +609,7 @@ module LavinMQ
           @running.set(false, :release)
         else
           send AMQP::Frame::Channel::Close.new(ex.channel, code.value, code.to_s, ex.class_id, ex.method_id)
-          @channels.lock { |chs| chs.delete(ex.channel) }.try &.close
+          @channels.lock(&.delete(ex.channel)).try &.close
         end
       end
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -670,7 +670,7 @@ module LavinMQ
           send_access_refused(frame, "Not allowed to delete the default exchange")
         elsif NameValidator.reserved_prefix?(frame.exchange_name)
           send_access_refused(frame, "Prefix #{NameValidator::PREFIX_LIST} forbidden, please choose another name")
-        elsif !@vhost.exchanges_has_key? frame.exchange_name
+        elsif !@vhost.exchange_exists? frame.exchange_name
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Exchange::DeleteOk.new(frame.channel) unless frame.no_wait
         elsif !@user.can_config?(@vhost.name, frame.exchange_name)
@@ -802,7 +802,7 @@ module LavinMQ
         q = @vhost.queue?(frame.queue_name)
         if q.nil?
           send_not_found frame, "Queue '#{frame.queue_name}' not found"
-        elsif !@vhost.exchanges_has_key? frame.exchange_name
+        elsif !@vhost.exchange_exists? frame.exchange_name
           send_not_found frame, "Exchange '#{frame.exchange_name}' not found"
         elsif !@user.can_read?(@vhost.name, frame.exchange_name)
           send_access_refused(frame, "User '#{@user.name}' doesn't have read permissions to exchange '#{frame.exchange_name}'")
@@ -830,7 +830,7 @@ module LavinMQ
         if q.nil?
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)
-        elsif !@vhost.exchanges_has_key? frame.exchange_name
+        elsif !@vhost.exchange_exists? frame.exchange_name
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)
         elsif !@user.can_read?(@vhost.name, frame.exchange_name)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -675,7 +675,7 @@ module LavinMQ
           send AMQP::Frame::Exchange::DeleteOk.new(frame.channel) unless frame.no_wait
         elsif !@user.can_config?(@vhost.name, frame.exchange_name)
           send_access_refused(frame, "User '#{@user.name}' doesn't have permissions to delete exchange '#{frame.exchange_name}'")
-        elsif frame.if_unused && @vhost.exchanges_byname(frame.exchange_name).in_use?
+        elsif frame.if_unused && @vhost.exchange(frame.exchange_name).in_use?
           send_precondition_failed(frame, "Exchange '#{frame.exchange_name}' in use")
         else
           @vhost.apply(frame)
@@ -781,7 +781,7 @@ module LavinMQ
         @vhost.apply(frame)
         @last_queue_name = frame.queue_name
         if frame.exclusive
-          @exclusive_queues << @vhost.queues_byname(frame.queue_name)
+          @exclusive_queues << @vhost.queue(frame.queue_name)
         end
         unless frame.no_wait
           send AMQP::Frame::Queue::DeclareOk.new(frame.channel, frame.queue_name, 0_u32, 0_u32)
@@ -799,7 +799,7 @@ module LavinMQ
         end
         return unless valid_q_bind_unbind?(frame)
 
-        q = @vhost.queues_byname?(frame.queue_name)
+        q = @vhost.queue?(frame.queue_name)
         if q.nil?
           send_not_found frame, "Queue '#{frame.queue_name}' not found"
         elsif !@vhost.exchanges_has_key? frame.exchange_name
@@ -826,7 +826,7 @@ module LavinMQ
         end
         return unless valid_q_bind_unbind?(frame)
 
-        q = @vhost.queues_byname?(frame.queue_name)
+        q = @vhost.queue?(frame.queue_name)
         if q.nil?
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -599,7 +599,7 @@ module LavinMQ
           send_precondition_failed(frame, "Exchange name isn't valid")
         elsif frame.exchange_name.empty?
           send_access_refused(frame, "Not allowed to declare the default exchange")
-        elsif e = @vhost.exchanges.fetch(frame.exchange_name, nil)
+        elsif e = @vhost.exchanges_fetch(frame.exchange_name, nil)
           redeclare_exchange(e, frame)
         elsif frame.passive
           send_passive_not_found(frame, "Exchange '#{frame.exchange_name}' doesn't exists")
@@ -638,12 +638,12 @@ module LavinMQ
           send_access_refused(frame, "Not allowed to delete the default exchange")
         elsif NameValidator.reserved_prefix?(frame.exchange_name)
           send_access_refused(frame, "Prefix #{NameValidator::PREFIX_LIST} forbidden, please choose another name")
-        elsif !@vhost.exchanges.has_key? frame.exchange_name
+        elsif !@vhost.exchanges_has_key? frame.exchange_name
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Exchange::DeleteOk.new(frame.channel) unless frame.no_wait
         elsif !@user.can_config?(@vhost.name, frame.exchange_name)
           send_access_refused(frame, "User '#{@user.name}' doesn't have permissions to delete exchange '#{frame.exchange_name}'")
-        elsif frame.if_unused && @vhost.exchanges[frame.exchange_name].in_use?
+        elsif frame.if_unused && @vhost.exchanges_byname(frame.exchange_name).in_use?
           send_precondition_failed(frame, "Exchange '#{frame.exchange_name}' in use")
         else
           @vhost.apply(frame)
@@ -660,7 +660,7 @@ module LavinMQ
           send_precondition_failed(frame, "Queue name isn't valid")
           return
         end
-        q = @vhost.queues.fetch(frame.queue_name, nil)
+        q = @vhost.queues_fetch(frame.queue_name, nil)
         if q.nil?
           send AMQP::Frame::Queue::DeleteOk.new(frame.channel, 0_u32) unless frame.no_wait
         elsif queue_exclusive_to_other_client?(q)
@@ -686,7 +686,7 @@ module LavinMQ
       private def declare_queue(frame)
         if !frame.queue_name.empty? && !NameValidator.valid_entity_name?(frame.queue_name)
           send_precondition_failed(frame, "Queue name isn't valid")
-        elsif q = @vhost.queues.fetch(frame.queue_name, nil)
+        elsif q = @vhost.queues_fetch(frame.queue_name, nil)
           redeclare_queue(frame, q)
         elsif {"amq.rabbitmq.reply-to", "amq.direct.reply-to"}.includes? frame.queue_name
           unless frame.no_wait
@@ -694,7 +694,7 @@ module LavinMQ
           end
         elsif frame.queue_name.starts_with?("amq.direct.reply-to.")
           consumer_tag = frame.queue_name[20..]
-          if @vhost.direct_reply_consumers.has_key? consumer_tag
+          if @vhost.direct_reply_consumer_has_key? consumer_tag
             send AMQP::Frame::Queue::DeclareOk.new(frame.channel, frame.queue_name, 0_u32, 1_u32)
           else
             send_not_found(frame, "Queue '#{frame.queue_name}' doesn't exists")
@@ -703,7 +703,7 @@ module LavinMQ
           send_passive_not_found(frame, "Queue '#{frame.queue_name}' doesn't exists")
         elsif NameValidator.reserved_prefix?(frame.queue_name)
           send_access_refused(frame, "Prefix #{NameValidator::PREFIX_LIST} forbidden, please choose another name")
-        elsif @vhost.max_queues.try { |max| @vhost.queues.size >= max }
+        elsif @vhost.max_queues.try { |max| @vhost.queues_size >= max }
           send_access_refused(frame, "queue limit in vhost '#{@vhost.name}' (#{@vhost.max_queues}) is reached")
         else
           declare_new_queue(frame)
@@ -749,7 +749,7 @@ module LavinMQ
         @vhost.apply(frame)
         @last_queue_name = frame.queue_name
         if frame.exclusive
-          @exclusive_queues << @vhost.queues[frame.queue_name]
+          @exclusive_queues << @vhost.queues_byname(frame.queue_name)
         end
         unless frame.no_wait
           send AMQP::Frame::Queue::DeclareOk.new(frame.channel, frame.queue_name, 0_u32, 0_u32)
@@ -767,10 +767,10 @@ module LavinMQ
         end
         return unless valid_q_bind_unbind?(frame)
 
-        q = @vhost.queues[frame.queue_name]?
+        q = @vhost.queues_byname?(frame.queue_name)
         if q.nil?
           send_not_found frame, "Queue '#{frame.queue_name}' not found"
-        elsif !@vhost.exchanges.has_key? frame.exchange_name
+        elsif !@vhost.exchanges_has_key? frame.exchange_name
           send_not_found frame, "Exchange '#{frame.exchange_name}' not found"
         elsif !@user.can_read?(@vhost.name, frame.exchange_name)
           send_access_refused(frame, "User '#{@user.name}' doesn't have read permissions to exchange '#{frame.exchange_name}'")
@@ -794,11 +794,11 @@ module LavinMQ
         end
         return unless valid_q_bind_unbind?(frame)
 
-        q = @vhost.queues[frame.queue_name]?
+        q = @vhost.queues_byname?(frame.queue_name)
         if q.nil?
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)
-        elsif !@vhost.exchanges.has_key? frame.exchange_name
+        elsif !@vhost.exchanges_has_key? frame.exchange_name
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)
         elsif !@user.can_read?(@vhost.name, frame.exchange_name)
@@ -829,8 +829,8 @@ module LavinMQ
       end
 
       private def bind_exchange(frame)
-        source = @vhost.exchanges.fetch(frame.source, nil)
-        destination = @vhost.exchanges.fetch(frame.destination, nil)
+        source = @vhost.exchanges_fetch(frame.source, nil)
+        destination = @vhost.exchanges_fetch(frame.destination, nil)
         if destination.nil?
           send_not_found frame, "Exchange '#{frame.destination}' doesn't exists"
         elsif source.nil?
@@ -848,8 +848,8 @@ module LavinMQ
       end
 
       private def unbind_exchange(frame)
-        source = @vhost.exchanges.fetch(frame.source, nil)
-        destination = @vhost.exchanges.fetch(frame.destination, nil)
+        source = @vhost.exchanges_fetch(frame.source, nil)
+        destination = @vhost.exchanges_fetch(frame.destination, nil)
         if destination.nil?
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Exchange::UnbindOk.new(frame.channel)
@@ -878,7 +878,7 @@ module LavinMQ
         end
         if !NameValidator.valid_entity_name?(frame.queue_name)
           send_precondition_failed(frame, "Queue name isn't valid")
-        elsif q = @vhost.queues.fetch(frame.queue_name, nil)
+        elsif q = @vhost.queues_fetch(frame.queue_name, nil)
           if queue_exclusive_to_other_client?(q)
             send_resource_locked(frame, "Queue '#{q.name}' is exclusive")
           else

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -169,7 +169,7 @@ module LavinMQ
         vhost_name = open.vhost.empty? ? "/" : open.vhost
         if vhost = @vhosts[vhost_name]?
           if user.find_permission(vhost_name)
-            if vhost.max_connections.try { |max| vhost.connections.size >= max }
+            if vhost.max_connections.try { |max| vhost.connections_size >= max }
               log.warn { "Max connections (#{vhost.max_connections}) reached for vhost #{vhost_name}" }
               reply_text = "access to vhost '#{vhost_name}' refused: connection limit (#{vhost.max_connections}) is reached"
               return close_connection(socket, ConnectionReplyCode::NOT_ALLOWED, reply_text, open)

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -230,7 +230,7 @@ module LavinMQ
 
       def cancel
         @channel.send AMQP::Frame::Basic::Cancel.new(@channel.id, @tag, no_wait: true)
-        @channel.consumers.delete self
+        @channel.consumers_delete(self)
         close
       end
 

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -135,14 +135,16 @@ module LavinMQ
         if @queue.has_priority_consumers? && @queue.single_active_consumer.nil?
           @log.debug { "Waiting for higher priority consumers to not have capacity" }
           flush
-          higher_prio_consumers = @queue.consumers.select { |c| c.priority > @priority }
+          higher_prio_consumers = Array(Client::Channel::Consumer).new
+          @queue.consumers_each { |c| higher_prio_consumers << c if c.priority > @priority }
           return false unless higher_prio_consumers.any? &.accepts?
           loop do
             # FIXME: doesnt take into account that new higher prio consumer might connect
             ::Channel.receive_first(higher_prio_consumers.map(&.has_capacity.when_false))
             break
           rescue ::Channel::ClosedError
-            higher_prio_consumers = @queue.consumers.select { |c| c.priority > @priority }
+            higher_prio_consumers = Array(Client::Channel::Consumer).new
+            @queue.consumers_each { |c| higher_prio_consumers << c if c.priority > @priority }
             break if higher_prio_consumers.empty?
             next
           end

--- a/src/lavinmq/amqp/exchange/default.cr
+++ b/src/lavinmq/amqp/exchange/default.cr
@@ -12,7 +12,7 @@ module LavinMQ
       end
 
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
-        if q = @vhost.queues_byname?(routing_key)
+        if q = @vhost.queue?(routing_key)
           yield q
         end
       end

--- a/src/lavinmq/amqp/exchange/default.cr
+++ b/src/lavinmq/amqp/exchange/default.cr
@@ -12,7 +12,7 @@ module LavinMQ
       end
 
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
-        if q = @vhost.queues[routing_key]?
+        if q = @vhost.queues_byname?(routing_key)
           yield q
         end
       end

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -271,7 +271,7 @@ module LavinMQ
         end
 
         if queues.empty? && (ae_name = alternate_exchange)
-          @vhost.exchanges_byname?(ae_name).try do |ae|
+          @vhost.exchange?(ae_name).try do |ae|
             ae.find_queues(routing_key, headers, queues, exchanges)
           end
         end

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -135,7 +135,7 @@ module LavinMQ
 
       def in_use?
         return true unless bindings_details.empty?
-        @vhost.exchanges.any? do |_, x|
+        @vhost.exchanges_any? do |_, x|
           x.bindings_details.any? { |bd| bd.destination == self }
         end
       end
@@ -146,7 +146,7 @@ module LavinMQ
 
         @delayed_queue = queue = AMQP::DelayedExchangeQueue.create(@vhost, @name, durable: durable?, auto_delete: @auto_delete)
 
-        @vhost.queues[queue.name] = queue
+        @vhost.queues_unsafe_put(queue.name, queue)
       end
 
       REPUBLISH_HEADERS = {"x-head", "x-tail", "x-from"}
@@ -270,8 +270,8 @@ module LavinMQ
           find_cc_queues(hdrs, "BCC", queues)
         end
 
-        if queues.empty? && alternate_exchange
-          @vhost.exchanges[alternate_exchange]?.try do |ae|
+        if queues.empty? && (ae_name = alternate_exchange)
+          @vhost.exchanges_byname?(ae_name).try do |ae|
             ae.find_queues(routing_key, headers, queues, exchanges)
           end
         end

--- a/src/lavinmq/amqp/exchange/fanout.cr
+++ b/src/lavinmq/amqp/exchange/fanout.cr
@@ -1,24 +1,30 @@
+require "sync/shared"
 require "./exchange"
 
 module LavinMQ
   module AMQP
     class FanoutExchange < Exchange
-      @bindings = Set({Destination, BindingKey}).new
+      @bindings : Sync::Shared(Set({Destination, BindingKey})) = Sync::Shared.new(Set({Destination, BindingKey}).new)
 
       def type : String
         "fanout"
       end
 
       def bindings_details : Iterator(BindingDetails)
-        @bindings.each.map do |d, binding_key|
-          BindingDetails.new(name, vhost.name, binding_key, d)
-        end
+        @bindings.shared do |bindings|
+          bindings.map do |d, binding_key|
+            BindingDetails.new(name, vhost.name, binding_key, d)
+          end
+        end.each
       end
 
       def bind(destination : Destination, routing_key, arguments = nil)
         validate_delayed_binding!(destination)
         binding_key = BindingKey.new(routing_key, arguments)
-        return false unless @bindings.add?({destination, binding_key})
+        added = @bindings.lock do |bindings|
+          bindings.add?({destination, binding_key})
+        end
+        return false unless added
         data = BindingDetails.new(name, vhost.name, binding_key, destination)
         notify_observers(ExchangeEvent::Bind, data)
         true
@@ -26,16 +32,22 @@ module LavinMQ
 
       def unbind(destination : Destination, routing_key, arguments = nil)
         binding_key = BindingKey.new(routing_key, arguments)
-        return false unless @bindings.delete({destination, binding_key})
+        result = @bindings.lock do |bindings|
+          deleted = bindings.delete({destination, binding_key})
+          {deleted, deleted && @auto_delete && bindings.empty?}
+        end
+        return false unless result[0]
         data = BindingDetails.new(name, vhost.name, binding_key, destination)
         notify_observers(ExchangeEvent::Unbind, data)
-        delete if @auto_delete && @bindings.empty?
+        delete if result[1]
         true
       end
 
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
-        @bindings.each do |destination, _binding_key|
-          yield destination
+        @bindings.shared do |bindings|
+          bindings.each do |destination, _binding_key|
+            yield destination
+          end
         end
       end
     end

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -126,7 +126,7 @@ module LavinMQ::AMQP
         headers.delete("x-delay")
         msg.properties.headers = headers
       end
-      @vhost.exchanges[@exchange_name].route_msg Message.new(msg.timestamp, @exchange_name, msg.routing_key,
+      @vhost.exchanges_byname(@exchange_name).route_msg Message.new(msg.timestamp, @exchange_name, msg.routing_key,
         msg.properties, msg.bodysize, IO::Memory.new(msg.body))
       delete_message sp
     end

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -126,7 +126,7 @@ module LavinMQ::AMQP
         headers.delete("x-delay")
         msg.properties.headers = headers
       end
-      @vhost.exchanges_byname(@exchange_name).route_msg Message.new(msg.timestamp, @exchange_name, msg.routing_key,
+      @vhost.exchange(@exchange_name).route_msg Message.new(msg.timestamp, @exchange_name, msg.routing_key,
         msg.properties, msg.bodysize, IO::Memory.new(msg.body))
       delete_message sp
     end

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -176,7 +176,7 @@ module LavinMQ::AMQP
     end
 
     private def notify_all_stream_consumers
-      @consumers.each do |consumer|
+      consumers_each do |consumer|
         if stream_consumer = consumer.as?(AMQP::StreamConsumer)
           stream_consumer.notify_new_message if stream_consumer.waiting_for_messages?
         end
@@ -238,8 +238,8 @@ module LavinMQ::AMQP
 
     private def unmap_and_remove_segments
       used_segments = Set(UInt32).new
-      @consumers_lock.synchronize do
-        @consumers.each do |consumer|
+      @consumers.shared do |consumers|
+        consumers.each do |consumer|
           used_segments << consumer.as(AMQP::StreamConsumer).segment
         end
       end

--- a/src/lavinmq/auth/permission_cache.cr
+++ b/src/lavinmq/auth/permission_cache.cr
@@ -6,7 +6,17 @@ module LavinMQ
       @cache = Hash(PermissionKey, Bool).new
       property revision = 0_u32
 
-      forward_missing_to @cache
+      def []?(key : PermissionKey) : Bool?
+        @cache[key]?
+      end
+
+      def []=(key : PermissionKey, value : Bool) : Bool
+        @cache[key] = value
+      end
+
+      def clear
+        @cache.clear
+      end
     end
   end
 end

--- a/src/lavinmq/auth/permission_cache.cr
+++ b/src/lavinmq/auth/permission_cache.cr
@@ -14,6 +14,10 @@ module LavinMQ
         @cache[key] = value
       end
 
+      def size
+        @cache.size
+      end
+
       def clear
         @cache.clear
       end

--- a/src/lavinmq/auth/permission_cache.cr
+++ b/src/lavinmq/auth/permission_cache.cr
@@ -1,25 +1,35 @@
+require "sync/exclusive"
+
 module LavinMQ
   module Auth
     record PermissionKey, vhost : String, name : String
 
     class PermissionCache
-      @cache = Hash(PermissionKey, Bool).new
-      property revision = 0_u32
+      @cache : Sync::Exclusive(Hash(PermissionKey, Bool)) = Sync::Exclusive.new(Hash(PermissionKey, Bool).new)
+      @revision = Atomic(UInt32).new(0_u32)
+
+      def revision : UInt32
+        @revision.get(:relaxed)
+      end
+
+      def revision=(value : UInt32)
+        @revision.set(value, :relaxed)
+      end
 
       def []?(key : PermissionKey) : Bool?
-        @cache[key]?
+        @cache.lock { |h| h[key]? }
       end
 
       def []=(key : PermissionKey, value : Bool) : Bool
-        @cache[key] = value
+        @cache.lock { |h| h[key] = value }
       end
 
       def size
-        @cache.size
+        @cache.lock(&.size)
       end
 
       def clear
-        @cache.clear
+        @cache.lock(&.clear)
       end
     end
   end

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -43,7 +43,7 @@ module LavinMQ
       end
 
       def has_key?(name : String) : Bool
-        @users.shared { |h| h.has_key?(name) }
+        @users.shared(&.has_key?(name))
       end
 
       def size : Int32
@@ -59,7 +59,7 @@ module LavinMQ
       end
 
       def select(*args)
-        @users.shared { |h| h.select(*args) }
+        @users.shared(&.select(*args))
       end
 
       def each(&)
@@ -134,7 +134,7 @@ module LavinMQ
 
       def delete(name, save = true) : User?
         return if name == DIRECT_USER
-        user = @users.lock { |h| h.delete(name) }
+        user = @users.lock(&.delete(name))
         if user
           user.permissions.clear
           user.clear_permissions_cache

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -102,7 +102,7 @@ module LavinMQ
 
       def add_permission(user, vhost, config, read, write)
         perm = {config: config, read: read, write: write}
-        @users.shared do |h|
+        @users.lock do |h|
           if h[user].permissions[vhost]? && h[user].permissions[vhost] == perm
             return perm
           end
@@ -114,7 +114,7 @@ module LavinMQ
       end
 
       def rm_permission(user, vhost)
-        perm = @users.shared do |h|
+        perm = @users.lock do |h|
           if p = h[user].permissions.delete(vhost)
             h[user].clear_permissions_cache
             p
@@ -128,7 +128,7 @@ module LavinMQ
       end
 
       def rm_vhost_permissions_for_all(vhost)
-        @users.shared do |h|
+        @users.lock do |h|
           h.each_value do |user|
             user.permissions.delete(vhost)
             user.clear_permissions_cache

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -1,4 +1,5 @@
 require "json"
+require "sync/shared"
 require "./user"
 
 module LavinMQ
@@ -9,41 +10,83 @@ module LavinMQ
       Log         = LavinMQ::Log.for "user_store"
 
       def direct_user
-        @users[DIRECT_USER]
+        @users.shared { |h| h[DIRECT_USER] }
       end
 
       def self.hidden?(name)
         DIRECT_USER == name
       end
 
+      @users : Sync::Shared(Hash(String, User))
+
       def initialize(@data_dir : String, @replicator : Clustering::Replicator?)
-        @users = Hash(String, User).new
+        @users = Sync::Shared.new(Hash(String, User).new)
         load!
       end
 
-      forward_missing_to @users
+      # Explicit accessors replacing forward_missing_to
+
+      def []?(name : String) : User?
+        @users.shared { |h| h[name]? }
+      end
+
+      def [](name : String) : User
+        @users.shared { |h| h[name] }
+      end
+
+      def each_value(& : User ->)
+        @users.shared { |h| h.each_value { |v| yield v } }
+      end
+
+      def each_value : Iterator(User)
+        @users.shared(&.values).each
+      end
+
+      def has_key?(name : String) : Bool
+        @users.shared { |h| h.has_key?(name) }
+      end
+
+      def size : Int32
+        @users.shared(&.size)
+      end
+
+      def values : Array(User)
+        @users.shared(&.values)
+      end
+
+      def compact_map(& : {String, User} -> U?) : Array(U) forall U
+        @users.shared { |h| h.compact_map { |kv| yield kv } }
+      end
+
+      def select(*args)
+        @users.shared { |h| h.select(*args) }
+      end
 
       def each(&)
-        @users.each do |kv|
-          yield kv
+        @users.shared do |h|
+          h.each do |kv|
+            yield kv
+          end
         end
       end
 
-      # Adds a user to the use store
+      # Adds a user to the user store
       def create(name, password, tags = Array(Tag).new, save = true)
-        if user = @users[name]?
-          return user
+        @users.lock do |h|
+          if user = h[name]?
+            return user
+          end
+          user = User.create(name, password, "SHA256", tags)
+          h[name] = user
+          Log.info { "Created user=#{name}" }
+          save! if save
+          user
         end
-        user = User.create(name, password, "SHA256", tags)
-        @users[name] = user
-        Log.info { "Created user=#{name}" }
-        save! if save
-        user
       end
 
       def add(name, password_hash, password_algorithm, tags = Array(Tag).new, save = true)
         user = User.new(name, password_hash, password_algorithm, tags)
-        @users[name] = user
+        @users.lock { |h| h[name] = user }
         save! if save
         user
       end
@@ -54,18 +97,25 @@ module LavinMQ
 
       def add_permission(user, vhost, config, read, write)
         perm = {config: config, read: read, write: write}
-        if @users[user].permissions[vhost]? && @users[user].permissions[vhost] == perm
-          return perm
+        @users.shared do |h|
+          if h[user].permissions[vhost]? && h[user].permissions[vhost] == perm
+            return perm
+          end
+          h[user].permissions[vhost] = perm
+          h[user].clear_permissions_cache
         end
-        @users[user].permissions[vhost] = perm
-        @users[user].clear_permissions_cache
         save!
         perm
       end
 
       def rm_permission(user, vhost)
-        if perm = @users[user].permissions.delete vhost
-          @users[user].clear_permissions_cache
+        perm = @users.shared do |h|
+          if p = h[user].permissions.delete(vhost)
+            h[user].clear_permissions_cache
+            p
+          end
+        end
+        if perm
           Log.info { "Removed permissions for user=#{user} on vhost=#{vhost}" }
           save!
           perm
@@ -73,16 +123,19 @@ module LavinMQ
       end
 
       def rm_vhost_permissions_for_all(vhost)
-        @users.each_value do |user|
-          user.permissions.delete(vhost)
-          user.clear_permissions_cache
+        @users.shared do |h|
+          h.each_value do |user|
+            user.permissions.delete(vhost)
+            user.clear_permissions_cache
+          end
         end
         save!
       end
 
       def delete(name, save = true) : User?
         return if name == DIRECT_USER
-        if user = @users.delete name
+        user = @users.lock { |h| h.delete(name) }
+        if user
           user.permissions.clear
           user.clear_permissions_cache
           Log.info { "Deleted user=#{name}" }
@@ -92,14 +145,16 @@ module LavinMQ
       end
 
       def default_user : User
-        @users.each_value do |u|
-          if u.tags.includes?(Tag::Administrator) && !u.hidden?
-            return u
+        @users.shared do |h|
+          h.each_value do |u|
+            if u.tags.includes?(Tag::Administrator) && !u.hidden?
+              return u
+            end
           end
-        end
-        @users.each_value do |u|
-          if u.tags.includes?(Tag::Administrator)
-            return u
+          h.each_value do |u|
+            if u.tags.includes?(Tag::Administrator)
+              return u
+            end
           end
         end
         raise "No user with administrator privileges found"
@@ -114,17 +169,15 @@ module LavinMQ
         end
       end
 
-      def direct_user
-        @users[DIRECT_USER]
-      end
-
       private def load!
         path = File.join(@data_dir, "users.json")
         if File.exists? path
           Log.debug { "Loading users from file" }
           File.open(path) do |f|
-            Array(User).from_json(f) do |user|
-              @users[user.name] = user
+            @users.lock do |h|
+              Array(User).from_json(f) do |user|
+                h[user.name] = user
+              end
             end
             @replicator.try &.register_file f
           end
@@ -146,9 +199,11 @@ module LavinMQ
       end
 
       private def create_direct_user
-        @users[DIRECT_USER] = User.create_hidden_user(DIRECT_USER)
-        perm = {config: /.*/, read: /.*/, write: /.*/}
-        @users[DIRECT_USER].permissions["/"] = perm
+        @users.lock do |h|
+          h[DIRECT_USER] = User.create_hidden_user(DIRECT_USER)
+          perm = {config: /.*/, read: /.*/, write: /.*/}
+          h[DIRECT_USER].permissions["/"] = perm
+        end
       end
 
       def save!

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -297,6 +297,11 @@ module LavinMQ
       @[IniOpt(section: "amqp")]
       property max_consumers_per_channel = 0
 
+      @[CliOpt("", "--thread-count=COUNT", "Number of worker threads (default: number of CPUs)", section: "options")]
+      @[IniOpt(section: "main")]
+      @[EnvOpt("LAVINMQ_THREAD_COUNT")]
+      property thread_count = 0 # 0 means auto-detect (CPU count)
+
       @[IniOpt(section: "main", transform: ->ConsistentHashAlgorithm.parse(String))]
       property default_consistent_hash_algorithm : ConsistentHashAlgorithm = ConsistentHashAlgorithm::Ring
 

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -316,6 +316,7 @@ module LavinMQ
               @log.debug { "Waiting for consumers" }
               select
               when @consumer_available.receive?
+                return if @consumer_available.closed?
                 consume_upstream_and_federate(q, no_ack)
               when @state_changed.receive?
                 return if @state_changed.closed?

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -6,7 +6,7 @@ require "./link"
 module LavinMQ
   module Federation
     class Upstream
-      @links : Sync::Exclusive({Hash(String, QueueLink), Hash(String, ExchangeLink)})
+      @links : Sync::Exclusive(NamedTuple(queue: Hash(String, QueueLink), exchange: Hash(String, ExchangeLink)))
       @queue : String?
       @exchange : String?
       @expires : Int64?
@@ -23,23 +23,23 @@ module LavinMQ
                      consumer_tag = nil)
         @consumer_tag = "federation-link-#{@name}"
         @uri = URI.parse(raw_uri)
-        @links = Sync::Exclusive.new({Hash(String, QueueLink).new, Hash(String, ExchangeLink).new})
+        @links = Sync::Exclusive.new({queue: Hash(String, QueueLink).new, exchange: Hash(String, ExchangeLink).new})
       end
 
       # delete x-federation-upstream exchange on upstream
       # delete queue on upstream
       def stop_link(federated_exchange : Exchange)
-        old = @links.lock(&.[1].delete(federated_exchange.name))
+        old = @links.lock(&.[:exchange].delete(federated_exchange.name))
         old.try(&.terminate)
       end
 
       def stop_link(federated_q : Queue)
-        old = @links.lock(&.[0].delete(federated_q.name))
+        old = @links.lock(&.[:queue].delete(federated_q.name))
         old.try(&.terminate)
       end
 
       def links : Array(Link)
-        @links.lock { |state| state[0].values + state[1].values }
+        @links.lock { |l| l[:queue].values + l[:exchange].values }
       end
 
       # declare queue on upstream
@@ -51,7 +51,7 @@ module LavinMQ
       # add bindings from upstream exchange to x-federation-upstream exchange
       # keep downstream exchange bindings reflected on x-federation-upstream exchange
       def link(federated_exchange : Exchange) : ExchangeLink
-        existing = @links.lock { |state| state[1][federated_exchange.name]? }
+        existing = @links.lock { |l| l[:exchange][federated_exchange.name]? }
         return existing if existing
         upstream_exchange = @exchange
         if upstream_exchange.nil? || upstream_exchange.empty?
@@ -59,7 +59,7 @@ module LavinMQ
         end
         upstream_q = "federation: #{upstream_exchange} -> #{System.hostname}:#{vhost.name}:#{federated_exchange.name}"
         link = ExchangeLink.new(self, federated_exchange, upstream_q, upstream_exchange)
-        @links.lock { |state| state[1][federated_exchange.name] = link }
+        @links.lock { |l| l[:exchange][federated_exchange.name] = link }
         link.run
         link
       end
@@ -68,24 +68,23 @@ module LavinMQ
       # If all consumers disconnect, the connections are closed.
       # When the policy or the upstream is removed the link is also removed.
       def link(federated_q : Queue) : QueueLink
-        existing = @links.lock { |state| state[0][federated_q.name]? }
+        existing = @links.lock { |l| l[:queue][federated_q.name]? }
         return existing if existing
         upstream_q = @queue
         if upstream_q.nil? || upstream_q.empty?
           upstream_q = federated_q.name
         end
         link = QueueLink.new(self, federated_q, upstream_q)
-        @links.lock { |state| state[0][federated_q.name] = link }
+        @links.lock { |l| l[:queue][federated_q.name] = link }
         link.run
         link
       end
 
       def close
-        to_terminate = @links.lock do |state|
-          q_links, ex_links = state
-          result = q_links.values.map(&.as(Link)) + ex_links.values.map(&.as(Link))
-          q_links.clear
-          ex_links.clear
+        to_terminate = @links.lock do |l|
+          result = l[:queue].values.map(&.as(Link)) + l[:exchange].values.map(&.as(Link))
+          l[:queue].clear
+          l[:exchange].clear
           result
         end
         to_terminate.each(&.terminate)

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -29,12 +29,12 @@ module LavinMQ
       # delete x-federation-upstream exchange on upstream
       # delete queue on upstream
       def stop_link(federated_exchange : Exchange)
-        old = @links.lock { |state| state[1].delete(federated_exchange.name) }
+        old = @links.lock(&.[1].delete(federated_exchange.name))
         old.try(&.terminate)
       end
 
       def stop_link(federated_q : Queue)
-        old = @links.lock { |state| state[0].delete(federated_q.name) }
+        old = @links.lock(&.[0].delete(federated_q.name))
         old.try(&.terminate)
       end
 

--- a/src/lavinmq/federation/upstream_store.cr
+++ b/src/lavinmq/federation/upstream_store.cr
@@ -16,10 +16,14 @@ module LavinMQ
       end
 
       def each(&)
-        upstreams = @lock.lock { |state| state[0].values }
+        upstreams = @lock.lock(&.[0].values)
         upstreams.each do |v|
           yield v
         end
+      end
+
+      def []?(name : String) : Upstream?
+        @lock.lock { |state| state[0][name]? }
       end
 
       def create_upstream(name, config)
@@ -80,7 +84,7 @@ module LavinMQ
       end
 
       def stop_link(resource : Queue | Exchange)
-        upstreams = @lock.lock { |state| state[0].values }
+        upstreams = @lock.lock(&.[0].values)
         upstreams.each do |upstream|
           upstream.stop_link(resource)
         end
@@ -113,7 +117,7 @@ module LavinMQ
       end
 
       def delete_upstream_set(name)
-        @lock.lock { |state| state[1].delete(name) }
+        @lock.lock(&.[1].delete(name))
         @log.info { "Upstream set '#{name}' deleted" }
       end
 

--- a/src/lavinmq/http/binding_helpers.cr
+++ b/src/lavinmq/http/binding_helpers.cr
@@ -5,7 +5,7 @@ module LavinMQ
   module HTTP
     module BindingHelpers
       private def bindings(vhost)
-        vhost.exchanges.each_value.flat_map do |e|
+        vhost.exchanges_each_value.flat_map do |e|
           e.bindings_details
         end
       end

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,7 +15,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            conns = vhost.connections.each
+            conns = vhost.connections_each
             channels = conns.flat_map(&.channels.each_value)
             page(context, channels)
           end

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -16,7 +16,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
             conns = vhost.connections_each
-            channels = conns.flat_map(&.channels.each_value)
+            channels = conns.flat_map(&.channels_each_value.each)
             page(context, channels)
           end
         end
@@ -44,7 +44,7 @@ module LavinMQ
       end
 
       private def all_channels(user)
-        Iterator(Client::Channel).chain(connections(user).map(&.channels.each_value))
+        Iterator(Client::Channel).chain(connections(user).map(&.channels_each_value.each))
       end
 
       private def with_channel(context, params, &)

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -45,7 +45,7 @@ module LavinMQ
 
         get "/api/connections/:name/channels" do |context, params|
           with_connection(context, params) do |connection|
-            page(context, connection.channels.each_value)
+            page(context, connection.channels_each_value.each)
           end
         end
 

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -25,7 +25,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/connections" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.connections.each)
+            page(context, vhost.connections_each)
           end
         end
 

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -41,7 +41,7 @@ module LavinMQ
               context.response.status_code = 404
               break
             end
-            consumer = channel.consumers.find(&.tag.==(consumer_tag))
+            consumer = channel.consumers_find(&.tag.==(consumer_tag))
             unless consumer
               context.response.status_code = 404
               break

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -18,7 +18,7 @@ module LavinMQ
             refuse_unless_management(context, user, vhost)
             itr = connections(user).each.select(&.vhost.==(vhost))
               .flat_map do |conn|
-                conn.channels.each_value.flat_map &.consumers
+                conn.channels_each_value.each.flat_map &.consumers
               end
             page(context, itr)
           end
@@ -36,7 +36,7 @@ module LavinMQ
               context.response.status_code = 404
               break
             end
-            channel = connection.channels[ch_id]?
+            channel = connection.channels_byid?(ch_id)
             unless channel
               context.response.status_code = 404
               break
@@ -55,7 +55,7 @@ module LavinMQ
 
       private def all_consumers(user)
         Iterator(Client::Channel::Consumer)
-          .chain(connections(user).map { |c| c.channels.each_value.flat_map &.consumers })
+          .chain(connections(user).map { |c| c.channels_each_value.each.flat_map &.consumers })
       end
     end
   end

--- a/src/lavinmq/http/controller/definitions.cr
+++ b/src/lavinmq/http/controller/definitions.cr
@@ -285,7 +285,7 @@ module LavinMQ
         private def export_queues(json)
           json.array do
             vhosts.each_value do |v|
-              v.queues.each_value do |q|
+              v.queues_each_value do |q|
                 next if q.exclusive?
                 {
                   "name":        q.name,
@@ -302,7 +302,7 @@ module LavinMQ
         private def export_exchanges(json)
           json.array do
             vhosts.each_value do |v|
-              v.exchanges.each_value.reject(&.internal?).each do |e|
+              v.exchanges_each_value.reject(&.internal?).each do |e|
                 delayed = e.arguments["x-delayed-exchange"]?
                 if delayed
                   arguments = e.arguments.clone
@@ -326,7 +326,7 @@ module LavinMQ
         private def export_bindings(json)
           json.array do
             vhosts.each_value do |v|
-              v.exchanges.each_value do |e|
+              v.exchanges_each_value do |e|
                 e.bindings_details.each do |b|
                   b.to_json(json)
                 end

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -8,7 +8,7 @@ module LavinMQ
       private def exchange(context, params, vhost, key = "name")
         name = params[key]
         name = "" if name == "amq.default"
-        e = vhost.exchanges_byname?(name)
+        e = vhost.exchange?(name)
         not_found(context) unless e
         e
       end
@@ -60,7 +60,7 @@ module LavinMQ
             unless user.can_config?(vhost.name, name) && ae_ok
               access_refused(context, "User doesn't have permissions to declare exchange '#{name}'")
             end
-            e = vhost.exchanges_byname?(name)
+            e = vhost.exchange?(name)
             if e
               unless e.match?(type, durable, auto_delete, internal, tbl)
                 bad_request(context, "Existing exchange declared with other arguments arg")

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -8,7 +8,7 @@ module LavinMQ
       private def exchange(context, params, vhost, key = "name")
         name = params[key]
         name = "" if name == "amq.default"
-        e = vhost.exchanges[name]?
+        e = vhost.exchanges_byname?(name)
         not_found(context) unless e
         e
       end
@@ -21,14 +21,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/exchanges" do |context, _params|
-          itr = vhosts(user(context)).flat_map &.exchanges.each_value
+          itr = vhosts(user(context)).flat_map &.exchanges_each_value
           page(context, itr)
         end
 
         get "/api/exchanges/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.exchanges.each_value)
+            page(context, vhost.exchanges_each_value)
           end
         end
 
@@ -60,7 +60,7 @@ module LavinMQ
             unless user.can_config?(vhost.name, name) && ae_ok
               access_refused(context, "User doesn't have permissions to declare exchange '#{name}'")
             end
-            e = vhost.exchanges[name]?
+            e = vhost.exchanges_byname?(name)
             if e
               unless e.match?(type, durable, auto_delete, internal, tbl)
                 bad_request(context, "Existing exchange declared with other arguments arg")

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -40,7 +40,7 @@ module LavinMQ
 
           vhosts(user(context)).each do |vhost|
             next if x_vhost && vhost.name != x_vhost
-            vhost.connections.each do |c|
+            vhost.connections_each do |c|
               connections += 1
               channels += c.channels.size
               consumers += c.channels.each_value.sum &.consumers.size
@@ -50,9 +50,9 @@ module LavinMQ
               add_logs!(recv_rate_log, stats_details[:recv_oct_details][:log])
               add_logs!(send_rate_log, stats_details[:send_oct_details][:log])
             end
-            exchanges += vhost.exchanges.size
-            queues += vhost.queues.size
-            vhost.queues.each_value do |q|
+            exchanges += vhost.exchanges_size
+            queues += vhost.queues_size
+            vhost.queues_each_value do |q|
               ready += q.message_count
               unacked += q.unacked_count
               add_logs!(ready_log, q.message_count_log)
@@ -135,7 +135,7 @@ module LavinMQ
               IO::Memory.new("test"))
             ok = vhost.publish(msg)
             env = nil
-            vhost.queues["aliveness-test"].basic_get(true) { |e| env = e }
+            vhost.queues_byname("aliveness-test").basic_get(true) { |e| env = e }
             ok = ok && env && String.new(env.message.body) == "test"
             {status: ok ? "ok" : "failed"}.to_json(context.response)
           end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -44,7 +44,7 @@ module LavinMQ
               connections += 1
               channels += c.channels_size
               consumer_sum = 0
-              c.channels_each_value { |ch| consumer_sum += ch.consumers.size }
+              c.channels_each_value { |ch| consumer_sum += ch.consumers_size }
               consumers += consumer_sum
               stats_details = c.stats_details
               recv_rate += stats_details[:recv_oct_details][:rate]

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -137,7 +137,7 @@ module LavinMQ
               IO::Memory.new("test"))
             ok = vhost.publish(msg)
             env = nil
-            vhost.queues_byname("aliveness-test").basic_get(true) { |e| env = e }
+            vhost.queue("aliveness-test").basic_get(true) { |e| env = e }
             ok = ok && env && String.new(env.message.body) == "test"
             {status: ok ? "ok" : "failed"}.to_json(context.response)
           end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -42,8 +42,10 @@ module LavinMQ
             next if x_vhost && vhost.name != x_vhost
             vhost.connections_each do |c|
               connections += 1
-              channels += c.channels.size
-              consumers += c.channels.each_value.sum &.consumers.size
+              channels += c.channels_size
+              consumer_sum = 0
+              c.channels_each_value { |ch| consumer_sum += ch.consumers.size }
+              consumers += consumer_sum
               stats_details = c.stats_details
               recv_rate += stats_details[:recv_oct_details][:rate]
               send_rate += stats_details[:send_oct_details][:rate]

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -78,7 +78,7 @@ module LavinMQ
           partitions:         Tuple.new,
           proc_used:          Fiber.count,
           run_queue:          0,
-          sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
+          sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections_size },
           followers:          @amqp_server.followers,
         }
       end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -298,7 +298,7 @@ module LavinMQ
                       type:  "gauge",
                       help:  "Open file descriptors"})
         writer.write({name:  "process_open_tcp_sockets",
-                      value: @amqp_server.vhosts.sum { |_, v| v.connections.size },
+                      value: @amqp_server.vhosts.sum { |_, v| v.connections_size },
                       type:  "gauge",
                       help:  "Open TCP sockets"})
         writer.write({name:  "process_resident_memory_bytes",
@@ -349,14 +349,14 @@ module LavinMQ
           d = vhost.message_details
           ready += d[:messages_ready]
           unacked += d[:messages_unacknowledged]
-          connections += vhost.connections.size
-          vhost.connections.each do |conn|
+          connections += vhost.connections_size
+          vhost.connections_each do |conn|
             channels += conn.channels.size
             conn.channels.each_value do |ch|
               consumers += ch.consumers.size
             end
           end
-          queues += vhost.queues.size
+          queues += vhost.queues_size
         end
         writer.write({name:  "connections",
                       value: connections,
@@ -488,7 +488,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages_ready", "gauge",
           "Messages ready to be delivered to consumers")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages_ready", q.message_count, labels)
           end
@@ -497,7 +497,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages_unacked", "gauge",
           "Messages delivered to consumers but not yet acknowledged")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages_unacked", q.unacked_count, labels)
           end
@@ -506,7 +506,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages", "gauge",
           "Sum of ready and unacknowledged messages - total queue depth")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages", q.message_count + q.unacked_count, labels)
           end
@@ -515,7 +515,7 @@ module LavinMQ
         writer.write_header("detailed_queue_deduplication", "counter",
           "Number of deduplicated messages for this queue")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_deduplication", q.dedup_count, labels)
           end
@@ -528,7 +528,7 @@ module LavinMQ
 
         # Write values
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_consumers", q.consumers.size, labels)
           end
@@ -542,7 +542,7 @@ module LavinMQ
 
         # Write values
         vhosts.each do |vhost|
-          vhost.exchanges.each_value do |e|
+          vhost.exchanges_each_value do |e|
             labels = {exchange: e.name, vhost: vhost.name}
             writer.write_value("detailed_exchange_deduplication", e.dedup_count, labels)
           end
@@ -554,7 +554,7 @@ module LavinMQ
         writer.write_header("detailed_connection_incoming_bytes_total", "counter",
           "Total number of bytes received on a connection")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_incoming_bytes_total", conn.recv_oct_count, labels)
           end
@@ -563,7 +563,7 @@ module LavinMQ
         writer.write_header("detailed_connection_outgoing_bytes_total", "counter",
           "Total number of bytes sent on a connection")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_outgoing_bytes_total", conn.send_oct_count, labels)
           end
@@ -572,7 +572,7 @@ module LavinMQ
         writer.write_header("detailed_connection_channels", "counter",
           "Channels on a connection")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_channels", conn.channels.size, labels)
           end
@@ -583,7 +583,7 @@ module LavinMQ
         # Group TYPE, HELP and values together for each metric
         writer.write_header("detailed_channel_consumers", "gauge", "Consumers on a channel")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             conn.channels.each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_consumers", ch.details_tuple[:consumer_count], labels)
@@ -594,7 +594,7 @@ module LavinMQ
         writer.write_header("detailed_messages_unacked", "gauge",
           "Delivered but not yet acknowledged messages")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             conn.channels.each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_messages_unacked", ch.details_tuple[:messages_unacknowledged], labels)
@@ -605,7 +605,7 @@ module LavinMQ
         writer.write_header("detailed_channel_prefetch", "gauge",
           "Total limit of unacknowledged messages for all consumers on a channel")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             conn.channels.each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_prefetch", ch.details_tuple[:prefetch_count], labels)

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -351,8 +351,8 @@ module LavinMQ
           unacked += d[:messages_unacknowledged]
           connections += vhost.connections_size
           vhost.connections_each do |conn|
-            channels += conn.channels.size
-            conn.channels.each_value do |ch|
+            channels += conn.channels_size
+            conn.channels_each_value do |ch|
               consumers += ch.consumers.size
             end
           end
@@ -530,7 +530,7 @@ module LavinMQ
         vhosts.each do |vhost|
           vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
-            writer.write_value("detailed_queue_consumers", q.consumers.size, labels)
+            writer.write_value("detailed_queue_consumers", q.consumers_size, labels)
           end
         end
       end
@@ -574,7 +574,7 @@ module LavinMQ
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
             labels = {channel: conn.name}
-            writer.write_value("detailed_connection_channels", conn.channels.size, labels)
+            writer.write_value("detailed_connection_channels", conn.channels_size, labels)
           end
         end
       end
@@ -584,7 +584,7 @@ module LavinMQ
         writer.write_header("detailed_channel_consumers", "gauge", "Consumers on a channel")
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
-            conn.channels.each_value do |ch|
+            conn.channels_each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_consumers", ch.details_tuple[:consumer_count], labels)
             end
@@ -595,7 +595,7 @@ module LavinMQ
           "Delivered but not yet acknowledged messages")
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
-            conn.channels.each_value do |ch|
+            conn.channels_each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_messages_unacked", ch.details_tuple[:messages_unacknowledged], labels)
             end
@@ -606,7 +606,7 @@ module LavinMQ
           "Total limit of unacknowledged messages for all consumers on a channel")
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
-            conn.channels.each_value do |ch|
+            conn.channels_each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_prefetch", ch.details_tuple[:prefetch_count], labels)
             end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -353,7 +353,7 @@ module LavinMQ
           vhost.connections_each do |conn|
             channels += conn.channels_size
             conn.channels_each_value do |ch|
-              consumers += ch.consumers.size
+              consumers += ch.consumers_size
             end
           end
           queues += vhost.queues_size

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -9,13 +9,13 @@ module LavinMQ
     module QueueHelpers
       private def find_queue(context, params, vhost, key = "name")
         name = params[key]
-        q = vhost.queues_byname?(name)
+        q = vhost.queue?(name)
         not_found(context, "Not Found") unless q
         q
       end
 
       private def find_stream(context, vhost, name)
-        q = vhost.queues_byname?(name)
+        q = vhost.queue?(name)
         not_found(context, "Not Found") unless q
         not_found(context, "Not Found") unless q.is_a?(LavinMQ::AMQP::Stream)
         q.as(LavinMQ::AMQP::Stream)
@@ -74,7 +74,7 @@ module LavinMQ
             unless user.can_config?(vhost.name, name) && dlx_ok
               access_refused(context, "User doesn't have permissions to declare queue '#{name}'")
             end
-            q = vhost.queues_byname?(name)
+            q = vhost.queue?(name)
             if q
               unless q.match?(durable, false, auto_delete, tbl)
                 bad_request(context, "Existing queue declared with other arguments arg")

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -9,13 +9,13 @@ module LavinMQ
     module QueueHelpers
       private def find_queue(context, params, vhost, key = "name")
         name = params[key]
-        q = vhost.queues[name]?
+        q = vhost.queues_byname?(name)
         not_found(context, "Not Found") unless q
         q
       end
 
       private def find_stream(context, vhost, name)
-        q = vhost.queues[name]?
+        q = vhost.queues_byname?(name)
         not_found(context, "Not Found") unless q
         not_found(context, "Not Found") unless q.is_a?(LavinMQ::AMQP::Stream)
         q.as(LavinMQ::AMQP::Stream)
@@ -29,14 +29,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/queues" do |context, _|
-          itr = Iterator(Queue).chain(vhosts(user(context)).map &.queues.each_value)
+          itr = Iterator(Queue).chain(vhosts(user(context)).map &.queues_each_value)
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.queues.each_value)
+            page(context, vhost.queues_each_value)
           end
         end
 
@@ -74,7 +74,7 @@ module LavinMQ
             unless user.can_config?(vhost.name, name) && dlx_ok
               access_refused(context, "User doesn't have permissions to declare queue '#{name}'")
             end
-            q = vhost.queues[name]?
+            q = vhost.queues_byname?(name)
             if q
               unless q.match?(durable, false, auto_delete, tbl)
                 bad_request(context, "Existing queue declared with other arguments arg")

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -23,6 +23,8 @@ module LavinMQ
     @replicator : Clustering::Server?
 
     def initialize(@config : Config)
+      thread_count = @config.thread_count < 1 ? System.cpu_count.to_i : @config.thread_count
+      Fiber::ExecutionContext.default.resize(thread_count)
       print_environment_info
       print_max_map_count
       fd_limit = System.maximize_fd_limit
@@ -113,7 +115,7 @@ module LavinMQ
         Log.warn { "Not built in release mode" }
       {% end %}
       {% if flag?(:preview_mt) %}
-        Log.info { "Multithreading: #{ENV.fetch("CRYSTAL_WORKERS", "4")} threads" }
+        Log.info { "Multithreading: #{Fiber::ExecutionContext.default.capacity}" }
       {% end %}
       Log.info { "PID: #{Process.pid}" }
       # we do this here to have nice consistent logging

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -69,7 +69,7 @@ module LavinMQ
             sessions.delete(client_id) if session.clean_session?
           end
         end
-        @clients.lock { |clients| clients.delete client_id }
+        @clients.lock(&.delete(client_id))
         @vhost.rm_connection(client)
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -27,7 +27,7 @@ module LavinMQ
         @clients = Hash(String, Client).new
         @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @replicator)
         @exchange = MQTT::Exchange.new(@vhost, EXCHANGE, @retain_store)
-        @vhost.exchanges[EXCHANGE] = @exchange
+        @vhost.exchanges_unsafe_put(EXCHANGE, @exchange)
       end
 
       def session_present?(client_id : String, clean_session) : Bool

--- a/src/lavinmq/mqtt/brokers.cr
+++ b/src/lavinmq/mqtt/brokers.cr
@@ -30,7 +30,7 @@ module LavinMQ
           broker = Broker.new(@vhosts[vhost], @replicator)
           @brokers.lock { |brokers| brokers[vhost] = broker }
         in VHostStore::Event::Deleted
-          @brokers.lock { |brokers| brokers.delete(vhost) }
+          @brokers.lock(&.delete(vhost))
         in VHostStore::Event::Closed
           broker = @brokers.shared { |brokers| brokers[vhost]? }
           broker.try &.close

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -14,7 +14,7 @@ module LavinMQ
       include Stats
       include SortableJSON
 
-      getter channels, log, name, user, client_id, socket, connection_info
+      getter log, name, user, client_id, socket, connection_info
       getter? clean_session
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
@@ -24,6 +24,21 @@ module LavinMQ
 
       def vhost
         @broker.vhost
+      end
+
+      def channels_size : Int32
+        0
+      end
+
+      def channels_each_value(& : LavinMQ::Client::Channel ->) : Nil
+      end
+
+      def channels_each_value : Array(LavinMQ::Client::Channel)
+        Array(LavinMQ::Client::Channel).new
+      end
+
+      def channels_byid?(id) : LavinMQ::Client::Channel?
+        nil
       end
 
       def initialize(@io : MQTT::IO,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -35,7 +35,8 @@ module LavinMQ
           break if @closed
           next @msg_store.empty.when_false.receive? if @msg_store.empty?
           next @consumers_empty.when_false.receive? if consumers_empty?
-          consumer = consumers_first?.not_nil!.as(MQTT::Consumer)
+          consumer = consumers_first?.as?(MQTT::Consumer)
+          next unless consumer
           get_packet do |pub_packet|
             consumer.deliver(pub_packet)
           end

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -4,18 +4,15 @@ require "../vhost"
 module LavinMQ
   module MQTT
     class Sessions
-      @queues : Hash(String, Queue)
-
       def initialize(@vhost : VHost)
-        @queues = @vhost.queues
       end
 
       def []?(client_id : String) : Session?
-        @queues["mqtt.#{client_id}"]?.try &.as(Session)
+        @vhost.queues_byname?("mqtt.#{client_id}").try &.as(Session)
       end
 
       def [](client_id : String) : Session
-        @queues["mqtt.#{client_id}"].as(Session)
+        @vhost.queues_byname("mqtt.#{client_id}").as(Session)
       end
 
       def declare(client : Client)

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -8,11 +8,11 @@ module LavinMQ
       end
 
       def []?(client_id : String) : Session?
-        @vhost.queues_byname?("mqtt.#{client_id}").try &.as(Session)
+        @vhost.queue?("mqtt.#{client_id}").try &.as(Session)
       end
 
       def [](client_id : String) : Session
-        @vhost.queues_byname("mqtt.#{client_id}").as(Session)
+        @vhost.queue("mqtt.#{client_id}").as(Session)
       end
 
       def declare(client : Client)

--- a/src/lavinmq/observable.cr
+++ b/src/lavinmq/observable.cr
@@ -1,3 +1,5 @@
+require "sync/shared"
+
 module LavinMQ
   module Observer(EventT)
     abstract def on(event : EventT, data : Object?)
@@ -6,18 +8,18 @@ module LavinMQ
   module Observable(EventT)
     macro included
       {% observers_ivar = ("@__" + EventT.name.stringify.downcase.gsub(/[^a-z_]+/, "_") + "_observers").id %}
-      {{ observers_ivar }} = Set(LavinMQ::Observer({{ EventT }})).new
+      {{ observers_ivar }} : Sync::Shared(Set(LavinMQ::Observer({{ EventT }}))) = Sync::Shared.new(Set(LavinMQ::Observer({{ EventT }})).new)
 
       def register_observer(observer : LavinMQ::Observer({{ EventT }}))
-        {{ observers_ivar }}.add(observer)
+        {{ observers_ivar }}.lock { |obs| obs.add(observer) }
       end
 
       def unregister_observer(observer : LavinMQ::Observer({{ EventT }}))
-        {{ observers_ivar }}.delete(observer)
+        {{ observers_ivar }}.lock { |obs| obs.delete(observer) }
       end
 
       def notify_observers(event : {{ EventT }}, data : Object? = nil)
-        {{ observers_ivar }}.each &.on(event, data)
+        {{ observers_ivar }}.shared { |obs| obs.each &.on(event, data) }
       end
     end
   end

--- a/src/lavinmq/observable.cr
+++ b/src/lavinmq/observable.cr
@@ -19,7 +19,8 @@ module LavinMQ
       end
 
       def notify_observers(event : {{ EventT }}, data : Object? = nil)
-        {{ observers_ivar }}.shared { |obs| obs.each &.on(event, data) }
+        observers_copy = {{ observers_ivar }}.shared(&.to_a)
+        observers_copy.each &.on(event, data)
       end
     end
   end

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -37,7 +37,7 @@ module LavinMQ
     end
 
     def has_key?(id) : Bool
-      @parameters.shared { |h| h.has_key?(id) }
+      @parameters.shared(&.has_key?(id))
     end
 
     def size : Int32
@@ -62,7 +62,7 @@ module LavinMQ
     end
 
     def delete(id, save = true) : T?
-      parameter = @parameters.lock { |h| h.delete(id) }
+      parameter = @parameters.lock(&.delete(id))
       if parameter
         save! if save
         parameter

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -1,4 +1,5 @@
 require "json"
+require "sync/shared"
 require "./parameter"
 require "./logger"
 
@@ -8,22 +9,61 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "parameter_store"
 
+    @parameters : Sync::Shared(Hash(ParameterId?, T))
+
     def initialize(@data_dir : String, @file_name : String, @replicator : Clustering::Replicator?, vhost : String? = nil)
       metadata = vhost ? ::Log::Metadata.build({vhost: vhost}) : ::Log::Metadata.empty
       @log = Logger.new(Log, metadata)
-      @parameters = Hash(ParameterId?, T).new
+      @parameters = Sync::Shared.new(Hash(ParameterId?, T).new)
       load!
     end
 
-    forward_missing_to @parameters
+    # Explicit accessors replacing forward_missing_to
+
+    def []?(id) : T?
+      @parameters.shared { |h| h[id]? }
+    end
+
+    def [](id) : T
+      @parameters.shared { |h| h[id] }
+    end
+
+    def each_value(& : T ->)
+      @parameters.shared { |h| h.each_value { |v| yield v } }
+    end
+
+    def each_value : Iterator(T)
+      @parameters.shared(&.values).each
+    end
+
+    def has_key?(id) : Bool
+      @parameters.shared { |h| h.has_key?(id) }
+    end
+
+    def size : Int32
+      @parameters.shared(&.size)
+    end
+
+    def values : Array(T)
+      @parameters.shared(&.values)
+    end
+
+    def empty? : Bool
+      @parameters.shared(&.empty?)
+    end
+
+    def any?(& : {ParameterId?, T} -> Bool) : Bool
+      @parameters.shared { |h| h.any? { |kv| yield kv } }
+    end
 
     def create(parameter : T, save = true)
-      @parameters[parameter.name] = parameter
+      @parameters.lock { |h| h[parameter.name] = parameter }
       save! if save
     end
 
     def delete(id, save = true) : T?
-      if parameter = @parameters.delete id
+      parameter = @parameters.lock { |h| h.delete(id) }
+      if parameter
         save! if save
         parameter
       end
@@ -31,7 +71,7 @@ module LavinMQ
 
     def apply(parameter : Parameter? = nil, &)
       itr = if parameter.nil?
-              @parameters.each_value
+              values.each
             else
               [parameter].each
             end
@@ -45,8 +85,10 @@ module LavinMQ
     end
 
     def each(&)
-      @parameters.each do |kv|
-        yield kv
+      @parameters.shared do |h|
+        h.each do |kv|
+          yield kv
+        end
       end
     end
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -342,7 +342,7 @@ module LavinMQ
         vhost.exchanges_each_value(&.update_rates)
         vhost.connections_each do |connection|
           connection.update_rates
-          connection.channels.each_value(&.update_rates)
+          connection.channels_each_value(&.update_rates)
         end
         vhost.update_rates
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -111,7 +111,7 @@ module LavinMQ
     end
 
     def connections
-      Iterator(Client).chain(@vhosts.each_value.map(&.connections.each))
+      Iterator(Client).chain(@vhosts.each_value.map(&.connections_each))
     end
 
     def listen(s : TCPServer, protocol : Protocol)
@@ -338,9 +338,9 @@ module LavinMQ
 
     def update_stats_rates
       @vhosts.each_value do |vhost|
-        vhost.queues.each_value(&.update_rates)
-        vhost.exchanges.each_value(&.update_rates)
-        vhost.connections.each do |connection|
+        vhost.queues_each_value(&.update_rates)
+        vhost.exchanges_each_value(&.update_rates)
+        vhost.connections_each do |connection|
           connection.update_rates
           connection.channels.each_value(&.update_rates)
         end

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -46,7 +46,7 @@ module LavinMQ
       end
 
       def has_key?(name : String) : Bool
-        @shovels.lock { |h| h.has_key?(name) }
+        @shovels.lock(&.has_key?(name))
       end
 
       # ameba:disable Metrics/CyclomaticComplexity
@@ -142,7 +142,7 @@ module LavinMQ
       end
 
       def delete(name)
-        shovel = @shovels.lock { |h| h.delete(name) }
+        shovel = @shovels.lock(&.delete(name))
         if shovel
           shovel.delete
           shovel

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -1,3 +1,4 @@
+require "sync/exclusive"
 require "./runner"
 require "./amqp_source"
 require "./http_destination.cr"
@@ -12,11 +13,41 @@ module LavinMQ
     class ConfigError < Error; end
 
     class Store
+      @shovels : Sync::Exclusive(Hash(String, Shovel::Runner))
+
       def initialize(@vhost : VHost)
-        @shovels = Hash(String, Shovel::Runner).new
+        @shovels = Sync::Exclusive.new(Hash(String, Shovel::Runner).new)
       end
 
-      forward_missing_to @shovels
+      # Explicit accessors replacing forward_missing_to
+
+      def []?(name : String) : Shovel::Runner?
+        @shovels.lock { |h| h[name]? }
+      end
+
+      def [](name : String) : Shovel::Runner
+        @shovels.lock { |h| h[name] }
+      end
+
+      def each_value(& : Shovel::Runner ->)
+        @shovels.lock { |h| h.each_value { |v| yield v } }
+      end
+
+      def each_value : Iterator(Shovel::Runner)
+        @shovels.lock(&.values).each
+      end
+
+      def size : Int32
+        @shovels.lock(&.size)
+      end
+
+      def empty? : Bool
+        @shovels.lock(&.empty?)
+      end
+
+      def has_key?(name : String) : Bool
+        @shovels.lock { |h| h.has_key?(name) }
+      end
 
       # ameba:disable Metrics/CyclomaticComplexity
       def self.validate_config!(config : JSON::Any, user : Auth::BaseUser?)
@@ -85,7 +116,7 @@ module LavinMQ
       end
 
       def create(name, config)
-        @shovels[name]?.try &.terminate
+        @shovels.lock { |h| h[name]?.try &.terminate }
         delete_after_str = config["src-delete-after"]?.try(&.as_s.delete("-")).to_s
         delete_after = Shovel::DeleteAfter.parse?(delete_after_str) || Shovel::DEFAULT_DELETE_AFTER
         ack_mode_str = config["ack-mode"]?.try(&.as_s.delete("-")).to_s
@@ -103,7 +134,7 @@ module LavinMQ
           direct_user: @vhost.users.direct_user)
         dest = destination(name, config, ack_mode)
         shovel = Shovel::Runner.new(src, dest, name, @vhost, reconnect_delay)
-        @shovels[name] = shovel
+        @shovels.lock { |h| h[name] = shovel }
         spawn(shovel.run, name: "Shovel name=#{name} vhost=#{@vhost.name}")
         shovel
       rescue KeyError
@@ -111,7 +142,8 @@ module LavinMQ
       end
 
       def delete(name)
-        if shovel = @shovels.delete name
+        shovel = @shovels.lock { |h| h.delete(name) }
+        if shovel
           shovel.delete
           shovel
         end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -56,7 +56,7 @@ module LavinMQ
       @exchanges.shared { |h| h[name] }
     end
 
-    def exchanges_has_key?(name : String) : Bool
+    def exchange_exists?(name : String) : Bool
       @exchanges.shared(&.has_key?(name))
     end
 
@@ -86,7 +86,7 @@ module LavinMQ
       @queues.shared { |h| h[name] }
     end
 
-    def queues_has_key?(name : String) : Bool
+    def queue_exists?(name : String) : Bool
       @queues.shared(&.has_key?(name))
     end
 

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -48,11 +48,11 @@ module LavinMQ
 
     # Synchronized exchange accessors
 
-    def exchanges_byname?(name : String) : Exchange?
+    def exchange?(name : String) : Exchange?
       @exchanges.shared { |h| h[name]? }
     end
 
-    def exchanges_byname(name : String) : Exchange
+    def exchange(name : String) : Exchange
       @exchanges.shared { |h| h[name] }
     end
 
@@ -82,11 +82,11 @@ module LavinMQ
 
     # Synchronized queue accessors
 
-    def queues_byname?(name : String) : Queue?
+    def queue?(name : String) : Queue?
       @queues.shared { |h| h[name]? }
     end
 
-    def queues_byname(name : String) : Queue
+    def queue(name : String) : Queue
       @queues.shared { |h| h[name] }
     end
 
@@ -260,7 +260,7 @@ module LavinMQ
     # When this method finishes, the position will be the same, start of the body
     def publish(msg : Message, immediate = false,
                 visited = Set(LavinMQ::Exchange).new, found_queues = Set(LavinMQ::Queue).new) : Bool
-      ex = exchanges_byname?(msg.exchange_name) || return false
+      ex = exchange?(msg.exchange_name) || return false
       ex.publish(msg, immediate, found_queues, visited)
     ensure
       visited.clear

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -1,5 +1,7 @@
 require "json"
 require "../stdlib/*"
+require "sync/shared"
+require "sync/exclusive"
 require "./logger"
 require "./policy"
 require "./parameter_store"
@@ -25,8 +27,7 @@ module LavinMQ
                 "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
                 "redeliver", "reject", "consumer_added", "consumer_removed"})
 
-    getter name, exchanges, queues, data_dir, operator_policies, policies, parameters, shovels,
-      direct_reply_consumers, connections, dir, users
+    getter name, data_dir, operator_policies, policies, parameters, shovels, dir, users
 
     def flow?
       @flow.get(:acquire)
@@ -45,12 +46,129 @@ module LavinMQ
     property max_connections : Int32?
     property max_queues : Int32?
 
-    @exchanges = Hash(String, Exchange).new
-    @queues = Hash(String, Queue).new
-    @direct_reply_consumers = Hash(String, Client::Channel).new
+    # Synchronized exchange accessors
+
+    def exchanges_byname?(name : String) : Exchange?
+      @exchanges.shared { |h| h[name]? }
+    end
+
+    def exchanges_byname(name : String) : Exchange
+      @exchanges.shared { |h| h[name] }
+    end
+
+    def exchanges_fetch(name : String, default) : Exchange?
+      @exchanges.shared { |h| h.fetch(name, default) }
+    end
+
+    def exchanges_has_key?(name : String) : Bool
+      @exchanges.shared { |h| h.has_key?(name) }
+    end
+
+    def exchanges_each_value(& : Exchange ->) : Nil
+      @exchanges.shared { |h| h.each_value { |v| yield v } }
+    end
+
+    def exchanges_each_value : Iterator(Exchange)
+      @exchanges.shared(&.values).each
+    end
+
+    def exchanges_size : Int32
+      @exchanges.shared(&.size)
+    end
+
+    def exchanges_any?(& : {String, Exchange} -> Bool) : Bool
+      @exchanges.shared { |h| h.any? { |kv| yield kv } }
+    end
+
+    # Synchronized queue accessors
+
+    def queues_byname?(name : String) : Queue?
+      @queues.shared { |h| h[name]? }
+    end
+
+    def queues_byname(name : String) : Queue
+      @queues.shared { |h| h[name] }
+    end
+
+    def queues_fetch(name : String, default) : Queue?
+      @queues.shared { |h| h.fetch(name, default) }
+    end
+
+    def queues_has_key?(name : String) : Bool
+      @queues.shared { |h| h.has_key?(name) }
+    end
+
+    def queues_each_value(& : Queue ->) : Nil
+      @queues.shared { |h| h.each_value { |v| yield v } }
+    end
+
+    def queues_each_value : Iterator(Queue)
+      @queues.shared(&.values).each
+    end
+
+    def queues_size : Int32
+      @queues.shared(&.size)
+    end
+
+    # Synchronized connection accessors
+
+    def connections_each(& : Client ->) : Nil
+      @connections.lock { |a| a.each { |c| yield c } }
+    end
+
+    def connections_each : Iterator(Client)
+      @connections.lock(&.dup).each
+    end
+
+    def connections_size : Int32
+      @connections.lock(&.size)
+    end
+
+    def queues_values : Array(Queue)
+      @queues.shared(&.values)
+    end
+
+    # Internal: direct write, acquires exclusive lock.
+    # Used by Exchange#init_delayed_queue and tests.
+    protected def queues_unsafe_put(name : String, queue : Queue) : Nil
+      @queues.lock { |h| h[name] = queue }
+    end
+
+    # Internal: direct write, acquires exclusive lock.
+    # Used by MQTT::Broker during initialization and tests.
+    protected def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
+      @exchanges.lock { |h| h[name] = exchange }
+    end
+
+    # Internal: clear all queues. Used only in tests.
+    protected def queues_clear : Nil
+      @queues.lock(&.clear)
+    end
+
+    # Synchronized direct reply consumer accessors
+
+    def direct_reply_consumer?(consumer_tag : String) : Client::Channel?
+      @direct_reply_consumers.lock { |h| h[consumer_tag]? }
+    end
+
+    def direct_reply_consumer_set(consumer_tag : String, channel : Client::Channel) : Nil
+      @direct_reply_consumers.lock { |h| h[consumer_tag] = channel }
+    end
+
+    def direct_reply_consumer_delete(consumer_tag : String) : Client::Channel?
+      @direct_reply_consumers.lock { |h| h.delete(consumer_tag) }
+    end
+
+    def direct_reply_consumer_has_key?(consumer_tag : String) : Bool
+      @direct_reply_consumers.lock { |h| h.has_key?(consumer_tag) }
+    end
+
+    @exchanges : Sync::Shared(Hash(String, Exchange))
+    @queues : Sync::Shared(Hash(String, Queue))
+    @direct_reply_consumers : Sync::Exclusive(Hash(String, Client::Channel))
     @shovels : Shovel::Store?
     @upstreams : Federation::UpstreamStore?
-    @connections = Array(Client).new(512)
+    @connections : Sync::Exclusive(Array(Client))
     @definitions_file : File
     @definitions_lock = Mutex.new(:reentrant)
     @definitions_file_path : String
@@ -67,6 +185,10 @@ module LavinMQ
       @definitions_file = File.open(@definitions_file_path, "a+")
       @replicator.try &.register_file(@definitions_file)
       File.write(File.join(@data_dir, ".vhost"), @name)
+      @exchanges = Sync::Shared.new(Hash(String, Exchange).new)
+      @queues = Sync::Shared.new(Hash(String, Queue).new)
+      @connections = Sync::Exclusive.new(Array(Client).new(512))
+      @direct_reply_consumers = Sync::Exclusive.new(Hash(String, Client::Channel).new)
       load_limits
       @operator_policies = ParameterStore(OperatorPolicy).new(@data_dir, "operator_policies.json", @replicator, vhost: @name)
       @policies = ParameterStore(Policy).new(@data_dir, "policies.json", @replicator, vhost: @name)
@@ -81,7 +203,7 @@ module LavinMQ
       loop do
         sleep Config.instance.consumer_timeout_loop_interval.seconds
         return if closed?
-        @connections.each do |c|
+        connections_each do |c|
           c.channels.each_value do |ch|
             ch.check_consumer_timeout
           end
@@ -138,7 +260,7 @@ module LavinMQ
     # When this method finishes, the position will be the same, start of the body
     def publish(msg : Message, immediate = false,
                 visited = Set(LavinMQ::Exchange).new, found_queues = Set(LavinMQ::Queue).new) : Bool
-      ex = @exchanges[msg.exchange_name]? || return false
+      ex = exchanges_byname?(msg.exchange_name) || return false
       ex.publish(msg, immediate, found_queues, visited)
     ensure
       visited.clear
@@ -159,7 +281,7 @@ module LavinMQ
     def message_details
       ready = unacked = 0_u64
       ack = confirm = deliver = deliver_no_ack = get = get_no_ack = publish = redeliver = return_unroutable = deliver_get = 0_u64
-      @queues.each_value do |q|
+      queues_each_value do |q|
         ready += q.message_count
         unacked += q.unacked_count
         ack += q.ack_count
@@ -237,76 +359,113 @@ module LavinMQ
 
     # ameba:disable Metrics/CyclomaticComplexity
     def apply(f, loading = false) : Bool
+      should_compact = false
       @definitions_lock.synchronize do
         case f
         when AMQP::Frame::Exchange::Declare
-          return false if @exchanges.has_key? f.exchange_name
-          e = @exchanges[f.exchange_name] =
-            make_exchange(self, f.exchange_name, f.exchange_type, f.durable, f.auto_delete, f.internal, f.arguments)
-          apply_policies([e] of Exchange) unless loading
-          store_definition(f) if !loading && f.durable
+          @exchanges.lock do |exchanges|
+            return false if exchanges.has_key? f.exchange_name
+            e = exchanges[f.exchange_name] =
+              make_exchange(self, f.exchange_name, f.exchange_type, f.durable, f.auto_delete, f.internal, f.arguments)
+            apply_policies([e] of Exchange) unless loading
+            store_definition(f) if !loading && f.durable
+            nil
+          end
         when AMQP::Frame::Exchange::Delete
-          if x = @exchanges.delete f.exchange_name
-            @exchanges.each_value do |ex|
-              ex.bindings_details.each do |binding|
-                next unless binding.destination == x
-                ex.unbind(x, binding.routing_key, binding.arguments)
+          @exchanges.lock do |exchanges|
+            if x = exchanges.delete f.exchange_name
+              exchanges.each_value do |ex|
+                ex.bindings_details.each do |binding|
+                  next unless binding.destination == x
+                  ex.unbind(x, binding.routing_key, binding.arguments)
+                end
               end
+              x.delete
+              should_compact = track_dirty_definition(f, !loading && x.durable?)
+            else
+              return false
             end
-            x.delete
-            store_definition(f, dirty: true) if !loading && x.durable?
-          else
-            return false
+            nil
           end
         when AMQP::Frame::Exchange::Bind
-          src = @exchanges[f.source]? || return false
-          dst = @exchanges[f.destination]? || return false
-          return false unless src.bind(dst, f.routing_key, f.arguments)
-          store_definition(f) if !loading && src.durable? && dst.durable?
+          @exchanges.lock do |exchanges|
+            src = exchanges[f.source]? || return false
+            dst = exchanges[f.destination]? || return false
+            return false unless src.bind(dst, f.routing_key, f.arguments)
+            store_definition(f) if !loading && src.durable? && dst.durable?
+            nil
+          end
         when AMQP::Frame::Exchange::Unbind
-          src = @exchanges[f.source]? || return false
-          dst = @exchanges[f.destination]? || return false
-          return false unless src.unbind(dst, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && src.durable? && dst.durable?
+          @exchanges.lock do |exchanges|
+            src = exchanges[f.source]? || return false
+            dst = exchanges[f.destination]? || return false
+            return false unless src.unbind(dst, f.routing_key, f.arguments)
+            should_compact = track_dirty_definition(f, !loading && src.durable? && dst.durable?)
+            nil
+          end
         when AMQP::Frame::Queue::Declare
-          return false if @queues.has_key? f.queue_name
-          q = @queues[f.queue_name] = QueueFactory.make(self, f)
-          apply_policies([q] of Queue) unless loading
-          store_definition(f) if !loading && f.durable && !f.exclusive
-          event_tick(EventType::QueueDeclared) unless loading
+          @queues.lock do |queues|
+            return false if queues.has_key? f.queue_name
+            q = queues[f.queue_name] = QueueFactory.make(self, f)
+            apply_policies([q] of Queue) unless loading
+            store_definition(f) if !loading && f.durable && !f.exclusive
+            event_tick(EventType::QueueDeclared) unless loading
+            nil
+          end
         when AMQP::Frame::Queue::Delete
-          if q = @queues.delete(f.queue_name)
-            @exchanges.each_value do |ex|
-              ex.bindings_details.each do |binding|
-                next unless binding.destination == q
-                ex.unbind(q, binding.routing_key, binding.arguments)
+          # Lock order: always @exchanges before @queues to prevent deadlocks
+          @exchanges.lock do |exchanges|
+            @queues.lock do |queues|
+              if q = queues.delete(f.queue_name)
+                exchanges.each_value do |ex|
+                  ex.bindings_details.each do |binding|
+                    next unless binding.destination == q
+                    ex.unbind(q, binding.routing_key, binding.arguments)
+                  end
+                end
+                should_compact = track_dirty_definition(f, !loading && q.durable? && !q.exclusive?)
+                event_tick(EventType::QueueDeleted) unless loading
+                q.delete
+              else
+                return false
               end
+              nil
             end
-            store_definition(f, dirty: true) if !loading && q.durable? && !q.exclusive?
-            event_tick(EventType::QueueDeleted) unless loading
-            q.delete
-          else
-            return false
+            nil
           end
         when AMQP::Frame::Queue::Bind
-          x = @exchanges[f.exchange_name]? || return false
-          q = @queues[f.queue_name]? || return false
-          return false unless x.bind(q, f.routing_key, f.arguments)
-          store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
+          @exchanges.shared do |exchanges|
+            @queues.shared do |queues|
+              x = exchanges[f.exchange_name]? || return false
+              q = queues[f.queue_name]? || return false
+              return false unless x.bind(q, f.routing_key, f.arguments)
+              store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
+              nil
+            end
+            nil
+          end
         when AMQP::Frame::Queue::Unbind
-          x = @exchanges[f.exchange_name]? || return false
-          q = @queues[f.queue_name]? || return false
-          return false unless x.unbind(q, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
+          @exchanges.shared do |exchanges|
+            @queues.shared do |queues|
+              x = exchanges[f.exchange_name]? || return false
+              q = queues[f.queue_name]? || return false
+              return false unless x.unbind(q, f.routing_key, f.arguments)
+              should_compact = track_dirty_definition(f, !loading && x.durable? && q.durable? && !q.exclusive?)
+              nil
+            end
+            nil
+          end
         else raise "Cannot apply frame #{f.class} in vhost #{@name}"
         end
-        true
       end
+      # Compact outside the hash locks to avoid deadlock
+      compact! if should_compact
+      true
     end
 
     def queue_bindings(queue : Queue) : Iterator(BindingDetails)
       default_binding = BindingDetails.new("", name, BindingKey.new(queue.name), queue)
-      bindings = @exchanges.each_value.flat_map do |ex|
+      bindings = exchanges_each_value.flat_map do |ex|
         ex.bindings_details.select { |binding| binding.destination == queue }
       end
       {default_binding}.each.chain(bindings)
@@ -346,12 +505,12 @@ module LavinMQ
 
     def add_connection(client : Client)
       event_tick(EventType::ConnectionCreated)
-      @connections << client
+      @connections.lock { |a| a << client }
     end
 
     def rm_connection(client : Client)
       event_tick(EventType::ConnectionClosed)
-      @connections.delete client
+      @connections.lock { |a| a.delete client }
     end
 
     SHOVEL                  = "shovel"
@@ -389,10 +548,12 @@ module LavinMQ
     end
 
     private def close_connections(reason)
+      # Snapshot connections under lock, then close outside lock
+      conns = @connections.lock(&.dup)
       WaitGroup.wait do |wg|
         to_close = Channel(Client).new
         fiber_count = 0
-        @connections.each do |client|
+        conns.each do |client|
           select
           when to_close.send client
           else # spawn another fiber closing channels
@@ -431,13 +592,13 @@ module LavinMQ
       when close_done.receive?
         @log.info { "All connections closed gracefully" }
       when timeout 15.seconds
-        @log.warn { "Timeout waiting for connections to close. #{@connections.size} left that will be forced closed." }
+        @log.warn { "Timeout waiting for connections to close. #{connections_size} left that will be forced closed." }
       end
       close_done.close
       # then force close the remaining (close tcp socket)
-      @connections.each &.force_close
+      connections_each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
-      @queues.each_value &.close
+      queues_each_value &.close
       Fiber.yield
       @definitions_file.close
       FileUtils.rm_rf File.join(@data_dir, "transient")
@@ -453,7 +614,7 @@ module LavinMQ
       resources = if resources
                     resources.each
                   else
-                    Iterator.chain({@queues.each_value, @exchanges.each_value})
+                    Iterator.chain({queues_each_value, exchanges_each_value})
                   end
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse
@@ -579,66 +740,85 @@ module LavinMQ
 
     private def load_default_definitions
       @log.info { "Loading default definitions" }
-      @exchanges[""] = AMQP::DefaultExchange.new(self, "", true, false, false)
-      @exchanges["amq.direct"] = AMQP::DirectExchange.new(self, "amq.direct", true, false, false)
-      @exchanges["amq.fanout"] = AMQP::FanoutExchange.new(self, "amq.fanout", true, false, false)
-      @exchanges["amq.topic"] = AMQP::TopicExchange.new(self, "amq.topic", true, false, false)
-      @exchanges["amq.headers"] = AMQP::HeadersExchange.new(self, "amq.headers", true, false, false)
-      @exchanges["amq.match"] = AMQP::HeadersExchange.new(self, "amq.match", true, false, false)
-    end
-
-    private def compact!
-      @definitions_lock.synchronize do
-        @log.info { "Compacting definitions" }
-        io = File.open("#{@definitions_file_path}.tmp", "a+")
-        SchemaVersion.prefix(io, :definition)
-        @exchanges.each_value.select(&.durable?).each do |e|
-          f = AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, e.name, e.type,
-            false, e.durable?, e.auto_delete?, e.internal?,
-            false, e.arguments)
-          io.write_bytes f
-        end
-        @queues.each_value.select(&.durable?).each do |q|
-          f = AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, q.name, false, q.durable?, q.exclusive?,
-            q.auto_delete?, false, q.arguments)
-          io.write_bytes f
-        end
-        @exchanges.each_value.select(&.durable?).each do |e|
-          e.bindings_details.each do |binding|
-            args = binding.arguments || AMQP::Table.new
-            frame = case binding.destination
-                    when Queue
-                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
-                    when Exchange
-                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
-                    end
-            if f = frame
-              io.write_bytes f
-            end
-          end
-        end
-        io.fsync
-        File.rename io.path, @definitions_file_path
-        @replicator.try &.replace_file @definitions_file_path
-        @definitions_file.close
-        @definitions_file = io
+      @exchanges.lock do |exchanges|
+        exchanges[""] = AMQP::DefaultExchange.new(self, "", true, false, false)
+        exchanges["amq.direct"] = AMQP::DirectExchange.new(self, "amq.direct", true, false, false)
+        exchanges["amq.fanout"] = AMQP::FanoutExchange.new(self, "amq.fanout", true, false, false)
+        exchanges["amq.topic"] = AMQP::TopicExchange.new(self, "amq.topic", true, false, false)
+        exchanges["amq.headers"] = AMQP::HeadersExchange.new(self, "amq.headers", true, false, false)
+        exchanges["amq.match"] = AMQP::HeadersExchange.new(self, "amq.match", true, false, false)
       end
     end
 
-    private def store_definition(frame, dirty = false)
+    # Called from apply() which already holds @exchanges.lock and @queues.lock
+    private def compact!(exchanges : Hash(String, Exchange), queues : Hash(String, Queue))
+      @definitions_lock.synchronize do
+        do_compact!(exchanges, queues)
+      end
+    end
+
+    # Called during load when no other fibers are active
+    private def compact!
+      @definitions_lock.synchronize do
+        @exchanges.lock do |exchanges|
+          @queues.lock do |queues|
+            do_compact!(exchanges, queues)
+          end
+        end
+      end
+    end
+
+    private def do_compact!(exchanges : Hash(String, Exchange), queues : Hash(String, Queue))
+      @log.info { "Compacting definitions" }
+      io = File.open("#{@definitions_file_path}.tmp", "a+")
+      SchemaVersion.prefix(io, :definition)
+      exchanges.each_value.select(&.durable?).each do |e|
+        f = AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, e.name, e.type,
+          false, e.durable?, e.auto_delete?, e.internal?,
+          false, e.arguments)
+        io.write_bytes f
+      end
+      queues.each_value.select(&.durable?).each do |q|
+        f = AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, q.name, false, q.durable?, q.exclusive?,
+          q.auto_delete?, false, q.arguments)
+        io.write_bytes f
+      end
+      exchanges.each_value.select(&.durable?).each do |e|
+        e.bindings_details.each do |binding|
+          args = binding.arguments || AMQP::Table.new
+          frame = case binding.destination
+                  when Queue
+                    AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
+                      binding.routing_key, false, args)
+                  when Exchange
+                    AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
+                      binding.routing_key, false, args)
+                  end
+          if f = frame
+            io.write_bytes f
+          end
+        end
+      end
+      io.fsync
+      File.rename io.path, @definitions_file_path
+      @replicator.try &.replace_file @definitions_file_path
+      @definitions_file.close
+      @definitions_file = io
+    end
+
+    private def store_definition(frame)
       @log.debug { "Storing definition: #{frame.inspect}" }
       bytes = frame.to_slice
       @definitions_file.write bytes
       @replicator.try &.append @definitions_file_path, bytes
       @definitions_file.fsync
-      if dirty
-        if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions
-          compact!
-          @definitions_deletes = 0
-        end
-      end
+    end
+
+    # Writes a dirty (delete/unbind) definition and returns true if compaction is needed
+    private def track_dirty_definition(frame, should_store : Bool) : Bool
+      return false unless should_store
+      store_definition(frame)
+      (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions
     end
 
     private def make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -204,7 +204,7 @@ module LavinMQ
         sleep Config.instance.consumer_timeout_loop_interval.seconds
         return if closed?
         connections_each do |c|
-          c.channels.each_value do |ch|
+          c.channels_each_value do |ch|
             ch.check_consumer_timeout
           end
         end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -56,10 +56,6 @@ module LavinMQ
       @exchanges.shared { |h| h[name] }
     end
 
-    def exchanges_fetch(name : String, default) : Exchange?
-      @exchanges.shared(&.fetch(name, default))
-    end
-
     def exchanges_has_key?(name : String) : Bool
       @exchanges.shared(&.has_key?(name))
     end
@@ -88,10 +84,6 @@ module LavinMQ
 
     def queue(name : String) : Queue
       @queues.shared { |h| h[name] }
-    end
-
-    def queues_fetch(name : String, default) : Queue?
-      @queues.shared(&.fetch(name, default))
     end
 
     def queues_has_key?(name : String) : Bool

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -57,11 +57,11 @@ module LavinMQ
     end
 
     def exchanges_fetch(name : String, default) : Exchange?
-      @exchanges.shared { |h| h.fetch(name, default) }
+      @exchanges.shared(&.fetch(name, default))
     end
 
     def exchanges_has_key?(name : String) : Bool
-      @exchanges.shared { |h| h.has_key?(name) }
+      @exchanges.shared(&.has_key?(name))
     end
 
     def exchanges_each_value(& : Exchange ->) : Nil
@@ -91,11 +91,11 @@ module LavinMQ
     end
 
     def queues_fetch(name : String, default) : Queue?
-      @queues.shared { |h| h.fetch(name, default) }
+      @queues.shared(&.fetch(name, default))
     end
 
     def queues_has_key?(name : String) : Bool
-      @queues.shared { |h| h.has_key?(name) }
+      @queues.shared(&.has_key?(name))
     end
 
     def queues_each_value(& : Queue ->) : Nil
@@ -156,11 +156,11 @@ module LavinMQ
     end
 
     def direct_reply_consumer_delete(consumer_tag : String) : Client::Channel?
-      @direct_reply_consumers.lock { |h| h.delete(consumer_tag) }
+      @direct_reply_consumers.lock(&.delete(consumer_tag))
     end
 
     def direct_reply_consumer_has_key?(consumer_tag : String) : Bool
-      @direct_reply_consumers.lock { |h| h.has_key?(consumer_tag) }
+      @direct_reply_consumers.lock(&.has_key?(consumer_tag))
     end
 
     @exchanges : Sync::Shared(Hash(String, Exchange))
@@ -510,7 +510,7 @@ module LavinMQ
 
     def rm_connection(client : Client)
       event_tick(EventType::ConnectionClosed)
-      @connections.lock { |a| a.delete client }
+      @connections.lock(&.delete(client))
     end
 
     SHOVEL                  = "shovel"

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -42,7 +42,7 @@ module LavinMQ
     end
 
     def has_key?(name : String) : Bool
-      @vhosts.shared { |h| h.has_key?(name) }
+      @vhosts.shared(&.has_key?(name))
     end
 
     def size : Int32
@@ -82,7 +82,7 @@ module LavinMQ
     end
 
     def delete(name) : VHost?
-      vhost = @vhosts.lock { |h| h.delete(name) }
+      vhost = @vhosts.lock(&.delete(name))
       if vhost
         @users.rm_vhost_permissions_for_all(name)
         vhost.delete

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -1,4 +1,5 @@
 require "json"
+require "sync/shared"
 require "./vhost"
 require "./auth/base_user"
 require "./observable"
@@ -15,35 +16,74 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "vhost_store"
 
+    @vhosts : Sync::Shared(Hash(String, VHost))
+
     def initialize(@data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?)
-      @vhosts = Hash(String, VHost).new
+      @vhosts = Sync::Shared.new(Hash(String, VHost).new)
       load!
     end
 
-    forward_missing_to @vhosts
+    # Explicit accessors replacing forward_missing_to
+
+    def []?(name : String) : VHost?
+      @vhosts.shared { |h| h[name]? }
+    end
+
+    def [](name : String) : VHost
+      @vhosts.shared { |h| h[name] }
+    end
+
+    def each_value(& : VHost ->)
+      @vhosts.shared { |h| h.each_value { |v| yield v } }
+    end
+
+    def each_value : Iterator(VHost)
+      @vhosts.shared(&.values).each
+    end
+
+    def has_key?(name : String) : Bool
+      @vhosts.shared { |h| h.has_key?(name) }
+    end
+
+    def size : Int32
+      @vhosts.shared(&.size)
+    end
+
+    def values : Array(VHost)
+      @vhosts.shared(&.values)
+    end
+
+    def first_value : VHost
+      @vhosts.shared(&.first_value)
+    end
 
     def each(&)
-      @vhosts.each do |kv|
-        yield kv
+      @vhosts.shared do |h|
+        h.each do |kv|
+          yield kv
+        end
       end
     end
 
     def create(name : String, user : Auth::BaseUser = @users.default_user, description = "", tags = Array(String).new(0), save : Bool = true)
-      if v = @vhosts[name]?
-        return v
+      @vhosts.lock do |h|
+        if v = h[name]?
+          return v
+        end
+        vhost = VHost.new(name, @data_dir, @users, @replicator, description, tags)
+        Log.info { "Created vhost #{name}" }
+        @users.add_permission(user.name, name, /.*/, /.*/, /.*/)
+        @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/)
+        h[name] = vhost
+        save! if save
+        notify_observers(Event::Added, name)
+        vhost
       end
-      vhost = VHost.new(name, @data_dir, @users, @replicator, description, tags)
-      Log.info { "Created vhost #{name}" }
-      @users.add_permission(user.name, name, /.*/, /.*/, /.*/)
-      @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/)
-      @vhosts[name] = vhost
-      save! if save
-      notify_observers(Event::Added, name)
-      vhost
     end
 
     def delete(name) : VHost?
-      if vhost = @vhosts.delete name
+      vhost = @vhosts.lock { |h| h.delete(name) }
+      if vhost
         @users.rm_vhost_permissions_for_all(name)
         vhost.delete
         notify_observers(Event::Deleted, name)
@@ -54,8 +94,9 @@ module LavinMQ
     end
 
     def close
+      vhosts = @vhosts.shared(&.values)
       WaitGroup.wait do |wg|
-        @vhosts.each_value do |vhost|
+        vhosts.each do |vhost|
           wg.spawn do
             vhost.close
             notify_observers(Event::Closed, vhost.name)
@@ -66,8 +107,10 @@ module LavinMQ
 
     def to_json(json : JSON::Builder)
       json.array do
-        @vhosts.each_value do |vhost|
-          vhost.to_json(json)
+        @vhosts.shared do |h|
+          h.each_value do |vhost|
+            vhost.to_json(json)
+          end
         end
       end
     end
@@ -77,12 +120,14 @@ module LavinMQ
       if File.exists? path
         Log.debug { "Loading vhosts from file" }
         File.open(path) do |f|
-          JSON.parse(f).as_a.each do |vhost|
-            name = vhost["name"].as_s
-            tags = vhost["tags"]?.try(&.as_a.map(&.to_s)) || [] of String
-            description = vhost["description"]?.try &.as_s || ""
-            @vhosts[name] = VHost.new(name, @data_dir, @users, @replicator, description, tags)
-            @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/)
+          @vhosts.lock do |h|
+            JSON.parse(f).as_a.each do |vhost|
+              name = vhost["name"].as_s
+              tags = vhost["tags"]?.try(&.as_a.map(&.to_s)) || [] of String
+              description = vhost["description"]?.try &.as_s || ""
+              h[name] = VHost.new(name, @data_dir, @users, @replicator, description, tags)
+              @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/)
+            end
           end
           @replicator.try &.register_file(f)
         end


### PR DESCRIPTION
## Summary
- Migrates shared mutable state to use `Sync::Shared` (RWLock) and `Sync::Exclusive` (Mutex) wrappers for thread safety with `Fiber::ExecutionContext::Parallel`
- Wraps atomic bools, global registries (UserStore, VHostStore, ParameterStore, Shovel::Store), VHost exchanges/queues/connections, exchange bindings, queue consumers, MQTT broker state, Observable observers, and federation upstream links
- Fixes recursive lock deadlocks in VHost#apply and a federation link TOCTOU race condition
- Makes worker thread count configurable via `--thread-count` / `LAVINMQ_THREAD_COUNT` (default: CPU count)

## Test plan
- [ ] `make test` passes all specs
- [ ] Manual smoke test with `bin/lavinmq --data-dir ./tmp/data --debug`
- [ ] Verify `--thread-count=N` configures the correct number of worker threads
- [ ] Stress test concurrent AMQP and MQTT connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)