### PR TITLE
[oauth] Default to "sub" and "client_id" when preferred_username_claims is not configured

### DIFF
--- a/spec/oauth_config_spec.cr
+++ b/spec/oauth_config_spec.cr
@@ -12,9 +12,9 @@ describe LavinMQ::Config do
       config.oauth_jwks_cache_ttl.should eq(1.hours)
     end
 
-    it "sets default oauth_preferred_username_claims to empty array" do
+    it "sets default oauth_preferred_username_claims to sub and client_id" do
       config = LavinMQ::Config.new
-      config.oauth_preferred_username_claims.should be_empty
+      config.oauth_preferred_username_claims.should eq(["sub", "client_id"])
     end
 
     it "sets default oauth_additional_scopes_key to nil" do

--- a/spec/token_parser_spec.cr
+++ b/spec/token_parser_spec.cr
@@ -5,7 +5,7 @@ module TokenParserTestHelper
   extend self
 
   def create_token_parser(
-    preferred_username_claims = ["preferred_username"],
+    preferred_username_claims = ["sub", "client_id"],
     resource_server_id : String? = nil,
     scope_prefix : String? = nil,
     additional_scopes_key : String? = nil,
@@ -80,7 +80,7 @@ describe LavinMQ::Auth::JWT::TokenParser do
     end
 
     it "defaults to 'sub' claim when preferred_username_claims is not configured" do
-      parser = TokenParserTestHelper.create_token_parser(Array(String).new)
+      parser = TokenParserTestHelper.create_token_parser
       payload = LavinMQ::Auth::JWT::Payload.new(exp: RoughTime.utc.to_unix + 3600, sub: "sub-user")
       token = TokenParserTestHelper.create_mock_token(payload)
       claims = parser.parse(token)
@@ -88,7 +88,7 @@ describe LavinMQ::Auth::JWT::TokenParser do
     end
 
     it "falls back to 'client_id' when 'sub' is missing and no claims configured" do
-      parser = TokenParserTestHelper.create_token_parser(Array(String).new)
+      parser = TokenParserTestHelper.create_token_parser
       payload = LavinMQ::Auth::JWT::Payload.new(exp: RoughTime.utc.to_unix + 3600)
       payload["client_id"] = JSON::Any.new("my-service-account")
       token = TokenParserTestHelper.create_mock_token(payload)

--- a/src/lavinmq/auth/jwt/token_claim.cr
+++ b/src/lavinmq/auth/jwt/token_claim.cr
@@ -22,7 +22,6 @@ module LavinMQ
 
         private def extract_username(payload : JWT::Payload) : String
           claims = @config.oauth_preferred_username_claims
-          claims = {"sub", "client_id"} if claims.empty?
           claims.each do |claim|
             # Check standard JWT properties first
             username = case claim

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -356,7 +356,7 @@ module LavinMQ
       @[IniOpt(section: "oauth", ini_name: resource_server_id)]
       property oauth_resource_server_id : String? = nil
       @[IniOpt(section: "oauth", ini_name: preferred_username_claims)]
-      property oauth_preferred_username_claims = Array(String).new
+      property oauth_preferred_username_claims : Array(String) = ["sub", "client_id"]
       @[IniOpt(section: "oauth", ini_name: additional_scopes_key)]
       property oauth_additional_scopes_key : String? = nil
       @[IniOpt(section: "oauth", ini_name: scope_prefix)]


### PR DESCRIPTION
### WHAT is this pull request doing?

Unlike RabbitMQs oauth2.0 implementation, LavinMQ does not have a built-in default for `preferred_username_claims`. Without it set, LavinMQ won't know which JWT claim to use as the username. 
`DEBUG lmq.oauth2 authentication failed for user "": Could not decode token - No username found in JWT claims (tried: )`

Hence, it needs to be set in the config. I think it would be a good idea to fall back to 'sub', 'client_id' in those cases, as that is the behavior for RabbitMQ .

### HOW can this pull request be tested?
Specs.
