### PR TITLE
Rename Routing key to Binding key in binding UI

### DIFF
--- a/views/exchange.ecr
+++ b/views/exchange.ecr
@@ -48,7 +48,7 @@
             <tr>
               <th class="left">Type</th>
               <th class="left">To</th>
-              <th class="left">Routing key</th>
+              <th class="left">Binding key</th>
               <th class="left">Arguments</th>
               <th></th>
             </tr>
@@ -68,7 +68,7 @@
         <datalist id="exchange-dest-list"></datalist>
       </label>
       <label>
-        <span>Routing key</span>
+        <span>Binding key</span>
         <input name="routing_key" type="text">
       </label>
       <label>

--- a/views/queue.ecr
+++ b/views/queue.ecr
@@ -116,7 +116,7 @@
             <thead>
               <tr>
                 <th class="left">From</th>
-                <th class="left">Routing key</th>
+                <th class="left">Binding key</th>
                 <th class="left">Arguments</th>
                 <th></th>
               </tr>
@@ -133,7 +133,7 @@
           <datalist id="exchange-list"></datalist>
         </label>
         <label>
-          <span>Routing key</span>
+          <span>Binding key</span>
           <input name="routing_key" type="text">
         </label>
         <label>

--- a/views/stream.ecr
+++ b/views/stream.ecr
@@ -99,7 +99,7 @@
             <thead>
               <tr>
                 <th class="left">From</th>
-                <th class="left">Routing key</th>
+                <th class="left">Binding key</th>
                 <th class="left">Arguments</th>
                 <th></th>
               </tr>
@@ -116,7 +116,7 @@
           <datalist id="exchange-list"></datalist>
         </label>
         <label>
-          <span>Routing key</span>
+          <span>Binding key</span>
           <input name="routing_key" type="text">
         </label>
         <label>


### PR DESCRIPTION
## Summary
- Rename "Routing key" to "Binding key" in binding table headers and form labels across queue, exchange, and stream views

Fixes #1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)