### PR TITLE
set z-index of tooltip to 10000 (1 higher than menu) to make it appear on top of menu

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1753,7 +1753,7 @@ fieldset.inline {
   left: 50%;
   transform: translateX(-50%);
   position: absolute;
-  z-index: 1;
+  z-index: 10000;
   white-space: normal;
 }
 


### PR DESCRIPTION
### WHAT is this pull request doing?
Sets z-index of `.prop-tooltip` to 10000, 1 higher than menu, to make it appear on top of the menu. 

Fixes #1713

### HOW can this pull request be tested?
build and look
