### PR TITLE
Only allow one follower to do bulk sync at a time

### DIFF
--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -185,6 +185,10 @@ module LavinMQ
           end
           @followers << follower # Starts in Syncing state
         end
+        # Only allow one follower to do bulk sync at a time
+        # The bandwidth between nodes should be very high, so
+        # better with one fully synced than 2 partially synced followers
+        # Also @files and @checksums are not protected by locks
         @sync_lock.synchronize do
           follower.full_sync # sync the bulk
         end


### PR DESCRIPTION
### WHAT is this pull request doing?

Serializes follower `full_sync` so only one follower syncs at a time. Two followers doing `full_sync` simultaneously crashes the leader with `SIGSEGV` because both iterate `@files` and write to `@checksums` from separate threads without synchronization.

Fixes #1708 

### HOW can this pull request be tested?
TBA
