### PR TITLE
Aggregate data rates at vhost level for all protocols

### DIFF
--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "./mqtt/spec_helper"
 require "../src/lavinmq/config"
 
 describe LavinMQ::VHost do
@@ -99,6 +100,151 @@ describe LavinMQ::VHost do
           vhost.deliver_count.should eq 1
           vhost.deliver_no_ack_count.should eq 1
           vhost.deliver_get_count.should eq 2
+        end
+      end
+    end
+  end
+end
+
+# This module uses `extend MqttHelpers` to get access to MQTT test helpers
+# (with_server, with_client_io, connect, publish, etc.)
+module VHostByteRateSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  # Sends data over the given protocol and returns the number of bytes
+  # the vhost should have tracked. Uses exhaustive case (case...in) on
+  # the Protocol enum so that adding a new protocol variant without
+  # handling it here will cause a compile error.
+  def self.send_and_receive_over_protocol(protocol, s, vhost)
+    case protocol
+    in LavinMQ::Server::Protocol::AMQP
+      port = s.@listeners.keys.select(TCPServer).first.local_address.port
+      conn = AMQP::Client.new(port: port, name: "byte-rate-spec").connect
+      ch = conn.channel
+      q = ch.queue("byte_rate_q")
+      q.publish "amqp byte rate test message"
+      received = Channel(Nil).new
+      q.subscribe { received.send(nil) }
+      received.receive
+      conn.close(no_wait: false)
+      wait_for { vhost.connections.none?(LavinMQ::AMQP::Client) }
+    in LavinMQ::Server::Protocol::MQTT
+      with_client_io(s) do |sub_io|
+        connect(sub_io)
+        subscribe(sub_io, topic_filters: mk_topic_filters({"test/byte_rates", 0}))
+
+        with_client_io(s) do |pub_io|
+          connect(pub_io, client_id: "publisher")
+          publish(pub_io, topic: "test/byte_rates", payload: "mqtt byte rate test".to_slice, qos: 0u8)
+        end
+
+        read_packet(sub_io)
+      end
+    end
+  end
+
+  describe LavinMQ::VHost do
+    describe "Byte rate stats" do
+      it "should track recv bytes at vhost level from AMQP publish" do
+        with_server do |s|
+          vhost = s.vhosts["/"]
+          before = vhost.recv_oct_count
+
+          port = s.@listeners.keys.select(TCPServer).first.local_address.port
+          conn = AMQP::Client.new(port: port, name: "byte-rate-spec").connect
+          ch = conn.channel
+          q = ch.queue("byte_rate_q")
+          q.publish "test message"
+          wait_for { vhost.recv_oct_count > before }
+          conn.close(no_wait: false)
+
+          vhost.recv_oct_count.should be > before
+        end
+      end
+
+      it "should track send bytes at vhost level from AMQP consume" do
+        with_server do |s|
+          vhost = s.vhosts["/"]
+
+          port = s.@listeners.keys.select(TCPServer).first.local_address.port
+          conn = AMQP::Client.new(port: port, name: "byte-rate-spec").connect
+          ch = conn.channel
+          q = ch.queue("byte_rate_q")
+          q.publish "test message"
+
+          before = vhost.send_oct_count
+          received = Channel(Nil).new
+          q.subscribe { received.send(nil) }
+          received.receive
+
+          wait_for { vhost.send_oct_count > before }
+          vhost.send_oct_count.should be > before
+          conn.close(no_wait: false)
+        end
+      end
+
+      it "should track recv bytes at vhost level from MQTT publish" do
+        with_server do |s|
+          vhost = s.vhosts["/"]
+          before = vhost.recv_oct_count
+
+          with_client_io(s) do |io|
+            connect(io)
+            publish(io, topic: "test/byte_rates", payload: "mqtt payload".to_slice, qos: 0u8)
+            pingpong(io)
+          end
+
+          vhost.recv_oct_count.should be > before
+        end
+      end
+
+      it "should track send bytes at vhost level from MQTT deliver" do
+        with_server do |s|
+          vhost = s.vhosts["/"]
+
+          with_client_io(s) do |io|
+            connect(io)
+            subscribe(io, topic_filters: mk_topic_filters({"test/byte_rates", 0}))
+
+            before = vhost.send_oct_count
+
+            with_client_io(s) do |pub_io|
+              connect(pub_io, client_id: "publisher")
+              publish(pub_io, topic: "test/byte_rates", payload: "mqtt payload".to_slice, qos: 0u8)
+            end
+
+            read_packet(io)
+
+            wait_for { vhost.send_oct_count > before }
+            vhost.send_oct_count.should be > before
+          end
+        end
+      end
+
+      # This test exercises every protocol (via exhaustive case...in on the
+      # Protocol enum) and verifies that vhost-level byte counts are at least
+      # as large as the sum of per-connection byte counts. If a new protocol
+      # is added to the enum without handling it in send_and_receive_over_protocol,
+      # this spec will fail to compile.
+      it "all protocols should aggregate byte counts to vhost level" do
+        with_server do |s|
+          vhost = s.vhosts["/"]
+
+          LavinMQ::Server::Protocol.each do |protocol|
+            send_and_receive_over_protocol(protocol, s, vhost)
+          end
+
+          wait_for { vhost.connections.empty? || vhost.connections.all? { |c| c.recv_oct_count > 0 } }
+
+          conn_recv_sum = vhost.connections.sum(&.recv_oct_count)
+          conn_send_sum = vhost.connections.sum(&.send_oct_count)
+
+          vhost.recv_oct_count.should be >= conn_recv_sum
+          vhost.send_oct_count.should be >= conn_send_sum
+          # Verify we actually tracked something
+          vhost.recv_oct_count.should be > 0
+          vhost.send_oct_count.should be > 0
         end
       end
     end

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -146,6 +146,8 @@ module LavinMQ
               IO::Memory.new(content))
             Log.debug { "Post to exchange=#{e.name} on vhost=#{e.vhost.name} with routing_key=#{routing_key} payload_encoding=#{payload_encoding} properties=#{properties} size=#{size}" }
             ok = e.vhost.publish(msg)
+            e.vhost.event_tick(EventType::ClientPublish)
+            e.vhost.add_recv_bytes(size)
             {routed: ok}.to_json(context.response)
           end
         end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -44,11 +44,6 @@ module LavinMQ
               connections += 1
               channels += c.channels.size
               consumers += c.channels.each_value.sum &.consumers.size
-              stats_details = c.stats_details
-              recv_rate += stats_details[:recv_oct_details][:rate]
-              send_rate += stats_details[:send_oct_details][:rate]
-              add_logs!(recv_rate_log, stats_details[:recv_oct_details][:log])
-              add_logs!(send_rate_log, stats_details[:send_oct_details][:log])
             end
             exchanges += vhost.exchanges.size
             queues += vhost.queues.size
@@ -59,6 +54,10 @@ module LavinMQ
               add_logs!(unacked_log, q.unacked_count_log)
             end
             vhost_stats_details = vhost.stats_details
+            recv_rate += vhost_stats_details[:recv_oct_details][:rate]
+            send_rate += vhost_stats_details[:send_oct_details][:rate]
+            add_logs!(recv_rate_log, vhost_stats_details[:recv_oct_details][:log])
+            add_logs!(send_rate_log, vhost_stats_details[:send_oct_details][:log])
             {% for sm in OVERVIEW_STATS %}
               {{ sm.id }}_count += vhost_stats_details[:{{ sm.id }}]
               {{ sm.id }}_rate += vhost_stats_details[:{{ sm.id }}_details][:rate]

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -195,6 +195,10 @@ module LavinMQ
                 get_count.times do
                   q.basic_get(false, true) do |env|
                     sps << env.segment_position
+                    # Track vhost-level metrics for HTTP API consumption
+                    event_type = ack ? EventType::ClientGet : EventType::ClientGetNoAck
+                    vhost.event_tick(event_type)
+                    vhost.add_send_bytes(env.message.bodysize.to_u64)
                     j.object do
                       payload_encoding = "string"
                       j.field("payload_bytes", env.message.bodysize)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -97,6 +97,7 @@ module LavinMQ
         packet = @io.read_packet
         @log.trace { "Received packet:  #{packet.inspect}" }
         @recv_oct_count.add(packet.bytesize, :relaxed)
+        vhost.add_recv_bytes(packet.bytesize.to_u64)
 
         case packet
         when MQTT::Publish     then recieve_publish(packet)
@@ -115,6 +116,7 @@ module LavinMQ
           @io.write_packet(packet)
           @io.flush
           @send_oct_count.add(packet.bytesize, :relaxed)
+          vhost.add_send_bytes(packet.bytesize.to_u64)
         end
         case packet
         when MQTT::Publish

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -23,7 +23,7 @@ module LavinMQ
 
     rate_stats({"channel_closed", "channel_created", "connection_closed", "connection_created",
                 "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
-                "redeliver", "reject", "consumer_added", "consumer_removed"})
+                "redeliver", "reject", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
 
     getter name, exchanges, queues, data_dir, operator_policies, policies, parameters, shovels,
       direct_reply_consumers, connections, dir, users
@@ -692,6 +692,14 @@ module LavinMQ
         @deliver_no_ack_count.add(1, :relaxed)
         @deliver_get_count.add(1, :relaxed)
       end
+    end
+
+    def add_recv_bytes(bytes : UInt64) : Nil
+      @recv_oct_count.add(bytes, :relaxed)
+    end
+
+    def add_send_bytes(bytes : UInt64) : Nil
+      @send_oct_count.add(bytes, :relaxed)
     end
 
     def sync : Nil


### PR DESCRIPTION
### WHAT is this pull request doing?

Track data rates at vhost level across all protocols

Previously, byte rates in the overview were aggregated from per-connection stats, which meant HTTP API traffic was invisible in the data rates graph since HTTP has no persistent connections. This adds `recv_oct` and `send_oct` counters to the `vhost`, fed by all three protocols: AMQP and MQTT clients bubble up their per-connection byte counts to the vhost alongside existing connection-level tracking, and HTTP reports bytes directly to the vhost. The overview endpoint now reads byte rates from the vhost instead of summing connections, giving a complete picture of all traffic.
  
Based off discussion in #1682 


### HOW can this pull request be tested?
specs to come
