### PR TITLE
Fix RPM test stage to run on target OS

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Generate version string
         run: echo "version=$(./packaging/rpm/rpm-version)" >> $GITHUB_ENV
 
+      - name: Determine test image
+        run: |
+          OS="${{ matrix.os }}"
+          case "$OS" in
+            fedora-*) echo "test_image=fedora:${OS#fedora-}" >> $GITHUB_ENV ;;
+            el-*) echo "test_image=rockylinux:${OS#el-}" >> $GITHUB_ENV ;;
+          esac
+
       - uses: depot/setup-action@v1
       - uses: depot/build-push-action@v1
         with:
@@ -47,6 +55,7 @@ jobs:
           pull: true
           build-args: |
             build_image=84codes/crystal:latest-${{ matrix.os }}
+            test_image=${{ env.test_image }}
             version=${{ env.version }}
             MAKEFLAGS=-j1
           outputs: RPMS

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -1,4 +1,5 @@
 ARG build_image=84codes/crystal:latest-fedora-42
+ARG test_image=fedora:42
 
 FROM $build_image AS builder
 # Enable CRB repository for el-9 to access help2man
@@ -23,12 +24,14 @@ ARG MAKEFLAGS=-j2
 RUN rpmbuild -ba /root/rpmbuild/SPECS/lavinmq.spec
 RUN rpmlint /root/rpmbuild/RPMS/* || true
 
-FROM fedora:42 AS test
+FROM $test_image AS test
 COPY --from=builder /root/rpmbuild/RPMS /tmp/RPMS
 RUN find /tmp/RPMS -type f -exec dnf install -y {} \;
 RUN lavinmq --version
 RUN getent passwd lavinmq
 
-# Copy the deb package to a scratch image, that then can be exported
+# Copy the RPM packages to a scratch image, that then can be exported.
+# Copying from 'test' (not 'builder') ensures the test stage is executed.
 FROM scratch
-COPY --from=builder /root/rpmbuild/RPMS /root/rpmbuild/SRPMS .
+COPY --from=test /tmp/RPMS .
+COPY --from=builder /root/rpmbuild/SRPMS .


### PR DESCRIPTION
## Summary
- The RPM Dockerfile test stage was hardcoded to `fedora:42`, so packages built for other targets (fc43, el-9) were never tested on the actual target OS.
- The final `scratch` stage only referenced the `builder` stage via `COPY --from=builder`, so BuildKit skipped the `test` stage entirely — it was never executed in CI.
- This allowed a broken fc43 RPM (missing `Provides: user(lavinmq)` / `group(lavinmq)`) to be published, causing `dnf install lavinmq` to fail with unresolvable dependencies.

The fix parameterizes the test image via a `test_image` build arg (set per matrix entry in CI) and routes the RPMS through the test stage so BuildKit must execute it.

## Test plan
- [x] Verified `podman build` with `test_image=fedora:42` passes
- [x] Verified `podman build` with `test_image=fedora:43` passes
- [x] Verified output image structure matches CI expectations (`x86_64/*.rpm` + `*.src.rpm`)
- [ ] CI RPM workflow should pass for all matrix entries (fedora-41, fedora-42, fedora-43, el-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)