### PR TITLE
Dont log stack traces when client present a bad certificate

### DIFF
--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -319,6 +319,9 @@ module LavinMQ
       ctx.private_key = @config.tls_key_path.empty? ? @config.tls_cert_path : @config.tls_key_path
       ctx.ciphers = @config.tls_ciphers unless @config.tls_ciphers.empty?
       reload_ssl_keylog(ctx)
+    rescue e : OpenSSL::Error
+      Log.error { "Failed to initiate the OpenSSL context: #{e.message}" }
+      exit 1
     end
 
     private def reload_ssl_keylog(ctx)

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -280,6 +280,9 @@ module LavinMQ
       ctx = OpenSSL::SSL::Context::Server.new
       configure_tls_context(ctx)
       ctx
+    rescue e : OpenSSL::Error
+      Log.error { "Failed to initiate the OpenSSL context: #{e.message}" }
+      exit 1
     end
 
     private def warn_if_ktls_unavailable
@@ -296,6 +299,8 @@ module LavinMQ
         configure_tls_context(ctx)
       end
       @config.sni_manager.reload
+    rescue e : OpenSSL::Error
+      Log.error { "Failed to reload the OpenSSL context, keeping previous configuration: #{e.message}" }
     end
 
     private def configure_tls_context(ctx : OpenSSL::SSL::Context::Server)
@@ -319,9 +324,6 @@ module LavinMQ
       ctx.private_key = @config.tls_key_path.empty? ? @config.tls_cert_path : @config.tls_key_path
       ctx.ciphers = @config.tls_ciphers unless @config.tls_ciphers.empty?
       reload_ssl_keylog(ctx)
-    rescue e : OpenSSL::Error
-      Log.error { "Failed to initiate the OpenSSL context: #{e.message}" }
-      exit 1
     end
 
     private def reload_ssl_keylog(ctx)

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -225,8 +225,11 @@ module LavinMQ
           Log.info { "#{remote_addr} connected with #{ssl_client.tls_version} #{ssl_client.cipher}" }
           handle_tls_connection(ssl_client, client.local_address, remote_addr, protocol)
         end
+      rescue ex : OpenSSL::SSL::Error
+        Log.warn { "Error accepting TLS connection from #{remote_addr}: #{ex.message}" }
+        client.close rescue nil
       rescue ex
-        Log.warn(exception: ex) { "Error accepting TLS connection from #{remote_addr}" }
+        Log.error(exception: ex) { "Error accepting TLS connection from #{remote_addr}" }
         client.close rescue nil
       end
     end


### PR DESCRIPTION
### WHAT is this pull request doing?

Stop logging stack traces when a client connects over TLS using a bad certificate. Instead logs the message on why the connection was closed. 

Stop logging stack traces when loading TLS context and the config points to a file that doesn't exist. Still logs as error with the message. After logging stops the process.  

### HOW can this pull request be tested?

Configure TLS and point to a cert file that doesn't exists then start lavinmq. 