### PR TITLE
Add connection rate limiting

### DIFF
--- a/spec/connection_rate_limit_spec.cr
+++ b/spec/connection_rate_limit_spec.cr
@@ -1,0 +1,130 @@
+require "./spec_helper"
+
+describe LavinMQ::ConnectionRateLimiter do
+  describe "global rate limit" do
+    it "allows connections when disabled (limit=0)" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit = 0
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      100.times { limiter.allow?("127.0.0.1").should be_true }
+    end
+
+    it "allows connections up to the limit" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit = 5
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      5.times { |i| limiter.allow?("127.0.0.1").should(be_true, "failed on attempt #{i}") }
+      limiter.allow?("127.0.0.1").should be_false
+    end
+
+    it "replenishes tokens over time" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit = 10
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      10.times { limiter.allow?("127.0.0.1") }
+      limiter.allow?("127.0.0.1").should be_false
+      sleep 0.2.seconds
+      limiter.allow?("127.0.0.1").should be_true
+    end
+  end
+
+  describe "per-IP rate limit" do
+    it "allows connections when disabled (limit=0)" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit_per_ip = 0
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      100.times { limiter.allow?("10.0.0.1").should be_true }
+    end
+
+    it "limits each IP independently" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit_per_ip = 2
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      2.times { limiter.allow?("10.0.0.1").should be_true }
+      limiter.allow?("10.0.0.1").should be_false
+      2.times { limiter.allow?("10.0.0.2").should be_true }
+      limiter.allow?("10.0.0.2").should be_false
+    end
+
+    it "replenishes per-IP tokens over time" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit_per_ip = 10
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      10.times { limiter.allow?("10.0.0.1") }
+      limiter.allow?("10.0.0.1").should be_false
+      sleep 0.2.seconds
+      limiter.allow?("10.0.0.1").should be_true
+    end
+  end
+
+  describe "combined global and per-IP limits" do
+    it "per-IP limit stops connections before global limit" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit = 10
+      config.connection_rate_limit_per_ip = 2
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      2.times { limiter.allow?("10.0.0.1").should be_true }
+      # Per-IP limit reached, even though global has tokens
+      limiter.allow?("10.0.0.1").should be_false
+      # Different IP still works
+      2.times { limiter.allow?("10.0.0.2").should be_true }
+      limiter.allow?("10.0.0.2").should be_false
+    end
+
+    it "global limit stops connections even if per-IP has tokens" do
+      config = LavinMQ::Config.new
+      config.connection_rate_limit = 3
+      config.connection_rate_limit_per_ip = 5
+      limiter = LavinMQ::ConnectionRateLimiter.new(config)
+      3.times { limiter.allow?("10.0.0.1").should be_true }
+      # Global limit reached
+      limiter.allow?("10.0.0.1").should be_false
+      # Different IP also blocked by global limit
+      limiter.allow?("10.0.0.2").should be_false
+    end
+  end
+end
+
+describe "Server connection rate limiting" do
+  it "rejects connections exceeding the global rate limit" do
+    config = LavinMQ::Config.new
+    config.connection_rate_limit = 2
+    with_amqp_server(config: config) do |s|
+      conn1 = AMQP::Client.new(port: amqp_port(s)).connect
+      conn2 = AMQP::Client.new(port: amqp_port(s)).connect
+      # Third connection should fail - server closes socket before handshake
+      expect_raises(Exception) do
+        AMQP::Client.new(port: amqp_port(s)).connect
+      end
+      conn1.close
+      conn2.close
+    end
+  end
+
+  it "allows unlimited connections when rate limit is 0" do
+    config = LavinMQ::Config.new
+    config.connection_rate_limit = 0
+    with_amqp_server(config: config) do |s|
+      conns = Array(AMQP::Client::Connection).new
+      5.times do
+        conns << AMQP::Client.new(port: amqp_port(s)).connect
+      end
+      conns.size.should eq 5
+      conns.each &.close
+    end
+  end
+
+  it "rejects connections exceeding the per-IP rate limit" do
+    config = LavinMQ::Config.new
+    config.connection_rate_limit_per_ip = 2
+    with_amqp_server(config: config) do |s|
+      conn1 = AMQP::Client.new(port: amqp_port(s)).connect
+      conn2 = AMQP::Client.new(port: amqp_port(s)).connect
+      expect_raises(Exception) do
+        AMQP::Client.new(port: amqp_port(s)).connect
+      end
+      conn1.close
+      conn2.close
+    end
+  end
+end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -300,6 +300,12 @@ module LavinMQ
       @[IniOpt(section: "main", transform: ->ConsistentHashAlgorithm.parse(String))]
       property default_consistent_hash_algorithm : ConsistentHashAlgorithm = ConsistentHashAlgorithm::Ring
 
+      @[IniOpt(section: "main")]
+      property connection_rate_limit = 0 # max new connections per second, 0 = unlimited
+
+      @[IniOpt(section: "main")]
+      property connection_rate_limit_per_ip = 0 # max new connections per second per source IP, 0 = unlimited
+
       # Deprecated options - these forward to the primary option in [main]
 
       @[IniOpt(ini_name: tls_cert, section: "amqp", deprecated: "tls_cert in [main]")]

--- a/src/lavinmq/connection_rate_limiter.cr
+++ b/src/lavinmq/connection_rate_limiter.cr
@@ -1,0 +1,112 @@
+module LavinMQ
+  # Token bucket rate limiter for incoming connections.
+  # Fiber-safe (single-threaded Crystal runtime).
+  class ConnectionRateLimiter
+    Log = LavinMQ::Log.for "rate_limiter"
+
+    @global_tokens : Float64
+    @global_last_refill : Time::Instant
+    @last_log_time : Time::Instant
+
+    def initialize(@config : Config)
+      @global_tokens = @config.connection_rate_limit.to_f
+      @global_last_refill = Time.instant
+      @per_ip_tokens = Hash(String, Float64).new
+      @per_ip_last_refill = Hash(String, Time::Instant).new
+      @last_log_time = Time.instant
+      @log_suppressed = false
+    end
+
+    # Returns true if the connection should be allowed.
+    def allow?(remote_address : String) : Bool
+      return true unless rate_limiting_enabled?
+      allow_global? && allow_per_ip?(remote_address)
+    end
+
+    private def rate_limiting_enabled? : Bool
+      @config.connection_rate_limit > 0 ||
+        @config.connection_rate_limit_per_ip > 0
+    end
+
+    private def allow_global? : Bool
+      limit = @config.connection_rate_limit
+      return true if limit <= 0
+      consume_token(
+        limit,
+        pointerof(@global_tokens),
+        pointerof(@global_last_refill)
+      )
+    end
+
+    private def allow_per_ip?(ip : String) : Bool
+      limit = @config.connection_rate_limit_per_ip
+      return true if limit <= 0
+
+      now = Time.instant
+      unless @per_ip_last_refill.has_key?(ip)
+        @per_ip_tokens[ip] = limit.to_f
+        @per_ip_last_refill[ip] = now
+      end
+
+      last_refill = @per_ip_last_refill[ip]
+      tokens = @per_ip_tokens[ip]
+      elapsed = (now - last_refill).total_seconds
+      tokens = Math.min(limit.to_f, tokens + elapsed * limit)
+      @per_ip_last_refill[ip] = now
+
+      if tokens >= 1.0
+        @per_ip_tokens[ip] = tokens - 1.0
+        true
+      else
+        @per_ip_tokens[ip] = tokens
+        false
+      end
+    end
+
+    private def consume_token(
+      limit : Int32,
+      tokens_ptr : Pointer(Float64),
+      last_refill_ptr : Pointer(Time::Instant),
+    ) : Bool
+      now = Time.instant
+      elapsed = (now - last_refill_ptr.value).total_seconds
+      tokens = Math.min(
+        limit.to_f,
+        tokens_ptr.value + elapsed * limit
+      )
+      last_refill_ptr.value = now
+
+      if tokens >= 1.0
+        tokens_ptr.value = tokens - 1.0
+        true
+      else
+        tokens_ptr.value = tokens
+        false
+      end
+    end
+
+    def log_rate_limited(remote_address : String)
+      now = Time.instant
+      if (now - @last_log_time).total_seconds >= 1.0
+        @last_log_time = now
+        Log.warn { "Connection rate limited: #{remote_address}" }
+        @log_suppressed = false
+      elsif !@log_suppressed
+        @log_suppressed = true
+      end
+    end
+
+    # Remove stale per-IP entries to prevent unbounded growth.
+    # Called periodically (e.g. from stats_loop).
+    def cleanup_stale_entries
+      return if @config.connection_rate_limit_per_ip <= 0
+      now = Time.instant
+      @per_ip_last_refill.reject! do |ip, last_refill|
+        if (now - last_refill).total_seconds > 60
+          @per_ip_tokens.delete(ip)
+          true
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/connection_rate_limiter.cr
+++ b/src/lavinmq/connection_rate_limiter.cr
@@ -1,6 +1,6 @@
 module LavinMQ
   # Token bucket rate limiter for incoming connections.
-  # Fiber-safe (single-threaded Crystal runtime).
+  # Thread-safe via a mutex.
   class ConnectionRateLimiter
     Log             = LavinMQ::Log.for "rate_limiter"
     MAX_TRACKED_IPS = 100_000
@@ -9,6 +9,7 @@ module LavinMQ
       tokens : Float64,
       last_refill : Time::Instant
 
+    @mu = Mutex.new
     @global_tokens : Float64
     @global_last_refill : Time::Instant
     @last_log_time : Time::Instant
@@ -29,7 +30,7 @@ module LavinMQ
     # This is acceptable since tokens refill continuously.
     def allow?(remote_address : String) : Bool
       return true unless rate_limiting_enabled?
-      allow_per_ip?(remote_address) && allow_global?
+      @mu.synchronize { allow_per_ip?(remote_address) && allow_global? }
     end
 
     private def rate_limiting_enabled? : Bool
@@ -84,10 +85,11 @@ module LavinMQ
 
     def log_rate_limited(remote_address : String)
       now = Time.instant
-      if (now - @last_log_time).total_seconds >= 1.0
+      @mu.synchronize do
+        return unless (now - @last_log_time).total_seconds >= 1.0
         @last_log_time = now
-        Log.warn { "Connection rate limited: #{remote_address}" }
       end
+      Log.warn { "Connection rate limited: #{remote_address}" }
     end
 
     # Remove stale per-IP entries to prevent unbounded growth.
@@ -95,8 +97,10 @@ module LavinMQ
     def cleanup_stale_entries
       return if @config.connection_rate_limit_per_ip <= 0
       now = Time.instant
-      @per_ip.reject! do |_ip, state|
-        (now - state.last_refill).total_seconds > 60
+      @mu.synchronize do
+        @per_ip.reject! do |_ip, state|
+          (now - state.last_refill).total_seconds > 60
+        end
       end
     end
 

--- a/src/lavinmq/connection_rate_limiter.cr
+++ b/src/lavinmq/connection_rate_limiter.cr
@@ -5,6 +5,10 @@ module LavinMQ
     Log             = LavinMQ::Log.for "rate_limiter"
     MAX_TRACKED_IPS = 100_000
 
+    private record PerIPState,
+      tokens : Float64,
+      last_refill : Time::Instant
+
     @global_tokens : Float64
     @global_last_refill : Time::Instant
     @last_log_time : Time::Instant
@@ -13,15 +17,16 @@ module LavinMQ
     def initialize(@config : Config)
       @global_tokens = @config.connection_rate_limit.to_f
       @global_last_refill = Time.instant
-      @per_ip_tokens = Hash(String, Float64).new
-      @per_ip_last_refill = Hash(String, Time::Instant).new
+      @per_ip = Hash(String, PerIPState).new
       @last_log_time = Time.instant
       @last_table_full_log_time = Time.instant
     end
 
     # Returns true if the connection should be allowed.
     # Per-IP is checked first to avoid consuming a global token
-    # when the per-IP limit already rejects the connection.
+    # when the per-IP limit rejects the connection. Note: if per-IP
+    # passes but global rejects, the per-IP token is still consumed.
+    # This is acceptable since tokens refill continuously.
     def allow?(remote_address : String) : Bool
       return true unless rate_limiting_enabled?
       allow_per_ip?(remote_address) && allow_global?
@@ -57,25 +62,22 @@ module LavinMQ
       return true if limit <= 0
 
       now = Time.instant
-      unless @per_ip_last_refill.has_key?(ip)
-        if @per_ip_tokens.size >= MAX_TRACKED_IPS
+      unless @per_ip.has_key?(ip)
+        if @per_ip.size >= MAX_TRACKED_IPS
           evict_oldest_entry
         end
-        @per_ip_tokens[ip] = limit.to_f
-        @per_ip_last_refill[ip] = now
+        @per_ip[ip] = PerIPState.new(limit.to_f, now)
       end
 
-      last_refill = @per_ip_last_refill[ip]
-      tokens = @per_ip_tokens[ip]
-      elapsed = (now - last_refill).total_seconds
-      tokens = Math.min(limit.to_f, tokens + elapsed * limit)
-      @per_ip_last_refill[ip] = now
+      state = @per_ip[ip]
+      elapsed = (now - state.last_refill).total_seconds
+      tokens = Math.min(limit.to_f, state.tokens + elapsed * limit)
 
       if tokens >= 1.0
-        @per_ip_tokens[ip] = tokens - 1.0
+        @per_ip[ip] = PerIPState.new(tokens - 1.0, now)
         true
       else
-        @per_ip_tokens[ip] = tokens
+        @per_ip[ip] = PerIPState.new(tokens, now)
         false
       end
     end
@@ -93,23 +95,21 @@ module LavinMQ
     def cleanup_stale_entries
       return if @config.connection_rate_limit_per_ip <= 0
       now = Time.instant
-      @per_ip_last_refill.reject! do |ip, last_refill|
-        if (now - last_refill).total_seconds > 60
-          @per_ip_tokens.delete(ip)
-          true
-        end
+      @per_ip.reject! do |_ip, state|
+        (now - state.last_refill).total_seconds > 60
       end
     end
 
+    # Evict the oldest-inserted entry. Crystal's Hash is
+    # insertion-ordered, so `first` is O(1).
     private def evict_oldest_entry
       now = Time.instant
       if (now - @last_table_full_log_time).total_seconds >= 1.0
         @last_table_full_log_time = now
         Log.warn { "Per-IP tracking limit reached (#{MAX_TRACKED_IPS}), evicting oldest entry" }
       end
-      oldest_ip = @per_ip_last_refill.min_by { |_, t| t }[0]
-      @per_ip_last_refill.delete(oldest_ip)
-      @per_ip_tokens.delete(oldest_ip)
+      oldest_ip = @per_ip.first_key
+      @per_ip.delete(oldest_ip)
     end
   end
 end

--- a/src/lavinmq/connection_rate_limiter.cr
+++ b/src/lavinmq/connection_rate_limiter.cr
@@ -8,6 +8,7 @@ module LavinMQ
     @global_tokens : Float64
     @global_last_refill : Time::Instant
     @last_log_time : Time::Instant
+    @last_table_full_log_time : Time::Instant
 
     def initialize(@config : Config)
       @global_tokens = @config.connection_rate_limit.to_f
@@ -15,7 +16,7 @@ module LavinMQ
       @per_ip_tokens = Hash(String, Float64).new
       @per_ip_last_refill = Hash(String, Time::Instant).new
       @last_log_time = Time.instant
-      @log_suppressed = false
+      @last_table_full_log_time = Time.instant
     end
 
     # Returns true if the connection should be allowed.
@@ -34,11 +35,21 @@ module LavinMQ
     private def allow_global? : Bool
       limit = @config.connection_rate_limit
       return true if limit <= 0
-      consume_token(
-        limit,
-        pointerof(@global_tokens),
-        pointerof(@global_last_refill)
+
+      now = Time.instant
+      elapsed = (now - @global_last_refill).total_seconds
+      @global_tokens = Math.min(
+        limit.to_f,
+        @global_tokens + elapsed * limit
       )
+      @global_last_refill = now
+
+      if @global_tokens >= 1.0
+        @global_tokens -= 1.0
+        true
+      else
+        false
+      end
     end
 
     private def allow_per_ip?(ip : String) : Bool
@@ -48,8 +59,7 @@ module LavinMQ
       now = Time.instant
       unless @per_ip_last_refill.has_key?(ip)
         if @per_ip_tokens.size >= MAX_TRACKED_IPS
-          Log.warn { "Per-IP tracking limit reached (#{MAX_TRACKED_IPS}), rejecting new IP: #{ip}" }
-          return false
+          evict_oldest_entry
         end
         @per_ip_tokens[ip] = limit.to_f
         @per_ip_last_refill[ip] = now
@@ -70,36 +80,11 @@ module LavinMQ
       end
     end
 
-    private def consume_token(
-      limit : Int32,
-      tokens_ptr : Pointer(Float64),
-      last_refill_ptr : Pointer(Time::Instant),
-    ) : Bool
-      now = Time.instant
-      elapsed = (now - last_refill_ptr.value).total_seconds
-      tokens = Math.min(
-        limit.to_f,
-        tokens_ptr.value + elapsed * limit
-      )
-      last_refill_ptr.value = now
-
-      if tokens >= 1.0
-        tokens_ptr.value = tokens - 1.0
-        true
-      else
-        tokens_ptr.value = tokens
-        false
-      end
-    end
-
     def log_rate_limited(remote_address : String)
       now = Time.instant
       if (now - @last_log_time).total_seconds >= 1.0
         @last_log_time = now
         Log.warn { "Connection rate limited: #{remote_address}" }
-        @log_suppressed = false
-      elsif !@log_suppressed
-        @log_suppressed = true
       end
     end
 
@@ -114,6 +99,17 @@ module LavinMQ
           true
         end
       end
+    end
+
+    private def evict_oldest_entry
+      now = Time.instant
+      if (now - @last_table_full_log_time).total_seconds >= 1.0
+        @last_table_full_log_time = now
+        Log.warn { "Per-IP tracking limit reached (#{MAX_TRACKED_IPS}), evicting oldest entry" }
+      end
+      oldest_ip = @per_ip_last_refill.min_by { |_, t| t }[0]
+      @per_ip_last_refill.delete(oldest_ip)
+      @per_ip_tokens.delete(oldest_ip)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add token bucket rate limiter that rejects new connections at the TCP level before the AMQP/MQTT handshake
- Two config options: `connection_rate_limit` (global max new connections/sec) and `connection_rate_limit_per_ip` (per source IP), both default to 0 (unlimited)
- Rate limiting runs synchronously in the accept loop before spawning a fiber, so rejected connections never allocate a fiber or enter the handshake
- Rate-limited log messages (max 1/sec) to avoid log spam when rejecting

## Motivation
When LavinMQ is CPU-saturated, handshake timeouts cause clients to disconnect and immediately reconnect, creating a death spiral. Each reconnection goes through the full AMQP handshake (confirm_header, start, authenticate, tune, open), consuming CPU that should serve existing connections. Rejecting at the TCP level is orders of magnitude cheaper.

## Test plan
- [ ] `make test SPEC=spec/connection_rate_limit_spec.cr` (11 specs)
- [ ] Manual test: set `connection_rate_limit = 10`, connect many clients, verify excess connections are rejected immediately
- [ ] Verify existing connection tests still pass