### PR TITLE
Prevent theme flash by applying the theme before loading the css

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -84,21 +84,8 @@ class ThemeSwitcher {
   }
 
   applyTheme (theme) {
-    const html = document.documentElement
-
-    // Remove existing theme classes
-    html.classList.remove('theme-light', 'theme-dark')
-
-    if (theme === 'light') {
-      html.classList.add('theme-light')
-      html.style.colorScheme = 'light'
-    } else if (theme === 'dark') {
-      html.classList.add('theme-dark')
-      html.style.colorScheme = 'dark'
-    } else { // system
-      // Let CSS color-scheme handle it
-      html.style.colorScheme = 'light dark'
-    }
+    // Uses the global applyTheme() defined in partials/theme.ecr
+    applyTheme(theme)
   }
 
   updateActiveButton () {
@@ -112,22 +99,6 @@ class ThemeSwitcher {
     }
   }
 }
-
-// Initialize theme immediately to prevent flash
-(function () {
-  const savedTheme = window.localStorage.getItem('theme') || 'system'
-  const html = document.documentElement
-
-  if (savedTheme === 'light') {
-    html.classList.add('theme-light')
-    html.style.colorScheme = 'light'
-  } else if (savedTheme === 'dark') {
-    html.classList.add('theme-dark')
-    html.style.colorScheme = 'dark'
-  } else {
-    html.style.colorScheme = 'light dark'
-  }
-})()
 
 // Check if sidebar is collapsed or expanded
 document.addEventListener('DOMContentLoaded', () => {

--- a/views/login.ecr
+++ b/views/login.ecr
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Login | LavinMQ</title>
+    <% render "partials/theme" %>
     <link href="main.css" rel="stylesheet">
     <meta name="google" content="notranslate">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/views/partials/head.ecr
+++ b/views/partials/head.ecr
@@ -1,10 +1,9 @@
+<% render "partials/theme" %>
 <script>
-  (function () {
-    try {
-      var collapsed = window.localStorage.getItem("menuCollapsed") === "true";
-      document.documentElement.classList.toggle("menu-collapsed", collapsed);
-    } catch (e) {}
-  })();
+  try {
+    var collapsed = window.localStorage.getItem("menuCollapsed") === "true";
+    document.documentElement.classList.toggle("menu-collapsed", collapsed);
+  } catch (e) {}
 </script>
 <script type="module" src="js/layout.js"></script>
 <title><%=pagename%> | LavinMQ</title>

--- a/views/partials/theme.ecr
+++ b/views/partials/theme.ecr
@@ -1,0 +1,18 @@
+<script>
+  function applyTheme(theme) {
+    var html = document.documentElement;
+    html.classList.remove("theme-light", "theme-dark");
+    if (theme === "light") {
+      html.classList.add("theme-light");
+      html.style.colorScheme = "light";
+    } else if (theme === "dark") {
+      html.classList.add("theme-dark");
+      html.style.colorScheme = "dark";
+    } else {
+      html.style.colorScheme = "light dark";
+    }
+  }
+  try {
+    applyTheme(localStorage.getItem("theme") || "system");
+  } catch (e) {}
+</script>


### PR DESCRIPTION
### WHAT is this pull request doing?

I noticed when trying out the light theme but my OS theme was dark that it first renders the page in darkmode, causing a flash.
Read [this article](https://dev.to/gaisdav/how-to-prevent-theme-flash-in-a-react-instant-dark-mode-switching-o20) on best practices in react applications for avoiding problems like this and asked claude for some suggestions. And keep in mind this is just a suggestion on how this can be solved :) 

Following the article, This PR:
1. Extracts all theme-apply logic into a single global appyTheme function defined in a new shared partial (partials/theme.ecr
2. Adds the shared partial to head 
3. Adds the shared partial to login page

### HOW can this pull request be tested?

This can be tested visually. Apply a theme on your OS and switch between themes. logout etc.


https://github.com/user-attachments/assets/9d3e265a-9786-45ac-a2d6-13207b12660f


