### PR TITLE
Encapsulate collections and extract stores (prep for MT safety)

### DIFF
--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -65,7 +65,7 @@ describe LavinMQ::HTTP::BindingsController do
         response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
         response.status_code.should eq 201
         response.headers["Location"].should eq "bindings_q1/rk"
-        s.vhosts["/"].exchanges["be1"].bindings_details.first.routing_key.should eq "rk"
+        s.vhosts["/"].exchange("be1").bindings_details.first.routing_key.should eq "rk"
       end
     end
 
@@ -142,7 +142,7 @@ describe LavinMQ::HTTP::BindingsController do
         props = binding[0]["properties_key"].as_s
         response = http.delete("/api/bindings/%2f/e/be1/q/bindings_q1/#{props}")
         response.status_code.should eq 204
-        s.vhosts["/"].exchanges["be1"].bindings_details.empty?.should be_true
+        s.vhosts["/"].exchange("be1").bindings_details.empty?.should be_true
       end
     end
   end

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -84,7 +84,7 @@ describe LavinMQ::GlobalDefinitions do
       begin
         with_amqp_server do |s|
           LavinMQ::GlobalDefinitions.import_from_file(tmpfile, s)
-          s.vhosts["/"].queues.has_key?("load_def_q1").should be_true
+          s.vhosts["/"].queue_exists?("load_def_q1").should be_true
         end
       ensure
         File.delete?(tmpfile)

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -264,7 +264,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "queues": [{ "name": "import_q1", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].queues.has_key?("import_q1").should be_true
+        s.vhosts["/"].queue_exists?("import_q1").should be_true
       end
     end
 
@@ -273,7 +273,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "exchanges": [{ "name": "import_x1", "type": "direct", "vhost": "/", "durable": true, "internal": false, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].exchanges.has_key?("import_x1").should be_true
+        s.vhosts["/"].exchange_exists?("import_x1").should be_true
       end
     end
 
@@ -302,19 +302,19 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        ex = s.vhosts["/"].exchanges["import_x1"]
+        ex = s.vhosts["/"].exchange("import_x1")
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
-        res << s.vhosts["/"].exchanges["import_x1"]
-        res << s.vhosts["/"].exchanges["import_x2"]
+        res << s.vhosts["/"].exchange("import_x1")
+        res << s.vhosts["/"].exchange("import_x2")
         es.should eq res
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
-        res << s.vhosts["/"].queues["import_q1"]
+        res << s.vhosts["/"].queue("import_q1")
         qs.should eq res
       end
     end
@@ -670,7 +670,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "queues": [{ "name": "import_q1", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].queues.has_key?("import_q1").should be_true
+        s.vhosts["/"].queue_exists?("import_q1").should be_true
       end
     end
 
@@ -679,7 +679,7 @@ describe LavinMQ::HTTP::Server do
         body = %({ "exchanges": [{ "name": "import_x1", "type": "direct", "vhost": "/", "durable": true, "internal": false, "auto_delete": false, "arguments": {} }] })
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        s.vhosts["/"].exchanges.has_key?("import_x1").should be_true
+        s.vhosts["/"].exchange_exists?("import_x1").should be_true
       end
     end
 
@@ -708,19 +708,19 @@ describe LavinMQ::HTTP::Server do
       ]})
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
-        ex = s.vhosts["/"].exchanges["import_x1"]
+        ex = s.vhosts["/"].exchange("import_x1")
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("r.k2", nil, qs, es)
         res = Set(LavinMQ::Exchange).new
-        res << s.vhosts["/"].exchanges["import_x1"]
-        res << s.vhosts["/"].exchanges["import_x2"]
+        res << s.vhosts["/"].exchange("import_x1")
+        res << s.vhosts["/"].exchange("import_x2")
         es.should eq res
         qs = Set(LavinMQ::Queue).new
         es = Set(LavinMQ::Exchange).new
         ex.find_queues("rk", nil, qs, es)
         res = Set(LavinMQ::Queue).new
-        res << s.vhosts["/"].queues["import_q1"]
+        res << s.vhosts["/"].queue("import_q1")
         qs.should eq res
       end
     end
@@ -922,7 +922,7 @@ describe LavinMQ::HTTP::Server do
       args = {"x-delayed-message", false, false, false, LavinMQ::AMQP::Table.new({"x-delayed-type": "direct"})}
       vhost.declare_exchange "test", *args
       http.get("/api/definitions")
-      vhost.exchanges["test"].match?(*args).should be_true
+      vhost.exchange("test").match?(*args).should be_true
     end
   end
 

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -381,7 +381,7 @@ describe LavinMQ::HTTP::Server do
         sleep 0.1.seconds # Start the shovel
         wait_for do
           shovels = s.vhosts["/"].shovels.not_nil!
-          shovels.values_dup.all? &.running?
+          shovels.values.all? &.running?
         end
         s.vhosts["/"].parameters.any? { |_, p| p.parameter_name == "import_shovel_param" }
           .should be_true

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -224,7 +224,9 @@ describe LavinMQ::HTTP::Server do
       })
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
-        s.users.select("sha256", "sha512", "bcrypt", "md5").each do |_, u|
+        {"sha256", "sha512", "bcrypt", "md5"}.each do |name|
+          u = s.users[name]?
+          next unless u
           u.should be_a(LavinMQ::Auth::BaseUser)
           ok = u.not_nil!.password.not_nil!.verify "hej"
           {u.name, ok}.should(eq({u.name, true}))

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -381,7 +381,7 @@ describe LavinMQ::HTTP::Server do
         sleep 0.1.seconds # Start the shovel
         wait_for do
           shovels = s.vhosts["/"].shovels.not_nil!
-          shovels.each_value.all? &.running?
+          shovels.values_dup.all? &.running?
         end
         s.vhosts["/"].parameters.any? { |_, p| p.parameter_name == "import_shovel_param" }
           .should be_true

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -259,7 +259,7 @@ describe LavinMQ::HTTP::ExchangesController do
         response.status_code.should eq 200
         body = JSON.parse(response.body)
         body["routed"].as_bool.should be_true
-        s.vhosts["/"].queues["q1p"].message_count.should eq 1
+        s.vhosts["/"].queue("q1p").message_count.should eq 1
       end
     end
 

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -286,7 +286,7 @@ describe LavinMQ::HTTP::Server do
             100.times { x.publish("msg", q.name) }
           end
         end
-        wait_for { vhost.exchanges["b-exchange"].details_tuple["message_stats"]["publish_in_details"]["rate"] > 0 }
+        wait_for { vhost.exchange("b-exchange").details_tuple["message_stats"]["publish_in_details"]["rate"] > 0 }
         response = http.get("/api/exchanges?page=1&sort=message_stats.publish_in_details.rate&sort_reverse=false")
         response.status_code.should eq 200
         items = JSON.parse(response.body).as_h["items"].as_a

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -130,8 +130,8 @@ describe LavinMQ::HTTP::QueuesController do
             2.times { q.publish "m1" }
             q.subscribe(no_ack: false) { }
 
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 2 }
-            s.vhosts["/"].queues["unacked_q"].basic_get_unacked.size.should eq 0
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 2 }
+            s.vhosts["/"].queue("unacked_q").basic_get_unacked.size.should eq 0
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -149,7 +149,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) do |msg|
               msg.ack
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
 
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
@@ -168,7 +168,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) do |msg|
               msg.reject
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
 
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
@@ -187,7 +187,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
 
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues["unacked_q"].basic_get_unacked.size == 1 }
+            wait_for { s.vhosts["/"].queue("unacked_q").basic_get_unacked.size == 1 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -203,10 +203,10 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
             ch.prefetch(1)
             if msg = q.get(no_ack: false)
-              wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 1 }
+              wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 1 }
               msg.ack
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -223,10 +223,10 @@ describe LavinMQ::HTTP::QueuesController do
 
             ch.prefetch(1)
             if msg = q.get(no_ack: false)
-              wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 1 }
+              wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 1 }
               msg.reject
             end
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -243,9 +243,9 @@ describe LavinMQ::HTTP::QueuesController do
 
             ch.prefetch(1)
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 1 }
+            wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 1 }
           end
-          wait_for { s.vhosts["/"].queues["unacked_q"].unacked_count == 0 }
+          wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 0 }
           response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
           response.status_code.should eq 200
           body = JSON.parse(response.body)
@@ -382,7 +382,7 @@ describe LavinMQ::HTTP::QueuesController do
           keys = ["payload_bytes", "redelivered", "exchange", "routing_key", "message_count",
                   "properties", "payload", "payload_encoding"]
           body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
-          s.vhosts["/"].queues["q3"].message_count.should be > 0
+          s.vhosts["/"].queue("q3").message_count.should be > 0
         end
       end
     end
@@ -392,7 +392,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues["q4"]
+          q4 = s.vhosts["/"].queue("q4")
           q.publish "m1"
           wait_for { q4.message_count == 1 }
           body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
@@ -409,7 +409,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues["q4"]
+          q4 = s.vhosts["/"].queue("q4")
           mem_io = IO::Memory.new
           Compress::Deflate::Writer.open(mem_io, Compress::Deflate::BEST_SPEED) { |deflate| deflate.print("m1") }
           encoded_msg = mem_io.to_s
@@ -430,7 +430,7 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           q = ch.queue("q4")
-          q4 = s.vhosts["/"].queues["q4"]
+          q4 = s.vhosts["/"].queue("q4")
           message_count = 100
           message_count.times { q.publish "m1" * 100000 } # Larger messages to slow down JSON serialization
           wait_for { q4.message_count == message_count }
@@ -556,7 +556,7 @@ describe LavinMQ::HTTP::QueuesController do
         with_channel(s) do |ch|
           ch.queue("confqueue")
 
-          q = s.vhosts["/"].queues["confqueue"]
+          q = s.vhosts["/"].queue("confqueue")
           q.pause!
 
           response = http.get("/api/queues/%2f/confqueue")
@@ -600,7 +600,7 @@ describe LavinMQ::HTTP::QueuesController do
           queue_name = "restart_queue"
           ch.queue(queue_name)
 
-          q = s.vhosts["/"].queues[queue_name]
+          q = s.vhosts["/"].queue(queue_name)
           q.close
 
           response = http.get("/api/queues/%2f/#{queue_name}")
@@ -625,7 +625,7 @@ describe LavinMQ::HTTP::QueuesController do
           queue_name = "restart_queue"
           ch.queue(queue_name)
 
-          s.vhosts["/"].queues[queue_name]
+          s.vhosts["/"].queue(queue_name)
           response = http.put("/api/queues/%2f/#{queue_name}/restart")
           response.status_code.should eq 400
 

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -131,7 +131,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.subscribe(no_ack: false) { }
 
             wait_for { s.vhosts["/"].queue("unacked_q").unacked_count == 2 }
-            s.vhosts["/"].queue("unacked_q").basic_get_unacked.size.should eq 0
+            s.vhosts["/"].queue("unacked_q").basic_get_unacked_size.should eq 0
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)
@@ -187,7 +187,7 @@ describe LavinMQ::HTTP::QueuesController do
             q.publish "m1"
 
             q.get(no_ack: false)
-            wait_for { s.vhosts["/"].queue("unacked_q").basic_get_unacked.size == 1 }
+            wait_for { s.vhosts["/"].queue("unacked_q").basic_get_unacked_size == 1 }
             response = http.get("/api/queues/%2f/unacked_q/unacked?page=1&page_size=100")
             response.status_code.should eq 200
             body = JSON.parse(response.body)

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -66,7 +66,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
 
       server = LavinMQ::Server.new(cluster.follower_config)
       begin
-        q = server.vhosts["/"].queues["repli"].as(LavinMQ::AMQP::DurableQueue)
+        q = server.vhosts["/"].queue("repli").as(LavinMQ::AMQP::DurableQueue)
         q.message_count.should eq 1
         q.basic_get(true) do |env|
           String.new(env.message.body).to_s.should eq "hello world"
@@ -478,7 +478,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
           ch.queue("dotqueue_test", durable: true)
         end
         vhost = s.vhosts["/"]
-        dotqfile = File.join(vhost.queues["dotqueue_test"].as(LavinMQ::AMQP::Queue).@data_dir, ".queue")
+        dotqfile = File.join(vhost.queue("dotqueue_test").as(LavinMQ::AMQP::Queue).@data_dir, ".queue")
         dotqfile_relative = dotqfile[(s.data_dir.size + 1)..]
         replicated_dotqfile = File.join(cluster.follower_config.data_dir, dotqfile_relative)
         wait_for { File.exists?(replicated_dotqfile) }
@@ -494,7 +494,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
         with_channel(s) do |ch|
           q = ch.queue("dotqueue_test", durable: true)
           vhost = s.vhosts["/"]
-          dotqfile = File.join(vhost.queues["dotqueue_test"].as(LavinMQ::AMQP::Queue).@data_dir, ".queue")
+          dotqfile = File.join(vhost.queue("dotqueue_test").as(LavinMQ::AMQP::Queue).@data_dir, ".queue")
           dotqfile_relative = dotqfile[(s.data_dir.size + 1)..]
           replicated_dotqfile = File.join(cluster.follower_config.data_dir, dotqfile_relative)
           wait_for { File.exists?(replicated_dotqfile) }
@@ -514,7 +514,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
           ch.queue("dotqueue_transient", durable: false)
         end
         vhost = s.vhosts["/"]
-        dotqfile = File.join(vhost.queues["dotqueue_transient"].as(LavinMQ::AMQP::Queue).@data_dir, ".queue")
+        dotqfile = File.join(vhost.queue("dotqueue_transient").as(LavinMQ::AMQP::Queue).@data_dir, ".queue")
         dotqfile_relative = dotqfile[(s.data_dir.size + 1)..]
         wait_for { File.exists?(dotqfile) }
         Fiber.yield

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -103,7 +103,7 @@ describe LavinMQ::Server do
         conn = AMQP::Client.new(port: amqp_port(s), channel_max: 0).connect
         conn.channel
         conn.channel
-        s.connections.first.channels_size.should eq 2
+        s.connections.first.channel_count.should eq 2
         s.connections.first.as(LavinMQ::AMQP::Client).channel_max.should eq 0
       end
     end

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -103,7 +103,7 @@ describe LavinMQ::Server do
         conn = AMQP::Client.new(port: amqp_port(s), channel_max: 0).connect
         conn.channel
         conn.channel
-        s.connections.first.channels.size.should eq 2
+        s.connections.first.channels_size.should eq 2
         s.connections.first.as(LavinMQ::AMQP::Client).channel_max.should eq 0
       end
     end

--- a/spec/consistent_hash_exchange_spec.cr
+++ b/spec/consistent_hash_exchange_spec.cr
@@ -9,8 +9,8 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         vhost = s.vhosts["/"]
         vhost.declare_exchange "con-hash", "x-consistent-hash", durable: true, auto_delete: false
         vhost.declare_queue "my-queue", durable: true, auto_delete: false
-        exchange = vhost.exchanges["con-hash"].should be_a(LavinMQ::AMQP::ConsistentHashExchange)
-        queue = vhost.queues["my-queue"].as(LavinMQ::AMQP::Queue)
+        exchange = vhost.exchange("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
+        queue = vhost.queue("my-queue").as(LavinMQ::AMQP::Queue)
         expect_raises(LavinMQ::Error::PreconditionFailed) do
           exchange.bind(queue, "non-numeric", nil)
         end
@@ -25,8 +25,8 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         vhost = s.vhosts["/"]
         vhost.declare_exchange "con-hash", "x-consistent-hash", durable: true, auto_delete: false
         vhost.declare_queue "my-queue", durable: true, auto_delete: false
-        exchange = vhost.exchanges["con-hash"].should be_a(LavinMQ::AMQP::ConsistentHashExchange)
-        queue = vhost.queues["my-queue"].as(LavinMQ::AMQP::Queue)
+        exchange = vhost.exchange("con-hash").should be_a(LavinMQ::AMQP::ConsistentHashExchange)
+        queue = vhost.queue("my-queue").as(LavinMQ::AMQP::Queue)
         expect_raises(LavinMQ::Error::PreconditionFailed) do
           exchange.unbind(queue, "non-numeric", nil)
         end
@@ -257,7 +257,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "jump"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq JumpConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -267,7 +267,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "ring"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -277,7 +277,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
         with_channel(s) do |ch|
           LavinMQ::Config.instance.default_consistent_hash_algorithm.should eq LavinMQ::ConsistentHashAlgorithm::Ring
           ch.exchange(x_name, "x-consistent-hash")
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end
@@ -288,7 +288,7 @@ describe LavinMQ::AMQP::ConsistentHashExchange do
           LavinMQ::Config.instance.default_consistent_hash_algorithm.should eq LavinMQ::ConsistentHashAlgorithm::Ring
           x_args = AMQP::Client::Arguments.new({"x-algorithm" => "juump"})
           ch.exchange(x_name, "x-consistent-hash", args: x_args)
-          ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::ConsistentHashExchange)
+          ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::ConsistentHashExchange)
           ex.@hasher.class.should eq RingConsistentHasher(LavinMQ::AMQP::Exchange | LavinMQ::AMQP::Queue)
         end
       end

--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -183,7 +183,7 @@ describe LavinMQ::Deduplication::Deduper do
             "x-deduplication-header" => "msg1",
           })
 
-          exchange = s.vhosts["/"].exchanges["delayed_ex"].should be_a(LavinMQ::AMQP::Exchange)
+          exchange = s.vhosts["/"].exchange("delayed_ex").should be_a(LavinMQ::AMQP::Exchange)
           delay_q = exchange.@delayed_queue.should be_a(LavinMQ::AMQP::DelayedExchangeQueue)
 
           # Publish a message and verify it has been delayed and not thrown away

--- a/spec/definitions_frame_size_spec.cr
+++ b/spec/definitions_frame_size_spec.cr
@@ -16,9 +16,9 @@ describe LavinMQ::VHost do
       )
     )
     with_amqp_server do |s|
-      exchanges = s.vhosts["test"].exchanges
-      src_x = exchanges["source.exchange"]
-      dst_x = exchanges["destination.exchange"]
+      vhost = s.vhosts["test"]
+      src_x = vhost.exchange("source.exchange")
+      dst_x = vhost.exchange("destination.exchange")
       src_x.bindings_details.to_a.should_not be_empty
       dst_x.bindings_details.to_a.should_not be_empty
     end

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -16,7 +16,7 @@ describe "Delayed Message Exchange" do
 
         with_channel(s) do |ch|
           ch.exchange(x_name, "topic", args: x_args)
-          q = s.vhosts["/"].queues[legacy_q_name]?
+          q = s.vhosts["/"].queue?(legacy_q_name)
           q.should_not be_nil
         end
       end
@@ -26,7 +26,7 @@ describe "Delayed Message Exchange" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.exchange(x_name, "topic", args: x_args)
-          q = s.vhosts["/"].queues[delay_q_name]?
+          q = s.vhosts["/"].queue?(delay_q_name)
           q.should_not be_nil
           dlx_exchange = q.not_nil!.arguments["x-dead-letter-exchange"]?.try &.as?(String)
           dlx_exchange.should eq x_name
@@ -41,7 +41,7 @@ describe "Delayed Message Exchange" do
           ch.exchange(x_name, "topic", args: x_args)
           ch.exchange("", delay_q_name, args: x_args)
           ch.basic_publish_confirm "test", exchange: "", routing_key: delay_q_name
-          s.vhosts["/"].queues[delay_q_name].message_count.should eq 0
+          s.vhosts["/"].queue(delay_q_name).message_count.should eq 0
         end
       end
     end
@@ -52,12 +52,12 @@ describe "Delayed Message Exchange" do
         with_channel(s) do |ch|
           ex = ch.exchange(x_name, "topic", args: x_args)
           ex.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-          s.vhosts["/"].queues[delay_q_name].message_count.should eq 1
+          s.vhosts["/"].queue(delay_q_name).message_count.should eq 1
         end
         s.restart
-        s.vhosts["/"].queues[delay_q_name].message_count.should eq 1
+        s.vhosts["/"].queue(delay_q_name).message_count.should eq 1
         sleep 1.second
-        wait_for { s.vhosts["/"].queues[delay_q_name].message_count == 0 }
+        wait_for { s.vhosts["/"].queue(delay_q_name).message_count == 0 }
       end
     end
 
@@ -69,10 +69,10 @@ describe "Delayed Message Exchange" do
           q.bind(x.name, "#")
           hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
           x.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-          wait_for { s.vhosts["/"].queues["delayed_q"].message_count == 1 }
+          wait_for { s.vhosts["/"].queue("delayed_q").message_count == 1 }
         end
         # All messages in delayed queue are now expired and acked
-        s.vhosts["/"].queues[delay_q_name].message_count.should eq 0
+        s.vhosts["/"].queue(delay_q_name).message_count.should eq 0
         data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest(delay_q_name))
 
         s.stop
@@ -83,7 +83,7 @@ describe "Delayed Message Exchange" do
         File.open(seg_file, "r+") { |f| f.truncate(f.size // 2) }
 
         s.restart
-        s.vhosts["/"].queues[delay_q_name].message_count.should eq 0
+        s.vhosts["/"].queue(delay_q_name).message_count.should eq 0
       end
     end
 
@@ -94,7 +94,7 @@ describe "Delayed Message Exchange" do
           # No consumer bound, so message stays in the delayed queue
           hdrs = AMQP::Client::Arguments.new({"x-delay" => 300_000})
           x.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-          s.vhosts["/"].queues[delay_q_name].message_count.should eq 1
+          s.vhosts["/"].queue(delay_q_name).message_count.should eq 1
         end
         data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest(delay_q_name))
 
@@ -106,7 +106,7 @@ describe "Delayed Message Exchange" do
         File.open(seg_file, "a") { |f| f.write_bytes(1i64, IO::ByteFormat::SystemEndian) }
 
         s.restart
-        s.vhosts["/"].queues[delay_q_name].message_count.should eq 1
+        s.vhosts["/"].queue(delay_q_name).message_count.should eq 1
       end
     end
   end
@@ -120,7 +120,7 @@ describe "Delayed Message Exchange" do
         q.bind(x.name, "#")
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
@@ -138,7 +138,7 @@ describe "Delayed Message Exchange" do
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "test message 1", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         x.publish "test message 2", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 2 }
         queue.message_count.should eq 2
@@ -158,7 +158,7 @@ describe "Delayed Message Exchange" do
         x.publish "delay-long", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 1})
         x.publish "delay-short", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count >= 1 }
         q.get(no_ack: true).try(&.body_io.to_s).should eq("delay-short")
@@ -192,7 +192,7 @@ describe "Delayed Message Exchange" do
         # the message published with 6000ms should be published. Also, the new message
         # with 1500ms should be published
         sleep 2.seconds
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 3
         sleep 3.seconds # total 10, the 9000ms message should have been published
         queue.message_count.should eq 4
@@ -215,7 +215,7 @@ describe "Delayed Message Exchange" do
         q.bind(x.name, "rk")
         hdrs = AMQP::Client::Arguments.new({"x-delay" => 5})
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queue(q_name)
         queue.message_count.should eq 0
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
@@ -256,7 +256,7 @@ describe "Delayed Message Exchange" do
         x = ch.exchange(x_name, "topic", args: x_args)
         q = ch.queue(q_name)
         q.bind(x.name, "#")
-        ex = s.vhosts["/"].exchanges[x_name].as(LavinMQ::AMQP::Exchange)
+        ex = s.vhosts["/"].exchange(x_name).as(LavinMQ::AMQP::Exchange)
 
         delayed_q = ex.@delayed_queue.should_not be_nil
 
@@ -291,7 +291,7 @@ describe "Delayed Message Exchange" do
       with_channel(s) do |ch|
         ch.exchange(x_name, "topic", args: x_args)
         # The internal delayed queue should exist
-        internal_queue = s.vhosts["/"].queues[delay_q_name]?
+        internal_queue = s.vhosts["/"].queue?(delay_q_name)
         internal_queue.should_not be_nil
 
         # Attempting to bind the delayed exchange to its internal queue should raise an error
@@ -315,12 +315,12 @@ describe "Delayed Message Exchange" do
         x.publish "test message", "test.routing.key"
 
         # Message should reach the bound queue, not create a loop
-        queue = s.vhosts["/"].queues[q_name]
+        queue = s.vhosts["/"].queue(q_name)
         wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
 
         # Internal delayed queue should remain empty
-        internal_queue = s.vhosts["/"].queues[delay_q_name]
+        internal_queue = s.vhosts["/"].queue(delay_q_name)
         internal_queue.message_count.should eq 0
       end
     end

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -16,8 +16,8 @@ describe LavinMQ::Exchange do
               x = ch.exchange("test", exchange_type)
               q = ch.queue("q")
               q.bind(x.name, routing_key, args: LavinMQ::AMQP::Table.new({"x-foo": "bar"}))
-              ex = s.vhosts["/"].exchanges["test"]
-              q = s.vhosts["/"].queues["q"]
+              ex = s.vhosts["/"].exchange("test")
+              q = s.vhosts["/"].queue("q")
               bd = ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
               bd.binding_key.arguments.should eq LavinMQ::AMQP::Table.new({"x-foo": "bar"})
             end
@@ -31,8 +31,8 @@ describe LavinMQ::Exchange do
               ch_q = ch.queue("q")
               bd_args = LavinMQ::AMQP::Table.new({"x-foo": "bar"})
               ch_q.bind(x.name, routing_key, args: bd_args)
-              ex = s.vhosts["/"].exchanges["test"]
-              q = s.vhosts["/"].queues["q"]
+              ex = s.vhosts["/"].exchange("test")
+              q = s.vhosts["/"].queue("q")
               ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
               ch_q.unbind(x.name, routing_key)
               ex.bindings_details.find { |b| b.destination == q }.should_not be_nil
@@ -86,7 +86,7 @@ describe LavinMQ::Exchange do
           x_args = AMQP::Client::Arguments.new
           x = ch.exchange(x_name, "topic", args: x_args)
           x.publish_confirm "test message 1", "none"
-          s.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+          s.vhosts["/"].exchange(x_name).unroutable_count.should eq 1
         end
       end
     end
@@ -100,7 +100,7 @@ describe LavinMQ::Exchange do
           q.bind(x.name, q.name)
           x.publish_confirm "test message 1", "none"
           x.publish_confirm "test message 2", q.name
-          s.vhosts["/"].exchanges[x_name].unroutable_count.should eq 1
+          s.vhosts["/"].exchange(x_name).unroutable_count.should eq 1
         end
       end
     end
@@ -142,7 +142,7 @@ describe LavinMQ::Exchange do
           expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
             ch.exchange("test2", "x-delayed-message", args: illegal_dmx_args)
           end
-          s.vhosts["/"].exchanges["test2"]?.should be_nil
+          s.vhosts["/"].exchange?("test2").should be_nil
         end
       end
     end
@@ -174,8 +174,8 @@ describe LavinMQ::Exchange do
         with_channel(s) do |ch|
           ch.exchange("e1", "topic", auto_delete: true)
           ch.exchange("e2", "topic", auto_delete: true)
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_false
-          s.vhosts["/"].exchanges["e2"].in_use?.should be_false
+          s.vhosts["/"].exchange("e1").in_use?.should be_false
+          s.vhosts["/"].exchange("e2").in_use?.should be_false
         end
       end
     end
@@ -185,7 +185,7 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic", auto_delete: true)
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges["e2"].in_use?.should be_true
+          s.vhosts["/"].exchange("e2").in_use?.should be_true
         end
       end
     end
@@ -195,7 +195,7 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic", auto_delete: true)
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_true
+          s.vhosts["/"].exchange("e1").in_use?.should be_true
         end
       end
     end
@@ -206,9 +206,9 @@ describe LavinMQ::Exchange do
           x1 = ch.exchange("e1", "topic")
           x2 = ch.exchange("e2", "topic", auto_delete: true)
           x2.bind(x1.name, "#")
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_true
+          s.vhosts["/"].exchange("e1").in_use?.should be_true
           x2.unbind(x1.name, "#")
-          s.vhosts["/"].exchanges["e1"].in_use?.should be_false
+          s.vhosts["/"].exchange("e1").in_use?.should be_false
         end
       end
     end
@@ -222,8 +222,8 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchanges["test"]
-          q = s.vhosts["/"].queues.first_value
+          ex = s.vhosts["/"].exchange("test")
+          q = s.vhosts["/"].queues_each_value.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
@@ -251,8 +251,8 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchanges["test"]
-          q = s.vhosts["/"].queues.first_value
+          ex = s.vhosts["/"].exchange("test")
+          q = s.vhosts["/"].queues_each_value.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))
@@ -310,7 +310,7 @@ describe LavinMQ::Exchange do
             definition = {"federation-upstream" => JSON::Any.new("upstream")}
             downstream_vhost.add_policy("fed", "^fed", "exchanges", definition, 1i8)
             downstream_vhost.declare_exchange("fed.internal", "topic", durable: true, auto_delete: false, internal: true)
-            wait_for(100.milliseconds) { downstream_vhost.exchanges["fed.internal"].policy.try &.name == "fed" }
+            wait_for(100.milliseconds) { downstream_vhost.exchange("fed.internal").policy.try &.name == "fed" }
             downstream_vhost.upstreams.@upstreams["upstream"].links.empty?.should be_true
           end
         end

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -223,7 +223,7 @@ describe LavinMQ::Exchange do
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
           ex = s.vhosts["/"].exchange("test")
-          q = s.vhosts["/"].queues_each_value.first
+          q = s.vhosts["/"].each_queue.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
@@ -252,7 +252,7 @@ describe LavinMQ::Exchange do
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
           ex = s.vhosts["/"].exchange("test")
-          q = s.vhosts["/"].queues_each_value.first
+          q = s.vhosts["/"].each_queue.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -223,7 +223,7 @@ describe LavinMQ::Exchange do
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
           ex = s.vhosts["/"].exchange("test")
-          q = s.vhosts["/"].each_queue.first
+          q = s.vhosts["/"].queues_dup.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
@@ -252,7 +252,7 @@ describe LavinMQ::Exchange do
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
           ex = s.vhosts["/"].exchange("test")
-          q = s.vhosts["/"].each_queue.first
+          q = s.vhosts["/"].queues_dup.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -223,7 +223,7 @@ describe LavinMQ::Exchange do
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
           ex = s.vhosts["/"].exchange("test")
-          q = s.vhosts["/"].queues_dup.first
+          q = s.vhosts["/"].queues.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
@@ -252,7 +252,7 @@ describe LavinMQ::Exchange do
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
           ex = s.vhosts["/"].exchange("test")
-          q = s.vhosts["/"].queues_dup.first
+          q = s.vhosts["/"].queues.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -108,7 +108,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.queues.has_key?("new_queue").should be_true
+        vhost.queue_exists?("new_queue").should be_true
 
         result = run_lavinmqctl(http.addr.to_s, ["delete_queue", "new_queue"])
         result[:exit].should eq(0)
@@ -197,7 +197,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.exchanges.has_key?("test_exchange").should be_true
+        vhost.exchange_exists?("test_exchange").should be_true
 
         result = run_lavinmqctl(http.addr.to_s, ["delete_exchange", "test_exchange"])
         result[:exit].should eq(0)
@@ -210,7 +210,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.exchanges.has_key?("test_durable_exchange").should be_true
+        vhost.exchange_exists?("test_durable_exchange").should be_true
       end
     end
 
@@ -220,7 +220,7 @@ describe "LavinMQCtl" do
         result[:exit].should eq(0)
 
         vhost = s.vhosts["/"]
-        vhost.queues.has_key?("test_durable_queue").should be_true
+        vhost.queue_exists?("test_durable_queue").should be_true
       end
     end
 

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -171,7 +171,7 @@ module MqttSpecs
           with_server do |server|
             with_client_io(server) do |io|
               connect(io, client_id: "", clean_session: true)
-              server.vhosts["/"].each_connection.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
+              server.vhosts["/"].connections_dup.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
             end
           end
         end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -171,7 +171,7 @@ module MqttSpecs
           with_server do |server|
             with_client_io(server) do |io|
               connect(io, client_id: "", clean_session: true)
-              server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
+              server.vhosts["/"].connections_each.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
             end
           end
         end
@@ -314,7 +314,7 @@ module MqttSpecs
               disconnect(io)
             end
             sleep 100.milliseconds
-            server.vhosts["/"].queues["mqtt.client_id"].consumers.should be_empty
+            server.vhosts["/"].queue("mqtt.client_id").consumers.should be_empty
           end
         end
       end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -171,7 +171,7 @@ module MqttSpecs
           with_server do |server|
             with_client_io(server) do |io|
               connect(io, client_id: "", clean_session: true)
-              server.vhosts["/"].connections_each.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
+              server.vhosts["/"].each_connection.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
             end
           end
         end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -314,7 +314,7 @@ module MqttSpecs
               disconnect(io)
             end
             sleep 100.milliseconds
-            server.vhosts["/"].queue("mqtt.client_id").consumers.should be_empty
+            server.vhosts["/"].queue("mqtt.client_id").consumers_empty?.should be_true
           end
         end
       end

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -171,7 +171,7 @@ module MqttSpecs
           with_server do |server|
             with_client_io(server) do |io|
               connect(io, client_id: "", clean_session: true)
-              server.vhosts["/"].connections_dup.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
+              server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first.client_id.should_not eq("")
             end
           end
         end

--- a/spec/mqtt/multi_vhost_spec.cr
+++ b/spec/mqtt/multi_vhost_spec.cr
@@ -7,7 +7,7 @@ module MqttSpecs
       it "should create mqtt exchange when vhost is created" do
         with_amqp_server do |server|
           server.vhosts.create("new")
-          server.vhosts["new"].exchanges[LavinMQ::MQTT::EXCHANGE]?.should_not be_nil
+          server.vhosts["new"].exchange?(LavinMQ::MQTT::EXCHANGE).should_not be_nil
         end
       end
 

--- a/spec/msg_segment_meta_files_spec.cr
+++ b/spec/msg_segment_meta_files_spec.cr
@@ -7,7 +7,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("meta_test")
-          queue = vhost.queues["meta_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("meta_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create a large message to fill segments faster
           segment_size = LavinMQ::Config.instance.segment_size
@@ -43,7 +43,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("stream_meta_test", args: AMQP::Client::Arguments.new({"x-queue-type" => "stream"}))
-          queue = vhost.queues["stream_meta_test"].as(LavinMQ::AMQP::Stream)
+          queue = vhost.queue("stream_meta_test").as(LavinMQ::AMQP::Stream)
 
           # Publish enough messages to trigger new segment creation
           segment_size = LavinMQ::Config.instance.segment_size
@@ -85,7 +85,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("metadata_load_test")
-          queue = vhost.queues["metadata_load_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("metadata_load_test").as(LavinMQ::AMQP::DurableQueue)
 
           large_message = "x" * (LavinMQ::Config.instance.segment_size // 4) # message is 1/4 of segment size
           5.times { q.publish_confirm large_message }
@@ -118,7 +118,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("fallback_test")
-          queue = vhost.queues["fallback_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("fallback_test").as(LavinMQ::AMQP::DurableQueue)
 
           25.times { |i| q.publish_confirm "message #{i}" }
           msg_dir = queue.@msg_store.@msg_dir
@@ -141,7 +141,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("delete_test")
-          queue = vhost.queues["delete_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("delete_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Fill multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -179,7 +179,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("purge_test")
-          queue = vhost.queues["purge_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("purge_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Fill segments enough to create multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -212,7 +212,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("cleanup_test")
-          queue = vhost.queues["cleanup_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("cleanup_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create enough messages to span multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -255,7 +255,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("count_test")
-          queue = vhost.queues["count_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("count_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Create enough messages to fill multiple segments
           segment_size = LavinMQ::Config.instance.segment_size
@@ -286,7 +286,7 @@ describe "Message segment metadata files" do
         vhost = s.vhosts.create("test_vhost")
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("init_test")
-          queue = vhost.queues["init_test"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("init_test").as(LavinMQ::AMQP::DurableQueue)
 
           # Publish messages
           large_message = "x" * (LavinMQ::Config.instance.segment_size // 4) # message is 1/4 of segment size

--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -27,13 +27,13 @@ describe LavinMQ::VHost do
 
   it "should remove policy from resource when deleted" do
     PoliciesSpec.with_vhost do |vhost|
-      vhost.queues["test1"] = LavinMQ::QueueFactory.make(vhost, "test")
+      vhost.queues_unsafe_put("test1", LavinMQ::QueueFactory.make(vhost, "test"))
       vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
       sleep 10.milliseconds
-      vhost.queues["test1"].policy.try(&.name).should eq "test"
+      vhost.queue("test1").policy.try(&.name).should eq "test"
       vhost.delete_policy("test")
       sleep 10.milliseconds
-      vhost.queues["test1"].policy.should be_nil
+      vhost.queue("test1").policy.should be_nil
     end
   end
 
@@ -58,21 +58,21 @@ describe LavinMQ::VHost do
   it "should apply policy" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+      vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
       vhost.add_policy("ml", "^.*$", "queues", defs, 11_i8)
       sleep 10.milliseconds
-      vhost.queues["test"].policy.not_nil!.name.should eq "ml"
+      vhost.queue("test").policy.not_nil!.name.should eq "ml"
     end
   end
 
   it "should respect priority" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      vhost.queues["test2"] = LavinMQ::QueueFactory.make(vhost, "test")
+      vhost.queues_unsafe_put("test2", LavinMQ::QueueFactory.make(vhost, "test"))
       vhost.add_policy("ml2", "^.*$", "queues", defs, 1_i8)
       vhost.add_policy("ml1", "^.*$", "queues", defs, 0_i8)
       sleep 10.milliseconds
-      vhost.queues["test2"].policy.not_nil!.name.should eq "ml2"
+      vhost.queue("test2").policy.not_nil!.name.should eq "ml2"
     end
   end
 
@@ -129,7 +129,7 @@ describe LavinMQ::VHost do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         ch.queue("qttl", args: AMQP::Client::Arguments.new({"x-expires" => 1000}))
-        queue = s.vhosts["/"].queues["qttl"].as(LavinMQ::AMQP::Queue)
+        queue = s.vhosts["/"].queue("qttl").as(LavinMQ::AMQP::Queue)
         Fiber.yield
         expire_before = queue.@expires
         expire_before.should eq 1000
@@ -280,10 +280,10 @@ describe LavinMQ::VHost do
                               "federation-upstream", "federation-upstream-set",
                               "delivery-limit", "max-age", "alternate-exchange",
                               "delayed-message"}
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
         sleep 10.milliseconds
-        vhost.queues["test"].details_tuple[:effective_policy_definition].as(Hash(String, JSON::Any)).each_key do |k|
+        vhost.queue("test").details_tuple[:effective_policy_definition].as(Hash(String, JSON::Any)).each_key do |k|
           supported_policies.includes?(k).should be_true
         end
         vhost.delete_policy("test")
@@ -294,9 +294,11 @@ describe LavinMQ::VHost do
   describe "together with arguments" do
     it "arguments should have priority for non numeric arguments" do
       PoliciesSpec.with_vhost do |vhost|
-        no_ae_ex = vhost.exchanges["no-ae"] = LavinMQ::AMQP::DirectExchange.new(vhost, "no-ae")
-        ae_ex = vhost.exchanges["x-with-ae"] = LavinMQ::AMQP::DirectExchange.new(vhost, "x-with-ae",
+        no_ae_ex = LavinMQ::AMQP::DirectExchange.new(vhost, "no-ae")
+        vhost.exchanges_unsafe_put("no-ae", no_ae_ex)
+        ae_ex = LavinMQ::AMQP::DirectExchange.new(vhost, "x-with-ae",
           arguments: AMQ::Protocol::Table.new({"x-alternate-exchange": "ae2"}))
+        vhost.exchanges_unsafe_put("x-with-ae", ae_ex)
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
         no_ae_ex.@alternate_exchange.should eq "dead-letters"
@@ -310,34 +312,34 @@ describe LavinMQ::VHost do
 
     it "should use the lowest value" do
       PoliciesSpec.with_vhost do |vhost|
-        vhost.queues["test1"] = LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64}))
-        vhost.queues["test2"] = LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64}))
+        vhost.queues_unsafe_put("test1", LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64})))
+        vhost.queues_unsafe_put("test2", LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64})))
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
-        vhost.queues["test1"].as(LavinMQ::AMQP::Queue).@max_length.should eq 1
-        vhost.queues["test2"].as(LavinMQ::AMQP::Queue).@max_length.should eq 10
+        vhost.queue("test1").as(LavinMQ::AMQP::Queue).@max_length.should eq 1
+        vhost.queue("test2").as(LavinMQ::AMQP::Queue).@max_length.should eq 10
         vhost.delete_policy("test")
         sleep 10.milliseconds
-        vhost.queues["test1"].as(LavinMQ::AMQP::Queue).@max_length.should eq 1
-        vhost.queues["test2"].as(LavinMQ::AMQP::Queue).@max_length.should eq 11
+        vhost.queue("test1").as(LavinMQ::AMQP::Queue).@max_length.should eq 1
+        vhost.queue("test2").as(LavinMQ::AMQP::Queue).@max_length.should eq 11
       end
     end
 
     it "should use the lowest value for delivery-limit" do
       PoliciesSpec.with_vhost do |vhost|
-        vhost.queues["test1"] = LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 1_i64}))
-        vhost.queues["test2"] = LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 11_i64}))
-        vhost.queues["test3"] = LavinMQ::QueueFactory.make(vhost, "test3")
+        vhost.queues_unsafe_put("test1", LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 1_i64})))
+        vhost.queues_unsafe_put("test2", LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 11_i64})))
+        vhost.queues_unsafe_put("test3", LavinMQ::QueueFactory.make(vhost, "test3"))
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
-        vhost.queues["test1"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1
-        vhost.queues["test2"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 10
-        vhost.queues["test3"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 10
+        vhost.queue("test1").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1
+        vhost.queue("test2").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 10
+        vhost.queue("test3").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 10
         vhost.delete_policy("test")
         sleep 10.milliseconds
-        vhost.queues["test1"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1
-        vhost.queues["test2"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 11
-        vhost.queues["test3"].as(LavinMQ::AMQP::Queue).@delivery_limit.should eq nil
+        vhost.queue("test1").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1
+        vhost.queue("test2").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 11
+        vhost.queue("test3").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq nil
       end
     end
   end
@@ -349,10 +351,10 @@ describe LavinMQ::VHost do
           "max-length"  => JSON::Any.new("not-a-number"),
           "message-ttl" => JSON::Any.new(5000_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-type", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@max_length.should be_nil
         queue.@message_ttl.should eq 5000
         vhost.delete_policy("invalid-type")
@@ -365,10 +367,10 @@ describe LavinMQ::VHost do
           "max-length-bytes" => JSON::Any.new(true),
           "max-length"       => JSON::Any.new(10_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-bytes", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@max_length_bytes.should be_nil
         queue.@max_length.should eq 10
         vhost.delete_policy("invalid-bytes")
@@ -381,10 +383,10 @@ describe LavinMQ::VHost do
           "message-ttl" => JSON::Any.new("invalid"),
           "max-length"  => JSON::Any.new(20_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-ttl", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@message_ttl.should be_nil
         queue.@max_length.should eq 20
         vhost.delete_policy("invalid-ttl")
@@ -397,10 +399,10 @@ describe LavinMQ::VHost do
           "expires"    => JSON::Any.new([JSON::Any.new(1)]),
           "max-length" => JSON::Any.new(15_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-expires", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@expires.should be_nil
         queue.@max_length.should eq 15
         vhost.delete_policy("invalid-expires")
@@ -413,10 +415,10 @@ describe LavinMQ::VHost do
           "overflow"   => JSON::Any.new(123_i64),
           "max-length" => JSON::Any.new(25_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-overflow", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@reject_on_overflow.should be_false
         queue.@max_length.should eq 25
         vhost.delete_policy("invalid-overflow")
@@ -429,10 +431,10 @@ describe LavinMQ::VHost do
           "dead-letter-exchange" => JSON::Any.new(999_i64),
           "max-length"           => JSON::Any.new(30_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-dlx", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@dead_letter.@dlx.should be_nil
         queue.@max_length.should eq 30
         vhost.delete_policy("invalid-dlx")
@@ -445,10 +447,10 @@ describe LavinMQ::VHost do
           "dead-letter-routing-key" => JSON::Any.new([JSON::Any.new("dlrk")]),
           "max-length"              => JSON::Any.new("abc"),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-dlrk", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@dead_letter.@dlx.should be_nil
         queue.@max_length.should be_nil
         vhost.delete_policy("invalid-dlrk")
@@ -461,10 +463,10 @@ describe LavinMQ::VHost do
           "delivery-limit" => JSON::Any.new("five"),
           "max-length"     => JSON::Any.new(40_i64),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-limit", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@delivery_limit.should be_nil
         queue.@max_length.should eq 40
         vhost.delete_policy("invalid-limit")
@@ -483,10 +485,10 @@ describe LavinMQ::VHost do
           "dead-letter-routing-key" => JSON::Any.new("dlrk"),
           "delivery-limit"          => JSON::Any.new("bad"),
         }
-        vhost.queues["test"] = LavinMQ::QueueFactory.make(vhost, "test")
+        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("mixed", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
-        queue = vhost.queues["test"].as(LavinMQ::AMQP::Queue)
+        queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
         queue.@max_length.should eq 50
         queue.@max_length_bytes.should be_nil
         queue.@message_ttl.should eq 3000

--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -27,7 +27,7 @@ describe LavinMQ::VHost do
 
   it "should remove policy from resource when deleted" do
     PoliciesSpec.with_vhost do |vhost|
-      vhost.queues_unsafe_put("test1", LavinMQ::QueueFactory.make(vhost, "test"))
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test1"))
       vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
       sleep 10.milliseconds
       vhost.queue("test1").policy.try(&.name).should eq "test"
@@ -58,7 +58,7 @@ describe LavinMQ::VHost do
   it "should apply policy" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
       vhost.add_policy("ml", "^.*$", "queues", defs, 11_i8)
       sleep 10.milliseconds
       vhost.queue("test").policy.not_nil!.name.should eq "ml"
@@ -68,7 +68,7 @@ describe LavinMQ::VHost do
   it "should respect priority" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
-      vhost.queues_unsafe_put("test2", LavinMQ::QueueFactory.make(vhost, "test"))
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test2"))
       vhost.add_policy("ml2", "^.*$", "queues", defs, 1_i8)
       vhost.add_policy("ml1", "^.*$", "queues", defs, 0_i8)
       sleep 10.milliseconds
@@ -280,7 +280,7 @@ describe LavinMQ::VHost do
                               "federation-upstream", "federation-upstream-set",
                               "delivery-limit", "max-age", "alternate-exchange",
                               "delayed-message"}
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("test", "^.*$", "all", definitions, -10_i8)
         sleep 10.milliseconds
         vhost.queue("test").details_tuple[:effective_policy_definition].as(Hash(String, JSON::Any)).each_key do |k|
@@ -295,10 +295,10 @@ describe LavinMQ::VHost do
     it "arguments should have priority for non numeric arguments" do
       PoliciesSpec.with_vhost do |vhost|
         no_ae_ex = LavinMQ::AMQP::DirectExchange.new(vhost, "no-ae")
-        vhost.exchanges_unsafe_put("no-ae", no_ae_ex)
+        vhost.register_exchange(no_ae_ex)
         ae_ex = LavinMQ::AMQP::DirectExchange.new(vhost, "x-with-ae",
           arguments: AMQ::Protocol::Table.new({"x-alternate-exchange": "ae2"}))
-        vhost.exchanges_unsafe_put("x-with-ae", ae_ex)
+        vhost.register_exchange(ae_ex)
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
         no_ae_ex.@alternate_exchange.should eq "dead-letters"
@@ -312,8 +312,8 @@ describe LavinMQ::VHost do
 
     it "should use the lowest value" do
       PoliciesSpec.with_vhost do |vhost|
-        vhost.queues_unsafe_put("test1", LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64})))
-        vhost.queues_unsafe_put("test2", LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64})))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64})))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-max-length" => 11_i64})))
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
         vhost.queue("test1").as(LavinMQ::AMQP::Queue).@max_length.should eq 1
@@ -327,9 +327,9 @@ describe LavinMQ::VHost do
 
     it "should use the lowest value for delivery-limit" do
       PoliciesSpec.with_vhost do |vhost|
-        vhost.queues_unsafe_put("test1", LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 1_i64})))
-        vhost.queues_unsafe_put("test2", LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 11_i64})))
-        vhost.queues_unsafe_put("test3", LavinMQ::QueueFactory.make(vhost, "test3"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test1", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 1_i64})))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test2", arguments: LavinMQ::AMQP::Table.new({"x-delivery-limit" => 11_i64})))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test3"))
         vhost.add_policy("test", ".*", "all", definitions, 100_i8)
         sleep 10.milliseconds
         vhost.queue("test1").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1
@@ -351,7 +351,7 @@ describe LavinMQ::VHost do
           "max-length"  => JSON::Any.new("not-a-number"),
           "message-ttl" => JSON::Any.new(5000_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-type", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -367,7 +367,7 @@ describe LavinMQ::VHost do
           "max-length-bytes" => JSON::Any.new(true),
           "max-length"       => JSON::Any.new(10_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-bytes", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -383,7 +383,7 @@ describe LavinMQ::VHost do
           "message-ttl" => JSON::Any.new("invalid"),
           "max-length"  => JSON::Any.new(20_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-ttl", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -399,7 +399,7 @@ describe LavinMQ::VHost do
           "expires"    => JSON::Any.new([JSON::Any.new(1)]),
           "max-length" => JSON::Any.new(15_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-expires", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -415,7 +415,7 @@ describe LavinMQ::VHost do
           "overflow"   => JSON::Any.new(123_i64),
           "max-length" => JSON::Any.new(25_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-overflow", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -431,7 +431,7 @@ describe LavinMQ::VHost do
           "dead-letter-exchange" => JSON::Any.new(999_i64),
           "max-length"           => JSON::Any.new(30_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-dlx", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -447,7 +447,7 @@ describe LavinMQ::VHost do
           "dead-letter-routing-key" => JSON::Any.new([JSON::Any.new("dlrk")]),
           "max-length"              => JSON::Any.new("abc"),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-dlrk", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -463,7 +463,7 @@ describe LavinMQ::VHost do
           "delivery-limit" => JSON::Any.new("five"),
           "max-length"     => JSON::Any.new(40_i64),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("invalid-limit", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)
@@ -485,7 +485,7 @@ describe LavinMQ::VHost do
           "dead-letter-routing-key" => JSON::Any.new("dlrk"),
           "delivery-limit"          => JSON::Any.new("bad"),
         }
-        vhost.queues_unsafe_put("test", LavinMQ::QueueFactory.make(vhost, "test"))
+        vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "test"))
         vhost.add_policy("mixed", "^test$", "queues", defs, 0_i8)
         sleep 10.milliseconds
         queue = vhost.queue("test").as(LavinMQ::AMQP::Queue)

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -42,7 +42,7 @@ describe LavinMQ::AMQP::PriorityQueue do
 
           server = LavinMQ::Server.new(cluster.follower_config)
           begin
-            q = server.vhosts["/"].queues["repli"].as(LavinMQ::AMQP::DurablePriorityQueue)
+            q = server.vhosts["/"].queue("repli").as(LavinMQ::AMQP::DurablePriorityQueue)
             q.message_count.should eq 1
             q.basic_get(true) do |env|
               env.message.properties.priority.should eq 1

--- a/spec/queue_dead_lettering_spec.cr
+++ b/spec/queue_dead_lettering_spec.cr
@@ -278,7 +278,7 @@ module DeadLetteringSpec
 
       it "should only dead letter on nack multiple with requeue=false when basic get" do
         with_dead_lettering_setup do |q, dlq, _, s|
-          queue = s.vhosts["/"].queues["q"].should be_a LavinMQ::AMQP::Queue
+          queue = s.vhosts["/"].queue("q").should be_a LavinMQ::AMQP::Queue
 
           publish_n(3, q)
 

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -926,7 +926,7 @@ describe LavinMQ::AMQP::Queue do
           q = ch.queue("", exclusive: true, auto_delete: true)
           tag = q.subscribe(no_ack: true) { }
 
-          conn = s.vhosts["/"].connections_dup.first.as(LavinMQ::AMQP::Client)
+          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
           conn.@exclusive_queues.size.should eq 1
 
           ch.basic_cancel(tag) # last consumer leaves -> auto-delete fires
@@ -944,7 +944,7 @@ describe LavinMQ::AMQP::Queue do
         with_channel(s) do |c|
           ch = c
           5.times { c.queue("", exclusive: true, auto_delete: true) }
-          conn = s.vhosts["/"].connections_dup.first.as(LavinMQ::AMQP::Client)
+          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
           conn.@exclusive_queues.size.should eq 5
         end
         # Connection closed by `with_channel`. All 5 queues should be gone,
@@ -959,7 +959,7 @@ describe LavinMQ::AMQP::Queue do
           ch.queue("", exclusive: true,
             args: AMQP::Client::Arguments.new({"x-expires" => 100}))
 
-          conn = s.vhosts["/"].connections_dup.first.as(LavinMQ::AMQP::Client)
+          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
           conn.@exclusive_queues.size.should eq 1
 
           should_eventually(eq 0) { conn.@exclusive_queues.size }

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -8,7 +8,7 @@ def with_queue(&)
   with_amqp_server do |s|
     vhost = s.vhosts["/"]
     vhost.declare_queue("q", durable: true, auto_delete: false)
-    q = vhost.queues["q"]
+    q = vhost.queue("q")
     yield q
   ensure
     q.try &.delete
@@ -48,7 +48,7 @@ describe LavinMQ::AMQP::Queue do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         q = ch.queue("qexpires", args: AMQP::Client::Arguments.new({"x-expires" => 100}))
-        queue = s.vhosts["/"].queues["qexpires"]
+        queue = s.vhosts["/"].queue("qexpires")
         tag = q.subscribe { }
         sleep 110.milliseconds
         queue.closed?.should be_false
@@ -169,7 +169,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].queues[q.name]
+          iq = s.vhosts["/"].queue(q.name)
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -183,12 +183,12 @@ describe LavinMQ::AMQP::Queue do
         s.vhosts.create("/")
         v = s.vhosts["/"].not_nil!
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
-        s.vhosts["/"].queues["q"].pause!
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        s.vhosts["/"].queue("q").pause!
         File.exists?(File.join(data_dir, "paused")).should be_true
         s.restart
-        s.vhosts["/"].queues["q"].state.paused?.should be_true
-        s.vhosts["/"].queues["q"].resume!
+        s.vhosts["/"].queue("q").state.paused?.should be_true
+        s.vhosts["/"].queue("q").resume!
         File.exists?(File.join(data_dir, "paused")).should be_false
       end
     end
@@ -198,11 +198,11 @@ describe LavinMQ::AMQP::Queue do
         s.vhosts.create("/")
         v = s.vhosts["/"].not_nil!
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         File.touch(File.join(data_dir, ".paused"))
         s.restart
         File.exists?(File.join(data_dir, "paused")).should be_true
-        s.vhosts["/"].queues["q"].state.paused?.should be_true
+        s.vhosts["/"].queue("q").state.paused?.should be_true
       end
     end
 
@@ -216,7 +216,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].queues[q.name]
+          iq = s.vhosts["/"].queue(q.name)
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -249,7 +249,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message", q.name
           q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
 
-          iq = s.vhosts["/"].queues[q.name]
+          iq = s.vhosts["/"].queue(q.name)
           iq.pause!
 
           x.publish_confirm "test message 2", q.name
@@ -281,7 +281,7 @@ describe LavinMQ::AMQP::Queue do
         tag = "consumer-to-be-canceled"
         with_channel(s) do |ch|
           q = ch.queue(q_name)
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
           q.publish_confirm "m1"
 
           # Should get canceled
@@ -294,7 +294,7 @@ describe LavinMQ::AMQP::Queue do
         end
 
         # Queue is closed, delete to prevent spec failure because of closed queue
-        s.vhosts["/"].queues[q_name].try &.delete
+        s.vhosts["/"].queue(q_name).try &.delete
       end
     end
   end
@@ -305,7 +305,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Publish a message
           q.publish_confirm "test message"
@@ -330,7 +330,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
           q.publish_confirm "test message"
           queue.message_count.should eq 1
 
@@ -363,7 +363,7 @@ describe LavinMQ::AMQP::Queue do
           q = ch.queue(q_name, durable: true, args: AMQP::Client::Arguments.new(
             {"x-message-ttl" => 500, "x-dead-letter-exchange" => "", "x-dead-letter-routing-key" => "dlq"}
           ))
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Publish a message
           q.publish_confirm "test message"
@@ -386,7 +386,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.queue(q_name, durable: true, args: AMQP::Client::Arguments.new({"x-expires" => 100}))
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Close the queue
           queue.close
@@ -404,7 +404,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Apply a max-length policy
           definition = {"max-length" => JSON::Any.new(2i64)}
@@ -427,7 +427,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           # Try to restart without closing
           queue.restart!.should be_false
@@ -472,7 +472,7 @@ describe LavinMQ::AMQP::Queue do
           x.publish_confirm "test message 3", q.name
           x.publish_confirm "test message 4", q.name
 
-          internal_queue = s.vhosts["/"].queues[q.name]
+          internal_queue = s.vhosts["/"].queue(q.name)
           internal_queue.message_count.should eq 4
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents")
@@ -494,7 +494,7 @@ describe LavinMQ::AMQP::Queue do
           end
 
           vhost = s.vhosts["/"]
-          internal_queue = vhost.queues[q.name]
+          internal_queue = vhost.queue(q.name)
           internal_queue.message_count.should eq 10
 
           response = http.delete("/api/queues/%2f/#{q_name}/contents?count=5")
@@ -514,7 +514,7 @@ describe LavinMQ::AMQP::Queue do
 
         msg = q.get(no_ack: false)
         msg.should_not be_nil
-        sq = s.vhosts["/"].queues[q.name]
+        sq = s.vhosts["/"].queue(q.name)
         sq.unacked_count.should eq 1
         msg.not_nil!.ack
         sleep 10.milliseconds
@@ -534,7 +534,7 @@ describe LavinMQ::AMQP::Queue do
           done.send msg
         end
         msg = done.receive
-        sq = s.vhosts["/"].queues[q.name]
+        sq = s.vhosts["/"].queue(q.name)
         sq.unacked_count.should eq 1
         msg.ack
         sleep 10.milliseconds
@@ -548,7 +548,7 @@ describe LavinMQ::AMQP::Queue do
       with_channel(s) do |ch|
         ch.queue "transient", durable: false
       end
-      data_dir = s.vhosts["/"].queues["transient"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+      data_dir = s.vhosts["/"].queue("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
       s.stop
       Dir.exists?(data_dir).should be_false
     end
@@ -559,7 +559,7 @@ describe LavinMQ::AMQP::Queue do
       with_channel(s) do |ch|
         ch.queue "transient", durable: false
       end
-      data_dir = s.vhosts["/"].queues["transient"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+      data_dir = s.vhosts["/"].queue("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
       Dir.exists?(data_dir).should be_true
       File.exists?("#{data_dir}/msgs.0000000001").should be_false
     end
@@ -571,7 +571,7 @@ describe LavinMQ::AMQP::Queue do
       with_channel(s) do |ch|
         q = ch.queue "transient", durable: false
         q.publish_confirm "foobar"
-        data_dir = s.vhosts["/"].queues["transient"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("transient").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         FileUtils.cp_r data_dir, "#{s.vhosts["/"].data_dir}.copy"
       end
       s.stop
@@ -591,7 +591,7 @@ describe LavinMQ::AMQP::Queue do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         q = ch.queue("q", auto_delete: true)
-        data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         sub = q.subscribe(no_ack: true) { |_| }
         Dir.exists?(data_dir).should be_true
         q.unsubscribe(sub)
@@ -714,7 +714,7 @@ describe LavinMQ::AMQP::Queue do
         s.vhosts["/"].declare_queue("expire_test_queue", true, false, AMQP::Client::Arguments.new({
           "x-message-ttl" => 600,
         }))
-        queue = s.vhosts["/"].queues["expire_test_queue"].as(LavinMQ::AMQP::DurableQueue)
+        queue = s.vhosts["/"].queue("expire_test_queue").as(LavinMQ::AMQP::DurableQueue)
 
         10_000.times do
           queue.publish(LavinMQ::Message.new("ex", "rk", "body" * 250, AMQ::Protocol::Properties.new))
@@ -764,7 +764,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue
-          sq = s.vhosts["/"].queues[q.name].should be_a LavinMQ::AMQP::Queue
+          sq = s.vhosts["/"].queue(q.name).should be_a LavinMQ::AMQP::Queue
 
           q.publish_confirm "a"
           q.publish_confirm "b"
@@ -806,7 +806,7 @@ describe LavinMQ::AMQP::Queue do
         with_amqp_server do |s|
           q = s.vhosts["/"].try do |vhost|
             vhost.declare_queue("q", durable: true, auto_delete: false, arguments: AMQP::Client::Arguments.new(args))
-            vhost.queues["q"]
+            vhost.queue("q")
           end
 
           effective_arguments = q.details_tuple[:effective_arguments]
@@ -826,7 +826,7 @@ describe LavinMQ::AMQP::Queue do
         with_amqp_server do |s|
           q = s.vhosts["/"].try do |vhost|
             vhost.declare_queue("q", durable: true, auto_delete: false, arguments: AMQP::Client::Arguments.new(args))
-            vhost.queues["q"]
+            vhost.queue("q")
           end
 
           effective_arguments = q.details_tuple[:effective_arguments]
@@ -862,7 +862,7 @@ describe LavinMQ::AMQP::Queue do
         with_amqp_server do |s|
           q = s.vhosts["/"].try do |vhost|
             vhost.declare_queue("q", durable: true, auto_delete: false, arguments: AMQP::Client::Arguments.new(args))
-            vhost.queues["q"]
+            vhost.queue("q")
           end
           definition = JSON.parse(policy_args.to_json).as_h
           policy = LavinMQ::Policy.new("p1", "/", %r{"."}, LavinMQ::Policy::Target::All, definition, 1i8)

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -926,7 +926,7 @@ describe LavinMQ::AMQP::Queue do
           q = ch.queue("", exclusive: true, auto_delete: true)
           tag = q.subscribe(no_ack: true) { }
 
-          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
+          conn = s.vhosts["/"].connections_dup.first.as(LavinMQ::AMQP::Client)
           conn.@exclusive_queues.size.should eq 1
 
           ch.basic_cancel(tag) # last consumer leaves -> auto-delete fires
@@ -944,12 +944,12 @@ describe LavinMQ::AMQP::Queue do
         with_channel(s) do |c|
           ch = c
           5.times { c.queue("", exclusive: true, auto_delete: true) }
-          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
+          conn = s.vhosts["/"].connections_dup.first.as(LavinMQ::AMQP::Client)
           conn.@exclusive_queues.size.should eq 5
         end
         # Connection closed by `with_channel`. All 5 queues should be gone,
         # not just every other one.
-        should_eventually(eq 0) { s.vhosts["/"].queues.size }
+        should_eventually(eq 0) { s.vhosts["/"].queues_size }
       end
     end
 
@@ -959,7 +959,7 @@ describe LavinMQ::AMQP::Queue do
           ch.queue("", exclusive: true,
             args: AMQP::Client::Arguments.new({"x-expires" => 100}))
 
-          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
+          conn = s.vhosts["/"].connections_dup.first.as(LavinMQ::AMQP::Client)
           conn.@exclusive_queues.size.should eq 1
 
           should_eventually(eq 0) { conn.@exclusive_queues.size }

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -439,7 +439,7 @@ describe LavinMQ::AMQP::Queue do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue(q_name, durable: true)
-          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+          queue = s.vhosts["/"].queue(q_name).as(LavinMQ::AMQP::DurableQueue)
 
           q.subscribe(no_ack: true, exclusive: true) { }
           should_eventually(be_true) { queue.has_exclusive_consumer? }

--- a/spec/random_spec.cr
+++ b/spec/random_spec.cr
@@ -26,8 +26,8 @@ describe LavinMQ do
           count.should eq 0
 
           Fiber.yield
-          Server.vhosts["/"].queues[qname].@ready.size.should eq 2
-          Server.vhosts["/"].queues[qname].@unacked.size.should eq 0
+          Server.vhosts["/"].queue(qname).@ready.size.should eq 2
+          Server.vhosts["/"].queue(qname).@unacked.size.should eq 0
         end
       end
     end

--- a/spec/schema_version_spec.cr
+++ b/spec/schema_version_spec.cr
@@ -40,7 +40,7 @@ describe LavinMQ::SchemaVersion do
       with_amqp_server do |s|
         v = s.vhosts["/"]
         v.declare_queue("q", true, false)
-        data_dir = s.vhosts["/"].queues["q"].as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
+        data_dir = s.vhosts["/"].queue("q").as(LavinMQ::AMQP::Queue).@msg_store.@msg_dir
         path = File.join(data_dir, "msgs.0000000002")
         MFile.open(path, LavinMQ::Config.instance.segment_size) do |file|
           file.resize(LavinMQ::Config.instance.segment_size)

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -232,7 +232,7 @@ describe LavinMQ::Server do
         q.publish_confirm ttl_msg
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(ttl_msg)
-        s.vhosts["/"].queues[q.name].empty?.should be_true
+        s.vhosts["/"].queue(q.name).empty?.should be_true
         q.publish_confirm ttl_msg
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(ttl_msg)
@@ -250,7 +250,7 @@ describe LavinMQ::Server do
         msg.reject(requeue: true)
         msg = wait_for { dlq.get(no_ack: true) }
         msg.not_nil!.body_io.to_s.should eq(r_msg)
-        s.vhosts["/"].queues[q.name].empty?.should be_true
+        s.vhosts["/"].queue(q.name).empty?.should be_true
       end
     end
   end
@@ -278,7 +278,7 @@ describe LavinMQ::Server do
         tag = q.subscribe(no_ack: false) { |_| done.send nil }
         done.receive
         q.unsubscribe(tag)
-        s.vhosts["/"].queues["msg_q"].empty?.should be_true
+        s.vhosts["/"].queue("msg_q").empty?.should be_true
       end
     end
   end
@@ -651,7 +651,7 @@ describe LavinMQ::Server do
         definitions = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
         s.vhosts["/"].add_policy("test", "^mlq$", "queues", definitions, 10_i8)
         sleep 10.milliseconds
-        s.vhosts["/"].queues["mlq"].message_count.should eq 1
+        s.vhosts["/"].queue("mlq").message_count.should eq 1
       end
     end
   end
@@ -823,7 +823,7 @@ describe LavinMQ::Server do
         ch.queue("test", args: args)
         sleep 5.milliseconds
         Fiber.yield
-        s.vhosts["/"].queues.has_key?("test").should be_false
+        s.vhosts["/"].queue_exists?("test").should be_false
       end
     end
   end
@@ -837,7 +837,7 @@ describe LavinMQ::Server do
         q.subscribe(no_ack: true) { |_| }
         sleep 50.milliseconds
         Fiber.yield
-        s.vhosts["/"].queues.has_key?("test").should be_true
+        s.vhosts["/"].queue_exists?("test").should be_true
       end
     end
   end
@@ -993,7 +993,7 @@ describe LavinMQ::Server do
         msg.properties.headers.not_nil!["x-delivery-count"].as(Int32).should eq 1
         msg.reject(requeue: true)
         Fiber.yield
-        s.vhosts["/"].queues["delivery_limit"].empty?.should be_true
+        s.vhosts["/"].queue("delivery_limit").empty?.should be_true
       end
     end
   end
@@ -1129,8 +1129,8 @@ describe LavinMQ::Server do
         count.should eq 0
 
         Fiber.yield
-        s.vhosts["/"].queues[qname].message_count.should eq 1
-        s.vhosts["/"].queues[qname].unacked_count.should eq 0
+        s.vhosts["/"].queue(qname).message_count.should eq 1
+        s.vhosts["/"].queue(qname).unacked_count.should eq 0
       end
     end
   end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -29,7 +29,7 @@ describe LavinMQ::Shovel do
           s.vhosts["/"].queue("source").publish(LavinMQ::Message.new("", "", ""))
           expect_raises(AMQP::Client::Connection::ClosedException) do
             source.each do
-              s.vhosts["/"].connections_each &.close("spec")
+              s.vhosts["/"].each_connection &.close("spec")
             end
           end
           source.started?.should be_false

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -124,7 +124,7 @@ def with_amqp_server(tls = false, replicator = nil,
     # everything has been cleaned up after a `with_channel` inside the `with_amqp_server`.
     closed_queues = 3.times do
       Fiber.yield
-      queues = s.vhosts.flat_map { |_, vhost| vhost.queues.values.select &.closed? }
+      queues = s.vhosts.flat_map { |_, vhost| vhost.queues_values.select &.closed? }
       break if queues.empty?
       queues
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -124,7 +124,7 @@ def with_amqp_server(tls = false, replicator = nil,
     # everything has been cleaned up after a `with_channel` inside the `with_amqp_server`.
     closed_queues = 3.times do
       Fiber.yield
-      queues = s.vhosts.flat_map { |_, vhost| vhost.queues_values.select &.closed? }
+      queues = s.vhosts.flat_map { |_, vhost| vhost.queues.select &.closed? }
       break if queues.empty?
       queues
     end

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -14,7 +14,7 @@ describe LavinMQ::AMQP::DurableQueue do
       config = LavinMQ::Config.new.tap &.data_dir = "/tmp/lavinmq-spec-index-v2"
       server = LavinMQ::Server.new(config)
       begin
-        q = server.vhosts["/"].queues["queue"].as(LavinMQ::AMQP::DurableQueue)
+        q = server.vhosts["/"].queue("queue").as(LavinMQ::AMQP::DurableQueue)
         q.basic_get(true) do |env|
           String.new(env.message.body).to_s.should eq "message"
         end.should be_true
@@ -31,7 +31,7 @@ describe LavinMQ::AMQP::DurableQueue do
           vhost = s.vhosts.create("corrupt_vhost")
           with_channel(s, vhost: vhost.name) do |ch|
             q = ch.queue("corrupt_q")
-            queue = vhost.queues["corrupt_q"].as(LavinMQ::AMQP::DurableQueue)
+            queue = vhost.queue("corrupt_q").as(LavinMQ::AMQP::DurableQueue)
             q.publish_confirm "test message"
 
             sleep 10.milliseconds
@@ -48,7 +48,7 @@ describe LavinMQ::AMQP::DurableQueue do
             should_eventually(be_true) { queue.state.closed? }
           end
 
-          vhost.queues["corrupt_q"].try &.delete
+          vhost.queue?("corrupt_q").try &.delete
         end
       end
     end
@@ -59,7 +59,7 @@ describe LavinMQ::AMQP::DurableQueue do
         enq_path = ""
         with_channel(s, vhost: vhost.name) do |ch|
           q = ch.queue("corrupt_q2")
-          queue = vhost.queues["corrupt_q2"].as(LavinMQ::AMQP::DurableQueue)
+          queue = vhost.queue("corrupt_q2").as(LavinMQ::AMQP::DurableQueue)
           enq_path = queue.@msg_store.@segments.last_value.path
           2.times do |i|
             q.publish_confirm "test message #{i}"
@@ -84,7 +84,7 @@ describe LavinMQ::AMQP::DurableQueue do
       with_channel(s) do |ch|
         q = ch.queue("corruption_test", durable: true)
         q.publish_confirm "Hello world"
-        queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::AMQP::DurableQueue)
+        queue = s.vhosts["/"].queue("corruption_test").as(LavinMQ::AMQP::DurableQueue)
         enq_path = queue.@msg_store.@segments.last_value.path
       end
       s.stop
@@ -97,7 +97,7 @@ describe LavinMQ::AMQP::DurableQueue do
         q.publish_confirm "Hello world"
       end
       s.restart
-      queue = s.vhosts["/"].queues["corruption_test"].as(LavinMQ::AMQP::DurableQueue)
+      queue = s.vhosts["/"].queue("corruption_test").as(LavinMQ::AMQP::DurableQueue)
       queue.message_count.should eq 2
     end
   end
@@ -108,7 +108,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(queue_name)
-        queue = vhost.queues[queue_name].as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queue(queue_name).as(LavinMQ::AMQP::DurableQueue)
         mfile = queue.@msg_store.@segments.first_value
 
         # fill up one segment
@@ -140,7 +140,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(queue_name)
-        queue = vhost.queues[queue_name].as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queue(queue_name).as(LavinMQ::AMQP::DurableQueue)
         mfile = queue.@msg_store.@segments.first_value
 
         # fill up one segment
@@ -179,7 +179,7 @@ describe LavinMQ::AMQP::DurableQueue do
       vhost = s.vhosts.create("test_vhost")
       with_channel(s, vhost: vhost.name) do |ch|
         q = ch.queue(rk, durable: true)
-        queue = vhost.queues[rk].as(LavinMQ::AMQP::DurableQueue)
+        queue = vhost.queue(rk).as(LavinMQ::AMQP::DurableQueue)
         q.publish_confirm "a"
         store = LavinMQ::MessageStore.new(queue.@msg_store.@msg_dir, nil)
 
@@ -201,8 +201,8 @@ describe LavinMQ::VHost do
   pending "GC segments" do
     with_amqp_server do |s|
       vhost = s.vhosts["/"]
-      vhost.queues.each_value &.delete
-      vhost.queues.clear
+      vhost.queues_each_value &.delete
+      vhost.queues_clear
 
       msg_size = 5120
       overhead = 21

--- a/spec/storage_spec.cr
+++ b/spec/storage_spec.cr
@@ -201,7 +201,7 @@ describe LavinMQ::VHost do
   pending "GC segments" do
     with_amqp_server do |s|
       vhost = s.vhosts["/"]
-      vhost.queues_each_value &.delete
+      vhost.each_queue &.delete
       vhost.queues_clear
 
       msg_size = 5120

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -233,7 +233,7 @@ describe LavinMQ::AMQP::Stream do
         q.publish_confirm data
         # Derive target from msg1's stored timestamp; Time.utc here would race RoughTime's
         # 100ms coarsening and could land inside segment 2's bucket, hanging the consumer.
-        store = s.vhosts["/"].queues["stream-ts-across-segments"].as(LavinMQ::AMQP::Stream).stream_msg_store
+        store = s.vhosts["/"].queue("stream-ts-across-segments").as(LavinMQ::AMQP::Stream).stream_msg_store
         msg1_ts = store.@segment_last_ts.values.first
         target_time = Time.unix(msg1_ts // 1000 + 1)
         ch.prefetch 1

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -356,7 +356,7 @@ describe LavinMQ::AMQP::Stream do
           q = ch.queue("stream-max-length", args: AMQP::Client::Arguments.new(args))
           data = Bytes.new(LavinMQ::Config.instance.segment_size)
           3.times { q.publish_confirm data }
-          dir = s.vhosts["/"].queues["stream-max-length"].as(LavinMQ::AMQP::Stream).@data_dir
+          dir = s.vhosts["/"].queue("stream-max-length").as(LavinMQ::AMQP::Stream).@data_dir
           File.exists?(File.join(dir, "msgs.0000000001")).should be_false
           File.exists?(File.join(dir, "meta.0000000001")).should be_false
           q.message_count.should eq 1
@@ -374,7 +374,7 @@ describe LavinMQ::AMQP::Stream do
           3.times { q.publish_confirm data }
           q.message_count.should eq 3
 
-          stream = s.vhosts["/"].queues[queue_name].as(LavinMQ::AMQP::Stream)
+          stream = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Stream)
           stream.close
           stream.restart!
           stream.message_count.should eq 3
@@ -734,7 +734,7 @@ describe LavinMQ::AMQP::Stream do
           ch.prefetch 1
           args = {"x-queue-type": "stream"}
           q = ch.queue(queue_name, args: AMQP::Client::Arguments.new(args))
-          stream = s.vhosts["/"].queues[queue_name].as(LavinMQ::AMQP::Stream)
+          stream = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Stream)
           q.publish_confirm "test message"
           stream.message_count.should eq 1
 
@@ -773,7 +773,7 @@ describe LavinMQ::AMQP::Stream do
         msg = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
         StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 1
 
-        stream = s.vhosts["/"].queues[queue_name].as(LavinMQ::AMQP::Stream)
+        stream = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Stream)
         stream.close
         stream.closed?.should be_true
         stream.restart!

--- a/spec/stream_reader_spec.cr
+++ b/spec/stream_reader_spec.cr
@@ -15,7 +15,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}", q.name)
         end
 
-        iq = s.vhosts["/"].queues[q.name].as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queue(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader 5
 
         count = 0
@@ -40,7 +40,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}", q.name)
         end
 
-        iq = s.vhosts["/"].queues[q.name].as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queue(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader "first"
 
         count = 0
@@ -66,7 +66,7 @@ describe LavinMQ::AMQP::StreamReader do
           x.publish_confirm("test message #{i}" * 100, q.name)
         end
 
-        iq = s.vhosts["/"].queues[q.name].as(LavinMQ::AMQP::Stream)
+        iq = s.vhosts["/"].queue(q.name).as(LavinMQ::AMQP::Stream)
         stream = iq.reader 0
 
         count = 0

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -187,7 +187,7 @@ describe LavinMQ::Federation::Upstream do
 
         # Disconnect the federation link
         conn_id = nil
-        upstream_vhost.connections_each do |conn|
+        upstream_vhost.each_connection do |conn|
           next unless conn.client_name.starts_with?("Federation link")
           conn_id = conn.object_id
           conn.close
@@ -196,7 +196,7 @@ describe LavinMQ::Federation::Upstream do
         upstream.links.first.@state_changed.try_send nil
         wait_for { upstream_vhost.connections_size == 1 }
         conn = nil
-        upstream_vhost.connections_each { |c| conn = c if c.name.starts_with?("Federation link") }
+        upstream_vhost.each_connection { |c| conn = c if c.name.starts_with?("Federation link") }
         # Verify that it's a new connection... Any better assertion that can be done?
         conn.object_id.should_not eq conn_id
       end
@@ -442,7 +442,7 @@ describe LavinMQ::Federation::Upstream do
           end
         end
         all_empty = true
-        upstream_vhost.queues_each_value { |q| all_empty = false unless q.empty? }
+        upstream_vhost.each_queue { |q| all_empty = false unless q.empty? }
         all_empty.should be_true
       end
     end
@@ -484,7 +484,7 @@ describe LavinMQ::Federation::Upstream do
             upstream_ex.publish_confirm "msg1", "rk1"
             msgs.should be_receiving "msg1"
 
-            upstream_vhost.connections_each do |conn|
+            upstream_vhost.each_connection do |conn|
               next unless conn.client_name.starts_with?("Federation link")
               conn.close
             end
@@ -507,7 +507,7 @@ describe LavinMQ::Federation::Upstream do
           end
         end
         all_empty = true
-        upstream_vhost.queues_each_value { |q| all_empty = false unless q.empty? }
+        upstream_vhost.each_queue { |q| all_empty = false unless q.empty? }
         all_empty.should be_true
       end
     end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -61,7 +61,7 @@ module UpstreamSpecHelpers
       url.path = vhost_prev.name
       upstream = LavinMQ::Federation::Upstream.new(vhost, "ef from #{vhost_prev.name}", url.to_s, exchange: nil, queue: nil, max_hops: max_hops)
       upstreams << upstream
-      link = upstream.link(vhost.exchanges["fe"])
+      link = upstream.link(vhost.exchange("fe"))
       wait_for { link.state.running? }
       vhost_prev = vhost
     end
@@ -81,10 +81,10 @@ describe LavinMQ::Federation::Upstream do
 
         with_channel(s) do |ch|
           ch.queue("federated_q")
-          link = upstream.link(vhost_downstream.queues["federated_q"])
+          link = upstream.link(vhost_downstream.queue("federated_q"))
           link.name.should eq "federated_q"
           wait_for { link.state.running? }
-          vhost_upstream.queues.has_key?("federated_q").should be_true
+          vhost_upstream.queue_exists?("federated_q").should be_true
         end
       ensure
         upstream.try &.close
@@ -99,11 +99,11 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queue("federation_q2"))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
-          vhost.queues["federation_q1"].message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -118,10 +118,10 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x = UpstreamSpecHelpers.setup_qs(ch).first
           x.publish_confirm "federate me", "federation_q1"
-          link = upstream.link(vhost.queues["federation_q2"])
+          link = upstream.link(vhost.queue("federation_q2"))
           wait_for { link.state.running? }
-          vhost.queues["federation_q1"].message_count.should eq 1
-          vhost.queues["federation_q2"].message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 1
+          vhost.queue("federation_q2").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -137,11 +137,11 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queue("federation_q2"))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
-          vhost.queues["federation_q1"].message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -157,11 +157,11 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queue("federation_q2"))
           msgs = Channel(String).new
           q2.subscribe { |msg| msgs.send msg.body_io.to_s }
           msgs.should be_receiving "federate me"
-          vhost.queues["federation_q1"].message_count.should eq 0
+          vhost.queue("federation_q1").message_count.should eq 0
         end
       ensure
         upstream.try &.close
@@ -182,20 +182,21 @@ describe LavinMQ::Federation::Upstream do
         downstream_vhost.declare_exchange("downstream_ex", "topic", true, false)
         downstream_vhost.declare_queue("downstream_q", true, false)
 
-        wait_for { downstream_vhost.queues["downstream_q"].policy.try(&.name) == "FE" }
+        wait_for { downstream_vhost.queue("downstream_q").policy.try(&.name) == "FE" }
         wait_for { upstream.links.first?.try &.state.running? }
 
         # Disconnect the federation link
         conn_id = nil
-        upstream_vhost.connections.each do |conn|
+        upstream_vhost.connections_each do |conn|
           next unless conn.client_name.starts_with?("Federation link")
           conn_id = conn.object_id
           conn.close
         end
-        wait_for { upstream_vhost.connections.size == 0 }
+        wait_for { upstream_vhost.connections_size == 0 }
         upstream.links.first.@state_changed.try_send nil
-        wait_for { upstream_vhost.connections.size == 1 }
-        conn = upstream_vhost.connections.find(&.name.starts_with?("Federation link"))
+        wait_for { upstream_vhost.connections_size == 1 }
+        conn = nil
+        upstream_vhost.connections_each { |c| conn = c if c.name.starts_with?("Federation link") }
         # Verify that it's a new connection... Any better assertion that can be done?
         conn.object_id.should_not eq conn_id
       end
@@ -210,7 +211,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queue("federation_q2"))
           q2.subscribe do |msg|
             msgs << msg
           end
@@ -226,7 +227,7 @@ describe LavinMQ::Federation::Upstream do
           end
           wait_for { msgs.size == 2 }
           msgs.size.should eq 2
-          wait_for { vhost.queues["federation_q1"].message_count == 0 }
+          wait_for { vhost.queue("federation_q1").message_count == 0 }
         end
       ensure
         upstream.try &.close
@@ -241,7 +242,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish_confirm "federate me", "federation_q1", props: AMQP::Client::Properties.new(content_type: "application/json")
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queue("federation_q2"))
           msgs = [] of AMQP::Client::DeliverMessage
           q2.subscribe { |msg| msgs << msg }
           wait_for { msgs.size == 1 }
@@ -271,7 +272,7 @@ describe LavinMQ::Federation::Upstream do
         # consume 1 message
         with_channel(s, vhost: ds_vhost.name) do |downstream_ch|
           downstream_q = downstream_ch.queue(ds_queue_name)
-          wait_for { ds_vhost.queues[ds_queue_name].policy.try(&.name) == "FE" }
+          wait_for { ds_vhost.queue(ds_queue_name).policy.try(&.name) == "FE" }
           wait_for { upstream.links.first?.try &.state.running? }
 
           msgs = Channel(String).new
@@ -279,10 +280,10 @@ describe LavinMQ::Federation::Upstream do
             msgs.send msg.body_io.to_s
           end
           msgs.should be_receiving "msg1"
-          wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].message_count == 0 }
+          wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).message_count == 0 }
         end
 
-        wait_for { s.vhosts[ds_vhost.name].queues[ds_queue_name].consumers.empty? }
+        wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).consumers.empty? }
 
         # publish another message
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|
@@ -312,12 +313,12 @@ describe LavinMQ::Federation::Upstream do
         message_count = 2
 
         ds_vhost.declare_queue(ds_queue_name, true, false)
-        ds_queue = ds_vhost.queues[ds_queue_name].as(LavinMQ::AMQP::Queue)
+        ds_queue = ds_vhost.queue(ds_queue_name).as(LavinMQ::AMQP::Queue)
 
         link = wait_for { upstream.links.first? }
         loop { link.@state_changed.receive.try &.running? && break }
 
-        us_queue = us_vhost.queues[us_queue_name].as(LavinMQ::AMQP::Queue)
+        us_queue = us_vhost.queue(us_queue_name).as(LavinMQ::AMQP::Queue)
 
         # publish 2 messages to upstream queue
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|
@@ -379,8 +380,8 @@ describe LavinMQ::Federation::Upstream do
             vhost.declare_queue("q2", true, false)
 
             upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", nil, nil)
-            link1 = upstream.link(vhost.queues["q1"])
-            link2 = upstream.link(vhost.queues["q2"])
+            link1 = upstream.link(vhost.queue("q1"))
+            link2 = upstream.link(vhost.queue("q2"))
 
             link1.@upstream_q.should eq "q1"
             link2.@upstream_q.should eq "q2"
@@ -402,7 +403,7 @@ describe LavinMQ::Federation::Upstream do
           downstream_ex = ch.exchange("downstream_ex", "topic")
           downstream_q = ch.queue("downstream_q")
           downstream_q.bind(downstream_ex.name, "#")
-          link = upstream.link(vhost.exchanges[downstream_ex.name])
+          link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
           upstream_ex = ch.exchange("upstream_ex", "topic", passive: true)
           upstream_ex.publish "federate me", "rk"
@@ -426,7 +427,7 @@ describe LavinMQ::Federation::Upstream do
           with_channel(s, vhost: "downstream") do |downstream_ch|
             upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
             downstream_ch.exchange("downstream_ex", "topic")
-            wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
+            wait_for { downstream_vhost.exchange("downstream_ex").policy.try(&.name) == "FE" }
             # Assert setup is correct
             wait_for { upstream.links.first?.try &.state.running? }
             downstream_q = downstream_ch.queue("downstream_q")
@@ -440,7 +441,9 @@ describe LavinMQ::Federation::Upstream do
             msgs.first.not_nil!.body_io.to_s.should eq("federate me")
           end
         end
-        upstream_vhost.queues.each_value.all?(&.empty?).should be_true
+        all_empty = true
+        upstream_vhost.queues_each_value { |q| all_empty = false unless q.empty? }
+        all_empty.should be_true
       end
     end
 
@@ -475,13 +478,13 @@ describe LavinMQ::Federation::Upstream do
             # When state is running everything should be setup in the upstream
             wait_for { link.state.running? }
 
-            us_queue = upstream_vhost.queues[link.@upstream_q].should be_a LavinMQ::AMQP::Queue
+            us_queue = upstream_vhost.queue(link.@upstream_q).should be_a LavinMQ::AMQP::Queue
             us_queue.consumers_empty.when_true.receive
 
             upstream_ex.publish_confirm "msg1", "rk1"
             msgs.should be_receiving "msg1"
 
-            upstream_vhost.connections.each do |conn|
+            upstream_vhost.connections_each do |conn|
               next unless conn.client_name.starts_with?("Federation link")
               conn.close
             end
@@ -503,7 +506,9 @@ describe LavinMQ::Federation::Upstream do
             msgs.try &.close
           end
         end
-        upstream_vhost.queues.each_value.all?(&.empty?).should be_true
+        all_empty = true
+        upstream_vhost.queues_each_value { |q| all_empty = false unless q.empty? }
+        all_empty.should be_true
       end
     end
 
@@ -515,13 +520,13 @@ describe LavinMQ::Federation::Upstream do
 
         with_channel(s) do |ch|
           downstream_ex = ch.exchange("downstream_ex", "topic")
-          link = upstream.link(vhost.exchanges[downstream_ex.name])
+          link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
-          upstream_vhost.queues.has_key?(federation_name).should eq true
-          upstream_vhost.exchanges.has_key?(federation_name).should eq true
+          upstream_vhost.queue_exists?(federation_name).should eq true
+          upstream_vhost.exchange_exists?(federation_name).should eq true
           link.terminate
-          upstream_vhost.queues.has_key?(federation_name).should eq false
-          upstream_vhost.exchanges.has_key?(federation_name).should eq false
+          upstream_vhost.queue_exists?(federation_name).should eq false
+          upstream_vhost.exchange_exists?(federation_name).should eq false
         end
       end
     end
@@ -535,7 +540,7 @@ describe LavinMQ::Federation::Upstream do
           vhost.declare_exchange("ex1", "topic", true, false)
 
           upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", {{v}})
-          link1 = upstream.link(vhost.exchanges["ex1"])
+          link1 = upstream.link(vhost.exchange("ex1"))
 
           link1.@upstream_exchange.should eq "ex1"
         end
@@ -553,7 +558,7 @@ describe LavinMQ::Federation::Upstream do
         with_channel(s) do |ch|
           x, q2 = UpstreamSpecHelpers.setup_qs ch
           x.publish "foo", "federation_q1"
-          upstream.link(vhost.queues["federation_q2"])
+          upstream.link(vhost.queue("federation_q2"))
           msgs = [] of AMQP::Client::DeliverMessage
           wg = WaitGroup.new(1)
           q2.subscribe do |msg|
@@ -580,9 +585,9 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_queue("q2", durable: true, auto_delete: false)
         vhost3.declare_queue("q3", durable: true, auto_delete: false)
 
-        vhost1.queues["q1"]
-        q2 = vhost2.queues["q2"]
-        q3 = vhost3.queues["q3"]
+        vhost1.queue("q1")
+        q2 = vhost2.queue("q2")
+        q3 = vhost3.queue("q3")
 
         url = URI.parse(s.amqp_url)
 
@@ -642,7 +647,7 @@ describe LavinMQ::Federation::Upstream do
           UpstreamSpecHelpers.start_link(upstream)
           wait_for { upstream.links.first?.try &.state.running? }
 
-          upstream_ex = upstream_vhost.exchanges["upstream_ex"].as(LavinMQ::AMQP::Exchange)
+          upstream_ex = upstream_vhost.exchange("upstream_ex").as(LavinMQ::AMQP::Exchange)
           upstream_ex.bindings_details.size.should eq queues.size
 
           10.times do |i|
@@ -667,8 +672,8 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_exchange("downstream_ex", "topic", durable: true, auto_delete: false)
         vhost2.declare_queue("downstream_q", durable: true, auto_delete: false)
 
-        downstream_ex = vhost2.exchanges["downstream_ex"]
-        downstream_q = vhost2.queues["downstream_q"]
+        downstream_ex = vhost2.exchange("downstream_ex")
+        downstream_q = vhost2.queue("downstream_q")
         downstream_ex.bind(downstream_q, "#")
 
         url = URI.parse(s.amqp_url)
@@ -710,13 +715,13 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_exchange("ex2", "topic", durable: true, auto_delete: false)
         vhost3.declare_exchange("ex3", "topic", durable: true, auto_delete: false)
 
-        ex1 = vhost1.exchanges["ex1"]
-        ex2 = vhost2.exchanges["ex2"]
-        ex3 = vhost3.exchanges["ex3"]
+        ex1 = vhost1.exchange("ex1")
+        ex2 = vhost2.exchange("ex2")
+        ex3 = vhost3.exchange("ex3")
 
         vhost3.declare_queue("q3", durable: true, auto_delete: false)
-        downstream_q = vhost3.queues["q3"]
-        downstream_ex = vhost3.exchanges["ex3"]
+        downstream_q = vhost3.queue("q3")
+        downstream_ex = vhost3.exchange("ex3")
 
         url = URI.parse(s.amqp_url)
 
@@ -769,11 +774,11 @@ describe LavinMQ::Federation::Upstream do
         vhost2.declare_exchange("downstream_ex", "topic", durable: true, auto_delete: false)
         vhost2.declare_queue("downstream_q", durable: true, auto_delete: false)
 
-        downstream_ex = vhost2.exchanges["downstream_ex"]
-        downstream_q = vhost2.queues["downstream_q"]
+        downstream_ex = vhost2.exchange("downstream_ex")
+        downstream_q = vhost2.queue("downstream_q")
         downstream_ex.bind(downstream_q, "federation.link.rk")
 
-        upstream_ex = vhost1.exchanges["upstream_ex"]
+        upstream_ex = vhost1.exchange("upstream_ex")
 
         url = URI.parse(s.amqp_url)
         url.path = vhost1.name
@@ -798,9 +803,9 @@ describe LavinMQ::Federation::Upstream do
         with_http_server do |_http, s|
           UpstreamSpecHelpers.with_fe_chain(s, chain_length: 10) do
             downstream_vhost = s.vhosts["v10"]
-            downstream_ex = downstream_vhost.exchanges["fe"]
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues["q"]
+            q = downstream_vhost.queue("q")
             # This binding should be propagated all the way to "fe" in "v1"
             # For each hop x-bound-from should be extended with one new entry
             downstream_ex.bind(q, "spec.routing.key")
@@ -808,7 +813,7 @@ describe LavinMQ::Federation::Upstream do
             # Verify bindings on exchange "fe" from vhost v1 to
             # vhost v9.
             1.to(9) do |i|
-              fe = s.vhosts["v#{i}"].exchanges["fe"]
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 1
               fe_bk = fe.bindings_details.first.binding_key
               args = fe_bk.arguments.should_not be_nil
@@ -839,9 +844,9 @@ describe LavinMQ::Federation::Upstream do
             us.max_hops = 1
 
             downstream_vhost = s.vhosts["v10"]
-            downstream_ex = downstream_vhost.exchanges["fe"]
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues["q"]
+            q = downstream_vhost.queue("q")
             # This binding should only be propagated to "fe" in "v4", because
             # max_hops on v5 is 1.
             downstream_ex.bind(q, "spec.routing.key")
@@ -849,14 +854,14 @@ describe LavinMQ::Federation::Upstream do
             # Verify bindings on exchange "fe" from vhost v1 to
             # vhost v4.
             1.to(3) do |i|
-              fe = s.vhosts["v#{i}"].exchanges["fe"]
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 0
             end
 
             # Verify bindings on exchange "fe" from vhost v4 to
             # vhost v9.
             4.to(9) do |i|
-              fe = s.vhosts["v#{i}"].exchanges["fe"]
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 1
               fe_bk = fe.bindings_details.first.binding_key
               args = fe_bk.arguments.should_not be_nil
@@ -886,9 +891,9 @@ describe LavinMQ::Federation::Upstream do
             us.max_hops = 3
 
             downstream_vhost = s.vhosts["v10"]
-            downstream_ex = downstream_vhost.exchanges["fe"]
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues["q"]
+            q = downstream_vhost.queue("q")
             # This binding should only be propagated to "fe" in "v4", because
             # max_hops on v5 is 1.
             downstream_ex.bind(q, "spec.routing.key")
@@ -896,14 +901,14 @@ describe LavinMQ::Federation::Upstream do
             # Verify bindings on exchange "fe" from vhost v1 to
             # vhost v6.
             1.to(6) do |i|
-              fe = s.vhosts["v#{i}"].exchanges["fe"]
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq 0
             end
 
             # Verify bindings on exchange "fe" from vhost v7 to
             # vhost v9.
             7.to(9) do |i|
-              fe = s.vhosts["v#{i}"].exchanges["fe"]
+              fe = s.vhosts["v#{i}"].exchange("fe")
               fe.bindings_details.size.should eq(1), "FE in vhost v#{i} should have one binding"
               fe_bk = fe.bindings_details.first.binding_key
               args = fe_bk.arguments.should_not be_nil
@@ -926,9 +931,9 @@ describe LavinMQ::Federation::Upstream do
         with_http_server do |_http, s|
           UpstreamSpecHelpers.with_fe_chain(s, chain_length: 3) do
             downstream_vhost = s.vhosts["v3"]
-            downstream_ex = downstream_vhost.exchanges["fe"]
+            downstream_ex = downstream_vhost.exchange("fe")
             downstream_vhost.declare_queue("q", durable: true, auto_delete: false)
-            q = downstream_vhost.queues["q"]
+            q = downstream_vhost.queue("q")
             downstream_ex.bind(q, "spec.routing.key")
 
             with_channel(s, vhost: "v1") do |ch|
@@ -945,9 +950,9 @@ describe LavinMQ::Federation::Upstream do
               ch.exchange("fe", "topic").publish_confirm "foo", "spec.routing.key", props: props
             end
 
-            v1fe = s.vhosts["v1"].exchanges["fe"]
-            v2fe = s.vhosts["v2"].exchanges["fe"]
-            v3fe = s.vhosts["v3"].exchanges["fe"]
+            v1fe = s.vhosts["v1"].exchange("fe")
+            v2fe = s.vhosts["v2"].exchange("fe")
+            v3fe = s.vhosts["v3"].exchange("fe")
 
             # We have no good synchronization point, so we yield a few times (instead of sleep)
             # to make sure the message has been processed all the way

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -283,7 +283,7 @@ describe LavinMQ::Federation::Upstream do
           wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).message_count == 0 }
         end
 
-        wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).consumers.empty? }
+        wait_for { s.vhosts[ds_vhost.name].queue(ds_queue_name).consumers_empty? }
 
         # publish another message
         with_channel(s, vhost: us_vhost.name) do |upstream_ch|

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -30,7 +30,7 @@ describe LavinMQ::VHost do
       v = s.vhosts["test"].not_nil!
       v.declare_exchange("e", "direct", true, false)
       s.restart
-      s.vhosts["test"].exchanges["e"].should_not be_nil
+      s.vhosts["test"].exchange("e").should_not be_nil
     end
   end
 
@@ -59,7 +59,7 @@ describe LavinMQ::VHost do
       v = s.vhosts["test"].not_nil!
       v.declare_queue("q", true, false)
       s.restart
-      s.vhosts["test"].queues["q"].should_not be_nil
+      s.vhosts["test"].queue("q").should_not be_nil
     end
   end
 
@@ -71,7 +71,7 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.restart
-      s.vhosts["test"].exchanges["e"].bindings_details.first.destination.name.should eq "q"
+      s.vhosts["test"].exchange("e").bindings_details.first.destination.name.should eq "q"
     end
   end
 

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -82,9 +82,9 @@ describe LavinMQ::VHost do
       v.declare_exchange("e", "direct", true, false)
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
-      pos = v.definitions.@definitions_file.pos
+      pos = v.@definitions.not_nil!.@definitions_file.pos
       s.vhosts["test"].bind_queue("q", "e", "q")
-      v.definitions.@definitions_file.pos.should eq pos
+      v.@definitions.not_nil!.@definitions_file.pos.should eq pos
     end
   end
 
@@ -96,9 +96,9 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.vhosts["test"].unbind_queue("q", "e", "q")
-      pos = v.definitions.@definitions_file.pos
+      pos = v.@definitions.not_nil!.@definitions_file.pos
       s.vhosts["test"].unbind_queue("q", "e", "q")
-      v.definitions.@definitions_file.pos.should eq pos
+      v.@definitions.not_nil!.@definitions_file.pos.should eq pos
     end
   end
 
@@ -110,10 +110,10 @@ describe LavinMQ::VHost do
         v.declare_queue("q", true, false)
         v.delete_queue("q")
       end
-      file_size = v.definitions.@definitions_file.size
+      file_size = v.@definitions.not_nil!.@definitions_file.size
       v.declare_queue("q", true, false)
       v.delete_queue("q")
-      v.definitions.@definitions_file.size.should be < file_size
+      v.@definitions.not_nil!.@definitions_file.size.should be < file_size
     end
   end
   describe "auto add permissions" do

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -82,9 +82,9 @@ describe LavinMQ::VHost do
       v.declare_exchange("e", "direct", true, false)
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
-      pos = v.@definitions_file.pos
+      pos = v.definitions.@definitions_file.pos
       s.vhosts["test"].bind_queue("q", "e", "q")
-      v.@definitions_file.pos.should eq pos
+      v.definitions.@definitions_file.pos.should eq pos
     end
   end
 
@@ -96,9 +96,9 @@ describe LavinMQ::VHost do
       v.declare_queue("q", true, false)
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.vhosts["test"].unbind_queue("q", "e", "q")
-      pos = v.@definitions_file.pos
+      pos = v.definitions.@definitions_file.pos
       s.vhosts["test"].unbind_queue("q", "e", "q")
-      v.@definitions_file.pos.should eq pos
+      v.definitions.@definitions_file.pos.should eq pos
     end
   end
 
@@ -110,10 +110,10 @@ describe LavinMQ::VHost do
         v.declare_queue("q", true, false)
         v.delete_queue("q")
       end
-      file_size = v.@definitions_file.size
+      file_size = v.definitions.@definitions_file.size
       v.declare_queue("q", true, false)
       v.delete_queue("q")
-      v.@definitions_file.size.should be < file_size
+      v.definitions.@definitions_file.size.should be < file_size
     end
   end
   describe "auto add permissions" do

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -27,7 +27,7 @@ describe LavinMQ::VHost do
     it "should not delete stats when connection is closed" do
       with_amqp_server do |s|
         vhost = s.vhosts["/"]
-        wait_for { s.connections.sum(&.channels.size).zero? }
+        wait_for { s.connections.sum(&.channels_size).zero? }
 
         s.update_stats_rates
         initial_channels_created = vhost.channel_created_count

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -128,7 +128,7 @@ module VHostByteRateSpecs
       q.subscribe { received.send(nil) }
       received.receive
       conn.close(no_wait: false)
-      wait_for { vhost.connections.none?(LavinMQ::AMQP::Client) }
+      wait_for { vhost.connections_dup.none?(LavinMQ::AMQP::Client) }
     in LavinMQ::Server::Protocol::MQTT
       with_client_io(s) do |sub_io|
         connect(sub_io)
@@ -235,10 +235,10 @@ module VHostByteRateSpecs
             send_and_receive_over_protocol(protocol, s, vhost)
           end
 
-          wait_for { vhost.connections.empty? || vhost.connections.all? { |c| c.recv_oct_count > 0 } }
+          wait_for { vhost.connections_dup.empty? || vhost.connections_dup.all? { |c| c.recv_oct_count > 0 } }
 
-          conn_recv_sum = vhost.connections.sum(&.recv_oct_count)
-          conn_send_sum = vhost.connections.sum(&.send_oct_count)
+          conn_recv_sum = vhost.connections_dup.sum(&.recv_oct_count)
+          conn_send_sum = vhost.connections_dup.sum(&.send_oct_count)
 
           vhost.recv_oct_count.should be >= conn_recv_sum
           vhost.send_oct_count.should be >= conn_send_sum

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -27,7 +27,7 @@ describe LavinMQ::VHost do
     it "should not delete stats when connection is closed" do
       with_amqp_server do |s|
         vhost = s.vhosts["/"]
-        wait_for { s.connections.sum(&.channels_size).zero? }
+        wait_for { s.connections.sum(&.channel_count).zero? }
 
         s.update_stats_rates
         initial_channels_created = vhost.channel_created_count

--- a/spec/vhost_stats_spec.cr
+++ b/spec/vhost_stats_spec.cr
@@ -128,7 +128,7 @@ module VHostByteRateSpecs
       q.subscribe { received.send(nil) }
       received.receive
       conn.close(no_wait: false)
-      wait_for { vhost.connections_dup.none?(LavinMQ::AMQP::Client) }
+      wait_for { vhost.connections.none?(LavinMQ::AMQP::Client) }
     in LavinMQ::Server::Protocol::MQTT
       with_client_io(s) do |sub_io|
         connect(sub_io)
@@ -235,10 +235,10 @@ module VHostByteRateSpecs
             send_and_receive_over_protocol(protocol, s, vhost)
           end
 
-          wait_for { vhost.connections_dup.empty? || vhost.connections_dup.all? { |c| c.recv_oct_count > 0 } }
+          wait_for { vhost.connections.empty? || vhost.connections.all? { |c| c.recv_oct_count > 0 } }
 
-          conn_recv_sum = vhost.connections_dup.sum(&.recv_oct_count)
-          conn_send_sum = vhost.connections_dup.sum(&.send_oct_count)
+          conn_recv_sum = vhost.connections.sum(&.recv_oct_count)
+          conn_send_sum = vhost.connections.sum(&.send_oct_count)
 
           vhost.recv_oct_count.should be >= conn_recv_sum
           vhost.send_oct_count.should be >= conn_send_sum

--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -63,7 +63,7 @@ module LavinMQ::AMQP
         def route(msg : BytesMessage, reason, dlx_tasks : Tasks? = nil, &routed : MessageRoutedCallback) : Nil
           # No dead letter exchange => nothing to do
           return routed.call unless dlx = (msg.dlx || dlx())
-          ex = @vhost.exchanges[dlx.to_s]?.as?(AMQP::Exchange) || return routed.call
+          ex = @vhost.exchange?(dlx.to_s).as?(AMQP::Exchange) || return routed.call
 
           dlrk = msg.dlrk || dlrk()
 

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -30,11 +30,11 @@ module LavinMQ
         @consumers.size
       end
 
-      def consumers_find(& : Consumer -> Bool) : Consumer?
+      def find_consumer(& : Consumer -> Bool) : Consumer?
         @consumers.find { |c| yield c }
       end
 
-      def consumers_delete(consumer : Consumer) : Consumer?
+      def delete_consumer(consumer : Consumer) : Consumer?
         @consumers.delete(consumer)
       end
 

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -413,7 +413,7 @@ module LavinMQ
             ok = q.basic_get(frame.no_ack) do |env|
               delivery_tag = next_delivery_tag(q, env.segment_position, frame.no_ack, nil)
               unless frame.no_ack # track unacked messages
-                q.basic_get_unacked << UnackedMessage.new(self, delivery_tag, RoughTime.instant)
+                q.basic_get_unacked_push(UnackedMessage.new(self, delivery_tag, RoughTime.instant))
               end
               get_ok = AMQP::Frame::Basic::GetOk.new(frame.channel, delivery_tag,
                 env.redelivered, env.message.exchange_name,
@@ -509,7 +509,7 @@ module LavinMQ
           c.ack(unack.sp)
         end
         unack.queue.ack(unack.sp)
-        unack.queue.basic_get_unacked.reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
+        unack.queue.basic_get_unacked_reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
         @client.vhost.event_tick(EventType::ClientAck)
         @ack_count.add(1, :relaxed)
       end
@@ -588,7 +588,7 @@ module LavinMQ
           c.reject(unack.sp, requeue)
         end
         unack.queue.reject(unack.sp, requeue)
-        unack.queue.basic_get_unacked.reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
+        unack.queue.basic_get_unacked_reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
         @reject_count.add(1, :relaxed)
         @client.vhost.event_tick(EventType::ClientReject)
       end
@@ -662,7 +662,7 @@ module LavinMQ
           @unacked.each do |unack|
             @log.debug { "Requeing unacked msg #{unack.sp}" }
             unack.queue.reject(unack.sp, true)
-            unack.queue.basic_get_unacked.reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
+            unack.queue.basic_get_unacked_reject! { |u| u.channel == self && u.delivery_tag == unack.tag }
           end
           @unacked.clear
         end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -20,7 +20,24 @@ module LavinMQ
       getter id, name
       property? running = true
       getter? flow = true
-      getter consumers = Array(Consumer).new
+      @consumers = Array(Consumer).new
+
+      def consumers : Array(Consumer)
+        @consumers.dup
+      end
+
+      def consumers_size : Int32
+        @consumers.size
+      end
+
+      def consumers_find(& : Consumer -> Bool) : Consumer?
+        @consumers.find { |c| yield c }
+      end
+
+      def consumers_delete(consumer : Consumer) : Consumer?
+        @consumers.delete(consumer)
+      end
+
       getter prefetch_count : UInt16 = Config.instance.default_consumer_prefetch
       getter global_prefetch_count = 0_u16
       getter has_capacity = BoolChannel.new(true)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -47,19 +47,19 @@ module LavinMQ
 
       # Channel accessors
 
-      def channels_size : Int32
+      def channel_count : Int32
         @channels.size
       end
 
-      def channels_each_value(& : Client::Channel ->) : Nil
+      def each_channel(& : Client::Channel ->) : Nil
         @channels.each_value { |ch| yield ch }
       end
 
-      def channels_each_value : Iterator(Client::Channel)
+      def each_channel : Iterator(Client::Channel)
         @channels.each_value
       end
 
-      def channels_byid?(id : UInt16) : Client::Channel?
+      def channel?(id : UInt16) : Client::Channel?
         @channels[id]?
       end
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -24,7 +24,7 @@ module LavinMQ
         @exclusive_queues.delete(data) if event.deleted? && data.is_a?(Queue)
       end
 
-      getter vhost, channels, log, name
+      getter vhost, log, name
       getter user
       getter max_frame_size : UInt32
       getter channel_max : UInt16
@@ -44,6 +44,24 @@ module LavinMQ
       rate_stats({"send_oct", "recv_oct"})
       DEFAULT_EX = "amq.default"
       Log        = LavinMQ::Log.for "amqp.client"
+
+      # Channel accessors
+
+      def channels_size : Int32
+        @channels.size
+      end
+
+      def channels_each_value(& : Client::Channel ->) : Nil
+        @channels.each_value { |ch| yield ch }
+      end
+
+      def channels_each_value : Iterator(Client::Channel)
+        @channels.each_value
+      end
+
+      def channels_byid?(id : UInt16) : Client::Channel?
+        @channels[id]?
+      end
 
       def initialize(@socket : IO,
                      @connection_info : ConnectionInfo,

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -55,8 +55,8 @@ module LavinMQ
         @channels.each_value { |ch| yield ch }
       end
 
-      def each_channel : Iterator(Client::Channel)
-        @channels.each_value
+      def channels_dup : Array(Client::Channel)
+        @channels.values
       end
 
       def channel?(id : UInt16) : Client::Channel?

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -55,7 +55,7 @@ module LavinMQ
         @channels.each_value { |ch| yield ch }
       end
 
-      def channels_dup : Array(Client::Channel)
+      def channels : Array(Client::Channel)
         @channels.values
       end
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -614,7 +614,7 @@ module LavinMQ
           send_precondition_failed(frame, "Exchange name isn't valid")
         elsif frame.exchange_name.empty?
           send_access_refused(frame, "Not allowed to declare the default exchange")
-        elsif e = @vhost.exchanges.fetch(frame.exchange_name, nil)
+        elsif e = @vhost.exchange?(frame.exchange_name)
           redeclare_exchange(e, frame)
         elsif frame.passive
           send_passive_not_found(frame, "Exchange '#{frame.exchange_name}' doesn't exists")
@@ -653,12 +653,12 @@ module LavinMQ
           send_access_refused(frame, "Not allowed to delete the default exchange")
         elsif NameValidator.reserved_prefix?(frame.exchange_name)
           send_access_refused(frame, "Prefix #{NameValidator::PREFIX_LIST} forbidden, please choose another name")
-        elsif !@vhost.exchanges.has_key? frame.exchange_name
+        elsif !@vhost.exchange_exists?(frame.exchange_name)
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Exchange::DeleteOk.new(frame.channel) unless frame.no_wait
         elsif !@user.can_config?(@vhost.name, frame.exchange_name)
           send_access_refused(frame, "User '#{@user.name}' doesn't have permissions to delete exchange '#{frame.exchange_name}'")
-        elsif frame.if_unused && @vhost.exchanges[frame.exchange_name].in_use?
+        elsif frame.if_unused && @vhost.exchange(frame.exchange_name).in_use?
           send_precondition_failed(frame, "Exchange '#{frame.exchange_name}' in use")
         else
           @vhost.apply(frame)
@@ -675,7 +675,7 @@ module LavinMQ
           send_precondition_failed(frame, "Queue name isn't valid")
           return
         end
-        q = @vhost.queues.fetch(frame.queue_name, nil)
+        q = @vhost.queue?(frame.queue_name)
         if q.nil?
           send AMQP::Frame::Queue::DeleteOk.new(frame.channel, 0_u32) unless frame.no_wait
         elsif queue_exclusive_to_other_client?(q)
@@ -701,7 +701,7 @@ module LavinMQ
       private def declare_queue(frame)
         if !frame.queue_name.empty? && !NameValidator.valid_entity_name?(frame.queue_name)
           send_precondition_failed(frame, "Queue name isn't valid")
-        elsif q = @vhost.queues.fetch(frame.queue_name, nil)
+        elsif q = @vhost.queue?(frame.queue_name)
           redeclare_queue(frame, q)
         elsif {"amq.rabbitmq.reply-to", "amq.direct.reply-to"}.includes? frame.queue_name
           unless frame.no_wait
@@ -709,7 +709,7 @@ module LavinMQ
           end
         elsif frame.queue_name.starts_with?("amq.direct.reply-to.")
           consumer_tag = frame.queue_name[20..]
-          if @vhost.direct_reply_consumers.has_key? consumer_tag
+          if @vhost.direct_reply_consumer_has_key?(consumer_tag)
             send AMQP::Frame::Queue::DeclareOk.new(frame.channel, frame.queue_name, 0_u32, 1_u32)
           else
             send_not_found(frame, "Queue '#{frame.queue_name}' doesn't exists")
@@ -718,7 +718,7 @@ module LavinMQ
           send_passive_not_found(frame, "Queue '#{frame.queue_name}' doesn't exists")
         elsif NameValidator.reserved_prefix?(frame.queue_name)
           send_access_refused(frame, "Prefix #{NameValidator::PREFIX_LIST} forbidden, please choose another name")
-        elsif @vhost.max_queues.try { |max| @vhost.queues.size >= max }
+        elsif @vhost.max_queues.try { |max| @vhost.queues_size >= max }
           send_access_refused(frame, "queue limit in vhost '#{@vhost.name}' (#{@vhost.max_queues}) is reached")
         else
           declare_new_queue(frame)
@@ -764,7 +764,7 @@ module LavinMQ
         @vhost.apply(frame)
         @last_queue_name = frame.queue_name
         if frame.exclusive
-          q = @vhost.queues[frame.queue_name]
+          q = @vhost.queue(frame.queue_name)
           @exclusive_queues << q
           q.register_observer(self)
         end
@@ -784,10 +784,10 @@ module LavinMQ
         end
         return unless valid_q_bind_unbind?(frame)
 
-        q = @vhost.queues[frame.queue_name]?
+        q = @vhost.queue?(frame.queue_name)
         if q.nil?
           send_not_found frame, "Queue '#{frame.queue_name}' not found"
-        elsif !@vhost.exchanges.has_key? frame.exchange_name
+        elsif !@vhost.exchange_exists?(frame.exchange_name)
           send_not_found frame, "Exchange '#{frame.exchange_name}' not found"
         elsif !@user.can_read?(@vhost.name, frame.exchange_name)
           send_access_refused(frame, "User '#{@user.name}' doesn't have read permissions to exchange '#{frame.exchange_name}'")
@@ -811,11 +811,11 @@ module LavinMQ
         end
         return unless valid_q_bind_unbind?(frame)
 
-        q = @vhost.queues[frame.queue_name]?
+        q = @vhost.queue?(frame.queue_name)
         if q.nil?
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)
-        elsif !@vhost.exchanges.has_key? frame.exchange_name
+        elsif !@vhost.exchange_exists?(frame.exchange_name)
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Queue::UnbindOk.new(frame.channel)
         elsif !@user.can_read?(@vhost.name, frame.exchange_name)
@@ -846,8 +846,8 @@ module LavinMQ
       end
 
       private def bind_exchange(frame)
-        source = @vhost.exchanges.fetch(frame.source, nil)
-        destination = @vhost.exchanges.fetch(frame.destination, nil)
+        source = @vhost.exchange?(frame.source)
+        destination = @vhost.exchange?(frame.destination)
         if destination.nil?
           send_not_found frame, "Exchange '#{frame.destination}' doesn't exists"
         elsif source.nil?
@@ -865,8 +865,8 @@ module LavinMQ
       end
 
       private def unbind_exchange(frame)
-        source = @vhost.exchanges.fetch(frame.source, nil)
-        destination = @vhost.exchanges.fetch(frame.destination, nil)
+        source = @vhost.exchange?(frame.source)
+        destination = @vhost.exchange?(frame.destination)
         if destination.nil?
           # should return not_found according to spec but we make it idempotent
           send AMQP::Frame::Exchange::UnbindOk.new(frame.channel)
@@ -895,7 +895,7 @@ module LavinMQ
         end
         if !NameValidator.valid_entity_name?(frame.queue_name)
           send_precondition_failed(frame, "Queue name isn't valid")
-        elsif q = @vhost.queues.fetch(frame.queue_name, nil)
+        elsif q = @vhost.queue?(frame.queue_name)
           if queue_exclusive_to_other_client?(q)
             send_resource_locked(frame, "Queue '#{q.name}' is exclusive")
           else

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -169,7 +169,7 @@ module LavinMQ
         vhost_name = open.vhost.empty? ? "/" : open.vhost
         if vhost = @vhosts[vhost_name]?
           if user.find_permission(vhost_name)
-            if vhost.max_connections.try { |max| vhost.connections.size >= max }
+            if vhost.max_connections.try { |max| vhost.connections_size >= max }
               log.warn { "Max connections (#{vhost.max_connections}) reached for vhost #{vhost_name}" }
               reply_text = "access to vhost '#{vhost_name}' refused: connection limit (#{vhost.max_connections}) is reached"
               return close_connection(socket, ConnectionReplyCode::NOT_ALLOWED, reply_text, open)

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -228,7 +228,7 @@ module LavinMQ
 
       def cancel
         @channel.send AMQP::Frame::Basic::Cancel.new(@channel.id, @tag, no_wait: true)
-        @channel.consumers_delete(self)
+        @channel.delete_consumer(self)
         close
       end
 

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -228,7 +228,7 @@ module LavinMQ
 
       def cancel
         @channel.send AMQP::Frame::Basic::Cancel.new(@channel.id, @tag, no_wait: true)
-        @channel.consumers.delete self
+        @channel.consumers_delete(self)
         close
       end
 

--- a/src/lavinmq/amqp/exchange/consistent_hash.cr
+++ b/src/lavinmq/amqp/exchange/consistent_hash.cr
@@ -42,8 +42,8 @@ module LavinMQ
         end
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        @bindings.each.map do |destination, binding_key|
+      def bindings_details : Array(BindingDetails)
+        @bindings.map do |destination, binding_key|
           BindingDetails.new(name, vhost.name, binding_key, destination)
         end
       end

--- a/src/lavinmq/amqp/exchange/default.cr
+++ b/src/lavinmq/amqp/exchange/default.cr
@@ -9,8 +9,8 @@ module LavinMQ
         "direct"
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        Iterator(BindingDetails).empty
+      def bindings_details : Array(BindingDetails)
+        [] of BindingDetails
       end
 
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)

--- a/src/lavinmq/amqp/exchange/default.cr
+++ b/src/lavinmq/amqp/exchange/default.cr
@@ -14,7 +14,7 @@ module LavinMQ
       end
 
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
-        if q = @vhost.queues[routing_key]?
+        if q = @vhost.queue?(routing_key)
           yield q
         end
       end

--- a/src/lavinmq/amqp/exchange/direct.cr
+++ b/src/lavinmq/amqp/exchange/direct.cr
@@ -11,9 +11,9 @@ module LavinMQ
         "direct"
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        @bindings.each.flat_map do |_key, ds|
-          ds.each.map do |d, binding_key|
+      def bindings_details : Array(BindingDetails)
+        @bindings.flat_map do |_key, ds|
+          ds.map do |d, binding_key|
             BindingDetails.new(name, vhost.name, binding_key, d)
           end
         end

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -144,7 +144,7 @@ module LavinMQ
 
         @delayed_queue = queue = AMQP::DelayedExchangeQueue.create(@vhost, @name, durable: durable?, auto_delete: @auto_delete)
 
-        @vhost.queues_unsafe_put(queue.name, queue)
+        @vhost.register_queue(queue)
       end
 
       REPUBLISH_HEADERS = {"x-head", "x-tail", "x-from"}

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -133,7 +133,7 @@ module LavinMQ
 
       def in_use?
         return true unless bindings_details.empty?
-        @vhost.exchanges.any? do |_, x|
+        @vhost.exchanges_any? do |_, x|
           x.bindings_details.any? { |bd| bd.destination == self }
         end
       end
@@ -144,7 +144,7 @@ module LavinMQ
 
         @delayed_queue = queue = AMQP::DelayedExchangeQueue.create(@vhost, @name, durable: durable?, auto_delete: @auto_delete)
 
-        @vhost.queues[queue.name] = queue
+        @vhost.queues_unsafe_put(queue.name, queue)
       end
 
       REPUBLISH_HEADERS = {"x-head", "x-tail", "x-from"}
@@ -268,8 +268,8 @@ module LavinMQ
           find_cc_queues(hdrs, "BCC", queues)
         end
 
-        if queues.empty? && alternate_exchange
-          @vhost.exchanges[alternate_exchange]?.try do |ae|
+        if queues.empty? && (ae_name = alternate_exchange)
+          @vhost.exchange?(ae_name).try do |ae|
             ae.find_queues(routing_key, headers, queues, exchanges)
           end
         end

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -196,7 +196,7 @@ module LavinMQ
       abstract def type : String
       abstract def bind(destination : AMQP::Destination, routing_key : String, arguments : AMQP::Table?)
       abstract def unbind(destination : AMQP::Destination, routing_key : String, arguments : AMQP::Table?)
-      abstract def bindings_details : Iterator(BindingDetails)
+      abstract def bindings_details : Array(BindingDetails)
       abstract def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
 
       def publish(msg : Message, immediate : Bool,

--- a/src/lavinmq/amqp/exchange/fanout.cr
+++ b/src/lavinmq/amqp/exchange/fanout.cr
@@ -9,8 +9,8 @@ module LavinMQ
         "fanout"
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        @bindings.each.map do |d, binding_key|
+      def bindings_details : Array(BindingDetails)
+        @bindings.map do |d, binding_key|
           BindingDetails.new(name, vhost.name, binding_key, d)
         end
       end

--- a/src/lavinmq/amqp/exchange/headers.cr
+++ b/src/lavinmq/amqp/exchange/headers.cr
@@ -18,8 +18,8 @@ module LavinMQ
         "headers"
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        @bindings.each.flat_map do |_args, ds|
+      def bindings_details : Array(BindingDetails)
+        @bindings.flat_map do |_args, ds|
           ds.map do |d, binding_key|
             BindingDetails.new(name, vhost.name, binding_key, d)
           end

--- a/src/lavinmq/amqp/exchange/topic.cr
+++ b/src/lavinmq/amqp/exchange/topic.cr
@@ -113,9 +113,9 @@ module LavinMQ
         "topic"
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        @bindings.each.flat_map do |_rk, ds|
-          ds.each.map do |d, binding_key|
+      def bindings_details : Array(BindingDetails)
+        @bindings.flat_map do |_rk, ds|
+          ds.map do |d, binding_key|
             BindingDetails.new(name, vhost.name, binding_key, d)
           end
         end

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -126,7 +126,7 @@ module LavinMQ::AMQP
         headers.delete("x-delay")
         msg.properties.headers = headers
       end
-      @vhost.exchanges[@exchange_name].route_msg Message.new(msg.timestamp, @exchange_name, msg.routing_key,
+      @vhost.exchange(@exchange_name).route_msg Message.new(msg.timestamp, @exchange_name, msg.routing_key,
         msg.properties, msg.bodysize, IO::Memory.new(msg.body))
       delete_message sp
     end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -104,10 +104,6 @@ module LavinMQ::AMQP
       @basic_get_unacked.reject! { |u| yield u }
     end
 
-    def basic_get_unacked_dup : Array(UnackedMessage)
-      @basic_get_unacked.to_a
-    end
-
     def basic_get_unacked_size : Int32
       @basic_get_unacked.size
     end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -104,8 +104,8 @@ module LavinMQ::AMQP
       @basic_get_unacked.reject! { |u| yield u }
     end
 
-    def basic_get_unacked_each : Iterator(UnackedMessage)
-      @basic_get_unacked.each
+    def basic_get_unacked_dup : Array(UnackedMessage)
+      @basic_get_unacked.to_a
     end
 
     def basic_get_unacked_size : Int32
@@ -811,16 +811,16 @@ module LavinMQ::AMQP
       raise ClosedError.new(cause: ex)
     end
 
-    def unacked_messages
-      unacked_messages = consumers.each.select(AMQP::Consumer).flat_map do |c|
-        c.unacked_messages.each.compact_map do |u|
+    def unacked_messages : Array(UnackedMessage)
+      result = consumers.select(AMQP::Consumer).flat_map do |c|
+        c.unacked_messages.compact_map do |u|
           next unless u.queue == self
           if consumer = u.consumer
             UnackedMessage.new(c.channel, u.tag, u.delivered_at, consumer.tag)
           end
         end
       end
-      unacked_messages.chain(@basic_get_unacked.each)
+      result.concat(@basic_get_unacked.to_a)
     end
 
     private def with_delivery_count_header(env) : Envelope?

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -86,11 +86,11 @@ module LavinMQ::AMQP
       @consumers.any? { |c| yield c }
     end
 
-    def consumers_each(& : Client::Channel::Consumer ->) : Nil
+    def each_consumer(& : Client::Channel::Consumer ->) : Nil
       @consumers.each { |c| yield c }
     end
 
-    def consumers_first? : Client::Channel::Consumer?
+    def first_consumer : Client::Channel::Consumer?
       @consumers.first?
     end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -66,7 +66,51 @@ module LavinMQ::AMQP
     @consumers_lock = Mutex.new
     @message_ttl_change = ::Channel(Nil).new
 
-    getter basic_get_unacked = Deque(UnackedMessage).new
+    @basic_get_unacked = Deque(UnackedMessage).new
+
+    # Consumer accessors
+
+    def consumers : Array(Client::Channel::Consumer)
+      @consumers.dup
+    end
+
+    def consumers_size : Int32
+      @consumers.size
+    end
+
+    def consumers_empty? : Bool
+      @consumers.empty?
+    end
+
+    def consumers_any?(& : Client::Channel::Consumer -> Bool) : Bool
+      @consumers.any? { |c| yield c }
+    end
+
+    def consumers_each(& : Client::Channel::Consumer ->) : Nil
+      @consumers.each { |c| yield c }
+    end
+
+    def consumers_first? : Client::Channel::Consumer?
+      @consumers.first?
+    end
+
+    # BasicGet unacked accessors
+
+    def basic_get_unacked_push(msg : UnackedMessage) : Nil
+      @basic_get_unacked << msg
+    end
+
+    def basic_get_unacked_reject!(& : UnackedMessage -> Bool) : Nil
+      @basic_get_unacked.reject! { |u| yield u }
+    end
+
+    def basic_get_unacked_each : Iterator(UnackedMessage)
+      @basic_get_unacked.each
+    end
+
+    def basic_get_unacked_size : Int32
+      @basic_get_unacked.size
+    end
 
     @msg_store_lock = Mutex.new(:reentrant)
     @msg_store : MessageStore
@@ -140,7 +184,7 @@ module LavinMQ::AMQP
     rescue ::Channel::ClosedError
     end
 
-    getter name, arguments, vhost, consumers
+    getter name, arguments, vhost
     getter? auto_delete, exclusive
     getter? closed = false
     getter state = QueueState::Running
@@ -776,7 +820,7 @@ module LavinMQ::AMQP
           end
         end
       end
-      unacked_messages.chain(self.basic_get_unacked.each)
+      unacked_messages.chain(@basic_get_unacked.each)
     end
 
     private def with_delivery_count_header(env) : Envelope?

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -17,7 +17,33 @@ module LavinMQ
         load!
       end
 
-      forward_missing_to @users
+      def []?(name : String) : User?
+        @users[name]?
+      end
+
+      def [](name : String) : User
+        @users[name]
+      end
+
+      def each_value(& : User ->) : Nil
+        @users.each_value { |u| yield u }
+      end
+
+      def each_value : Iterator(User)
+        @users.each_value
+      end
+
+      def has_key?(name : String) : Bool
+        @users.has_key?(name)
+      end
+
+      def size : Int32
+        @users.size
+      end
+
+      def values : Array(User)
+        @users.values
+      end
 
       def each(&)
         @users.each do |kv|

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -29,10 +29,6 @@ module LavinMQ
         @users.each_value { |u| yield u }
       end
 
-      def values_dup : Array(User)
-        @users.values
-      end
-
       def has_key?(name : String) : Bool
         @users.has_key?(name)
       end

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -29,8 +29,8 @@ module LavinMQ
         @users.each_value { |u| yield u }
       end
 
-      def each_value : Iterator(User)
-        @users.each_value
+      def values_dup : Array(User)
+        @users.values
       end
 
       def has_key?(name : String) : Bool

--- a/src/lavinmq/connection_store.cr
+++ b/src/lavinmq/connection_store.cr
@@ -1,0 +1,60 @@
+require "wait_group"
+require "./client/client"
+require "./logger"
+
+module LavinMQ
+  class ConnectionStore
+    def initialize
+      @connections = Array(Client).new(512)
+    end
+
+    def add(client : Client)
+      @connections << client
+    end
+
+    def delete(client : Client)
+      @connections.delete client
+    end
+
+    def each(& : Client ->) : Nil
+      @connections.each { |c| yield c }
+    end
+
+    def dup : Array(Client)
+      @connections.dup
+    end
+
+    def size : Int32
+      @connections.size
+    end
+
+    def empty? : Bool
+      @connections.empty?
+    end
+
+    def close_all(reason : String, log : Logger) : Nil
+      WaitGroup.wait do |wg|
+        to_close = Channel(Client).new
+        fiber_count = 0
+        @connections.each do |client|
+          select
+          when to_close.send client
+          else
+            fiber_id = fiber_count &+= 1
+            log.trace { "spawning close conn fiber #{fiber_id} " }
+            client_inner = client
+            wg.spawn do
+              client_inner.close(reason)
+              while client_to_close = to_close.receive?
+                client_to_close.close(reason)
+              end
+              log.trace { "exiting close conn fiber #{fiber_id} " }
+            end
+            Fiber.yield
+          end
+        end
+        to_close.close
+      end
+    end
+  end
+end

--- a/src/lavinmq/connection_store.cr
+++ b/src/lavinmq/connection_store.cr
@@ -20,7 +20,7 @@ module LavinMQ
       @connections.each { |c| yield c }
     end
 
-    def dup : Array(Client)
+    def to_a : Array(Client)
       @connections.dup
     end
 

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -268,7 +268,7 @@ module LavinMQ
     private def export_exchanges(json)
       json.array do
         vhosts.each_value do |v|
-          v.exchanges_dup.reject(&.internal?).each do |e|
+          v.exchanges.reject(&.internal?).each do |e|
             delayed = e.arguments["x-delayed-exchange"]?
             if delayed
               arguments = e.arguments.clone

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -251,7 +251,7 @@ module LavinMQ
     private def export_queues(json)
       json.array do
         vhosts.each_value do |v|
-          v.queues.each_value do |q|
+          v.queues_each_value do |q|
             next if q.exclusive?
             {
               "name":        q.name,
@@ -268,7 +268,7 @@ module LavinMQ
     private def export_exchanges(json)
       json.array do
         vhosts.each_value do |v|
-          v.exchanges.each_value.reject(&.internal?).each do |e|
+          v.exchanges_each_value.reject(&.internal?).each do |e|
             delayed = e.arguments["x-delayed-exchange"]?
             if delayed
               arguments = e.arguments.clone
@@ -292,7 +292,7 @@ module LavinMQ
     private def export_bindings(json)
       json.array do
         vhosts.each_value do |v|
-          v.exchanges.each_value do |e|
+          v.exchanges_each_value do |e|
             e.bindings_details.each do |b|
               b.to_json(json)
             end

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -251,7 +251,7 @@ module LavinMQ
     private def export_queues(json)
       json.array do
         vhosts.each_value do |v|
-          v.queues_each_value do |q|
+          v.each_queue do |q|
             next if q.exclusive?
             {
               "name":        q.name,
@@ -268,7 +268,7 @@ module LavinMQ
     private def export_exchanges(json)
       json.array do
         vhosts.each_value do |v|
-          v.exchanges_each_value.reject(&.internal?).each do |e|
+          v.each_exchange.reject(&.internal?).each do |e|
             delayed = e.arguments["x-delayed-exchange"]?
             if delayed
               arguments = e.arguments.clone
@@ -292,7 +292,7 @@ module LavinMQ
     private def export_bindings(json)
       json.array do
         vhosts.each_value do |v|
-          v.exchanges_each_value do |e|
+          v.each_exchange do |e|
             e.bindings_details.each do |b|
               b.to_json(json)
             end

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -303,7 +303,7 @@ module LavinMQ
 
     private def export_permissions(json)
       json.array do
-        @amqp_server.users.values_dup.reject(&.hidden?).each do |u|
+        @amqp_server.users.values.reject(&.hidden?).each do |u|
           u.permissions_details.each do |p|
             p.to_json(json)
           end
@@ -313,7 +313,7 @@ module LavinMQ
 
     private def export_users(json)
       json.array do
-        @amqp_server.users.values_dup.reject(&.hidden?).each do |u|
+        @amqp_server.users.values.reject(&.hidden?).each do |u|
           {
             "hashing_algorithm": u.user_details["hashing_algorithm"],
             "name":              u.name,

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -268,7 +268,7 @@ module LavinMQ
     private def export_exchanges(json)
       json.array do
         vhosts.each_value do |v|
-          v.each_exchange.reject(&.internal?).each do |e|
+          v.exchanges_dup.reject(&.internal?).each do |e|
             delayed = e.arguments["x-delayed-exchange"]?
             if delayed
               arguments = e.arguments.clone
@@ -303,7 +303,7 @@ module LavinMQ
 
     private def export_permissions(json)
       json.array do
-        @amqp_server.users.each_value.reject(&.hidden?).each do |u|
+        @amqp_server.users.values_dup.reject(&.hidden?).each do |u|
           u.permissions_details.each do |p|
             p.to_json(json)
           end
@@ -313,7 +313,7 @@ module LavinMQ
 
     private def export_users(json)
       json.array do
-        @amqp_server.users.each_value.reject(&.hidden?).each do |u|
+        @amqp_server.users.values_dup.reject(&.hidden?).each do |u|
           {
             "hashing_algorithm": u.user_details["hashing_algorithm"],
             "name":              u.name,

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -1,0 +1,360 @@
+require "./logger"
+require "./schema"
+require "./event_type"
+require "./queue_factory"
+require "./amqp/exchange/*"
+require "./amqp/queue"
+
+module LavinMQ
+  class DefinitionsStore
+    Log = LavinMQ::Log.for "definitions_store"
+
+    def initialize(@vhost : VHost, @data_dir : String, @replicator : Clustering::Replicator?, @log : Logger)
+      @exchanges = Hash(String, Exchange).new
+      @queues = Hash(String, Queue).new
+      @definitions_lock = Mutex.new(:reentrant)
+      @definitions_file_path = File.join(@data_dir, "definitions.amqp")
+      @definitions_file = File.open(@definitions_file_path, "a+")
+      @replicator.try &.register_file(@definitions_file)
+      @definitions_deletes = 0
+    end
+
+    # Exchange accessors
+
+    def exchange?(name : String) : Exchange?
+      @exchanges[name]?
+    end
+
+    def exchange(name : String) : Exchange
+      @exchanges[name]
+    end
+
+    def exchange_exists?(name : String) : Bool
+      @exchanges.has_key?(name)
+    end
+
+    def each_exchange(& : Exchange ->) : Nil
+      @exchanges.each_value { |v| yield v }
+    end
+
+    def exchanges_dup : Array(Exchange)
+      @exchanges.values
+    end
+
+    def exchanges_size : Int32
+      @exchanges.size
+    end
+
+    def exchanges_any?(& : {String, Exchange} -> Bool) : Bool
+      @exchanges.any? { |kv| yield kv }
+    end
+
+    def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
+      @exchanges[name] = exchange
+    end
+
+    # Queue accessors
+
+    def queue?(name : String) : Queue?
+      @queues[name]?
+    end
+
+    def queue(name : String) : Queue
+      @queues[name]
+    end
+
+    def queue_exists?(name : String) : Bool
+      @queues.has_key?(name)
+    end
+
+    def each_queue(& : Queue ->) : Nil
+      @queues.each_value { |v| yield v }
+    end
+
+    def queues_dup : Array(Queue)
+      @queues.values
+    end
+
+    def queues_size : Int32
+      @queues.size
+    end
+
+    def queues_values : Array(Queue)
+      @queues.values
+    end
+
+    def queues_unsafe_put(name : String, queue : Queue) : Nil
+      @queues[name] = queue
+    end
+
+    def queues_clear : Nil
+      @queues.clear
+    end
+
+    # ameba:disable Metrics/CyclomaticComplexity
+    def apply(f, loading = false) : Bool
+      @definitions_lock.synchronize do
+        case f
+        when AMQP::Frame::Exchange::Declare
+          return false if @exchanges.has_key? f.exchange_name
+          e = @exchanges[f.exchange_name] =
+            make_exchange(@vhost, f.exchange_name, f.exchange_type, f.durable, f.auto_delete, f.internal, f.arguments)
+          @vhost.apply_policies([e] of Exchange) unless loading
+          store_definition(f) if !loading && f.durable
+        when AMQP::Frame::Exchange::Delete
+          if x = @exchanges.delete f.exchange_name
+            unless @vhost.closed?
+              @exchanges.each_value do |ex|
+                ex.bindings_details.each do |binding|
+                  next unless binding.destination == x
+                  ex.unbind(x, binding.routing_key, binding.arguments)
+                end
+              end
+            end
+            x.delete
+            store_definition(f, dirty: true) if !loading && x.durable?
+          else
+            return false
+          end
+        when AMQP::Frame::Exchange::Bind
+          src = @exchanges[f.source]? || return false
+          dst = @exchanges[f.destination]? || return false
+          return false unless src.bind(dst, f.routing_key, f.arguments)
+          store_definition(f) if !loading && src.durable? && dst.durable?
+        when AMQP::Frame::Exchange::Unbind
+          src = @exchanges[f.source]? || return false
+          dst = @exchanges[f.destination]? || return false
+          return false unless src.unbind(dst, f.routing_key, f.arguments)
+          store_definition(f, dirty: true) if !loading && src.durable? && dst.durable?
+        when AMQP::Frame::Queue::Declare
+          return false if @queues.has_key? f.queue_name
+          q = @queues[f.queue_name] = QueueFactory.make(@vhost, f)
+          @vhost.apply_policies([q] of Queue) unless loading
+          store_definition(f) if !loading && f.durable && !f.exclusive
+          @vhost.event_tick(EventType::QueueDeclared) unless loading
+        when AMQP::Frame::Queue::Delete
+          if q = @queues.delete(f.queue_name)
+            unless @vhost.closed?
+              @exchanges.each_value do |ex|
+                ex.bindings_details.each do |binding|
+                  next unless binding.destination == q
+                  ex.unbind(q, binding.routing_key, binding.arguments)
+                end
+              end
+            end
+            store_definition(f, dirty: true) if !loading && q.durable? && !q.exclusive?
+            @vhost.event_tick(EventType::QueueDeleted) unless loading
+            q.delete
+          else
+            return false
+          end
+        when AMQP::Frame::Queue::Bind
+          x = @exchanges[f.exchange_name]? || return false
+          q = @queues[f.queue_name]? || return false
+          return false unless x.bind(q, f.routing_key, f.arguments)
+          store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
+        when AMQP::Frame::Queue::Unbind
+          x = @exchanges[f.exchange_name]? || return false
+          q = @queues[f.queue_name]? || return false
+          return false unless x.unbind(q, f.routing_key, f.arguments)
+          store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
+        else raise "Cannot apply frame #{f.class} in vhost #{@vhost.name}"
+        end
+        true
+      end
+    end
+
+    def queue_bindings(queue : Queue) : Array(BindingDetails)
+      default_binding = BindingDetails.new("", @vhost.name, BindingKey.new(queue.name), queue)
+      bindings = @exchanges.values.flat_map do |ex|
+        ex.bindings_details.select { |binding| binding.destination == queue }
+      end
+      [default_binding] + bindings
+    end
+
+    # ameba:disable Metrics/CyclomaticComplexity
+    def load!
+      exchanges = Hash(String, AMQP::Frame::Exchange::Declare).new
+      queues = Hash(String, AMQP::Frame::Queue::Declare).new
+      queue_bindings = Hash(String, Array(AMQP::Frame::Queue::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Queue::Bind).new }
+      exchange_bindings = Hash(String, Array(AMQP::Frame::Exchange::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Exchange::Bind).new }
+      should_compact = false
+      io = @definitions_file
+      if io.size.zero?
+        load_default_definitions
+        compact!
+        return
+      end
+
+      @log.info { "Loading definitions" }
+      @definitions_lock.synchronize do
+        @log.debug { "Verifying schema" }
+        SchemaVersion.verify(io, :definition)
+        stream = AMQ::Protocol::Stream.new(io, format: IO::ByteFormat::SystemEndian)
+        loop do
+          f = stream.next_frame
+          @log.trace { "Reading frame #{f.inspect}" }
+          case f
+          when AMQP::Frame::Exchange::Declare
+            exchanges[f.exchange_name] = f
+          when AMQP::Frame::Exchange::Delete
+            exchanges.delete f.exchange_name
+            exchange_bindings.delete f.exchange_name
+            should_compact = true
+          when AMQP::Frame::Exchange::Bind
+            exchange_bindings[f.destination] << f
+          when AMQP::Frame::Exchange::Unbind
+            exchange_bindings[f.destination].reject! do |b|
+              b.source == f.source &&
+                b.routing_key == f.routing_key &&
+                b.arguments == f.arguments
+            end
+            should_compact = true
+          when AMQP::Frame::Queue::Declare
+            queues[f.queue_name] = f
+          when AMQP::Frame::Queue::Delete
+            queues.delete f.queue_name
+            queue_bindings.delete f.queue_name
+            should_compact = true
+          when AMQP::Frame::Queue::Bind
+            queue_bindings[f.queue_name] << f
+          when AMQP::Frame::Queue::Unbind
+            queue_bindings[f.queue_name].reject! do |b|
+              b.exchange_name == f.exchange_name &&
+                b.routing_key == f.routing_key &&
+                b.arguments == f.arguments
+            end
+            should_compact = true
+          else
+            raise "Cannot apply frame #{f.class} in vhost #{@vhost.name}"
+          end
+        rescue ex : IO::EOFError
+          break
+        end
+      end
+
+      @log.info { "Applying #{exchanges.size} exchanges" }
+      exchanges.each_value &->self.load_apply(AMQP::Frame)
+      @log.info { "Applying #{queues.size} queues" }
+      queues.each_value &->self.load_apply(AMQP::Frame)
+      @log.info { "Applying #{exchange_bindings.each_value.sum(0, &.size)} exchange bindings" }
+      exchange_bindings.each_value &.each(&->self.load_apply(AMQP::Frame))
+      @log.info { "Applying #{queue_bindings.each_value.sum(0, &.size)} queue bindings" }
+      queue_bindings.each_value &.each(&->self.load_apply(AMQP::Frame))
+
+      @log.info { "Definitions loaded" }
+      compact! if should_compact
+    end
+
+    def close : Nil
+      @definitions_file.close
+    end
+
+    def sync : Nil
+      {% if flag?(:linux) %}
+        ret = LibC.syncfs(@definitions_file.fd)
+        raise IO::Error.from_errno("syncfs") if ret != 0
+      {% else %}
+        LibC.sync
+      {% end %}
+    end
+
+    protected def load_apply(frame : AMQP::Frame)
+      apply frame, loading: true
+    rescue ex : LavinMQ::Error
+      @log.error(exception: ex) { "Failed to apply frame #{frame.inspect}" }
+    end
+
+    private def load_default_definitions
+      @log.info { "Loading default definitions" }
+      @exchanges[""] = AMQP::DefaultExchange.new(@vhost, "", true, false, false)
+      @exchanges["amq.direct"] = AMQP::DirectExchange.new(@vhost, "amq.direct", true, false, false)
+      @exchanges["amq.fanout"] = AMQP::FanoutExchange.new(@vhost, "amq.fanout", true, false, false)
+      @exchanges["amq.topic"] = AMQP::TopicExchange.new(@vhost, "amq.topic", true, false, false)
+      @exchanges["amq.headers"] = AMQP::HeadersExchange.new(@vhost, "amq.headers", true, false, false)
+      @exchanges["amq.match"] = AMQP::HeadersExchange.new(@vhost, "amq.match", true, false, false)
+    end
+
+    private def compact!
+      @definitions_lock.synchronize do
+        @log.info { "Compacting definitions" }
+        io = File.open("#{@definitions_file_path}.tmp", "a+")
+        SchemaVersion.prefix(io, :definition)
+        @exchanges.each_value.select(&.durable?).each do |e|
+          f = AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, e.name, e.type,
+            false, e.durable?, e.auto_delete?, e.internal?,
+            false, e.arguments)
+          io.write_bytes f
+        end
+        @queues.each_value.select(&.durable?).each do |q|
+          f = AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, q.name, false, q.durable?, q.exclusive?,
+            q.auto_delete?, false, q.arguments)
+          io.write_bytes f
+        end
+        @exchanges.each_value.select(&.durable?).each do |e|
+          e.bindings_details.each do |binding|
+            args = binding.arguments || AMQP::Table.new
+            frame = case binding.destination
+                    when Queue
+                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
+                        binding.routing_key, false, args)
+                    when Exchange
+                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
+                        binding.routing_key, false, args)
+                    end
+            if f = frame
+              io.write_bytes f
+            end
+          end
+        end
+        io.fsync
+        File.rename io.path, @definitions_file_path
+        @replicator.try &.replace_file @definitions_file_path
+        @definitions_file.close
+        @definitions_file = io
+      end
+    end
+
+    private def store_definition(frame, dirty = false)
+      @log.debug { "Storing definition: #{frame.inspect}" }
+      bytes = frame.to_slice
+      @definitions_file.write bytes
+      @replicator.try &.append @definitions_file_path, bytes
+      @definitions_file.fsync
+      if dirty
+        if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions
+          compact!
+          @definitions_deletes = 0
+        end
+      end
+    end
+
+    private def make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)
+      case type
+      when "direct"
+        if name.empty?
+          AMQP::DefaultExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+        else
+          AMQP::DirectExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+        end
+      when "fanout"
+        AMQP::FanoutExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+      when "topic"
+        AMQP::TopicExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+      when "headers"
+        AMQP::HeadersExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+      when "x-delayed-message", "x-delayed-exchange"
+        arguments = arguments.clone
+        type = arguments.delete("x-delayed-type")
+        raise Error::ExchangeTypeError.new("Missing required argument 'x-delayed-type'") unless type
+        arguments["x-delayed-exchange"] = true
+        make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)
+      when "x-federation-upstream"
+        AMQP::FederationExchange.new(vhost, name, arguments)
+      when "x-consistent-hash"
+        AMQP::ConsistentHashExchange.new(vhost, name, durable, auto_delete, internal, arguments)
+      else raise Error::ExchangeTypeError.new("unknown exchange type '#{type}'")
+      end
+    end
+  end
+end

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -37,7 +37,7 @@ module LavinMQ
       @exchanges.each_value { |v| yield v }
     end
 
-    def exchanges_dup : Array(Exchange)
+    def exchanges : Array(Exchange)
       @exchanges.values
     end
 
@@ -49,8 +49,14 @@ module LavinMQ
       @exchanges.any? { |kv| yield kv }
     end
 
-    def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
-      @exchanges[name] = exchange
+    # Insert a pre-built exchange (e.g. MQTT or other internal types that the
+    # frame-driven `apply` path can't construct). Locked; idempotent so callers
+    # like `init_delayed_queue` can re-register on exchange re-creation. Skips
+    # persistence and event ticks since these aren't replayed from frames.
+    def register_exchange(exchange : Exchange) : Nil
+      @definitions_lock.synchronize do
+        @exchanges[exchange.name] = exchange
+      end
     end
 
     # Queue accessors
@@ -71,7 +77,7 @@ module LavinMQ
       @queues.each_value { |v| yield v }
     end
 
-    def queues_dup : Array(Queue)
+    def queues : Array(Queue)
       @queues.values
     end
 
@@ -79,12 +85,15 @@ module LavinMQ
       @queues.size
     end
 
-    def queues_values : Array(Queue)
-      @queues.values
-    end
-
-    def queues_unsafe_put(name : String, queue : Queue) : Nil
-      @queues[name] = queue
+    # Insert a pre-built queue (e.g. DelayedExchangeQueue) that the
+    # frame-driven `apply` path can't construct. Locked; idempotent so it can be
+    # called when an exchange is re-imported and a delayed queue with the same
+    # name already exists. Skips persistence and event ticks since these aren't
+    # replayed from frames.
+    def register_queue(queue : Queue) : Nil
+      @definitions_lock.synchronize do
+        @queues[queue.name] = queue
+      end
     end
 
     def queues_clear : Nil

--- a/src/lavinmq/direct_reply_consumer_store.cr
+++ b/src/lavinmq/direct_reply_consumer_store.cr
@@ -1,0 +1,25 @@
+require "./client/client"
+
+module LavinMQ
+  class DirectReplyConsumerStore
+    def initialize
+      @consumers = Hash(String, Client::Channel).new
+    end
+
+    def []?(consumer_tag : String) : Client::Channel?
+      @consumers[consumer_tag]?
+    end
+
+    def []=(consumer_tag : String, channel : Client::Channel) : Client::Channel
+      @consumers[consumer_tag] = channel
+    end
+
+    def delete(consumer_tag : String) : Client::Channel?
+      @consumers.delete(consumer_tag)
+    end
+
+    def has_key?(consumer_tag : String) : Bool
+      @consumers.has_key?(consumer_tag)
+    end
+  end
+end

--- a/src/lavinmq/http/binding_helpers.cr
+++ b/src/lavinmq/http/binding_helpers.cr
@@ -5,7 +5,7 @@ module LavinMQ
   module HTTP
     module BindingHelpers
       private def bindings(vhost)
-        vhost.exchanges.each_value.flat_map do |e|
+        vhost.exchanges_each_value.flat_map do |e|
           e.bindings_details
         end
       end

--- a/src/lavinmq/http/binding_helpers.cr
+++ b/src/lavinmq/http/binding_helpers.cr
@@ -5,7 +5,7 @@ module LavinMQ
   module HTTP
     module BindingHelpers
       private def bindings(vhost)
-        vhost.exchanges_each_value.flat_map do |e|
+        vhost.each_exchange.flat_map do |e|
           e.bindings_details
         end
       end

--- a/src/lavinmq/http/binding_helpers.cr
+++ b/src/lavinmq/http/binding_helpers.cr
@@ -4,8 +4,8 @@ require "../exchange"
 module LavinMQ
   module HTTP
     module BindingHelpers
-      private def bindings(vhost)
-        vhost.each_exchange.flat_map do |e|
+      private def bindings(vhost) : Array(BindingDetails)
+        vhost.exchanges_dup.flat_map do |e|
           e.bindings_details
         end
       end

--- a/src/lavinmq/http/binding_helpers.cr
+++ b/src/lavinmq/http/binding_helpers.cr
@@ -5,7 +5,7 @@ module LavinMQ
   module HTTP
     module BindingHelpers
       private def bindings(vhost) : Array(BindingDetails)
-        vhost.exchanges_dup.flat_map do |e|
+        vhost.exchanges.flat_map do |e|
           e.bindings_details
         end
       end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -18,13 +18,12 @@ module LavinMQ
 
       private abstract def register_routes
 
-      private def page(context, iterator : Iterator(SortableJSON))
+      private def page(context, items : Array(SortableJSON))
         params = context.request.query_params
         page_size = extract_page_size(context)
         search_term = extract_search_term(params)
-        total_count = 0
-        all_items = iterator.compact_map do |i|
-          total_count += 1
+        total_count = items.size
+        all_items = items.compact_map do |i|
           next unless i.search_match?(search_term) if search_term
           i.details_tuple
         rescue ex
@@ -59,19 +58,16 @@ module LavinMQ
 
       private def sort(all_items, context)
         if sort_by = context.request.query_params.fetch("sort", nil).try &.split(".")
-          sorted_items = all_items.to_a
           begin
-            sort_by_key!(sorted_items, sort_by, context)
+            sort_by_key!(all_items, sort_by, context)
           rescue KeyError | TypeCastError
             bad_request(context, "Sort key #{sort_by.join(".")} is not valid")
           end
           if context.request.query_params["sort_reverse"]?.try { |s| !(s =~ /^false$/i) }
-            sorted_items.reverse!
+            all_items.reverse!
           end
-          sorted_items.each
-        else
-          all_items
         end
+        all_items
       end
 
       private def sort_by_key!(sorted_items, sort_by, context)
@@ -103,8 +99,8 @@ module LavinMQ
         end
       end
 
-      # Writes the items to the json, but also counts all items by iterating the whole iterator
-      # Reruns the number of number of written to the json and the total items in the iterator
+      # Writes the items to the json, but also counts all items
+      # Returns the number of items written to json and the total item count
       private def array_iterator_to_json(json, iterator, columns : Array(String)?, start : Int, page_size : Int) : Tuple(Int32, Int32)
         size = 0
         total = 0
@@ -223,8 +219,8 @@ module LavinMQ
         user
       end
 
-      def vhosts(user : Auth::BaseUser)
-        @amqp_server.vhosts.each_value.select do |v|
+      def vhosts(user : Auth::BaseUser) : Array(VHost)
+        @amqp_server.vhosts.values.select do |v|
           full_view_vhosts_access = user.tags.any? { |t| t.administrator? || t.monitoring? }
           amqp_access = user.permissions.has_key?(v.name)
           full_view_vhosts_access || (amqp_access && !user.tags.empty?)

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,7 +15,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            conns = vhost.connections.each
+            conns = vhost.connections_each
             channels = conns.flat_map(&.channels.each_value)
             page(context, channels)
           end

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,8 +15,8 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            conns = vhost.connections_each
-            channels = conns.flat_map(&.channels_each_value)
+            conns = vhost.each_connection
+            channels = conns.flat_map(&.each_channel)
             page(context, channels)
           end
         end
@@ -44,7 +44,7 @@ module LavinMQ
       end
 
       private def all_channels(user)
-        Iterator(Client::Channel).chain(connections(user).map(&.channels_each_value))
+        Iterator(Client::Channel).chain(connections(user).map(&.each_channel))
       end
 
       private def with_channel(context, params, &)

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -16,7 +16,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
             conns = vhost.connections_each
-            channels = conns.flat_map(&.channels.each_value)
+            channels = conns.flat_map(&.channels_each_value)
             page(context, channels)
           end
         end
@@ -44,7 +44,7 @@ module LavinMQ
       end
 
       private def all_channels(user)
-        Iterator(Client::Channel).chain(connections(user).map(&.channels.each_value))
+        Iterator(Client::Channel).chain(connections(user).map(&.channels_each_value))
       end
 
       private def with_channel(context, params, &)

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,8 +15,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            conns = vhost.each_connection
-            channels = conns.flat_map(&.each_channel)
+            channels = vhost.connections_dup.flat_map(&.channels_dup)
             page(context, channels)
           end
         end
@@ -43,8 +42,8 @@ module LavinMQ
         end
       end
 
-      private def all_channels(user)
-        Iterator(Client::Channel).chain(connections(user).map(&.each_channel))
+      private def all_channels(user) : Array(Client::Channel)
+        connections(user).flat_map(&.channels_dup)
       end
 
       private def with_channel(context, params, &)

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,7 +15,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            channels = vhost.connections_dup.flat_map(&.channels_dup)
+            channels = vhost.connections.flat_map(&.channels_dup)
             page(context, channels)
           end
         end

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -15,7 +15,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/channels" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            channels = vhost.connections.flat_map(&.channels_dup)
+            channels = vhost.connections.flat_map(&.channels)
             page(context, channels)
           end
         end
@@ -43,7 +43,7 @@ module LavinMQ
       end
 
       private def all_channels(user) : Array(Client::Channel)
-        connections(user).flat_map(&.channels_dup)
+        connections(user).flat_map(&.channels)
       end
 
       private def with_channel(context, params, &)

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -19,13 +19,13 @@ module LavinMQ
 
       private def register_routes
         get "/api/connections" do |context, _params|
-          page(context, connections(user(context)).each)
+          page(context, connections(user(context)))
         end
 
         get "/api/vhosts/:vhost/connections" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.each_connection)
+            page(context, vhost.connections_dup)
           end
         end
 
@@ -45,13 +45,13 @@ module LavinMQ
 
         get "/api/connections/:name/channels" do |context, params|
           with_connection(context, params) do |connection|
-            page(context, connection.each_channel)
+            page(context, connection.channels_dup)
           end
         end
 
         get "/api/connections/username/:username" do |context, params|
           connections = get_connections_by_username(context, params["username"])
-          page(context, connections.each)
+          page(context, connections)
         end
 
         delete "/api/connections/username/:username" do |context, params|

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -45,7 +45,7 @@ module LavinMQ
 
         get "/api/connections/:name/channels" do |context, params|
           with_connection(context, params) do |connection|
-            page(context, connection.channels.each_value)
+            page(context, connection.channels_each_value)
           end
         end
 

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -25,7 +25,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/connections" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.connections_each)
+            page(context, vhost.each_connection)
           end
         end
 
@@ -45,7 +45,7 @@ module LavinMQ
 
         get "/api/connections/:name/channels" do |context, params|
           with_connection(context, params) do |connection|
-            page(context, connection.channels_each_value)
+            page(context, connection.each_channel)
           end
         end
 

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -25,7 +25,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/connections" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.connections.each)
+            page(context, vhost.connections_each)
           end
         end
 

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -45,7 +45,7 @@ module LavinMQ
 
         get "/api/connections/:name/channels" do |context, params|
           with_connection(context, params) do |connection|
-            page(context, connection.channels_dup)
+            page(context, connection.channels)
           end
         end
 

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -25,7 +25,7 @@ module LavinMQ
         get "/api/vhosts/:vhost/connections" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.connections_dup)
+            page(context, vhost.connections)
           end
         end
 

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -18,7 +18,7 @@ module LavinMQ
             refuse_unless_management(context, user, vhost)
             itr = connections(user).each.select(&.vhost.==(vhost))
               .flat_map do |conn|
-                conn.channels_each_value.flat_map &.consumers
+                conn.each_channel.flat_map &.consumers
               end
             page(context, itr)
           end
@@ -36,12 +36,12 @@ module LavinMQ
               context.response.status_code = 404
               break
             end
-            channel = connection.channels_byid?(ch_id.to_u16)
+            channel = connection.channel?(ch_id.to_u16)
             unless channel
               context.response.status_code = 404
               break
             end
-            consumer = channel.consumers_find(&.tag.==(consumer_tag))
+            consumer = channel.find_consumer(&.tag.==(consumer_tag))
             unless consumer
               context.response.status_code = 404
               break
@@ -55,7 +55,7 @@ module LavinMQ
 
       private def all_consumers(user)
         Iterator(Client::Channel::Consumer)
-          .chain(connections(user).map { |c| c.channels_each_value.flat_map &.consumers })
+          .chain(connections(user).map { |c| c.each_channel.flat_map &.consumers })
       end
     end
   end

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -16,11 +16,11 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             user = user(context)
             refuse_unless_management(context, user, vhost)
-            itr = connections(user).each.select(&.vhost.==(vhost))
+            arr = connections(user).select(&.vhost.==(vhost))
               .flat_map do |conn|
-                conn.each_channel.flat_map &.consumers
+                conn.channels_dup.flat_map &.consumers
               end
-            page(context, itr)
+            page(context, arr)
           end
         end
 
@@ -53,9 +53,8 @@ module LavinMQ
         end
       end
 
-      private def all_consumers(user)
-        Iterator(Client::Channel::Consumer)
-          .chain(connections(user).map { |c| c.each_channel.flat_map &.consumers })
+      private def all_consumers(user) : Array(Client::Channel::Consumer)
+        connections(user).flat_map { |c| c.channels_dup.flat_map &.consumers }
       end
     end
   end

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -18,7 +18,7 @@ module LavinMQ
             refuse_unless_management(context, user, vhost)
             itr = connections(user).each.select(&.vhost.==(vhost))
               .flat_map do |conn|
-                conn.channels.each_value.flat_map &.consumers
+                conn.channels_each_value.flat_map &.consumers
               end
             page(context, itr)
           end
@@ -36,12 +36,12 @@ module LavinMQ
               context.response.status_code = 404
               break
             end
-            channel = connection.channels[ch_id]?
+            channel = connection.channels_byid?(ch_id.to_u16)
             unless channel
               context.response.status_code = 404
               break
             end
-            consumer = channel.consumers.find(&.tag.==(consumer_tag))
+            consumer = channel.consumers_find(&.tag.==(consumer_tag))
             unless consumer
               context.response.status_code = 404
               break
@@ -55,7 +55,7 @@ module LavinMQ
 
       private def all_consumers(user)
         Iterator(Client::Channel::Consumer)
-          .chain(connections(user).map { |c| c.channels.each_value.flat_map &.consumers })
+          .chain(connections(user).map { |c| c.channels_each_value.flat_map &.consumers })
       end
     end
   end

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -18,7 +18,7 @@ module LavinMQ
             refuse_unless_management(context, user, vhost)
             arr = connections(user).select(&.vhost.==(vhost))
               .flat_map do |conn|
-                conn.channels_dup.flat_map &.consumers
+                conn.channels.flat_map &.consumers
               end
             page(context, arr)
           end
@@ -54,7 +54,7 @@ module LavinMQ
       end
 
       private def all_consumers(user) : Array(Client::Channel::Consumer)
-        connections(user).flat_map { |c| c.channels_dup.flat_map &.consumers }
+        connections(user).flat_map { |c| c.channels.flat_map &.consumers }
       end
     end
   end

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -21,14 +21,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/exchanges" do |context, _params|
-          itr = vhosts(user(context)).flat_map &.exchanges_each_value
+          itr = vhosts(user(context)).flat_map &.each_exchange
           page(context, itr)
         end
 
         get "/api/exchanges/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.exchanges_each_value)
+            page(context, vhost.each_exchange)
           end
         end
 

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -21,14 +21,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/exchanges" do |context, _params|
-          itr = vhosts(user(context)).flat_map &.each_exchange
+          itr = vhosts(user(context)).flat_map &.exchanges_dup
           page(context, itr)
         end
 
         get "/api/exchanges/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.each_exchange)
+            page(context, vhost.exchanges_dup)
           end
         end
 

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -8,7 +8,7 @@ module LavinMQ
       private def exchange(context, params, vhost, key = "name")
         name = params[key]
         name = "" if name == "amq.default"
-        e = vhost.exchanges[name]?
+        e = vhost.exchange?(name)
         not_found(context) unless e
         e
       end
@@ -21,14 +21,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/exchanges" do |context, _params|
-          itr = vhosts(user(context)).flat_map &.exchanges.each_value
+          itr = vhosts(user(context)).flat_map &.exchanges_each_value
           page(context, itr)
         end
 
         get "/api/exchanges/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.exchanges.each_value)
+            page(context, vhost.exchanges_each_value)
           end
         end
 
@@ -60,7 +60,7 @@ module LavinMQ
             unless user.can_config?(vhost.name, name) && ae_ok
               access_refused(context, "User doesn't have permissions to declare exchange '#{name}'")
             end
-            e = vhost.exchanges[name]?
+            e = vhost.exchange?(name)
             if e
               unless e.match?(type, durable, auto_delete, internal, tbl)
                 bad_request(context, "Existing exchange declared with other arguments arg")

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -21,14 +21,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/exchanges" do |context, _params|
-          itr = vhosts(user(context)).flat_map &.exchanges_dup
+          itr = vhosts(user(context)).flat_map &.exchanges
           page(context, itr)
         end
 
         get "/api/exchanges/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.exchanges_dup)
+            page(context, vhost.exchanges)
           end
         end
 

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -43,7 +43,7 @@ module LavinMQ
             vhost.each_connection do |c|
               connections += 1
               channels += c.channel_count
-              consumers += c.channels_dup.sum &.consumers_size
+              consumers += c.channels.sum &.consumers_size
             end
             exchanges += vhost.exchanges_size
             queues += vhost.queues_size

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -40,14 +40,14 @@ module LavinMQ
 
           vhosts(user(context)).each do |vhost|
             next if x_vhost && vhost.name != x_vhost
-            vhost.connections_each do |c|
+            vhost.each_connection do |c|
               connections += 1
-              channels += c.channels_size
-              consumers += c.channels_each_value.sum &.consumers_size
+              channels += c.channel_count
+              consumers += c.each_channel.sum &.consumers_size
             end
             exchanges += vhost.exchanges_size
             queues += vhost.queues_size
-            vhost.queues_each_value do |q|
+            vhost.each_queue do |q|
               ready += q.message_count
               unacked += q.unacked_count
               add_logs!(ready_log, q.message_count_log)

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -42,8 +42,8 @@ module LavinMQ
             next if x_vhost && vhost.name != x_vhost
             vhost.connections_each do |c|
               connections += 1
-              channels += c.channels.size
-              consumers += c.channels.each_value.sum &.consumers.size
+              channels += c.channels_size
+              consumers += c.channels_each_value.sum &.consumers_size
             end
             exchanges += vhost.exchanges_size
             queues += vhost.queues_size

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -40,14 +40,14 @@ module LavinMQ
 
           vhosts(user(context)).each do |vhost|
             next if x_vhost && vhost.name != x_vhost
-            vhost.connections.each do |c|
+            vhost.connections_each do |c|
               connections += 1
               channels += c.channels.size
               consumers += c.channels.each_value.sum &.consumers.size
             end
-            exchanges += vhost.exchanges.size
-            queues += vhost.queues.size
-            vhost.queues.each_value do |q|
+            exchanges += vhost.exchanges_size
+            queues += vhost.queues_size
+            vhost.queues_each_value do |q|
               ready += q.message_count
               unacked += q.unacked_count
               add_logs!(ready_log, q.message_count_log)
@@ -134,7 +134,7 @@ module LavinMQ
               IO::Memory.new("test"))
             ok = vhost.publish(msg)
             env = nil
-            vhost.queues["aliveness-test"].basic_get(true) { |e| env = e }
+            vhost.queue("aliveness-test").basic_get(true) { |e| env = e }
             ok = ok && env && String.new(env.message.body) == "test"
             {status: ok ? "ok" : "failed"}.to_json(context.response)
           end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -43,7 +43,7 @@ module LavinMQ
             vhost.each_connection do |c|
               connections += 1
               channels += c.channel_count
-              consumers += c.each_channel.sum &.consumers_size
+              consumers += c.channels_dup.sum &.consumers_size
             end
             exchanges += vhost.exchanges_size
             queues += vhost.queues_size
@@ -141,20 +141,20 @@ module LavinMQ
         end
 
         get "/api/federation-links" do |context, _params|
-          itrs = vhosts(user(context)).flat_map do |vhost|
+          arr = vhosts(user(context)).flat_map do |vhost|
             vhost.upstreams.not_nil!.flat_map do |upstream|
-              upstream.links.each
+              upstream.links
             end
           end
-          page(context, itrs)
+          page(context, arr)
         end
 
         get "/api/federation-links/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
-            itrs = vhost.upstreams.not_nil!.map do |upstream|
-              upstream.links.each
+            arr = vhost.upstreams.not_nil!.flat_map do |upstream|
+              upstream.links
             end
-            page(context, Iterator(Federation::Upstream::Link).chain(itrs))
+            page(context, arr)
           end
         end
 

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -78,7 +78,7 @@ module LavinMQ
           partitions:         Tuple.new,
           proc_used:          Fiber.count,
           run_queue:          0,
-          sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
+          sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections_size },
           followers:          @amqp_server.followers,
         }
       end

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -33,32 +33,32 @@ module LavinMQ
         get "/api/parameters" do |context, _params|
           user = user(context)
           refuse_unless_policymaker(context, user)
-          itr = vhosts(user).flat_map do |v|
-            v.parameters.each_value.map { |p| map_parameter(v.name, p) }
+          arr = vhosts(user).flat_map do |v|
+            v.parameters.values_dup.map { |p| map_parameter(v.name, p) }
           end
-          page(context, itr)
+          page(context, arr)
         end
 
         get "/api/parameters/:component" do |context, params|
           user = user(context)
           refuse_unless_policymaker(context, user)
           component = params["component"]
-          itr = vhosts(user).flat_map do |v|
-            v.parameters.each_value
+          arr = vhosts(user).flat_map do |v|
+            v.parameters.values_dup
               .select { |p| p.component_name == component }
               .map { |p| map_parameter(v.name, p) }
           end
-          page(context, itr)
+          page(context, arr)
         end
 
         get "/api/parameters/:component/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_policymaker(context, user(context), vhost)
             component = params["component"]
-            itr = vhost.parameters.each_value
+            arr = vhost.parameters.values_dup
               .select { |p| p.component_name == component }
               .map { |p| map_parameter(vhost.name, p) }
-            page(context, itr)
+            page(context, arr)
           end
         end
 
@@ -109,7 +109,7 @@ module LavinMQ
 
         get "/api/global-parameters" do |context, _params|
           refuse_unless_policymaker(context, user(context))
-          page(context, @amqp_server.parameters.each_value.map { |p| map_parameter(nil, p) })
+          page(context, @amqp_server.parameters.values_dup.map { |p| map_parameter(nil, p) })
         end
 
         get "/api/global-parameters/:name" do |context, params|
@@ -147,14 +147,14 @@ module LavinMQ
         get "/api/policies" do |context, _params|
           user = user(context)
           refuse_unless_policymaker(context, user)
-          itr = Iterator(Policy).chain(vhosts(user).map(&.policies.each_value))
-          page(context, itr)
+          arr = vhosts(user).flat_map(&.policies.values_dup)
+          page(context, arr)
         end
 
         get "/api/policies/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_policymaker(context, user(context), vhost)
-            page(context, vhost.policies.each_value)
+            page(context, vhost.policies.values_dup)
           end
         end
 
@@ -205,14 +205,14 @@ module LavinMQ
         get "/api/operator-policies" do |context, _params|
           user = user(context)
           refuse_unless_policymaker(context, user)
-          itr = Iterator(OperatorPolicy).chain(vhosts(user).map(&.operator_policies.each_value))
-          page(context, itr)
+          arr = vhosts(user).flat_map(&.operator_policies.values_dup)
+          page(context, arr)
         end
 
         get "/api/operator-policies/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_policymaker(context, user(context), vhost)
-            page(context, vhost.operator_policies.each_value)
+            page(context, vhost.operator_policies.values_dup)
           end
         end
 

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -34,7 +34,7 @@ module LavinMQ
           user = user(context)
           refuse_unless_policymaker(context, user)
           arr = vhosts(user).flat_map do |v|
-            v.parameters.values_dup.map { |p| map_parameter(v.name, p) }
+            v.parameters.values.map { |p| map_parameter(v.name, p) }
           end
           page(context, arr)
         end
@@ -44,7 +44,7 @@ module LavinMQ
           refuse_unless_policymaker(context, user)
           component = params["component"]
           arr = vhosts(user).flat_map do |v|
-            v.parameters.values_dup
+            v.parameters.values
               .select { |p| p.component_name == component }
               .map { |p| map_parameter(v.name, p) }
           end
@@ -55,7 +55,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             refuse_unless_policymaker(context, user(context), vhost)
             component = params["component"]
-            arr = vhost.parameters.values_dup
+            arr = vhost.parameters.values
               .select { |p| p.component_name == component }
               .map { |p| map_parameter(vhost.name, p) }
             page(context, arr)
@@ -109,7 +109,7 @@ module LavinMQ
 
         get "/api/global-parameters" do |context, _params|
           refuse_unless_policymaker(context, user(context))
-          page(context, @amqp_server.parameters.values_dup.map { |p| map_parameter(nil, p) })
+          page(context, @amqp_server.parameters.values.map { |p| map_parameter(nil, p) })
         end
 
         get "/api/global-parameters/:name" do |context, params|
@@ -147,14 +147,14 @@ module LavinMQ
         get "/api/policies" do |context, _params|
           user = user(context)
           refuse_unless_policymaker(context, user)
-          arr = vhosts(user).flat_map(&.policies.values_dup)
+          arr = vhosts(user).flat_map(&.policies.values)
           page(context, arr)
         end
 
         get "/api/policies/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_policymaker(context, user(context), vhost)
-            page(context, vhost.policies.values_dup)
+            page(context, vhost.policies.values)
           end
         end
 
@@ -205,14 +205,14 @@ module LavinMQ
         get "/api/operator-policies" do |context, _params|
           user = user(context)
           refuse_unless_policymaker(context, user)
-          arr = vhosts(user).flat_map(&.operator_policies.values_dup)
+          arr = vhosts(user).flat_map(&.operator_policies.values)
           page(context, arr)
         end
 
         get "/api/operator-policies/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_policymaker(context, user(context), vhost)
-            page(context, vhost.operator_policies.values_dup)
+            page(context, vhost.operator_policies.values)
           end
         end
 

--- a/src/lavinmq/http/controller/permissions.cr
+++ b/src/lavinmq/http/controller/permissions.cr
@@ -29,10 +29,9 @@ module LavinMQ
       private def register_routes
         get "/api/permissions" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          itr = @amqp_server.users.each_value.reject(&.hidden?)
+          arr = @amqp_server.users.values_dup.reject(&.hidden?)
             .flat_map { |u| u.permissions.map { |vhost, p| PermissionsView.new(u, vhost, p) } }
-            .each
-          page(context, itr)
+          page(context, arr)
         end
 
         get "/api/permissions/:vhost/:user" do |context, params|

--- a/src/lavinmq/http/controller/permissions.cr
+++ b/src/lavinmq/http/controller/permissions.cr
@@ -29,7 +29,7 @@ module LavinMQ
       private def register_routes
         get "/api/permissions" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          arr = @amqp_server.users.values_dup.reject(&.hidden?)
+          arr = @amqp_server.users.values.reject(&.hidden?)
             .flat_map { |u| u.permissions.map { |vhost, p| PermissionsView.new(u, vhost, p) } }
           page(context, arr)
         end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -358,9 +358,9 @@ module LavinMQ
           ready += d[:messages_ready]
           unacked += d[:messages_unacknowledged]
           connections += vhost.connections_size
-          vhost.connections_each do |conn|
-            channels += conn.channels_size
-            conn.channels_each_value do |ch|
+          vhost.each_connection do |conn|
+            channels += conn.channel_count
+            conn.each_channel do |ch|
               consumers += ch.consumers_size
             end
           end
@@ -500,7 +500,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages_ready", "gauge",
           "Messages ready to be delivered to consumers")
         vhosts.each do |vhost|
-          vhost.queues_each_value do |q|
+          vhost.each_queue do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages_ready", q.message_count, labels)
           end
@@ -509,7 +509,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages_unacked", "gauge",
           "Messages delivered to consumers but not yet acknowledged")
         vhosts.each do |vhost|
-          vhost.queues_each_value do |q|
+          vhost.each_queue do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages_unacked", q.unacked_count, labels)
           end
@@ -518,7 +518,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages", "gauge",
           "Sum of ready and unacknowledged messages - total queue depth")
         vhosts.each do |vhost|
-          vhost.queues_each_value do |q|
+          vhost.each_queue do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages", q.message_count + q.unacked_count, labels)
           end
@@ -527,7 +527,7 @@ module LavinMQ
         writer.write_header("detailed_queue_deduplication", "counter",
           "Number of deduplicated messages for this queue")
         vhosts.each do |vhost|
-          vhost.queues_each_value do |q|
+          vhost.each_queue do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_deduplication", q.dedup_count, labels)
           end
@@ -540,7 +540,7 @@ module LavinMQ
 
         # Write values
         vhosts.each do |vhost|
-          vhost.queues_each_value do |q|
+          vhost.each_queue do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_consumers", q.consumers_size, labels)
           end
@@ -554,7 +554,7 @@ module LavinMQ
 
         # Write values
         vhosts.each do |vhost|
-          vhost.exchanges_each_value do |e|
+          vhost.each_exchange do |e|
             labels = {exchange: e.name, vhost: vhost.name}
             writer.write_value("detailed_exchange_deduplication", e.dedup_count, labels)
           end
@@ -566,7 +566,7 @@ module LavinMQ
         writer.write_header("detailed_connection_incoming_bytes_total", "counter",
           "Total number of bytes received on a connection")
         vhosts.each do |vhost|
-          vhost.connections_each do |conn|
+          vhost.each_connection do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_incoming_bytes_total", conn.recv_oct_count, labels)
           end
@@ -575,7 +575,7 @@ module LavinMQ
         writer.write_header("detailed_connection_outgoing_bytes_total", "counter",
           "Total number of bytes sent on a connection")
         vhosts.each do |vhost|
-          vhost.connections_each do |conn|
+          vhost.each_connection do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_outgoing_bytes_total", conn.send_oct_count, labels)
           end
@@ -584,9 +584,9 @@ module LavinMQ
         writer.write_header("detailed_connection_channels", "counter",
           "Channels on a connection")
         vhosts.each do |vhost|
-          vhost.connections_each do |conn|
+          vhost.each_connection do |conn|
             labels = {channel: conn.name}
-            writer.write_value("detailed_connection_channels", conn.channels_size, labels)
+            writer.write_value("detailed_connection_channels", conn.channel_count, labels)
           end
         end
       end
@@ -595,8 +595,8 @@ module LavinMQ
         # Group TYPE, HELP and values together for each metric
         writer.write_header("detailed_channel_consumers", "gauge", "Consumers on a channel")
         vhosts.each do |vhost|
-          vhost.connections_each do |conn|
-            conn.channels_each_value do |ch|
+          vhost.each_connection do |conn|
+            conn.each_channel do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_consumers", ch.details_tuple[:consumer_count], labels)
             end
@@ -606,8 +606,8 @@ module LavinMQ
         writer.write_header("detailed_messages_unacked", "gauge",
           "Delivered but not yet acknowledged messages")
         vhosts.each do |vhost|
-          vhost.connections_each do |conn|
-            conn.channels_each_value do |ch|
+          vhost.each_connection do |conn|
+            conn.each_channel do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_messages_unacked", ch.details_tuple[:messages_unacknowledged], labels)
             end
@@ -617,8 +617,8 @@ module LavinMQ
         writer.write_header("detailed_channel_prefetch", "gauge",
           "Total limit of unacknowledged messages for all consumers on a channel")
         vhosts.each do |vhost|
-          vhost.connections_each do |conn|
-            conn.channels_each_value do |ch|
+          vhost.each_connection do |conn|
+            conn.each_channel do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_prefetch", ch.details_tuple[:prefetch_count], labels)
             end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -306,7 +306,7 @@ module LavinMQ
                       type:  "gauge",
                       help:  "Open file descriptors"})
         writer.write({name:  "process_open_tcp_sockets",
-                      value: @amqp_server.vhosts.sum { |_, v| v.connections.size },
+                      value: @amqp_server.vhosts.sum { |_, v| v.connections_size },
                       type:  "gauge",
                       help:  "Open TCP sockets"})
         writer.write({name:  "process_resident_memory_bytes",
@@ -357,14 +357,14 @@ module LavinMQ
           d = vhost.message_details
           ready += d[:messages_ready]
           unacked += d[:messages_unacknowledged]
-          connections += vhost.connections.size
-          vhost.connections.each do |conn|
+          connections += vhost.connections_size
+          vhost.connections_each do |conn|
             channels += conn.channels.size
             conn.channels.each_value do |ch|
               consumers += ch.consumers.size
             end
           end
-          queues += vhost.queues.size
+          queues += vhost.queues_size
         end
         writer.write({name:  "connections",
                       value: connections,
@@ -500,7 +500,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages_ready", "gauge",
           "Messages ready to be delivered to consumers")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages_ready", q.message_count, labels)
           end
@@ -509,7 +509,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages_unacked", "gauge",
           "Messages delivered to consumers but not yet acknowledged")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages_unacked", q.unacked_count, labels)
           end
@@ -518,7 +518,7 @@ module LavinMQ
         writer.write_header("detailed_queue_messages", "gauge",
           "Sum of ready and unacknowledged messages - total queue depth")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_messages", q.message_count + q.unacked_count, labels)
           end
@@ -527,7 +527,7 @@ module LavinMQ
         writer.write_header("detailed_queue_deduplication", "counter",
           "Number of deduplicated messages for this queue")
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_deduplication", q.dedup_count, labels)
           end
@@ -540,7 +540,7 @@ module LavinMQ
 
         # Write values
         vhosts.each do |vhost|
-          vhost.queues.each_value do |q|
+          vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
             writer.write_value("detailed_queue_consumers", q.consumers.size, labels)
           end
@@ -554,7 +554,7 @@ module LavinMQ
 
         # Write values
         vhosts.each do |vhost|
-          vhost.exchanges.each_value do |e|
+          vhost.exchanges_each_value do |e|
             labels = {exchange: e.name, vhost: vhost.name}
             writer.write_value("detailed_exchange_deduplication", e.dedup_count, labels)
           end
@@ -566,7 +566,7 @@ module LavinMQ
         writer.write_header("detailed_connection_incoming_bytes_total", "counter",
           "Total number of bytes received on a connection")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_incoming_bytes_total", conn.recv_oct_count, labels)
           end
@@ -575,7 +575,7 @@ module LavinMQ
         writer.write_header("detailed_connection_outgoing_bytes_total", "counter",
           "Total number of bytes sent on a connection")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_outgoing_bytes_total", conn.send_oct_count, labels)
           end
@@ -584,7 +584,7 @@ module LavinMQ
         writer.write_header("detailed_connection_channels", "counter",
           "Channels on a connection")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             labels = {channel: conn.name}
             writer.write_value("detailed_connection_channels", conn.channels.size, labels)
           end
@@ -595,7 +595,7 @@ module LavinMQ
         # Group TYPE, HELP and values together for each metric
         writer.write_header("detailed_channel_consumers", "gauge", "Consumers on a channel")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             conn.channels.each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_consumers", ch.details_tuple[:consumer_count], labels)
@@ -606,7 +606,7 @@ module LavinMQ
         writer.write_header("detailed_messages_unacked", "gauge",
           "Delivered but not yet acknowledged messages")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             conn.channels.each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_messages_unacked", ch.details_tuple[:messages_unacknowledged], labels)
@@ -617,7 +617,7 @@ module LavinMQ
         writer.write_header("detailed_channel_prefetch", "gauge",
           "Total limit of unacknowledged messages for all consumers on a channel")
         vhosts.each do |vhost|
-          vhost.connections.each do |conn|
+          vhost.connections_each do |conn|
             conn.channels.each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_prefetch", ch.details_tuple[:prefetch_count], labels)

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -359,9 +359,9 @@ module LavinMQ
           unacked += d[:messages_unacknowledged]
           connections += vhost.connections_size
           vhost.connections_each do |conn|
-            channels += conn.channels.size
-            conn.channels.each_value do |ch|
-              consumers += ch.consumers.size
+            channels += conn.channels_size
+            conn.channels_each_value do |ch|
+              consumers += ch.consumers_size
             end
           end
           queues += vhost.queues_size
@@ -586,7 +586,7 @@ module LavinMQ
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
             labels = {channel: conn.name}
-            writer.write_value("detailed_connection_channels", conn.channels.size, labels)
+            writer.write_value("detailed_connection_channels", conn.channels_size, labels)
           end
         end
       end
@@ -596,7 +596,7 @@ module LavinMQ
         writer.write_header("detailed_channel_consumers", "gauge", "Consumers on a channel")
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
-            conn.channels.each_value do |ch|
+            conn.channels_each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_consumers", ch.details_tuple[:consumer_count], labels)
             end
@@ -607,7 +607,7 @@ module LavinMQ
           "Delivered but not yet acknowledged messages")
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
-            conn.channels.each_value do |ch|
+            conn.channels_each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_messages_unacked", ch.details_tuple[:messages_unacknowledged], labels)
             end
@@ -618,7 +618,7 @@ module LavinMQ
           "Total limit of unacknowledged messages for all consumers on a channel")
         vhosts.each do |vhost|
           vhost.connections_each do |conn|
-            conn.channels.each_value do |ch|
+            conn.channels_each_value do |ch|
               labels = {channel: ch.name}
               writer.write_value("detailed_channel_prefetch", ch.details_tuple[:prefetch_count], labels)
             end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -542,7 +542,7 @@ module LavinMQ
         vhosts.each do |vhost|
           vhost.queues_each_value do |q|
             labels = {queue: q.name, vhost: vhost.name}
-            writer.write_value("detailed_queue_consumers", q.consumers.size, labels)
+            writer.write_value("detailed_queue_consumers", q.consumers_size, labels)
           end
         end
       end

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -29,14 +29,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/queues" do |context, _|
-          itr = Iterator(Queue).chain(vhosts(user(context)).map &.each_queue)
+          itr = vhosts(user(context)).flat_map &.queues_dup
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.each_queue)
+            page(context, vhost.queues_dup)
           end
         end
 

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -9,13 +9,13 @@ module LavinMQ
     module QueueHelpers
       private def find_queue(context, params, vhost, key = "name")
         name = params[key]
-        q = vhost.queues[name]?
+        q = vhost.queue?(name)
         not_found(context, "Not Found") unless q
         q
       end
 
       private def find_stream(context, vhost, name)
-        q = vhost.queues[name]?
+        q = vhost.queue?(name)
         not_found(context, "Not Found") unless q
         not_found(context, "Not Found") unless q.is_a?(LavinMQ::AMQP::Stream)
         q.as(LavinMQ::AMQP::Stream)
@@ -29,14 +29,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/queues" do |context, _|
-          itr = Iterator(Queue).chain(vhosts(user(context)).map &.queues.each_value)
+          itr = Iterator(Queue).chain(vhosts(user(context)).map &.queues_each_value)
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.queues.each_value)
+            page(context, vhost.queues_each_value)
           end
         end
 
@@ -74,7 +74,7 @@ module LavinMQ
             unless user.can_config?(vhost.name, name) && dlx_ok
               access_refused(context, "User doesn't have permissions to declare queue '#{name}'")
             end
-            q = vhost.queues[name]?
+            q = vhost.queue?(name)
             if q
               unless q.match?(durable, false, auto_delete, tbl)
                 bad_request(context, "Existing queue declared with other arguments arg")

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -29,14 +29,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/queues" do |context, _|
-          itr = Iterator(Queue).chain(vhosts(user(context)).map &.queues_each_value)
+          itr = Iterator(Queue).chain(vhosts(user(context)).map &.each_queue)
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.queues_each_value)
+            page(context, vhost.each_queue)
           end
         end
 

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -29,14 +29,14 @@ module LavinMQ
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/queues" do |context, _|
-          itr = vhosts(user(context)).flat_map &.queues_dup
+          itr = vhosts(user(context)).flat_map &.queues
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.queues_dup)
+            page(context, vhost.queues)
           end
         end
 

--- a/src/lavinmq/http/controller/shovels.cr
+++ b/src/lavinmq/http/controller/shovels.cr
@@ -8,15 +8,15 @@ module LavinMQ
 
       private def register_routes
         get "/api/shovels" do |context, _params|
-          itrs = vhosts(user(context)).flat_map do |v|
-            v.shovels.each_value
+          arr = vhosts(user(context)).flat_map do |v|
+            v.shovels.values_dup
           end
-          page(context, itrs)
+          page(context, arr)
         end
 
         get "/api/shovels/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
-            page(context, vhost.shovels.each_value)
+            page(context, vhost.shovels.values_dup)
           end
         end
 

--- a/src/lavinmq/http/controller/shovels.cr
+++ b/src/lavinmq/http/controller/shovels.cr
@@ -9,14 +9,14 @@ module LavinMQ
       private def register_routes
         get "/api/shovels" do |context, _params|
           arr = vhosts(user(context)).flat_map do |v|
-            v.shovels.values_dup
+            v.shovels.values
           end
           page(context, arr)
         end
 
         get "/api/shovels/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
-            page(context, vhost.shovels.values_dup)
+            page(context, vhost.shovels.values)
           end
         end
 

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -36,16 +36,16 @@ module LavinMQ
       private def register_routes # ameba:disable Metrics/CyclomaticComplexity
         get "/api/users" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          page(context, @amqp_server.users.each_value.reject(&.hidden?)
+          page(context, @amqp_server.users.values_dup.reject(&.hidden?)
             .map { |u| UserView.new(u) })
         end
 
         get "/api/users/without-permissions" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          itr = @amqp_server.users.each_value.reject(&.hidden?)
+          arr = @amqp_server.users.values_dup.reject(&.hidden?)
             .select(&.permissions.empty?)
             .map { |u| UserView.new(u) }
-          page(context, itr)
+          page(context, arr)
         end
 
         post "/api/users/bulk-delete" do |context, _params|

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -36,13 +36,13 @@ module LavinMQ
       private def register_routes # ameba:disable Metrics/CyclomaticComplexity
         get "/api/users" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          page(context, @amqp_server.users.values_dup.reject(&.hidden?)
+          page(context, @amqp_server.users.values.reject(&.hidden?)
             .map { |u| UserView.new(u) })
         end
 
         get "/api/users/without-permissions" do |context, _params|
           refuse_unless_administrator(context, user(context))
-          arr = @amqp_server.users.values_dup.reject(&.hidden?)
+          arr = @amqp_server.users.values.reject(&.hidden?)
             .select(&.permissions.empty?)
             .map { |u| UserView.new(u) }
           page(context, arr)

--- a/src/lavinmq/http/controller/vhost-limits.cr
+++ b/src/lavinmq/http/controller/vhost-limits.cr
@@ -6,8 +6,8 @@ module LavinMQ
     class VHostLimitsController < Controller
       private def register_routes
         get "/api/vhost-limits" do |context, _params|
-          vhosts = vhosts(user(context)).compact_map { |v| VHostLimitsView.new(v).self_if_limited }
-          page(context, vhosts)
+          arr = vhosts(user(context)).compact_map { |v| VHostLimitsView.new(v).self_if_limited }
+          page(context, arr)
         end
 
         get "/api/vhost-limits/:vhost" do |context, params|

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -19,8 +19,8 @@ module LavinMQ
     class VHostsController < Controller
       private def register_routes
         get "/api/vhosts" do |context, _params|
-          vhosts = vhosts(user(context)).map { |v| VHostView.new(v) }
-          page(context, vhosts)
+          arr = vhosts(user(context)).map { |v| VHostView.new(v) }
+          page(context, arr)
         end
 
         get "/api/vhosts/:name" do |context, params|

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -27,7 +27,7 @@ module LavinMQ
         @clients = Hash(String, Client).new
         @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @replicator)
         @exchange = MQTT::Exchange.new(@vhost, EXCHANGE, @retain_store)
-        @vhost.exchanges[EXCHANGE] = @exchange
+        @vhost.exchanges_unsafe_put(EXCHANGE, @exchange)
       end
 
       def session_present?(client_id : String, clean_session) : Bool

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -27,7 +27,7 @@ module LavinMQ
         @clients = Hash(String, Client).new
         @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @replicator)
         @exchange = MQTT::Exchange.new(@vhost, EXCHANGE, @retain_store)
-        @vhost.exchanges_unsafe_put(EXCHANGE, @exchange)
+        @vhost.register_exchange(@exchange)
       end
 
       def session_present?(client_id : String, clean_session) : Bool

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -14,7 +14,7 @@ module LavinMQ
       include Stats
       include SortableJSON
 
-      getter channels, log, name, user, client_id, socket, connection_info
+      getter log, name, user, client_id, socket, connection_info
       getter? clean_session
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
@@ -24,6 +24,23 @@ module LavinMQ
 
       def vhost
         @broker.vhost
+      end
+
+      # Stub channel accessors for polymorphic dispatch with AMQP::Client
+
+      def channels_size : Int32
+        0
+      end
+
+      def channels_each_value(& : LavinMQ::Client::Channel ->) : Nil
+      end
+
+      def channels_each_value : Iterator(LavinMQ::Client::Channel)
+        ([] of LavinMQ::Client::Channel).each
+      end
+
+      def channels_byid?(id : UInt16) : LavinMQ::Client::Channel?
+        nil
       end
 
       def initialize(@io : MQTT::IO,

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -35,8 +35,8 @@ module LavinMQ
       def each_channel(& : LavinMQ::Client::Channel ->) : Nil
       end
 
-      def each_channel : Iterator(LavinMQ::Client::Channel)
-        ([] of LavinMQ::Client::Channel).each
+      def channels_dup : Array(LavinMQ::Client::Channel)
+        [] of LavinMQ::Client::Channel
       end
 
       def channel?(id : UInt16) : LavinMQ::Client::Channel?

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -28,18 +28,18 @@ module LavinMQ
 
       # Stub channel accessors for polymorphic dispatch with AMQP::Client
 
-      def channels_size : Int32
+      def channel_count : Int32
         0
       end
 
-      def channels_each_value(& : LavinMQ::Client::Channel ->) : Nil
+      def each_channel(& : LavinMQ::Client::Channel ->) : Nil
       end
 
-      def channels_each_value : Iterator(LavinMQ::Client::Channel)
+      def each_channel : Iterator(LavinMQ::Client::Channel)
         ([] of LavinMQ::Client::Channel).each
       end
 
-      def channels_byid?(id : UInt16) : LavinMQ::Client::Channel?
+      def channel?(id : UInt16) : LavinMQ::Client::Channel?
         nil
       end
 

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -35,7 +35,7 @@ module LavinMQ
       def each_channel(& : LavinMQ::Client::Channel ->) : Nil
       end
 
-      def channels_dup : Array(LavinMQ::Client::Channel)
+      def channels : Array(LavinMQ::Client::Channel)
         [] of LavinMQ::Client::Channel
       end
 

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -67,9 +67,9 @@ module LavinMQ
         count
       end
 
-      def bindings_details : Iterator(BindingDetails)
-        @bindings.each.flat_map do |binding_key, ds|
-          ds.each.map do |d|
+      def bindings_details : Array(BindingDetails)
+        @bindings.flat_map do |binding_key, ds|
+          ds.map do |d|
             BindingDetails.new(name, vhost.name, binding_key.inner, d)
           end
         end

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -4,18 +4,15 @@ require "../vhost"
 module LavinMQ
   module MQTT
     class Sessions
-      @queues : Hash(String, Queue)
-
       def initialize(@vhost : VHost)
-        @queues = @vhost.queues
       end
 
       def []?(client_id : String) : Session?
-        @queues["mqtt.#{client_id}"]?.try &.as(Session)
+        @vhost.queue?("mqtt.#{client_id}").try &.as(Session)
       end
 
       def [](client_id : String) : Session
-        @queues["mqtt.#{client_id}"].as(Session)
+        @vhost.queue?("mqtt.#{client_id}").not_nil!.as(Session)
       end
 
       def declare(client : Client)

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -12,7 +12,7 @@ module LavinMQ
       end
 
       def [](client_id : String) : Session
-        @vhost.queue?("mqtt.#{client_id}").not_nil!.as(Session)
+        @vhost.queue("mqtt.#{client_id}").as(Session)
       end
 
       def declare(client : Client)

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -27,8 +27,8 @@ module LavinMQ
       @parameters.each_value { |p| yield p }
     end
 
-    def each_value : Iterator(T)
-      @parameters.each_value
+    def values_dup : Array(T)
+      @parameters.values
     end
 
     def has_key?(id) : Bool

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -15,7 +15,41 @@ module LavinMQ
       load!
     end
 
-    forward_missing_to @parameters
+    def []?(id) : T?
+      @parameters[id]?
+    end
+
+    def [](id) : T
+      @parameters[id]
+    end
+
+    def each_value(& : T ->) : Nil
+      @parameters.each_value { |p| yield p }
+    end
+
+    def each_value : Iterator(T)
+      @parameters.each_value
+    end
+
+    def has_key?(id) : Bool
+      @parameters.has_key?(id)
+    end
+
+    def size : Int32
+      @parameters.size
+    end
+
+    def values : Array(T)
+      @parameters.values
+    end
+
+    def empty? : Bool
+      @parameters.empty?
+    end
+
+    def any?(& : {ParameterId?, T} -> Bool) : Bool
+      @parameters.any? { |kv| yield kv }
+    end
 
     def create(parameter : T, save = true)
       @parameters[parameter.name] = parameter

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -27,10 +27,6 @@ module LavinMQ
       @parameters.each_value { |p| yield p }
     end
 
-    def values_dup : Array(T)
-      @parameters.values
-    end
-
     def has_key?(id) : Bool
       @parameters.has_key?(id)
     end

--- a/src/lavinmq/policy.cr
+++ b/src/lavinmq/policy.cr
@@ -103,11 +103,13 @@ module LavinMQ
       d1 = p1.definition
       d2 = p2.definition
       merged = Hash(String, JSON::Any).new
-      Iterator.chain({d1.each, d2.each}).each do |k, v|
-        if value = v.as_i64?
-          merged[k] = v unless merged[k]?.try(&.as_i64?.try { |i| i < value })
-        else
-          merged[k] = v
+      {d1, d2}.each do |d|
+        d.each do |k, v|
+          if value = v.as_i64?
+            merged[k] = v unless merged[k]?.try(&.as_i64?.try { |i| i < value })
+          else
+            merged[k] = v
+          end
         end
       end
       merged.select { |key, _| SUPPORTED_POLICIES.includes?(key) }

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -113,7 +113,7 @@ module LavinMQ
     end
 
     def connections : Array(Client)
-      @vhosts.values.flat_map(&.connections_dup)
+      @vhosts.values.flat_map(&.connections)
     end
 
     def listen(s : TCPServer, protocol : Protocol)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -112,8 +112,8 @@ module LavinMQ
       Fiber.yield
     end
 
-    def connections
-      Iterator(Client).chain(@vhosts.each_value.map(&.each_connection))
+    def connections : Array(Client)
+      @vhosts.values.flat_map(&.connections_dup)
     end
 
     def listen(s : TCPServer, protocol : Protocol)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -113,7 +113,7 @@ module LavinMQ
     end
 
     def connections
-      Iterator(Client).chain(@vhosts.each_value.map(&.connections_each))
+      Iterator(Client).chain(@vhosts.each_value.map(&.each_connection))
     end
 
     def listen(s : TCPServer, protocol : Protocol)
@@ -340,11 +340,11 @@ module LavinMQ
 
     def update_stats_rates
       @vhosts.each_value do |vhost|
-        vhost.queues_each_value(&.update_rates)
-        vhost.exchanges_each_value(&.update_rates)
-        vhost.connections_each do |connection|
+        vhost.each_queue(&.update_rates)
+        vhost.each_exchange(&.update_rates)
+        vhost.each_connection do |connection|
           connection.update_rates
-          connection.channels_each_value(&.update_rates)
+          connection.each_channel(&.update_rates)
         end
         vhost.update_rates
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -340,7 +340,7 @@ module LavinMQ
         vhost.exchanges_each_value(&.update_rates)
         vhost.connections_each do |connection|
           connection.update_rates
-          connection.channels.each_value(&.update_rates)
+          connection.channels_each_value(&.update_rates)
         end
         vhost.update_rates
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -29,12 +29,20 @@ module LavinMQ
     end
 
     getter vhosts, users, data_dir, parameters, authenticator
-    getter? flow
     include ParameterTarget
 
     @start = Time.instant
     @closed = BoolChannel.new(false)
     @flow = true
+
+    def closed? : Bool
+      @closed.value
+    end
+
+    def flow? : Bool
+      @flow
+    end
+
     @listeners = Hash(Socket::Server, Protocol).new # Socket => protocol
     @connection_factories = Hash(Protocol, ConnectionFactory).new
     @replicator : Clustering::Replicator?
@@ -56,10 +64,6 @@ module LavinMQ
       }
       apply_parameter
       spawn stats_loop, name: "Server#stats_loop"
-    end
-
-    def closed?
-      @closed.value
     end
 
     def followers

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -109,7 +109,7 @@ module LavinMQ
     end
 
     def connections
-      Iterator(Client).chain(@vhosts.each_value.map(&.connections.each))
+      Iterator(Client).chain(@vhosts.each_value.map(&.connections_each))
     end
 
     def listen(s : TCPServer, protocol : Protocol)
@@ -336,9 +336,9 @@ module LavinMQ
 
     def update_stats_rates
       @vhosts.each_value do |vhost|
-        vhost.queues.each_value(&.update_rates)
-        vhost.exchanges.each_value(&.update_rates)
-        vhost.connections.each do |connection|
+        vhost.queues_each_value(&.update_rates)
+        vhost.exchanges_each_value(&.update_rates)
+        vhost.connections_each do |connection|
           connection.update_rates
           connection.channels.each_value(&.update_rates)
         end

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -16,7 +16,33 @@ module LavinMQ
         @shovels = Hash(String, Shovel::Runner).new
       end
 
-      forward_missing_to @shovels
+      def []?(name : String) : Runner?
+        @shovels[name]?
+      end
+
+      def [](name : String) : Runner
+        @shovels[name]
+      end
+
+      def each_value(& : Runner ->) : Nil
+        @shovels.each_value { |r| yield r }
+      end
+
+      def each_value : Iterator(Runner)
+        @shovels.each_value
+      end
+
+      def size : Int32
+        @shovels.size
+      end
+
+      def empty? : Bool
+        @shovels.empty?
+      end
+
+      def has_key?(name : String) : Bool
+        @shovels.has_key?(name)
+      end
 
       # ameba:disable Metrics/CyclomaticComplexity
       def self.validate_config!(config : JSON::Any, user : Auth::BaseUser?)

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -28,8 +28,8 @@ module LavinMQ
         @shovels.each_value { |r| yield r }
       end
 
-      def each_value : Iterator(Runner)
-        @shovels.each_value
+      def values_dup : Array(Runner)
+        @shovels.values
       end
 
       def size : Int32

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -28,7 +28,7 @@ module LavinMQ
         @shovels.each_value { |r| yield r }
       end
 
-      def values_dup : Array(Runner)
+      def values : Array(Runner)
         @shovels.values
       end
 

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -65,11 +65,11 @@ module LavinMQ
       @exchanges.has_key?(name)
     end
 
-    def exchanges_each_value(& : Exchange ->) : Nil
+    def each_exchange(& : Exchange ->) : Nil
       @exchanges.each_value { |v| yield v }
     end
 
-    def exchanges_each_value : Iterator(Exchange)
+    def each_exchange : Iterator(Exchange)
       @exchanges.each_value
     end
 
@@ -99,11 +99,11 @@ module LavinMQ
       @queues.has_key?(name)
     end
 
-    def queues_each_value(& : Queue ->) : Nil
+    def each_queue(& : Queue ->) : Nil
       @queues.each_value { |v| yield v }
     end
 
-    def queues_each_value : Iterator(Queue)
+    def each_queue : Iterator(Queue)
       @queues.each_value
     end
 
@@ -125,11 +125,11 @@ module LavinMQ
 
     # Connection accessors
 
-    def connections_each(& : Client ->) : Nil
+    def each_connection(& : Client ->) : Nil
       @connections.each { |c| yield c }
     end
 
-    def connections_each : Iterator(Client)
+    def each_connection : Iterator(Client)
       @connections.each
     end
 
@@ -188,8 +188,8 @@ module LavinMQ
         when closed.when_true.receive?
           return
         end
-        connections_each do |c|
-          c.channels_each_value do |ch|
+        each_connection do |c|
+          c.each_channel do |ch|
             ch.check_consumer_timeout
           end
         end
@@ -266,7 +266,7 @@ module LavinMQ
     def message_details
       ready = unacked = 0_u64
       ack = confirm = deliver = deliver_no_ack = get = get_no_ack = publish = redeliver = return_unroutable = deliver_get = 0_u64
-      queues_each_value do |q|
+      each_queue do |q|
         ready += q.message_count
         unacked += q.unacked_count
         ack += q.ack_count
@@ -417,7 +417,7 @@ module LavinMQ
 
     def queue_bindings(queue : Queue) : Iterator(BindingDetails)
       default_binding = BindingDetails.new("", name, BindingKey.new(queue.name), queue)
-      bindings = exchanges_each_value.flat_map do |ex|
+      bindings = each_exchange.flat_map do |ex|
         ex.bindings_details.select { |binding| binding.destination == queue }
       end
       {default_binding}.each.chain(bindings)
@@ -546,10 +546,10 @@ module LavinMQ
       end
       close_done.close
       # then force close the remaining (close tcp socket)
-      connections_each &.force_close
+      each_connection &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
-      queues_each_value &.close
-      exchanges_each_value &.close
+      each_queue &.close
+      each_exchange &.close
       Fiber.yield
       @definitions_file.close
       FileUtils.rm_rf File.join(@data_dir, "transient")
@@ -565,7 +565,7 @@ module LavinMQ
       resources = if resources
                     resources.each
                   else
-                    Iterator.chain({queues_each_value, exchanges_each_value})
+                    Iterator.chain({each_queue, each_exchange})
                   end
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -69,8 +69,8 @@ module LavinMQ
       @exchanges.each_value { |v| yield v }
     end
 
-    def each_exchange : Iterator(Exchange)
-      @exchanges.each_value
+    def exchanges_dup : Array(Exchange)
+      @exchanges.values
     end
 
     def exchanges_size : Int32
@@ -103,8 +103,8 @@ module LavinMQ
       @queues.each_value { |v| yield v }
     end
 
-    def each_queue : Iterator(Queue)
-      @queues.each_value
+    def queues_dup : Array(Queue)
+      @queues.values
     end
 
     def queues_size : Int32
@@ -129,8 +129,8 @@ module LavinMQ
       @connections.each { |c| yield c }
     end
 
-    def each_connection : Iterator(Client)
-      @connections.each
+    def connections_dup : Array(Client)
+      @connections.dup
     end
 
     def connections_size : Int32
@@ -415,12 +415,12 @@ module LavinMQ
       end
     end
 
-    def queue_bindings(queue : Queue) : Iterator(BindingDetails)
+    def queue_bindings(queue : Queue) : Array(BindingDetails)
       default_binding = BindingDetails.new("", name, BindingKey.new(queue.name), queue)
-      bindings = each_exchange.flat_map do |ex|
+      bindings = exchanges_dup.flat_map do |ex|
         ex.bindings_details.select { |binding| binding.destination == queue }
       end
-      {default_binding}.each.chain(bindings)
+      [default_binding] + bindings
     end
 
     def add_operator_policy(name : String, pattern : String, apply_to : String,
@@ -562,11 +562,7 @@ module LavinMQ
     end
 
     private def apply_policies(resources : Array(Queue | Exchange) | Nil = nil)
-      resources = if resources
-                    resources.each
-                  else
-                    Iterator.chain({each_queue, each_exchange})
-                  end
+      resources ||= (queues_dup.map(&.as(Queue | Exchange)) + exchanges_dup.map(&.as(Queue | Exchange)))
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse
       resources.each do |resource|

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -53,10 +53,6 @@ module LavinMQ
       @closed.value
     end
 
-    def definitions : DefinitionsStore
-      @definitions.not_nil!
-    end
-
     # Exchange accessors
 
     def exchange?(name : String) : Exchange?
@@ -75,8 +71,8 @@ module LavinMQ
       definitions.each_exchange { |v| yield v }
     end
 
-    def exchanges_dup : Array(Exchange)
-      definitions.exchanges_dup
+    def exchanges : Array(Exchange)
+      definitions.exchanges
     end
 
     def exchanges_size : Int32
@@ -87,8 +83,8 @@ module LavinMQ
       definitions.exchanges_any? { |kv| yield kv }
     end
 
-    def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
-      definitions.exchanges_unsafe_put(name, exchange)
+    def register_exchange(exchange : Exchange) : Nil
+      definitions.register_exchange(exchange)
     end
 
     # Queue accessors
@@ -109,20 +105,16 @@ module LavinMQ
       definitions.each_queue { |v| yield v }
     end
 
-    def queues_dup : Array(Queue)
-      definitions.queues_dup
+    def queues : Array(Queue)
+      definitions.queues
     end
 
     def queues_size : Int32
       definitions.queues_size
     end
 
-    def queues_values : Array(Queue)
-      definitions.queues_values
-    end
-
-    def queues_unsafe_put(name : String, queue : Queue) : Nil
-      definitions.queues_unsafe_put(name, queue)
+    def register_queue(queue : Queue) : Nil
+      definitions.register_queue(queue)
     end
 
     def queues_clear : Nil
@@ -135,8 +127,8 @@ module LavinMQ
       @connections.each { |c| yield c }
     end
 
-    def connections_dup : Array(Client)
-      @connections.dup
+    def connections : Array(Client)
+      @connections.to_a
     end
 
     def connections_size : Int32
@@ -464,7 +456,7 @@ module LavinMQ
     end
 
     def apply_policies(resources : Array(Queue | Exchange) | Nil = nil)
-      resources ||= (queues_dup.map(&.as(Queue | Exchange)) + exchanges_dup.map(&.as(Queue | Exchange)))
+      resources ||= (queues.map(&.as(Queue | Exchange)) + exchanges.map(&.as(Queue | Exchange)))
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse
       resources.each do |resource|
@@ -555,6 +547,10 @@ module LavinMQ
 
     def sync : Nil
       definitions.sync
+    end
+
+    private def definitions : DefinitionsStore
+      @definitions.not_nil!
     end
   end
 end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -25,24 +25,136 @@ module LavinMQ
                 "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
                 "redeliver", "reject", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
 
-    getter name, exchanges, queues, data_dir, operator_policies, policies, parameters, shovels,
-      direct_reply_consumers, connections, dir, users
-    property? flow = true
+    getter name, data_dir, operator_policies, policies, parameters, shovels, dir, users
     getter closed = BoolChannel.new(true)
-
-    def closed?
-      @closed.value
-    end
-
     property max_connections : Int32?
     property max_queues : Int32?
 
+    @flow = true
     @exchanges = Hash(String, Exchange).new
     @queues = Hash(String, Queue).new
     @direct_reply_consumers = Hash(String, Client::Channel).new
     @shovels : Shovel::Store?
     @upstreams : Federation::UpstreamStore?
     @connections = Array(Client).new(512)
+
+    # Bool accessors (later become Atomic)
+    def flow? : Bool
+      @flow
+    end
+
+    def flow=(active : Bool)
+      @flow = active
+    end
+
+    def closed? : Bool
+      @closed.value
+    end
+
+    # Exchange accessors
+
+    def exchange?(name : String) : Exchange?
+      @exchanges[name]?
+    end
+
+    def exchange(name : String) : Exchange
+      @exchanges[name]
+    end
+
+    def exchange_exists?(name : String) : Bool
+      @exchanges.has_key?(name)
+    end
+
+    def exchanges_each_value(& : Exchange ->) : Nil
+      @exchanges.each_value { |v| yield v }
+    end
+
+    def exchanges_each_value : Iterator(Exchange)
+      @exchanges.each_value
+    end
+
+    def exchanges_size : Int32
+      @exchanges.size
+    end
+
+    def exchanges_any?(& : {String, Exchange} -> Bool) : Bool
+      @exchanges.any? { |kv| yield kv }
+    end
+
+    protected def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
+      @exchanges[name] = exchange
+    end
+
+    # Queue accessors
+
+    def queue?(name : String) : Queue?
+      @queues[name]?
+    end
+
+    def queue(name : String) : Queue
+      @queues[name]
+    end
+
+    def queue_exists?(name : String) : Bool
+      @queues.has_key?(name)
+    end
+
+    def queues_each_value(& : Queue ->) : Nil
+      @queues.each_value { |v| yield v }
+    end
+
+    def queues_each_value : Iterator(Queue)
+      @queues.each_value
+    end
+
+    def queues_size : Int32
+      @queues.size
+    end
+
+    def queues_values : Array(Queue)
+      @queues.values
+    end
+
+    protected def queues_unsafe_put(name : String, queue : Queue) : Nil
+      @queues[name] = queue
+    end
+
+    protected def queues_clear : Nil
+      @queues.clear
+    end
+
+    # Connection accessors
+
+    def connections_each(& : Client ->) : Nil
+      @connections.each { |c| yield c }
+    end
+
+    def connections_each : Iterator(Client)
+      @connections.each
+    end
+
+    def connections_size : Int32
+      @connections.size
+    end
+
+    # Direct reply consumer accessors
+
+    def direct_reply_consumer?(consumer_tag : String) : Client::Channel?
+      @direct_reply_consumers[consumer_tag]?
+    end
+
+    def direct_reply_consumer_set(consumer_tag : String, channel : Client::Channel) : Nil
+      @direct_reply_consumers[consumer_tag] = channel
+    end
+
+    def direct_reply_consumer_delete(consumer_tag : String) : Client::Channel?
+      @direct_reply_consumers.delete(consumer_tag)
+    end
+
+    def direct_reply_consumer_has_key?(consumer_tag : String) : Bool
+      @direct_reply_consumers.has_key?(consumer_tag)
+    end
+
     @definitions_file : File
     @definitions_lock = Mutex.new(:reentrant)
     @definitions_file_path : String
@@ -76,7 +188,7 @@ module LavinMQ
         when closed.when_true.receive?
           return
         end
-        @connections.each do |c|
+        connections_each do |c|
           c.channels.each_value do |ch|
             ch.check_consumer_timeout
           end
@@ -133,7 +245,7 @@ module LavinMQ
     # When this method finishes, the position will be the same, start of the body
     def publish(msg : Message, immediate = false,
                 visited = Set(LavinMQ::Exchange).new, found_queues = Set(LavinMQ::Queue).new) : Bool
-      ex = @exchanges[msg.exchange_name]? || return false
+      ex = exchange?(msg.exchange_name) || return false
       ex.publish(msg, immediate, found_queues, visited)
     ensure
       visited.clear
@@ -154,7 +266,7 @@ module LavinMQ
     def message_details
       ready = unacked = 0_u64
       ack = confirm = deliver = deliver_no_ack = get = get_no_ack = publish = redeliver = return_unroutable = deliver_get = 0_u64
-      @queues.each_value do |q|
+      queues_each_value do |q|
         ready += q.message_count
         unacked += q.unacked_count
         ack += q.ack_count
@@ -305,7 +417,7 @@ module LavinMQ
 
     def queue_bindings(queue : Queue) : Iterator(BindingDetails)
       default_binding = BindingDetails.new("", name, BindingKey.new(queue.name), queue)
-      bindings = @exchanges.each_value.flat_map do |ex|
+      bindings = exchanges_each_value.flat_map do |ex|
         ex.bindings_details.select { |binding| binding.destination == queue }
       end
       {default_binding}.each.chain(bindings)
@@ -430,14 +542,14 @@ module LavinMQ
       when close_done.receive?
         @log.info { "All connections closed gracefully" }
       when timeout 15.seconds
-        @log.warn { "Timeout waiting for connections to close. #{@connections.size} left that will be forced closed." }
+        @log.warn { "Timeout waiting for connections to close. #{connections_size} left that will be forced closed." }
       end
       close_done.close
       # then force close the remaining (close tcp socket)
-      @connections.each &.force_close
+      connections_each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
-      @queues.each_value &.close
-      @exchanges.each_value &.close
+      queues_each_value &.close
+      exchanges_each_value &.close
       Fiber.yield
       @definitions_file.close
       FileUtils.rm_rf File.join(@data_dir, "transient")
@@ -453,7 +565,7 @@ module LavinMQ
       resources = if resources
                     resources.each
                   else
-                    Iterator.chain({@queues.each_value, @exchanges.each_value})
+                    Iterator.chain({queues_each_value, exchanges_each_value})
                   end
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -16,6 +16,7 @@ require "./stats"
 require "./queue_factory"
 require "./mqtt/session"
 require "./connection_store"
+require "./direct_reply_consumer_store"
 
 module LavinMQ
   class VHost
@@ -34,7 +35,7 @@ module LavinMQ
     @flow = true
     @exchanges = Hash(String, Exchange).new
     @queues = Hash(String, Queue).new
-    @direct_reply_consumers = Hash(String, Client::Channel).new
+    @direct_reply_consumers = DirectReplyConsumerStore.new
     @shovels : Shovel::Store?
     @upstreams : Federation::UpstreamStore?
     @connections = ConnectionStore.new

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -189,7 +189,7 @@ module LavinMQ
           return
         end
         connections_each do |c|
-          c.channels.each_value do |ch|
+          c.channels_each_value do |ch|
             ch.check_consumer_timeout
           end
         end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -17,6 +17,7 @@ require "./queue_factory"
 require "./mqtt/session"
 require "./connection_store"
 require "./direct_reply_consumer_store"
+require "./definitions_store"
 
 module LavinMQ
   class VHost
@@ -33,9 +34,8 @@ module LavinMQ
     property max_queues : Int32?
 
     @flow = true
-    @exchanges = Hash(String, Exchange).new
-    @queues = Hash(String, Queue).new
     @direct_reply_consumers = DirectReplyConsumerStore.new
+    @definitions : DefinitionsStore?
     @shovels : Shovel::Store?
     @upstreams : Federation::UpstreamStore?
     @connections = ConnectionStore.new
@@ -53,76 +53,80 @@ module LavinMQ
       @closed.value
     end
 
+    def definitions : DefinitionsStore
+      @definitions.not_nil!
+    end
+
     # Exchange accessors
 
     def exchange?(name : String) : Exchange?
-      @exchanges[name]?
+      definitions.exchange?(name)
     end
 
     def exchange(name : String) : Exchange
-      @exchanges[name]
+      definitions.exchange(name)
     end
 
     def exchange_exists?(name : String) : Bool
-      @exchanges.has_key?(name)
+      definitions.exchange_exists?(name)
     end
 
     def each_exchange(& : Exchange ->) : Nil
-      @exchanges.each_value { |v| yield v }
+      definitions.each_exchange { |v| yield v }
     end
 
     def exchanges_dup : Array(Exchange)
-      @exchanges.values
+      definitions.exchanges_dup
     end
 
     def exchanges_size : Int32
-      @exchanges.size
+      definitions.exchanges_size
     end
 
     def exchanges_any?(& : {String, Exchange} -> Bool) : Bool
-      @exchanges.any? { |kv| yield kv }
+      definitions.exchanges_any? { |kv| yield kv }
     end
 
-    protected def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
-      @exchanges[name] = exchange
+    def exchanges_unsafe_put(name : String, exchange : Exchange) : Nil
+      definitions.exchanges_unsafe_put(name, exchange)
     end
 
     # Queue accessors
 
     def queue?(name : String) : Queue?
-      @queues[name]?
+      definitions.queue?(name)
     end
 
     def queue(name : String) : Queue
-      @queues[name]
+      definitions.queue(name)
     end
 
     def queue_exists?(name : String) : Bool
-      @queues.has_key?(name)
+      definitions.queue_exists?(name)
     end
 
     def each_queue(& : Queue ->) : Nil
-      @queues.each_value { |v| yield v }
+      definitions.each_queue { |v| yield v }
     end
 
     def queues_dup : Array(Queue)
-      @queues.values
+      definitions.queues_dup
     end
 
     def queues_size : Int32
-      @queues.size
+      definitions.queues_size
     end
 
     def queues_values : Array(Queue)
-      @queues.values
+      definitions.queues_values
     end
 
-    protected def queues_unsafe_put(name : String, queue : Queue) : Nil
-      @queues[name] = queue
+    def queues_unsafe_put(name : String, queue : Queue) : Nil
+      definitions.queues_unsafe_put(name, queue)
     end
 
-    protected def queues_clear : Nil
-      @queues.clear
+    def queues_clear : Nil
+      definitions.queues_clear
     end
 
     # Connection accessors
@@ -167,10 +171,6 @@ module LavinMQ
       @direct_reply_consumers.has_key?(consumer_tag)
     end
 
-    @definitions_file : File
-    @definitions_lock = Mutex.new(:reentrant)
-    @definitions_file_path : String
-    @definitions_deletes = 0
     Log = LavinMQ::Log.for "vhost"
 
     def initialize(@name : String, @server_data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @description = "", @tags = Array(String).new(0))
@@ -179,9 +179,6 @@ module LavinMQ
       @data_dir = File.join(@server_data_dir, @dir)
       Dir.mkdir_p File.join(@data_dir)
       FileUtils.rm_rf File.join(@data_dir, "transient")
-      @definitions_file_path = File.join(@data_dir, "definitions.amqp")
-      @definitions_file = File.open(@definitions_file_path, "a+")
-      @replicator.try &.register_file(@definitions_file)
       File.write(File.join(@data_dir, ".vhost"), @name)
       load_limits
       @operator_policies = ParameterStore(OperatorPolicy).new(@data_dir, "operator_policies.json", @replicator, vhost: @name)
@@ -189,6 +186,7 @@ module LavinMQ
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator, vhost: @name)
       @shovels = Shovel::Store.new(self)
       @upstreams = Federation::UpstreamStore.new(self)
+      @definitions = DefinitionsStore.new(self, @data_dir, @replicator, @log)
       load!
       spawn check_consumer_timeouts_loop, name: "Consumer timeouts loop"
     end
@@ -354,85 +352,12 @@ module LavinMQ
         routing_key, false, arguments)
     end
 
-    # ameba:disable Metrics/CyclomaticComplexity
     def apply(f, loading = false) : Bool
-      @definitions_lock.synchronize do
-        case f
-        when AMQP::Frame::Exchange::Declare
-          return false if @exchanges.has_key? f.exchange_name
-          e = @exchanges[f.exchange_name] =
-            make_exchange(self, f.exchange_name, f.exchange_type, f.durable, f.auto_delete, f.internal, f.arguments)
-          apply_policies([e] of Exchange) unless loading
-          store_definition(f) if !loading && f.durable
-        when AMQP::Frame::Exchange::Delete
-          if x = @exchanges.delete f.exchange_name
-            unless closed?
-              @exchanges.each_value do |ex|
-                ex.bindings_details.each do |binding|
-                  next unless binding.destination == x
-                  ex.unbind(x, binding.routing_key, binding.arguments)
-                end
-              end
-            end
-            x.delete
-            store_definition(f, dirty: true) if !loading && x.durable?
-          else
-            return false
-          end
-        when AMQP::Frame::Exchange::Bind
-          src = @exchanges[f.source]? || return false
-          dst = @exchanges[f.destination]? || return false
-          return false unless src.bind(dst, f.routing_key, f.arguments)
-          store_definition(f) if !loading && src.durable? && dst.durable?
-        when AMQP::Frame::Exchange::Unbind
-          src = @exchanges[f.source]? || return false
-          dst = @exchanges[f.destination]? || return false
-          return false unless src.unbind(dst, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && src.durable? && dst.durable?
-        when AMQP::Frame::Queue::Declare
-          return false if @queues.has_key? f.queue_name
-          q = @queues[f.queue_name] = QueueFactory.make(self, f)
-          apply_policies([q] of Queue) unless loading
-          store_definition(f) if !loading && f.durable && !f.exclusive
-          event_tick(EventType::QueueDeclared) unless loading
-        when AMQP::Frame::Queue::Delete
-          if q = @queues.delete(f.queue_name)
-            unless closed?
-              @exchanges.each_value do |ex|
-                ex.bindings_details.each do |binding|
-                  next unless binding.destination == q
-                  ex.unbind(q, binding.routing_key, binding.arguments)
-                end
-              end
-            end
-            store_definition(f, dirty: true) if !loading && q.durable? && !q.exclusive?
-            event_tick(EventType::QueueDeleted) unless loading
-            q.delete
-          else
-            return false
-          end
-        when AMQP::Frame::Queue::Bind
-          x = @exchanges[f.exchange_name]? || return false
-          q = @queues[f.queue_name]? || return false
-          return false unless x.bind(q, f.routing_key, f.arguments)
-          store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
-        when AMQP::Frame::Queue::Unbind
-          x = @exchanges[f.exchange_name]? || return false
-          q = @queues[f.queue_name]? || return false
-          return false unless x.unbind(q, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
-        else raise "Cannot apply frame #{f.class} in vhost #{@name}"
-        end
-        true
-      end
+      definitions.apply(f, loading)
     end
 
     def queue_bindings(queue : Queue) : Array(BindingDetails)
-      default_binding = BindingDetails.new("", name, BindingKey.new(queue.name), queue)
-      bindings = exchanges_dup.flat_map do |ex|
-        ex.bindings_details.select { |binding| binding.destination == queue }
-      end
-      [default_binding] + bindings
+      definitions.queue_bindings(queue)
     end
 
     def add_operator_policy(name : String, pattern : String, apply_to : String,
@@ -528,7 +453,7 @@ module LavinMQ
       each_queue &.close
       each_exchange &.close
       Fiber.yield
-      @definitions_file.close
+      definitions.close
       FileUtils.rm_rf File.join(@data_dir, "transient")
     end
 
@@ -538,7 +463,7 @@ module LavinMQ
       FileUtils.rm_rf @data_dir
     end
 
-    private def apply_policies(resources : Array(Queue | Exchange) | Nil = nil)
+    def apply_policies(resources : Array(Queue | Exchange) | Nil = nil)
       resources ||= (queues_dup.map(&.as(Queue | Exchange)) + exchanges_dup.map(&.as(Queue | Exchange)))
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse
@@ -567,7 +492,7 @@ module LavinMQ
     end
 
     private def load!
-      load_definitions!
+      definitions.load!
       has_parameters = !@parameters.empty?
       has_policies = !@policies.empty? || !@operator_policies.empty?
       if has_parameters || has_policies
@@ -580,179 +505,6 @@ module LavinMQ
       end
       closed.set(false)
       Fiber.yield
-    end
-
-    # ameba:disable Metrics/CyclomaticComplexity
-    private def load_definitions!
-      exchanges = Hash(String, AMQP::Frame::Exchange::Declare).new
-      queues = Hash(String, AMQP::Frame::Queue::Declare).new
-      queue_bindings = Hash(String, Array(AMQP::Frame::Queue::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Queue::Bind).new }
-      exchange_bindings = Hash(String, Array(AMQP::Frame::Exchange::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Exchange::Bind).new }
-      should_compact = false
-      io = @definitions_file
-      if io.size.zero?
-        load_default_definitions
-        compact!
-        return
-      end
-
-      @log.info { "Loading definitions" }
-      @definitions_lock.synchronize do
-        @log.debug { "Verifying schema" }
-        SchemaVersion.verify(io, :definition)
-        stream = AMQ::Protocol::Stream.new(io, format: IO::ByteFormat::SystemEndian)
-        loop do
-          f = stream.next_frame
-          @log.trace { "Reading frame #{f.inspect}" }
-          case f
-          when AMQP::Frame::Exchange::Declare
-            exchanges[f.exchange_name] = f
-          when AMQP::Frame::Exchange::Delete
-            exchanges.delete f.exchange_name
-            exchange_bindings.delete f.exchange_name
-            should_compact = true
-          when AMQP::Frame::Exchange::Bind
-            exchange_bindings[f.destination] << f
-          when AMQP::Frame::Exchange::Unbind
-            exchange_bindings[f.destination].reject! do |b|
-              b.source == f.source &&
-                b.routing_key == f.routing_key &&
-                b.arguments == f.arguments
-            end
-            should_compact = true
-          when AMQP::Frame::Queue::Declare
-            queues[f.queue_name] = f
-          when AMQP::Frame::Queue::Delete
-            queues.delete f.queue_name
-            queue_bindings.delete f.queue_name
-            should_compact = true
-          when AMQP::Frame::Queue::Bind
-            queue_bindings[f.queue_name] << f
-          when AMQP::Frame::Queue::Unbind
-            queue_bindings[f.queue_name].reject! do |b|
-              b.exchange_name == f.exchange_name &&
-                b.routing_key == f.routing_key &&
-                b.arguments == f.arguments
-            end
-            should_compact = true
-          else
-            raise "Cannot apply frame #{f.class} in vhost #{@name}"
-          end
-        rescue ex : IO::EOFError
-          break
-        end # loop
-      end   # synchronize
-
-      # apply definitions
-      @log.info { "Applying #{exchanges.size} exchanges" }
-      exchanges.each_value &->self.load_apply(AMQP::Frame)
-      @log.info { "Applying #{queues.size} queues" }
-      queues.each_value &->self.load_apply(AMQP::Frame)
-      @log.info { "Applying #{exchange_bindings.each_value.sum(0, &.size)} exchange bindings" }
-      exchange_bindings.each_value &.each(&->self.load_apply(AMQP::Frame))
-      @log.info { "Applying #{queue_bindings.each_value.sum(0, &.size)} queue bindings" }
-      queue_bindings.each_value &.each(&->self.load_apply(AMQP::Frame))
-
-      @log.info { "Definitions loaded" }
-      compact! if should_compact
-    end
-
-    protected def load_apply(frame : AMQP::Frame)
-      apply frame, loading: true
-    rescue ex : LavinMQ::Error
-      @log.error(exception: ex) { "Failed to apply frame #{frame.inspect}" }
-    end
-
-    private def load_default_definitions
-      @log.info { "Loading default definitions" }
-      @exchanges[""] = AMQP::DefaultExchange.new(self, "", true, false, false)
-      @exchanges["amq.direct"] = AMQP::DirectExchange.new(self, "amq.direct", true, false, false)
-      @exchanges["amq.fanout"] = AMQP::FanoutExchange.new(self, "amq.fanout", true, false, false)
-      @exchanges["amq.topic"] = AMQP::TopicExchange.new(self, "amq.topic", true, false, false)
-      @exchanges["amq.headers"] = AMQP::HeadersExchange.new(self, "amq.headers", true, false, false)
-      @exchanges["amq.match"] = AMQP::HeadersExchange.new(self, "amq.match", true, false, false)
-    end
-
-    private def compact!
-      @definitions_lock.synchronize do
-        @log.info { "Compacting definitions" }
-        io = File.open("#{@definitions_file_path}.tmp", "a+")
-        SchemaVersion.prefix(io, :definition)
-        @exchanges.each_value.select(&.durable?).each do |e|
-          f = AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, e.name, e.type,
-            false, e.durable?, e.auto_delete?, e.internal?,
-            false, e.arguments)
-          io.write_bytes f
-        end
-        @queues.each_value.select(&.durable?).each do |q|
-          f = AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, q.name, false, q.durable?, q.exclusive?,
-            q.auto_delete?, false, q.arguments)
-          io.write_bytes f
-        end
-        @exchanges.each_value.select(&.durable?).each do |e|
-          e.bindings_details.each do |binding|
-            args = binding.arguments || AMQP::Table.new
-            frame = case binding.destination
-                    when Queue
-                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
-                    when Exchange
-                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
-                    end
-            if f = frame
-              io.write_bytes f
-            end
-          end
-        end
-        io.fsync
-        File.rename io.path, @definitions_file_path
-        @replicator.try &.replace_file @definitions_file_path
-        @definitions_file.close
-        @definitions_file = io
-      end
-    end
-
-    private def store_definition(frame, dirty = false)
-      @log.debug { "Storing definition: #{frame.inspect}" }
-      bytes = frame.to_slice
-      @definitions_file.write bytes
-      @replicator.try &.append @definitions_file_path, bytes
-      @definitions_file.fsync
-      if dirty
-        if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions
-          compact!
-          @definitions_deletes = 0
-        end
-      end
-    end
-
-    private def make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)
-      case type
-      when "direct"
-        if name.empty?
-          AMQP::DefaultExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-        else
-          AMQP::DirectExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-        end
-      when "fanout"
-        AMQP::FanoutExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      when "topic"
-        AMQP::TopicExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      when "headers"
-        AMQP::HeadersExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      when "x-delayed-message", "x-delayed-exchange"
-        arguments = arguments.clone
-        type = arguments.delete("x-delayed-type")
-        raise Error::ExchangeTypeError.new("Missing required argument 'x-delayed-type'") unless type
-        arguments["x-delayed-exchange"] = true
-        make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)
-      when "x-federation-upstream"
-        AMQP::FederationExchange.new(vhost, name, arguments)
-      when "x-consistent-hash"
-        AMQP::ConsistentHashExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      else raise Error::ExchangeTypeError.new("unknown exchange type '#{type}'")
-      end
     end
 
     def upstreams
@@ -802,12 +554,7 @@ module LavinMQ
     end
 
     def sync : Nil
-      {% if flag?(:linux) %}
-        ret = LibC.syncfs(@definitions_file.fd)
-        raise IO::Error.from_errno("syncfs") if ret != 0
-      {% else %}
-        LibC.sync
-      {% end %}
+      definitions.sync
     end
   end
 end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -15,6 +15,7 @@ require "./event_type"
 require "./stats"
 require "./queue_factory"
 require "./mqtt/session"
+require "./connection_store"
 
 module LavinMQ
   class VHost
@@ -36,7 +37,7 @@ module LavinMQ
     @direct_reply_consumers = Hash(String, Client::Channel).new
     @shovels : Shovel::Store?
     @upstreams : Federation::UpstreamStore?
-    @connections = Array(Client).new(512)
+    @connections = ConnectionStore.new
 
     # Bool accessors (later become Atomic)
     def flow? : Bool
@@ -135,6 +136,16 @@ module LavinMQ
 
     def connections_size : Int32
       @connections.size
+    end
+
+    def add_connection(client : Client)
+      event_tick(EventType::ConnectionCreated)
+      @connections.add client
+    end
+
+    def rm_connection(client : Client)
+      event_tick(EventType::ConnectionClosed)
+      @connections.delete client
     end
 
     # Direct reply consumer accessors
@@ -455,16 +466,6 @@ module LavinMQ
       @log.info { "Policy=#{name} Deleted" }
     end
 
-    def add_connection(client : Client)
-      event_tick(EventType::ConnectionCreated)
-      @connections << client
-    end
-
-    def rm_connection(client : Client)
-      event_tick(EventType::ConnectionClosed)
-      @connections.delete client
-    end
-
     SHOVEL                  = "shovel"
     FEDERATION_UPSTREAM     = "federation-upstream"
     FEDERATION_UPSTREAM_SET = "federation-upstream-set"
@@ -499,31 +500,6 @@ module LavinMQ
       upstreams.stop_all
     end
 
-    private def close_connections(reason)
-      WaitGroup.wait do |wg|
-        to_close = Channel(Client).new
-        fiber_count = 0
-        @connections.each do |client|
-          select
-          when to_close.send client
-          else # spawn another fiber closing channels
-            fiber_id = fiber_count &+= 1
-            @log.trace { "spawning close conn fiber #{fiber_id} " }
-            client_inner = client
-            wg.spawn do
-              client_inner.close(reason)
-              while client_to_close = to_close.receive?
-                client_to_close.close(reason)
-              end
-              @log.trace { "exiting close conn fiber #{fiber_id} " }
-            end
-            Fiber.yield
-          end
-        end
-        to_close.close
-      end
-    end
-
     def close(reason = "Broker shutdown")
       return if @closed.swap(true)
       stop_shovels
@@ -533,7 +509,7 @@ module LavinMQ
       close_done = Channel(Nil).new
 
       spawn do
-        close_connections reason
+        @connections.close_all(reason, @log)
         @log.debug { "Close sent to all connections" }
         close_done.close
       end

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -47,6 +47,10 @@ module LavinMQ
       @vhosts.first_value
     end
 
+    def first_value? : VHost?
+      @vhosts.first_value?
+    end
+
     def each(&)
       @vhosts.each do |kv|
         yield kv

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -31,8 +31,8 @@ module LavinMQ
       @vhosts.each_value { |v| yield v }
     end
 
-    def each_value : Iterator(VHost)
-      @vhosts.each_value
+    def values_dup : Array(VHost)
+      @vhosts.values
     end
 
     def has_key?(name : String) : Bool

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -19,7 +19,37 @@ module LavinMQ
       @vhosts = Hash(String, VHost).new
     end
 
-    forward_missing_to @vhosts
+    def []?(name : String) : VHost?
+      @vhosts[name]?
+    end
+
+    def [](name : String) : VHost
+      @vhosts[name]
+    end
+
+    def each_value(& : VHost ->) : Nil
+      @vhosts.each_value { |v| yield v }
+    end
+
+    def each_value : Iterator(VHost)
+      @vhosts.each_value
+    end
+
+    def has_key?(name : String) : Bool
+      @vhosts.has_key?(name)
+    end
+
+    def size : Int32
+      @vhosts.size
+    end
+
+    def values : Array(VHost)
+      @vhosts.values
+    end
+
+    def first_value : VHost
+      @vhosts.first_value
+    end
 
     def each(&)
       @vhosts.each do |kv|

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -31,10 +31,6 @@ module LavinMQ
       @vhosts.each_value { |v| yield v }
     end
 
-    def values_dup : Array(VHost)
-      @vhosts.values
-    end
-
     def has_key?(name : String) : Bool
       @vhosts.has_key?(name)
     end


### PR DESCRIPTION
## Motivation
First step toward multi-threading safety. LavinMQ's hot collections (`@exchanges`, `@queues`, `@connections`, `@channels`, `@consumers`, `@vhosts`, `@users`, `@parameters`, `@shovels`) and stat counters were exposed as raw `getter`/`forward_missing_to`, leaving every caller free to mutate or iterate them without coordination. That's fine under single-threaded `preview_mt`, but blocks any move to true concurrent execution.

Encapsulating the collections behind explicit accessors is the prerequisite. With every read/write going through a known method, the next step can swap each backing store for a thread-safe primitive without touching call sites:
- collections protected by `Sync::Shared` (or per-store mutex),
- counters replaced with `Atomic(UInt64)`,
- booleans (`@flow`, `@closed`, …) replaced with `Atomic(Bool)` / `BoolChannel`.

This PR does no locking changes itself — it just narrows the surface so a future PR can.

## Summary
- Encapsulate all mutable collections behind explicit accessor methods; remove `getter`/`forward_missing_to` exposure
- Extract three stores from `VHost`: `ConnectionStore`, `DirectReplyConsumerStore`, `DefinitionsStore` (queues + exchanges + definitions-file persistence)
- Replace `Iterator(T)` returns with `Array(T)` snapshots across HTTP controllers and collection accessors — iterators hold references to underlying collections and are not safe under concurrent mutation
- Replace `Server` and store `getter?` booleans with explicit methods for future atomic-safe access

## Key changes
- **VHost**: snapshot accessors are plain plurals (`queues`, `exchanges`, `connections`); block-form `each_*` retained for internal iteration; `definitions` is now private
- **Safe registration**: `register_exchange`/`register_queue` replace `*_unsafe_put` — locked, drop the explicit name parameter (read from the object), idempotent on duplicate to support `init_delayed_queue` re-registration
- **Stores** (VHostStore, UserStore, ParameterStore, Shovel::Store): single `values` accessor (no more parallel `values`/`values_dup`)
- **AMQP/MQTT Client**: `channels` snapshot accessor
- **Exchange types**: `bindings_details` returns `Array(BindingDetails)` instead of `Iterator`
- **HTTP `page()`**: accepts `Array(SortableJSON)` — since it always fully traverses for sorting/pagination, lazy evaluation provided no benefit
- **Queue**: `unacked_messages` and `bindings` return arrays; `consumers` encapsulated with accessor methods

## Next steps (separate PRs)
- Wrap collections with `Sync::Shared` / per-store mutex
- Convert stat counters to `Atomic`
- Convert `@flow`, `@closed`, etc. to atomic primitives

## Test plan
- [x] `make bin/lavinmq CRYSTAL_FLAGS=` compiles cleanly
- [x] `make lint` passes (0 failures)
- [x] `make test` passes (1653 examples, 0 failures, 9 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)