### PR TITLE
Prevent publisher starvation in MQTT throughput perf tool

### DIFF
--- a/src/lavinmqperf/mqtt/throughput.cr
+++ b/src/lavinmqperf/mqtt/throughput.cr
@@ -208,6 +208,7 @@ module LavinMQPerf
 
         start = Time.instant
         pubs_this_second = 0
+        local_pubs = 0_u64
         packet_id_generator = (1_u16..).each
         wait_until_all_are_connected(connected)
         until @stopped
@@ -233,7 +234,9 @@ module LavinMQPerf
           end
 
           pubs = @pubs.add(1, :relaxed) + 1
+          local_pubs &+= 1
           break if @pmessages > 0 && pubs >= @pmessages
+          Fiber.yield if @rate.zero? && local_pubs % (128*1024) == 0
 
           if !@rate.zero?
             pubs_this_second += 1


### PR DESCRIPTION
## Summary
 - Add `Fiber.yield` every 128k publishes when no rate limit is set in `lavinmqperf mqtt throughput`, ensuring fairness between multiple publishers sharing the same thread
 - Mirrors the approach applied to AMQP throughput in #1712

Note: MQTT consumers and publishers run in different threads, so this doesn't address the consume rate = 0 issue reported by @walro — that appears to be server-side.