### PR TITLE
Add option to disable message timestamp validation

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -92,6 +92,7 @@ describe LavinMQ::Config do
           log_file = /tmp/lavinmq-test.log
           stats_interval = 10000
           stats_log_size = 240
+          validate_timestamp = false
           set_timestamp = true
           socket_buffer_size = 32768
           tcp_nodelay = true
@@ -175,6 +176,7 @@ describe LavinMQ::Config do
       config.log_file.should eq "/tmp/lavinmq-test.log"
       config.stats_interval.should eq 10000
       config.stats_log_size.should eq 240
+      config.validate_timestamp?.should be_false
       config.set_timestamp?.should be_true
       config.socket_buffer_size.should eq 32768
       config.tcp_nodelay?.should be_true

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -221,7 +221,12 @@ module LavinMQ
         @publish_count.add(1, :relaxed)
         @client.vhost.event_tick(EventType::ClientPublish)
         props = @next_msg_props.not_nil!
-        props.timestamp = RoughTime.utc if props.timestamp.nil? && Config.instance.set_timestamp?
+        if props.timestamp_raw && Config.instance.validate_timestamp?
+          props.timestamp
+        end
+        if props.timestamp_raw.nil? && Config.instance.set_timestamp?
+          props.timestamp = RoughTime.utc
+        end
         msg = Message.new(RoughTime.unix_ms,
           @next_publish_exchange_name.not_nil!,
           @next_publish_routing_key.not_nil!,

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -163,6 +163,9 @@ module LavinMQ
       property stats_log_size = 120 # 10 mins at 5s interval
 
       @[IniOpt(section: "main")]
+      property? validate_timestamp = true # validate message timestamp if true, otherwise allow any Int64
+
+      @[IniOpt(section: "main")]
       property? set_timestamp = false # in message headers when receive
 
       @[IniOpt(section: "main")]


### PR DESCRIPTION
### WHAT is this pull request doing?

This pull request adds a new `validate_timestamp` configuration option that allows message timestamp validation to be explicitly disabled.

Fixes #1684

### HOW can this pull request be tested?

Specs have been added to `server_spec.cr‎` and updated in `config_spec.cr‎`.