### PR TITLE
Refactor menu to not need the active class (no javascript)

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -67,7 +67,7 @@
   --color-theme-switcher-active: light-dark(#ffffff, rgba(255, 255, 255, 0.15));
 
   scrollbar-width: thin;
-  --sidebar-width: 320px;
+  --sidebar-width: 260px;
 }
 
 :root.menu-collapsed { --sidebar-width: 68px; }
@@ -306,9 +306,6 @@ header {
 .lavinmq-logo {
   display: inline-block;
 }
-
-
-
 
 header a,
 header a:visited {
@@ -719,7 +716,7 @@ button {
   left: 0;
   top: 64px;
   width: 100%;
-  max-width: 320px;
+  max-width: var(--sidebar-width);
   height: calc(100vh - 64px);
   overflow-x: visible;
   overflow-y: auto;
@@ -919,6 +916,79 @@ footer .logo {
   margin: 0 8px;
 }
 
+.theme-light {
+  --icon-overview: url(img/icons/icon-overview-dark.svg);
+  --icon-nodes: url(img/icons/icon-nodes-dark.svg);
+  --icon-logs: url(img/icons/icon-logs-dark.svg);
+  --icon-connections: url(img/icons/icon-connections-dark.svg);
+  --icon-channels: url(img/icons/icon-channels-dark.svg);
+  --icon-consumers: url(img/icons/icon-consumers-dark.svg);
+  --icon-exchanges: url(img/icons/icon-exchanges-dark.svg);
+  --icon-queues: url(img/icons/icon-queues-dark.svg);
+  --icon-shovels: url(img/icons/icon-shovels-dark.svg);
+  --icon-federation: url(img/icons/icon-federation-dark.svg);
+  --icon-vhosts: url(img/icons/icon-vhosts-dark.svg);
+  --icon-policies: url(img/icons/icon-policies-dark.svg);
+  --icon-operator-policies: url(img/icons/icon-opolicies-dark.svg);
+  --icon-users: url(img/icons/icon-users-dark.svg);
+  --icon-http-api: url(img/icons/icon-external-dark.svg);
+}
+.theme-dark {
+  --icon-overview: url(img/icons/icon-overview-light.svg);
+  --icon-nodes: url(img/icons/icon-nodes-light.svg);
+  --icon-logs: url(img/icons/icon-logs-light.svg);
+  --icon-connections: url(img/icons/icon-connections-light.svg);
+  --icon-channels: url(img/icons/icon-channels-light.svg);
+  --icon-consumers: url(img/icons/icon-consumers-light.svg);
+  --icon-exchanges: url(img/icons/icon-exchanges-light.svg);
+  --icon-queues: url(img/icons/icon-queues-light.svg);
+  --icon-shovels: url(img/icons/icon-shovels-light.svg);
+  --icon-federation: url(img/icons/icon-federation-light.svg);
+  --icon-vhosts: url(img/icons/icon-vhosts-light.svg);
+  --icon-policies: url(img/icons/icon-policies-light.svg);
+  --icon-operator-policies: url(img/icons/icon-opolicies-light.svg);
+  --icon-users: url(img/icons/icon-users-light.svg);
+  --icon-http-api: url(img/icons/icon-external-light.svg);
+}
+@media (prefers-color-scheme: light) {
+  html:not(.theme-dark) {
+    --icon-overview: url(img/icons/icon-overview-dark.svg);
+    --icon-nodes: url(img/icons/icon-nodes-dark.svg);
+    --icon-logs: url(img/icons/icon-logs-dark.svg);
+    --icon-connections: url(img/icons/icon-connections-dark.svg);
+    --icon-channels: url(img/icons/icon-channels-dark.svg);
+    --icon-consumers: url(img/icons/icon-consumers-dark.svg);
+    --icon-exchanges: url(img/icons/icon-exchanges-dark.svg);
+    --icon-queues: url(img/icons/icon-queues-dark.svg);
+    --icon-shovels: url(img/icons/icon-shovels-dark.svg);
+    --icon-federation: url(img/icons/icon-federation-dark.svg);
+    --icon-vhosts: url(img/icons/icon-vhosts-dark.svg);
+    --icon-policies: url(img/icons/icon-policies-dark.svg);
+    --icon-operator-policies: url(img/icons/icon-opolicies-dark.svg);
+    --icon-users: url(img/icons/icon-users-dark.svg);
+    --icon-http-api: url(img/icons/icon-external-dark.svg);
+  }
+}
+@media (prefers-color-scheme: dark) {
+  html:not(.theme-light) {
+    --icon-overview: url(img/icons/icon-overview-light.svg);
+    --icon-nodes: url(img/icons/icon-nodes-light.svg);
+    --icon-logs: url(img/icons/icon-logs-light.svg);
+    --icon-connections: url(img/icons/icon-connections-light.svg);
+    --icon-channels: url(img/icons/icon-channels-light.svg);
+    --icon-consumers: url(img/icons/icon-consumers-light.svg);
+    --icon-exchanges: url(img/icons/icon-exchanges-light.svg);
+    --icon-queues: url(img/icons/icon-queues-light.svg);
+    --icon-shovels: url(img/icons/icon-shovels-light.svg);
+    --icon-federation: url(img/icons/icon-federation-light.svg);
+    --icon-vhosts: url(img/icons/icon-vhosts-light.svg);
+    --icon-policies: url(img/icons/icon-policies-light.svg);
+    --icon-operator-policies: url(img/icons/icon-opolicies-light.svg);
+    --icon-users: url(img/icons/icon-users-light.svg);
+    --icon-http-api: url(img/icons/icon-external-light.svg);
+  }
+}
+
 #menu>ul {
   margin-top: 20px;
 }
@@ -926,77 +996,160 @@ footer .logo {
 #menu ul {
   list-style: none;
   padding: 0 1.5rem;
-}
 
-#menu ul li.menu-group {
-  font-size: 12px;
-  line-height: 16px;
-  letter-spacing: 1.2px;
-  text-transform: uppercase;
-  margin-bottom: 0.5rem;
-}
+ & li.menu-group {
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
 
-#menu ul li.menu-group:not(:first-child) {
-  margin-top: 0.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--color-border-separator);
-}
+    &:not(:first-child) {
+      margin-top: 0.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--color-border-separator);
+    }
+  }
 
-#menu ul li.last-menu-item {
-  margin-top: 1rem;
-  border-top: 1px solid var(--color-border-separator);
+  li:not(.menu-group) {
+    a {
+      background-repeat: no-repeat;
+      background-position: 0.5rem center;
+      border-radius: 8px;
+    }
 
-  a {
-    margin-top: 0.5rem;
+    a:hover {
+      background-color: var(--highlight-color);
+      color: var(--color-text-primary);
+    }
+
+    a {
+      display: flex;
+      align-items: center;
+      padding: 0.5rem 2.5rem 0.5rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      font-weight: 600;
+      text-decoration: none;
+      margin: 2px auto;
+    }
+
+    a, a:visited {
+      color: var(--color-text-secondary);
+      text-decoration: none;
+    }
+
+    &.overview {
+      a { background-image: var(--icon-overview); }
+      .overview & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.nodes {
+     a { background-image: var(--icon-nodes); }
+      .nodes & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.logs {
+      a { background-image: var(--icon-logs); }
+      .logs & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.connections {
+      a { background-image: var(--icon-connections); }
+      .connections & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.channels {
+      a { background-image: var(--icon-channels); }
+      .channels & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.consumers {
+      a { background-image: var(--icon-consumers); }
+      .consumers & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.exchanges {
+      a { background-image: var(--icon-exchanges); }
+      .exchanges & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.queues {
+      a { background-image: var(--icon-queues); }
+      .queues & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.shovels {
+      a { background-image: var(--icon-shovels); }
+      .shovels & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.federation {
+      a { background-image: var(--icon-federation); }
+      .federation & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.vhosts {
+      a { background-image: var(--icon-vhosts); }
+      .vhosts & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.policies {
+      a { background-image: var(--icon-policies); }
+      .policies & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.operator-policies {
+      a { background-image: var(--icon-operator-policies); }
+      .operator-policies & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+    &.users {
+      a { background-image: var(--icon-users); }
+      .users & a {
+        background-color: var(--highlight-color);
+        color: var(--color-text-primary);
+      }
+    }
+
+    &.http-api {
+      margin-top: 1rem;
+      border-top: 1px solid var(--color-border-separator);
+      a {
+       background-image: var(--icon-http-api); 
+        margin-top: 0.5rem;
+      }
+    }
   }
 }
 
-#menu ul li a {
-  display: flex;
-  align-items: center;
-  padding: 0.5rem;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  border-radius: 8px;
-  font-weight: 600;
-  text-decoration: none;
-  margin: 2px auto;
-}
 
-#menu ul a,
-#menu ul a:visited {
-  color: var(--color-text-secondary);
-  text-decoration: none;
-}
-
-#menu ul a:hover {
-  background-color: var(--highlight-color);
-  color: var(--color-text-primary);
-}
-
-#menu li.active a {
-  background-color: var(--highlight-color);
-  color: var(--color-text-primary);
-}
-
-#menu ul li a img {
-  width: 1.5rem;
-  height: 1.5rem;
-  margin-right: 1rem;
-  opacity: .7;
-
-  &.icon-blank {
-    width: 1.25rem;
-    height: 1.25rem;
-    margin-left: 0.5rem;
-    position: relative;
-    bottom: 0.125rem;
-  }
-}
-
-#menu ul li.active a i, #menu ul li a:hover img {
-  opacity: 1;
-}
 
 .toggle-menu-label {
   position: fixed;
@@ -1016,10 +1169,6 @@ footer .logo {
 
 @media (min-width: 1000px) {
   .menu-collapsed {
-    #menu ul li.menu-group:not(:first-child) {
-      padding-top: 0.5rem;
-    }
-
     .menu-tooltip .menu-tooltip-label, .toggle-menu-label {
       position: fixed;
       transition-delay: 0s;
@@ -1040,64 +1189,68 @@ footer .logo {
       opacity: 1;
     }
 
-    #menu-content {
-      .menu-group {
-        margin-bottom: 0;
-
-        span {
-          display: none;
-        }
-      }
-
-      li a {
-        justify-content: center;
-      }
-
-      li a span.menu-tooltip-label {
-        transform: translateY(-50%);
-      }
-
-      li.last-menu-item a span.menu-item-label {
-        display: block;
-        font-size: 8px;
-        line-height: 10px;
-        width: 28px;
-        text-align: left;
-        border: 1px solid light-dark(#6B7280, #9D9C9A);
-        text-align: center;
-        padding: 4px 0;
-        border-radius: 2px;
-      }
-
-      .icon-blank {
-        display: none;
-      }
-    }
 
     #menu {
       width: auto;
-
       ul {
         padding: 0 0.75rem;
+
+        li.menu-group:not(:first-child) {
+          padding-top: 0.5rem;
+        }
+
+        li.menu-group {
+          margin-bottom: 0;
+
+          span {
+            display: none;
+          }
+        }
+
+        li a span.menu-tooltip-label {
+          transform: translateY(-50%);
+        }
+
+        li:not(.menu-group) a {
+          justify-content: center; 
+          background-position: center center;
+            padding: 1.5rem;
+        }
+
+        li.http-api {
+          background-image: none;
+          padding-top: 0.5rem;
+          a {
+            background-image: none;
+            padding: 0;
+            min-height: 48px;
+            min-width: 48px;
+            span.menu-item-label {
+              margin: auto 0.5rem;
+              font-size: 8px;
+              line-height: 10px;
+              text-align: left;
+              border: 1px solid light-dark(#6B7280, #9D9C9A);
+              text-align: center;
+              padding: 4px;
+              border-radius: 2px;
+            }
+          }
+        }
       }
-
-      ul li a img {
-        margin-right: 0;
-      }
-    }
-
-    .r-c {
-      left: 68px;
-    }
-
-    footer {
-      padding-left: 68px;
     }
   }
 
-  .menu-tooltip:hover .toggle-menu-label {
-    opacity: 1;
+
+  .r-c {
+    left: 68px;
   }
+
+  footer {
+    padding-left: 68px;
+  }
+}
+
 }
 
 .card:has(.table-header) {

--- a/views/channel.ecr
+++ b/views/channel.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Channel" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="channels">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/channel.js"></script>

--- a/views/channels.ecr
+++ b/views/channels.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Channels" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="channels">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/channels.js"></script>

--- a/views/connection.ecr
+++ b/views/connection.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Connection" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="connections">
   <head>
     <% render "partials/head" %>
    <script type="module" src="js/connection.js"></script>

--- a/views/connections.ecr
+++ b/views/connections.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Connections" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="connections">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/connections.js"></script>

--- a/views/consumers.ecr
+++ b/views/consumers.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Consumers" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="consumers">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/consumers.js"></script>

--- a/views/exchange.ecr
+++ b/views/exchange.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Exchange" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="exchanges">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/exchange.js"></script>

--- a/views/exchanges.ecr
+++ b/views/exchanges.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Exchanges" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="exchanges">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/exchanges.js"></script>

--- a/views/federation.ecr
+++ b/views/federation.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Federation" %>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="federation">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/federation.js"></script>

--- a/views/logs.ecr
+++ b/views/logs.ecr
@@ -1,6 +1,6 @@
 <% pagename = "Logs" %>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="logs">
   <head>
     <% render "partials/head" %>
     <script defer src="js/logs.js"></script>

--- a/views/nodes.ecr
+++ b/views/nodes.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Nodes" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="nodes">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/nodes.js"></script>

--- a/views/operator-policies.ecr
+++ b/views/operator-policies.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Operator policies" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="operator-policies">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/policies.js"></script>

--- a/views/overview.ecr
+++ b/views/overview.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Overview" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="overview">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/overview.js"></script>

--- a/views/partials/header.ecr
+++ b/views/partials/header.ecr
@@ -64,7 +64,7 @@
       {
         title: "Cluster",
         items: [
-          { href: ".", label: "Overview", icon: "img/icons/icon-overview-light.svg" },
+          { href: ".", label: "Overview", icon: nil },
           { href: "nodes", label: "Nodes", icon: "img/icons/icon-nodes-light.svg" },
           { href: "logs", label: "Logs", icon: "img/icons/icon-logs-light.svg" },
         ]
@@ -105,9 +105,8 @@
       <li class="menu-group"><span><%= group[:title] %></span></li>
 
       <% group[:items].each do |item| -%>
-        <li<%= " class=\"active\"" if active_path?(item[:href]) %>>
+        <li class="<%= item[:href] == "." ? "overview" : item[:href] %>">
           <a href="<%= item[:href] %>" class="menu-tooltip">
-            <img src="<%= item[:icon] %>"/>
             <span class="menu-item-label menu-tooltip-label"><%= item[:label] %></span>
           </a>
         </li>
@@ -115,6 +114,6 @@
 
     <%- end -%>
 
-    <li class="last-menu-item"><a class="menu-item" href="docs/" target="_blank"><span class="menu-item-label">HTTP API</span> <img class="icon-blank" src="img/icons/icon-external-light.svg" /></a></li>
+    <li class="http-api"><a class="menu-item" href="docs/" target="_blank"><span class="menu-item-label">HTTP API</span></a></li>
   </ul>
 </nav>

--- a/views/partials/header.ecr
+++ b/views/partials/header.ecr
@@ -64,40 +64,40 @@
       {
         title: "Cluster",
         items: [
-          { href: ".", label: "Overview", icon: nil },
-          { href: "nodes", label: "Nodes", icon: "img/icons/icon-nodes-light.svg" },
-          { href: "logs", label: "Logs", icon: "img/icons/icon-logs-light.svg" },
+          { href: ".", label: "Overview" },
+          { href: "nodes", label: "Nodes" },
+          { href: "logs", label: "Logs" },
         ]
       },
       {
         title: "Clients",
         items: [
-          { href: "connections", label: "Connections", icon: "img/icons/icon-connections-light.svg" },
-          { href: "channels", label: "Channels", icon: "img/icons/icon-channels-light.svg" },
-          { href: "consumers", label: "Consumers", icon: "img/icons/icon-consumers-light.svg" },
+          { href: "connections", label: "Connections" },
+          { href: "channels", label: "Channels" },
+          { href: "consumers", label: "Consumers" },
         ]
       },
       {
         title: "Messaging",
         items: [
-          { href: "exchanges", label: "Exchanges", icon: "img/icons/icon-exchanges-light.svg" },
-          { href: "queues", label: "Queues", icon: "img/icons/icon-queues-light.svg" },
+          { href: "exchanges", label: "Exchanges" },
+          { href: "queues", label: "Queues" },
         ]
       },
       {
         title: "Bridges",
         items: [
-          { href: "shovels", label: "Shovels", icon: "img/icons/icon-shovels-light.svg" },
-          { href: "federation", label: "Federation", icon: "img/icons/icon-federation-light.svg" },
+          { href: "shovels", label: "Shovels" },
+          { href: "federation", label: "Federation" },
         ]
       },
       {
         title: "Administration",
         items: [
-          { href: "vhosts", label: "Virtual hosts", icon: "img/icons/icon-vhosts-light.svg" },
-          { href: "policies", label: "Policies", icon: "img/icons/icon-policies-light.svg" },
-          { href: "operator-policies", label: "Operator policies", icon: "img/icons/icon-opolicies-light.svg" },
-          { href: "users", label: "Users", icon: "img/icons/icon-users-light.svg" },
+          { href: "vhosts", label: "Virtual hosts" },
+          { href: "policies", label: "Policies" },
+          { href: "operator-policies", label: "Operator policies" },
+          { href: "users", label: "Users" },
         ]
       },
     ].each do |group| -%>

--- a/views/policies.ecr
+++ b/views/policies.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Policies" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="policies">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/policies.js"></script>

--- a/views/queue.ecr
+++ b/views/queue.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Queue" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="queues">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/queue.js"></script>

--- a/views/queues.ecr
+++ b/views/queues.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Queues" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="queues">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/queues.js"></script>

--- a/views/shovels.ecr
+++ b/views/shovels.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Shovels" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="shovels">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/shovels.js"></script>

--- a/views/user.ecr
+++ b/views/user.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "User" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="users">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/user.js"></script>

--- a/views/users.ecr
+++ b/views/users.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Users" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="users">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/users.js"></script>

--- a/views/vhost.ecr
+++ b/views/vhost.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Virtual host" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="vhosts">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/vhost.js"> </script>

--- a/views/vhosts.ecr
+++ b/views/vhosts.ecr
@@ -1,6 +1,6 @@
 <%- pagename = "Virtual Hosts" -%>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="vhosts">
   <head>
     <% render "partials/head" %>
     <script type="module" src="js/vhosts.js"></script>


### PR DESCRIPTION
### WHAT is this pull request doing?
This refactors the menu to not need the active class in the menu item. Instead it relies on a class on the HTML tag together with a unique class per menu item. The menu CSS is also grouped better using nesting selectors.

This also fixes so the icons in the menu respect light and dark mode (before this only light icon is used).

This will support #1703 and get rids of the JavaScript to set active class.

Some repetitive code in the CSS to handle light/dark mode and active color. Part of this can probable removed if #1698 is merged and modified to handle system color mode in another way.

### HOW can this pull request be tested?
Manually
