### PR TITLE
Reuse the `message_expire_loop` for drop_overflow

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -896,4 +896,94 @@ describe LavinMQ::AMQP::Queue do
       end
     end
   end
+
+  describe "async overflow drop" do
+    it "should enforce max-length without consumers" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = AMQP::Client::Arguments.new({"x-max-length" => 3_i64})
+          q = ch.queue("overflow_no_consumer", args: args)
+          5.times { |i| q.publish_confirm "msg-#{i}" }
+          queue = s.vhosts["/"].queues["overflow_no_consumer"]
+          wait_for { queue.message_count <= 3 }
+          queue.message_count.should eq 3
+        end
+      end
+    end
+
+    it "should enforce max-length-bytes without consumers" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          body = "x" * 100
+          # Allow room for 2 messages but not 3
+          args = AMQP::Client::Arguments.new({"x-max-length-bytes" => 250_i64})
+          q = ch.queue("overflow_bytes_no_consumer", args: args)
+          5.times { q.publish_confirm body }
+          queue = s.vhosts["/"].queues["overflow_bytes_no_consumer"]
+          wait_for { queue.message_count <= 2 }
+          queue.message_count.should be <= 2
+        end
+      end
+    end
+
+    it "should not drop overflow when consumers can deliver" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = AMQP::Client::Arguments.new({"x-max-length" => 2_i64})
+          q = ch.queue("overflow_with_consumer", args: args)
+          msgs = [] of AMQP::Client::DeliverMessage
+          q.subscribe { |msg| msgs << msg }
+          5.times { |i| q.publish_confirm "msg-#{i}" }
+          wait_for { msgs.size == 5 }
+          msgs.size.should eq 5
+        end
+      end
+    end
+  end
+
+  describe "TTL and overflow interaction" do
+    it "should handle both TTL expiration and max-length on the same queue" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          dlq = ch.queue("ttl_overflow_dlq")
+          args = AMQP::Client::Arguments.new({
+            "x-max-length"              => 3_i64,
+            "x-message-ttl"             => 500,
+            "x-dead-letter-exchange"    => "",
+            "x-dead-letter-routing-key" => "ttl_overflow_dlq",
+          })
+          q = ch.queue("ttl_overflow_q", args: args)
+          queue = s.vhosts["/"].queues["ttl_overflow_q"]
+
+          # Publish 5 messages — overflow should drop 2 (max-length=3)
+          5.times { |i| q.publish_confirm "msg-#{i}" }
+          wait_for { queue.message_count <= 3 }
+          queue.message_count.should eq 3
+
+          # Wait for TTL to expire remaining messages
+          wait_for { queue.message_count == 0 }
+          queue.message_count.should eq 0
+
+          # All 5 should end up dead-lettered (2 maxlen + 3 expired)
+          dlq_queue = s.vhosts["/"].queues["ttl_overflow_dlq"]
+          wait_for { dlq_queue.message_count == 5 }
+          dlq_queue.message_count.should eq 5
+        end
+      end
+    end
+
+    it "should still expire TTL messages when overflow signal arrives" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = AMQP::Client::Arguments.new({"x-message-ttl" => 200})
+          q = ch.queue("ttl_with_overflow_signal", args: args)
+          queue = s.vhosts["/"].queues["ttl_with_overflow_signal"]
+
+          3.times { |i| q.publish_confirm "msg-#{i}" }
+          wait_for { queue.message_count == 0 }
+          queue.message_count.should eq 0
+        end
+      end
+    end
+  end
 end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -945,7 +945,7 @@ describe LavinMQ::AMQP::Queue do
     it "should handle both TTL expiration and max-length on the same queue" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
-          dlq = ch.queue("ttl_overflow_dlq")
+          ch.queue("ttl_overflow_dlq")
           args = AMQP::Client::Arguments.new({
             "x-max-length"              => 3_i64,
             "x-message-ttl"             => 500,

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -47,7 +47,7 @@ module LavinMQ::AMQP
         @msg_store.push(msg)
       end
       @publish_count.add(1, :relaxed)
-      @message_ttl_change.send nil
+      cleanup_messages(CleanupReason::TTLChange)
       true
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -71,13 +71,13 @@ module LavinMQ::AMQP
           end
           select
           when @msg_store.empty.when_true.receive # purge?
-          when @message_ttl_change.receive
+          when @cleanup_message_channel.receive
           when timeout ttl
             expire_messages
           end
         else
           select
-          when @message_ttl_change.receive
+          when @cleanup_message_channel.receive
           when @msg_store.empty.when_false.receive
             Fiber.yield
           end

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -47,7 +47,7 @@ module LavinMQ::AMQP
         @msg_store.push(msg)
       end
       @publish_count.add(1, :relaxed)
-      cleanup_messages(CleanupReason::TTLChange)
+      @cleanup_message_channel.try_send?(CleanupReason::TTLChange)
       true
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -671,20 +671,17 @@ module LavinMQ::AMQP
 
     private def expire_messages : Nil
       i = 0
-      @msg_store_lock.synchronize do
-        loop do
-          env = @msg_store.first? || break
-          msg = env.message
+      loop do
+        env = @msg_store_lock.synchronize do
+          first_env = @msg_store.first? || break
+          msg = first_env.message
           @log.debug { "Checking if next message #{msg} has expired" }
-          if has_expired?(msg)
-            # shift it out from the msgs store, first time was just a peek
-            env = @msg_store.shift? || break
-            expire_msg(env, :expired)
-            i += 1
-          else
-            break
-          end
-        end
+          break unless has_expired?(msg)
+          # shift it out from the msgs store, first time was just a peek
+          @msg_store.shift?
+        end || break
+        expire_msg(env, :expired)
+        i += 1
       end
       @log.info { "Expired #{i} messages" } if i > 0
     end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -229,6 +229,7 @@ module LavinMQ::AMQP
       # Recreate channels that were closed
       @queue_expiration_ttl_change = ::Channel(Nil).new
       @message_ttl_change = ::Channel(Nil).new
+      @drop_overflow_channel = ::Channel(Nil).new
       @paused = BoolChannel.new(false)
       @consumers_empty = BoolChannel.new(true)
       @single_active_consumer_change = ::Channel(Client::Channel::Consumer).new

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -284,20 +284,20 @@ module LavinMQ::AMQP
         unless @max_length.try &.< value.as_i64
           @max_length = value.as_i64
           @effective_args.delete("x-max-length")
-          cleanup_messages(CleanupReason::Overflow)
+          @cleanup_message_channel.try_send?(CleanupReason::Overflow)
           return true
         end
       when "max-length-bytes"
         unless @max_length_bytes.try &.< value.as_i64
           @max_length_bytes = value.as_i64
           @effective_args.delete("x-max-length-bytes")
-          cleanup_messages(CleanupReason::Overflow)
+          @cleanup_message_channel.try_send?(CleanupReason::Overflow)
           return true
         end
       when "message-ttl"
         unless @message_ttl.try &.< value.as_i64
           @message_ttl = value.as_i64
-          cleanup_messages(CleanupReason::TTLChange)
+          @cleanup_message_channel.try_send?(CleanupReason::TTLChange)
           @effective_args.delete("x-message-ttl")
           return true
         end
@@ -371,7 +371,7 @@ module LavinMQ::AMQP
       @effective_args << "x-max-length-bytes" if @max_length_bytes
       @message_ttl = parse_header("x-message-ttl", Int).try &.to_i64
       @effective_args << "x-message-ttl" if @message_ttl
-      cleanup_messages(CleanupReason::TTLChange)
+      @cleanup_message_channel.try_send?(CleanupReason::TTLChange)
       @delivery_limit = parse_header("x-delivery-limit", Int).try &.to_i64
       @effective_args << "x-delivery-limit" if @delivery_limit
       overflow = parse_header("x-overflow", String)
@@ -534,7 +534,7 @@ module LavinMQ::AMQP
         @msg_store.push(msg)
       end
       @publish_count.add(1, :relaxed)
-      cleanup_messages(CleanupReason::Overflow)
+      @cleanup_message_channel.try_send?(CleanupReason::Overflow)
       true
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -557,10 +557,6 @@ module LavinMQ::AMQP
           raise RejectOverFlow.new
         end
       end
-    end
-
-    private def cleanup_messages(reason : CleanupReason) : Nil
-      @cleanup_message_channel.try_send?(reason)
     end
 
     private def drop_overflow : Nil
@@ -762,7 +758,7 @@ module LavinMQ::AMQP
           # requeuing of failed delivery is up to the consumer
         end
         # Signal expire loop to recalculate wait time for next message
-        cleanup_messages(CleanupReason::TTLChange)
+        @cleanup_message_channel.try_send?(CleanupReason::TTLChange)
         return true
       end
       false
@@ -833,7 +829,7 @@ module LavinMQ::AMQP
           @msg_store_lock.synchronize do
             @msg_store.requeue(sp)
           end
-          cleanup_messages(CleanupReason::Overflow)
+          @cleanup_message_channel.try_send?(CleanupReason::Overflow)
         end
       else
         expire_msg(sp, :rejected)
@@ -906,7 +902,7 @@ module LavinMQ::AMQP
       @log.info { "Purged #{delete_count} messages" }
       # Signal expire loop to recalculate wait time for next message
       if delete_count > 0
-        cleanup_messages(CleanupReason::TTLChange)
+        @cleanup_message_channel.try_send?(CleanupReason::TTLChange)
       end
       delete_count
     rescue ex : MessageStore::Error

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -115,43 +115,43 @@ module LavinMQ::AMQP
       @vhost.closed.when_false.receive?
       loop do
         @msg_store.empty.when_false.receive
-        @log.debug { "Message store not empty" }
+        @log.debug { "message_expire_loop=\"Message store not empty\"" }
         if @consumers.empty?
           if ttl = time_to_message_expiration
-            @log.debug { "Next message TTL: #{ttl}" }
+            @log.debug { "message_expire_loop=\"Next message\" ttl=\"#{ttl}\"" }
             select
             when @message_ttl_change.receive
-              @log.debug { "Message TTL changed" }
+              @log.debug { "message_expire_loop=\"Message TTL changed\" ttl=\"#{ttl}\" consumers=0" }
             when @drop_overflow_channel.receive
-              @log.debug { "Drop overflow" }
+              @log.debug { "message_expire_loop=\"Drop overflow\" ttl=\"#{ttl}\" consumers=0" }
               drop_overflow
             when @msg_store.empty.when_true.receive
-              @log.debug { "Message store is empty" }
+              @log.debug { "message_expire_loop=\"Message store is empty\" ttl=\"#{ttl}\" consumers=0" }
             when @consumers_empty.when_false.receive
-              @log.debug { "Got consumers" }
+              @log.debug { "message_expire_loop=\"Got consumers\" ttl=\"#{ttl}\" consumers=0" }
             when timeout ttl
-              @log.debug { "Message TTL reached" }
+              @log.debug { "message_expire_loop=\"Message TTL reached\" ttl=\"#{ttl}\" consumers=0" }
               expire_messages
               drop_overflow
             end
           else
             select
             when @message_ttl_change.receive
-              @log.debug { "Message TTL changed" }
+              @log.debug { "message_expire_loop=\"Message TTL changed\" ttl=\"nil\" consumer=0" }
             when @drop_overflow_channel.receive
-              @log.debug { "Drop overflow" }
+              @log.debug { "message_expire_loop=\"Drop overflow\" ttl=\"nil\" consumer=0" }
               drop_overflow
             when @msg_store.empty.when_true.receive
-              @log.debug { "Msg store is empty" }
+              @log.debug { "message_expire_loop=\"Msg store is empty\" ttl=\"nil\" consumer=0" }
             end
           end
         else
           select
           when @drop_overflow_channel.receive
-            @log.debug { "Drop overflow" }
+            @log.debug { "message_expire_loop=\"Drop overflow while having consumers\"" }
             drop_overflow
           when @consumers_empty.when_true.receive
-            @log.debug { "Consumers empty" }
+            @log.debug { "message_expire_loop=\"Lost consumers\"" }
           end
         end
       end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -63,8 +63,11 @@ module LavinMQ::AMQP
     @deliveries = Hash(SegmentPosition, Int32).new
     @consumers = Array(Client::Channel::Consumer).new
     @consumers_lock = Mutex.new
-    @message_ttl_change = ::Channel(Nil).new
-    @drop_overflow_channel = ::Channel(Nil).new
+    enum CleanupReason
+      TTLChange
+      Overflow
+    end
+    @cleanup_message_channel = ::Channel(CleanupReason).new
 
     getter basic_get_unacked = Deque(UnackedMessage).new
     @unacked_count = Atomic(UInt32).new(0u32)
@@ -121,10 +124,8 @@ module LavinMQ::AMQP
           if ttl = time_to_message_expiration
             @log.debug { "message_expire_loop=\"Next message\" ttl=\"#{ttl}\"" }
             select
-            when @message_ttl_change.receive
-              @log.debug { "message_expire_loop=\"Message TTL changed\" ttl=\"#{ttl}\" consumers=0" }
-            when @drop_overflow_channel.receive
-              @log.debug { "message_expire_loop=\"Drop overflow\" ttl=\"#{ttl}\" consumers=0" }
+            when reason = @cleanup_message_channel.receive
+              @log.debug { "message_expire_loop=\"Message cleanup\" reason=#{reason} ttl=\"#{ttl}\" consumers=0" }
             when @msg_store.empty.when_true.receive
               @log.debug { "message_expire_loop=\"Message store is empty\" ttl=\"#{ttl}\" consumers=0" }
             when @consumers_empty.when_false.receive
@@ -135,18 +136,16 @@ module LavinMQ::AMQP
             end
           else
             select
-            when @message_ttl_change.receive
-              @log.debug { "message_expire_loop=\"Message TTL changed\" ttl=\"nil\" consumer=0" }
-            when @drop_overflow_channel.receive
-              @log.debug { "message_expire_loop=\"Drop overflow\" ttl=\"nil\" consumer=0" }
+            when reason = @cleanup_message_channel.receive
+              @log.debug { "message_expire_loop=\"Message cleanup\" reason=#{reason} ttl=\"nil\" consumers=0" }
             when @msg_store.empty.when_true.receive
               @log.debug { "message_expire_loop=\"Msg store is empty\" ttl=\"nil\" consumer=0" }
             end
           end
         else
           select
-          when @drop_overflow_channel.receive
-            @log.debug { "message_expire_loop=\"Drop overflow while having consumers\"" }
+          when reason = @cleanup_message_channel.receive
+            @log.debug { "message_expire_loop=\"Message cleanup\" reason=#{reason} having consumers" }
           when @consumers_empty.when_true.receive
             @log.debug { "message_expire_loop=\"Lost consumers\"" }
           end
@@ -225,8 +224,7 @@ module LavinMQ::AMQP
       @state = QueueState::Running
       # Recreate channels that were closed
       @queue_expiration_ttl_change = ::Channel(Nil).new
-      @message_ttl_change = ::Channel(Nil).new
-      @drop_overflow_channel = ::Channel(Nil).new
+      @cleanup_message_channel = ::Channel(CleanupReason).new
       @paused = BoolChannel.new(false)
       @consumers_empty = BoolChannel.new(true)
       @single_active_consumer_change = ::Channel(Client::Channel::Consumer).new
@@ -286,20 +284,20 @@ module LavinMQ::AMQP
         unless @max_length.try &.< value.as_i64
           @max_length = value.as_i64
           @effective_args.delete("x-max-length")
-          signal_drop_overflow
+          cleanup_messages(CleanupReason::Overflow)
           return true
         end
       when "max-length-bytes"
         unless @max_length_bytes.try &.< value.as_i64
           @max_length_bytes = value.as_i64
           @effective_args.delete("x-max-length-bytes")
-          signal_drop_overflow
+          cleanup_messages(CleanupReason::Overflow)
           return true
         end
       when "message-ttl"
         unless @message_ttl.try &.< value.as_i64
           @message_ttl = value.as_i64
-          @message_ttl_change.try_send? nil
+          cleanup_messages(CleanupReason::TTLChange)
           @effective_args.delete("x-message-ttl")
           return true
         end
@@ -373,7 +371,7 @@ module LavinMQ::AMQP
       @effective_args << "x-max-length-bytes" if @max_length_bytes
       @message_ttl = parse_header("x-message-ttl", Int).try &.to_i64
       @effective_args << "x-message-ttl" if @message_ttl
-      @message_ttl_change.try_send? nil
+      cleanup_messages(CleanupReason::TTLChange)
       @delivery_limit = parse_header("x-delivery-limit", Int).try &.to_i64
       @effective_args << "x-delivery-limit" if @delivery_limit
       overflow = parse_header("x-overflow", String)
@@ -443,8 +441,7 @@ module LavinMQ::AMQP
       @closed = true
       @state = QueueState::Closed
       @queue_expiration_ttl_change.close
-      @message_ttl_change.close
-      @drop_overflow_channel.close
+      @cleanup_message_channel.close
       @paused.close
       @consumers_empty.close
       @consumers_lock.synchronize do
@@ -537,7 +534,7 @@ module LavinMQ::AMQP
         @msg_store.push(msg)
       end
       @publish_count.add(1, :relaxed)
-      signal_drop_overflow
+      cleanup_messages(CleanupReason::Overflow)
       true
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -562,8 +559,8 @@ module LavinMQ::AMQP
       end
     end
 
-    private def signal_drop_overflow : Nil
-      @drop_overflow_channel.try_send?(nil) # if (@max_length || @max_length_bytes) && !immediate_delivery?
+    private def cleanup_messages(reason : CleanupReason) : Nil
+      @cleanup_message_channel.try_send?(reason) if (@max_length || @max_length_bytes) && !immediate_delivery?
     end
 
     private def drop_overflow : Nil
@@ -765,7 +762,7 @@ module LavinMQ::AMQP
           # requeuing of failed delivery is up to the consumer
         end
         # Signal expire loop to recalculate wait time for next message
-        @message_ttl_change.try_send? nil
+        cleanup_messages(CleanupReason::TTLChange)
         return true
       end
       false
@@ -836,7 +833,7 @@ module LavinMQ::AMQP
           @msg_store_lock.synchronize do
             @msg_store.requeue(sp)
           end
-          signal_drop_overflow
+          cleanup_messages(CleanupReason::Overflow)
         end
       else
         expire_msg(sp, :rejected)
@@ -909,7 +906,7 @@ module LavinMQ::AMQP
       @log.info { "Purged #{delete_count} messages" }
       # Signal expire loop to recalculate wait time for next message
       if delete_count > 0
-        @message_ttl_change.try_send? nil
+        cleanup_messages(CleanupReason::TTLChange)
       end
       delete_count
     rescue ex : MessageStore::Error

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -116,6 +116,8 @@ module LavinMQ::AMQP
       loop do
         @msg_store.empty.when_false.receive
         @log.debug { "message_expire_loop=\"Message store not empty\"" }
+        # Always check overflow here
+        drop_overflow
         if @consumers.empty?
           if ttl = time_to_message_expiration
             @log.debug { "message_expire_loop=\"Next message\" ttl=\"#{ttl}\"" }
@@ -124,7 +126,6 @@ module LavinMQ::AMQP
               @log.debug { "message_expire_loop=\"Message TTL changed\" ttl=\"#{ttl}\" consumers=0" }
             when @drop_overflow_channel.receive
               @log.debug { "message_expire_loop=\"Drop overflow\" ttl=\"#{ttl}\" consumers=0" }
-              drop_overflow
             when @msg_store.empty.when_true.receive
               @log.debug { "message_expire_loop=\"Message store is empty\" ttl=\"#{ttl}\" consumers=0" }
             when @consumers_empty.when_false.receive
@@ -132,7 +133,6 @@ module LavinMQ::AMQP
             when timeout ttl
               @log.debug { "message_expire_loop=\"Message TTL reached\" ttl=\"#{ttl}\" consumers=0" }
               expire_messages
-              drop_overflow
             end
           else
             select
@@ -140,7 +140,6 @@ module LavinMQ::AMQP
               @log.debug { "message_expire_loop=\"Message TTL changed\" ttl=\"nil\" consumer=0" }
             when @drop_overflow_channel.receive
               @log.debug { "message_expire_loop=\"Drop overflow\" ttl=\"nil\" consumer=0" }
-              drop_overflow
             when @msg_store.empty.when_true.receive
               @log.debug { "message_expire_loop=\"Msg store is empty\" ttl=\"nil\" consumer=0" }
             end
@@ -149,7 +148,6 @@ module LavinMQ::AMQP
           select
           when @drop_overflow_channel.receive
             @log.debug { "message_expire_loop=\"Drop overflow while having consumers\"" }
-            drop_overflow
           when @consumers_empty.when_true.receive
             @log.debug { "message_expire_loop=\"Lost consumers\"" }
           end
@@ -570,8 +568,9 @@ module LavinMQ::AMQP
     end
 
     private def drop_overflow : Nil
-      counter = 0
+      return if immediate_delivery?
 
+      counter = 0
       if ml = @max_length
         loop do
           env = @msg_store_lock.synchronize do

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -592,7 +592,7 @@ module LavinMQ::AMQP
       if mlb = @max_length_bytes
         loop do
           env = @msg_store_lock.synchronize do
-            if @msg_store.size > mlb
+            if @msg_store.bytesize > mlb
               @msg_store.shift?
             end
           end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -571,32 +571,38 @@ module LavinMQ::AMQP
 
     private def drop_overflow : Nil
       counter = 0
+
       if ml = @max_length
-        @msg_store_lock.synchronize do
-          while @msg_store.size > ml
-            env = @msg_store.shift? || break
-            @log.debug { "Overflow drop head sp=#{env.segment_position}" }
-            expire_msg(env, :maxlen)
-            counter &+= 1
-            if counter >= 16 * 1024
-              Fiber.yield
-              counter = 0
+        loop do
+          env = @msg_store_lock.synchronize do
+            if @msg_store.size > ml
+              @msg_store.shift?
             end
+          end
+          break unless env
+          expire_msg(env, :maxlen)
+          counter &+= 1
+          if counter >= 16 * 1024
+            Fiber.yield
+            counter = 0
           end
         end
       end
 
       if mlb = @max_length_bytes
-        @msg_store_lock.synchronize do
-          while @msg_store.bytesize > mlb
-            env = @msg_store.shift? || break
-            @log.debug { "Overflow drop head sp=#{env.segment_position}" }
-            expire_msg(env, :maxlenbytes)
-            counter &+= 1
-            if counter >= 16 * 1024
-              Fiber.yield
-              counter = 0
+        loop do
+          env = @msg_store_lock.synchronize do
+            if @msg_store.size > mlb
+              @msg_store.shift?
             end
+          end
+          break unless env
+          @log.debug { "Overflow drop head sp=#{env.segment_position}" }
+          expire_msg(env, :maxlenbytes)
+          counter &+= 1
+          if counter >= 16 * 1024
+            Fiber.yield
+            counter = 0
           end
         end
       end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -563,7 +563,7 @@ module LavinMQ::AMQP
     end
 
     private def signal_drop_overflow : Nil
-      @drop_overflow_channel.try_send?(nil) if (@max_length || @max_length_bytes) && !immediate_delivery?
+      @drop_overflow_channel.try_send?(nil) # if (@max_length || @max_length_bytes) && !immediate_delivery?
     end
 
     private def drop_overflow : Nil

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -560,6 +560,7 @@ module LavinMQ::AMQP
     end
 
     private def drop_overflow : Nil
+      return unless @max_length || @max_length_bytes
       return if immediate_delivery?
 
       counter = 0

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -560,7 +560,7 @@ module LavinMQ::AMQP
     end
 
     private def cleanup_messages(reason : CleanupReason) : Nil
-      @cleanup_message_channel.try_send?(reason) if (@max_length || @max_length_bytes) && !immediate_delivery?
+      @cleanup_message_channel.try_send?(reason)
     end
 
     private def drop_overflow : Nil

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -116,7 +116,6 @@ module LavinMQ::AMQP
       loop do
         @msg_store.empty.when_false.receive
         @log.debug { "message_expire_loop=\"Message store not empty\"" }
-        # Always check overflow here
         drop_overflow
         if @consumers.empty?
           if ttl = time_to_message_expiration
@@ -287,14 +286,14 @@ module LavinMQ::AMQP
         unless @max_length.try &.< value.as_i64
           @max_length = value.as_i64
           @effective_args.delete("x-max-length")
-          drop_overflow
+          signal_drop_overflow
           return true
         end
       when "max-length-bytes"
         unless @max_length_bytes.try &.< value.as_i64
           @max_length_bytes = value.as_i64
           @effective_args.delete("x-max-length-bytes")
-          drop_overflow
+          signal_drop_overflow
           return true
         end
       when "message-ttl"

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -611,19 +611,19 @@ module LavinMQ::AMQP
     private def drop_redelivered : Nil
       counter = 0
       if limit = @delivery_limit
-        @msg_store_lock.synchronize do
-          loop do
-            env = @msg_store.first? || break
-            delivery_count = @deliveries.fetch(env.segment_position, 0) || break
+        loop do
+          env = @msg_store_lock.synchronize do
+            first_env = @msg_store.first? || break
+            delivery_count = @deliveries.fetch(first_env.segment_position, 0) || break
             break unless delivery_count > limit
-            env = @msg_store.shift? || break
-            @log.debug { "Over delivery limit, drop sp=#{env.segment_position}" }
-            expire_msg(env, :delivery_limit)
-            counter &+= 1
-            if counter >= 16 * 1024
-              Fiber.yield
-              counter = 0
-            end
+            @msg_store.shift?
+          end || break
+          @log.debug { "Over delivery limit, drop sp=#{env.segment_position}" }
+          expire_msg(env, :delivery_limit)
+          counter &+= 1
+          if counter >= 16 * 1024
+            Fiber.yield
+            counter = 0
           end
         end
       end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -597,7 +597,6 @@ module LavinMQ::AMQP
             end
           end
           break unless env
-          @log.debug { "Overflow drop head sp=#{env.segment_position}" }
           expire_msg(env, :maxlenbytes)
           counter &+= 1
           if counter >= 16 * 1024
@@ -619,7 +618,6 @@ module LavinMQ::AMQP
             @msg_store.shift?
           end
           break unless env
-          @log.debug { "Over delivery limit, drop sp=#{env.segment_position}" }
           expire_msg(env, :delivery_limit)
           counter &+= 1
           if counter >= 16 * 1024
@@ -632,7 +630,6 @@ module LavinMQ::AMQP
 
     private def time_to_message_expiration : Time::Span?
       env = @msg_store_lock.synchronize { @msg_store.first? } || return
-      @log.debug { "Checking if message #{env.message} has to be expired" }
       if expire_at = expire_at(env.message)
         expire_in = expire_at - RoughTime.unix_ms
         if expire_in > 0
@@ -676,7 +673,7 @@ module LavinMQ::AMQP
         env = @msg_store_lock.synchronize do
           first_env = @msg_store.first? || break
           msg = first_env.message
-          @log.debug { "Checking if next message #{msg} has expired" }
+          @log.debug { "Checking if next message has expired sp=#{first_env.segment_position}" }
           break unless has_expired?(msg)
           # shift it out from the msgs store, first time was just a peek
           @msg_store.shift?
@@ -694,6 +691,7 @@ module LavinMQ::AMQP
         env = Envelope.new(sp, msg, false)
         expire_msg(env, reason)
       else
+        @log.debug { "Dropping sp=#{sp} reason=#{reason}" }
         delete_message sp
       end
     end
@@ -701,7 +699,7 @@ module LavinMQ::AMQP
     private def expire_msg(env : Envelope, reason : Symbol)
       sp = env.segment_position
       msg = env.message
-      @log.debug { "Expiring #{sp} now due to #{reason}" }
+      @log.debug { "Expiring sp=#{sp} reason=#{reason}" }
 
       @dead_letter.route(msg, reason)
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -64,6 +64,7 @@ module LavinMQ::AMQP
     @consumers = Array(Client::Channel::Consumer).new
     @consumers_lock = Mutex.new
     @message_ttl_change = ::Channel(Nil).new
+    @drop_overflow_channel = ::Channel(Nil).new
 
     getter basic_get_unacked = Deque(UnackedMessage).new
     @unacked_count = Atomic(UInt32).new(0u32)
@@ -113,32 +114,44 @@ module LavinMQ::AMQP
     private def message_expire_loop
       @vhost.closed.when_false.receive?
       loop do
-        @consumers_empty.when_true.receive
-        @log.debug { "Consumers empty" }
         @msg_store.empty.when_false.receive
         @log.debug { "Message store not empty" }
-        next unless @consumers.empty?
-        if ttl = time_to_message_expiration
-          @log.debug { "Next message TTL: #{ttl}" }
-          select
-          when @message_ttl_change.receive
-            @log.debug { "Message TTL changed" }
-          when @msg_store.empty.when_true.receive # might be empty now (from basic get)
-            @log.debug { "Message store is empty" }
-          when @consumers_empty.when_false.receive
-            @log.debug { "Got consumers" }
-          when timeout ttl
-            @log.debug { "Message TTL reached" }
-            expire_messages
+        if @consumers.empty?
+          if ttl = time_to_message_expiration
+            @log.debug { "Next message TTL: #{ttl}" }
+            select
+            when @message_ttl_change.receive
+              @log.debug { "Message TTL changed" }
+            when @drop_overflow_channel.receive
+              @log.debug { "Drop overflow" }
+              drop_overflow
+            when @msg_store.empty.when_true.receive
+              @log.debug { "Message store is empty" }
+            when @consumers_empty.when_false.receive
+              @log.debug { "Got consumers" }
+            when timeout ttl
+              @log.debug { "Message TTL reached" }
+              expire_messages
+              drop_overflow
+            end
+          else
+            select
+            when @message_ttl_change.receive
+              @log.debug { "Message TTL changed" }
+            when @drop_overflow_channel.receive
+              @log.debug { "Drop overflow" }
+              drop_overflow
+            when @msg_store.empty.when_true.receive
+              @log.debug { "Msg store is empty" }
+            end
           end
         else
-          # first message in queue should not be expired
-          # wait for empty queue or TTL change
           select
-          when @message_ttl_change.receive
-            @log.debug { "Message TTL changed" }
-          when @msg_store.empty.when_true.receive
-            @log.debug { "Msg store is empty" }
+          when @drop_overflow_channel.receive
+            @log.debug { "Drop overflow" }
+            drop_overflow
+          when @consumers_empty.when_true.receive
+            @log.debug { "Consumers empty" }
           end
         end
       end
@@ -433,6 +446,7 @@ module LavinMQ::AMQP
       @state = QueueState::Closed
       @queue_expiration_ttl_change.close
       @message_ttl_change.close
+      @drop_overflow_channel.close
       @paused.close
       @consumers_empty.close
       @consumers_lock.synchronize do
@@ -525,7 +539,7 @@ module LavinMQ::AMQP
         @msg_store.push(msg)
       end
       @publish_count.add(1, :relaxed)
-      drop_overflow_if_no_immediate_delivery
+      signal_drop_overflow
       true
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -550,8 +564,8 @@ module LavinMQ::AMQP
       end
     end
 
-    private def drop_overflow_if_no_immediate_delivery : Nil
-      drop_overflow if (@max_length || @max_length_bytes) && !immediate_delivery?
+    private def signal_drop_overflow : Nil
+      @drop_overflow_channel.try_send?(nil) if (@max_length || @max_length_bytes) && !immediate_delivery?
     end
 
     private def drop_overflow : Nil
@@ -820,7 +834,7 @@ module LavinMQ::AMQP
           @msg_store_lock.synchronize do
             @msg_store.requeue(sp)
           end
-          drop_overflow_if_no_immediate_delivery
+          signal_drop_overflow
         end
       else
         expire_msg(sp, :rejected)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -617,7 +617,8 @@ module LavinMQ::AMQP
             delivery_count = @deliveries.fetch(first_env.segment_position, 0) || break
             break unless delivery_count > limit
             @msg_store.shift?
-          end || break
+          end
+          break unless env
           @log.debug { "Over delivery limit, drop sp=#{env.segment_position}" }
           expire_msg(env, :delivery_limit)
           counter &+= 1
@@ -679,7 +680,8 @@ module LavinMQ::AMQP
           break unless has_expired?(msg)
           # shift it out from the msgs store, first time was just a peek
           @msg_store.shift?
-        end || break
+        end
+        break unless env
         expire_msg(env, :expired)
         i += 1
       end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -204,6 +204,10 @@ module LavinMQ
 
       private def message_expire_loop; end
 
+      private def signal_drop_overflow : Nil
+        drop_overflow if (@max_length || @max_length_bytes) && !immediate_delivery?
+      end
+
       private def queue_expire_loop; end
 
       private def next_id : UInt16?

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -204,10 +204,6 @@ module LavinMQ
 
       private def message_expire_loop; end
 
-      private def signal_drop_overflow : Nil
-        drop_overflow if (@max_length || @max_length_bytes) && !immediate_delivery?
-      end
-
       private def queue_expire_loop; end
 
       private def next_id : UInt16?


### PR DESCRIPTION
### WHAT is this pull request doing?

#### reason for the change

When a queue overflows, `drop_overflow` is called synchronously in the `publish` method.
`drop_overflow` dead-letters messages via `expire_msg`, which calls `vhost.publish` to
route the dead-lettered message to another queue. If that target queue also overflows, it
dead-letters back to the original queue, creating a recursive publish → drop_overflow →
publish → drop_overflow chain. The call stack grows with each cycle until the process
crashes.


#### solution 

Reuse the existing `message_expire_loop` fiber to perform `drop_overflow` asynchronously.
A new zero-buffered `@drop_overflow_channel` (`Channel(Nil)`) signals the fiber that
overflow needs to be checked. The `publish` and `requeue` methods send a non-blocking
signal (`try_send?`) instead of calling `drop_overflow` synchronously. This breaks the
recursive call stack because the dead-lettering happens in a separate fiber, not in the
caller's stack frame.


#### changed behaviour

**Overflow is no longer immediate**

Previously, `drop_overflow` ran synchronously inside `publish`, so the queue was trimmed
before `publish` returned. Now the overflow signal is processed by the
`message_expire_loop` fiber, which means there is a brief window where the queue
exceeds `max-length` or `max-length-bytes` until the fiber wakes up and trims it.
In practice this window is very short (a single fiber yield).

**Extra fiber wakeup per empty→non-empty transition**

The original loop was fully parked when consumers existed — it blocked on
`@consumers_empty.when_true.receive` at the top and never woke until all consumers
disconnected.

Now the loop blocks on `@msg_store.empty.when_false.receive`, which fires on the
empty→non-empty *state transition* (not per message). When consumers are present, the
fiber wakes, checks `@consumers.empty?`, enters the `select` in the `else` branch, and
parks again. This is one extra wakeup per transition, not per publish, so the overhead
is negligible.

