### PR TITLE
Use policymaker role consistently for global-parameters endpoints

### DIFF
--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -516,6 +516,17 @@ describe LavinMQ::HTTP::ParametersController do
     end
   end
   describe "DELETE /api/global-parameters/name" do
+    it "should refuse management users from deleting a global parameter" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
+        s.add_parameter(p)
+        response = http.delete("/api/global-parameters/name", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+
     it "should delete parameter" do
       with_http_server do |http, s|
         p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))

--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -406,6 +406,24 @@ describe LavinMQ::HTTP::ParametersController do
         body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
       end
     end
+
+    it "should allow policymaker to list global parameters" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/global-parameters", headers: hdrs)
+        response.status_code.should eq 200
+      end
+    end
+
+    it "should refuse management users from listing global parameters" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/global-parameters", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
   end
   describe "GET /api/global-parameters/name" do
     it "should return parameter" do
@@ -416,8 +434,38 @@ describe LavinMQ::HTTP::ParametersController do
         response.status_code.should eq 200
       end
     end
+
+    it "should allow policymaker to get a global parameter" do
+      with_http_server do |http, s|
+        p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new({} of String => JSON::Any))
+        s.add_parameter(p)
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/global-parameters/name", headers: hdrs)
+        response.status_code.should eq 200
+      end
+    end
+
+    it "should refuse management users from getting a global parameter" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/global-parameters/name", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
   end
   describe "PUT /api/global-parameters/name" do
+    it "should refuse management users from creating a global parameter" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        body = %({"value": {}})
+        response = http.put("/api/global-parameters/name", headers: hdrs, body: body)
+        response.status_code.should eq 403
+      end
+    end
+
     it "should create global parameter" do
       with_http_server do |http, s|
         s.delete_parameter(nil, "name")

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -108,12 +108,12 @@ module LavinMQ
         end
 
         get "/api/global-parameters" do |context, _params|
-          refuse_unless_administrator(context, user(context))
+          refuse_unless_policymaker(context, user(context))
           page(context, @amqp_server.parameters.each_value.map { |p| map_parameter(nil, p) })
         end
 
         get "/api/global-parameters/:name" do |context, params|
-          refuse_unless_administrator(context, user(context))
+          refuse_unless_policymaker(context, user(context))
           name = params["name"]
           param = param(context, @amqp_server.parameters, {nil, name})
           map_parameter(nil, param).to_json(context.response)
@@ -121,7 +121,7 @@ module LavinMQ
         end
 
         put "/api/global-parameters/:name" do |context, params|
-          refuse_unless_administrator(context, user(context))
+          refuse_unless_policymaker(context, user(context))
           name = params["name"]
           body = parse_body(context)
           value = body["value"]?


### PR DESCRIPTION
### WHAT is this pull request doing?
This adds consistent permission access across the global parameters endpoints. 
This follows rabbitmq's access management [For global parameters. Must be policymaker.](https://github.com/rabbitmq/rabbitmq-server/blob/008cf25f58dba5162f237c2c282d8e0c85bce495/deps/rabbitmq_management/src/rabbit_mgmt_util.erl#L185)

**Be clear in releasenotes that this may break someones workflow!**

### HOW can this pull request be tested?
run added specs