### PR TITLE
Fix invalid JSON warning on empty binding arguments

### DIFF
--- a/static/js/dom.js
+++ b/static/js/dom.js
@@ -1,11 +1,12 @@
 function parseJSON (data) {
   try {
+    data = data.trim()
     if (data.length) {
       return JSON.parse(data)
     }
     return {}
   } catch (e) {
-    if (e instanceof SyntaxError) { window.alert('Input must be JSON') }
+    if (e instanceof SyntaxError) { toast.error('Input must be JSON') }
     throw e
   }
 }


### PR DESCRIPTION
### WHAT is this pull request doing?
Trim whitespace in `parseJSON` so empty or whitespace-only Arguments input returns `{}` instead of showing an error. Replace `window.alert` with `toast.error` for invalid JSON feedback.

Fixes #1725 

### HOW can this pull request be tested?
In the UI, try to add a binding to a queue with an empty space in the JSON input field - Should pass
Then try to do the same but with invalid JSON - should not pass
