### PR TITLE
Allow any timestamp in AMQP messages

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -873,6 +873,19 @@ describe LavinMQ::Server do
     end
   end
 
+  it "allows any Int64 message timestamp" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue
+        props = AMQP::Client::Properties.new(timestamp: Int64::MAX)
+        q.publish "m1", props: props
+        msg = q.get(no_ack: true).not_nil!
+        msg.body_io.to_s.should eq "m1"
+        msg.properties.timestamp_raw.should eq Int64::MAX
+      end
+    end
+  end
+
   it "sets correct message timestamp" do
     LavinMQ::Config.instance.set_timestamp = true
     with_amqp_server do |s|

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -221,7 +221,7 @@ module LavinMQ
         @publish_count.add(1, :relaxed)
         @client.vhost.event_tick(EventType::ClientPublish)
         props = @next_msg_props.not_nil!
-        props.timestamp = RoughTime.utc if props.timestamp.nil? && Config.instance.set_timestamp?
+        props.timestamp = RoughTime.utc if props.timestamp_raw.nil? && Config.instance.set_timestamp?
         msg = Message.new(RoughTime.unix_ms,
           @next_publish_exchange_name.not_nil!,
           @next_publish_routing_key.not_nil!,


### PR DESCRIPTION
Don't parse the timestamp property as part of the publish path. Users might use invalid timestamps, and we don't want to reject those messages.

Fixes #1684
Closes #1685 