### PR TITLE
Refactor: Remove redundant policy getters from Queue and Exchange

### DIFF
--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -21,8 +21,6 @@ module LavinMQ
 
       getter name, arguments, vhost, type, alternate_exchange
       getter? durable, internal, auto_delete
-      getter policy : Policy?
-      getter operator_policy : OperatorPolicy?
       getter? delayed = false
 
       @alternate_exchange : String?
@@ -107,9 +105,9 @@ module LavinMQ
         {
           name: @name, type: type, durable: @durable, auto_delete: @auto_delete,
           internal: @internal, arguments: @arguments, vhost: @vhost.name,
-          policy: @policy.try &.name,
-          operator_policy: @operator_policy.try &.name,
-          effective_policy_definition: Policy.merge_definitions(@policy, @operator_policy),
+          policy: policy.try &.name,
+          operator_policy: operator_policy.try &.name,
+          effective_policy_definition: Policy.merge_definitions(policy, operator_policy),
           message_stats: current_stats_details,
           effective_arguments: @effective_args,
         }

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -154,8 +154,6 @@ module LavinMQ::AMQP
 
     getter name, arguments, vhost, consumers
     getter? auto_delete, exclusive
-    getter policy : Policy?
-    getter operator_policy : OperatorPolicy?
     getter? closed = false
     getter state = QueueState::Running
     getter empty : BoolChannel
@@ -490,12 +488,12 @@ module LavinMQ::AMQP
         unacked_bytes:                unacked_bytesize, # Deprecated, to be removed in next major version
         message_bytes_unacknowledged: unacked_bytesize,
         unacked_avg_bytes:            unacked_avg_bytes,
-        operator_policy:              @operator_policy.try &.name,
-        policy:                       @policy.try &.name,
+        operator_policy:              operator_policy.try &.name,
+        policy:                       policy.try &.name,
         exclusive_consumer_tag:       @exclusive ? @consumers.first?.try(&.tag) : nil,
         single_active_consumer_tag:   @single_active_consumer.try &.tag,
         state:                        @state,
-        effective_policy_definition:  Policy.merge_definitions(@policy, @operator_policy),
+        effective_policy_definition:  Policy.merge_definitions(policy, operator_policy),
         message_stats:                current_stats_details,
         effective_arguments:          @effective_args,
         effective_policy_arguments:   effective_policy_args,


### PR DESCRIPTION
### WHAT is this pull request doing?
`Queue` and `Exchange` both declared `getter policy` and `getter operator_policy`, which shadowed the identical getters already provided by the `PolicyTarget` module they include. This removes those redundant declarations and switches `details_tuple` in both classes to use the method calls (`policy`, `operator_policy`) instead of direct ivar access (`@policy`, `@operator_policy`), so all policy state is owned and accessed through `PolicyTarget`.

### HOW can this pull request be tested?
All tests should still pass
