### PR TITLE
Add empty cells in connection details for consistent rendering

### DIFF
--- a/views/connection.ecr
+++ b/views/connection.ecr
@@ -35,6 +35,8 @@
           <tr id="amqp-frame" style="display: none;">
             <th>Frame max</th>
             <td id="frame_max"></td>
+            <th></th>
+            <td></td>
           </tr>
           <tr>
             <th>TLS version</th>


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes #1696 by adding empty cells in details.

<img width="1978" height="734" alt="image" src="https://github.com/user-attachments/assets/7cb1b37c-e0d2-411d-a2f1-f1a9c5b316c3" />


### HOW can this pull request be tested?

Visually