### PR TITLE
fix: collapse whitespace in client capabilities display

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1382,6 +1382,7 @@ footer .logo {
 
 #cp-capabilities {
   white-space: pre-line;
+  margin: 0
 }
 
 #q-features span,


### PR DESCRIPTION
### Summary
As described in https://github.com/cloudamqp/lavinmq/issues/1696, the capabilities under "Client Properties" has an odd indentation. its because the `jsonToText` separates each field in the json object by newlines and adds a 2 space indentation before them, however trims the whitespaces on the first row.
Then we preserve the newlines by adding the pre-wrap to the pre-object. One solution could be to modify the jsonToText or separate each field in a div. But I figured this would be the smallest change.

### HOW can this pull request be tested?
Visually 👁️ 

https://github.com/user-attachments/assets/9af0071f-5c22-4a10-a2db-df72086a4f9f

