### PR TITLE
`lavinmqctl --help` touchups

### DIFF
--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -65,7 +65,7 @@ class LavinMQCtl
   end
 
   def parse_cmd
-    @parser.separator("\nCommands:")
+    @parser.separator("\nCommands")
     COMPAT_CMDS.each do |cmd|
       @parser.on(cmd[0], cmd[1]) do
         @cmd = cmd[0]
@@ -224,7 +224,7 @@ class LavinMQCtl
         @args["queue"] = JSON::Any.new(v)
       end
     end
-    @parser.separator("\nMiscellaneous:")
+    @parser.separator("\nMiscellaneous")
     @parser.on("-v", "--version", "Show version") { @io.puts LavinMQ::VERSION; exit 0 }
     @parser.on("--build-info", "Show build information") { @io.puts LavinMQ::BUILD_INFO; exit 0 }
     @parser.on("-h", "--help", "Show this help") do
@@ -349,7 +349,7 @@ class LavinMQCtl
   end
 
   private def global_options
-    @parser.separator("\nGlobal options:")
+    @parser.separator("\nGlobal options")
     @parser.on("-p vhost", "--vhost=vhost", "Specify vhost") do |v|
       @options["vhost"] = v
     end


### PR DESCRIPTION
### WHAT is this pull request doing?

- **Add a "Miscellaneous" separator to `lavinmqctl`**
  - For consistency with `lavinmq --help`
- **Return with exit code 0 for `lavinmqctl --help`**
  - It seems like the right exit code for a deliberate command, also consistent with `lavinmq --help`
- **Drop the colons on the separators in `lavinmqctl`**
  - For consistency with `lavinmq --help`

### HOW can this pull request be tested?

```sh
lavinmqctl --help # should show the --help and friends under a "Miscellaneous" separator
echo $? # now 0, previously 1
```
