### PR TITLE
add x-stream-offset header to StreamReader responses

### DIFF
--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -212,14 +212,13 @@ module LavinMQ::AMQP
       end
     end
 
-    def read(segment : UInt32, position : UInt32, offset : Int64) : Envelope?
+    def read(segment : UInt32, position : UInt32) : Envelope?
       return if @closed
       rfile = @segments[segment]
       return if position == rfile.size
       begin
         msg = BytesMessage.from_bytes(rfile.to_slice + position)
         sp = SegmentPosition.new(segment, position, msg.bytesize.to_u32)
-        msg.properties.headers = add_offset_header(msg.properties.headers, offset)
         Envelope.new(sp, msg, redelivered: false)
       rescue ex
         puts "read segment=#{segment} position=#{position}"

--- a/src/lavinmq/amqp/stream/stream_reader.cr
+++ b/src/lavinmq/amqp/stream/stream_reader.cr
@@ -14,8 +14,13 @@ module LavinMQ::AMQP
       offset, segment, position = store.find_offset(@start_offset)
       loop do
         break if store.closed
-        env = store.read(segment, position, offset)
+        env = store.read(segment, position)
         if env
+          if headers = env.message.properties.headers
+            headers["x-stream-offset"] = offset
+          else
+            env.message.properties.headers = AMQP::Table.new({"x-stream-offset": offset})
+          end
           position += env.segment_position.bytesize
           offset += 1
         else


### PR DESCRIPTION
### WHAT is this pull request doing?
After stream offsets were removed from disk storage(#1479), the `x-stream-offset` header is added dynamically at read time. The `shift?()` path handles this correctly, but the `read()` path (used by `StreamReader` for the `/api/queues/:vhost/:name/stream` endpoint) was missed.

Fixes #1773 

This PR adds an offset parameter to `StreamMessageStore#read()` and updates `StreamReader#each` to track and pass the offset through, so the header is added consistently across both code paths.

### HOW can this pull request be tested?
Run the added apec
