### PR TITLE
hold sync_lock for both full_sync calls

### DIFF
--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -185,17 +185,18 @@ module LavinMQ
           end
           @followers << follower # Starts in Syncing state
         end
-        # Only allow one follower to do bulk sync at a time
+        # Only allow one follower to do full sync at a time
         # The bandwidth between nodes should be very high, so
         # better with one fully synced than 2 partially synced followers
         # Also @files and @checksums are not protected by locks
+        # @sync_lock is always acquired before @lock to avoid deadlock
         @sync_lock.synchronize do
           follower.full_sync # sync the bulk
-        end
-        @lock.synchronize do
-          follower.full_sync    # sync the last
-          follower.mark_synced! # Change state to Synced
-          update_isr
+          @lock.synchronize do
+            follower.full_sync    # sync the last
+            follower.mark_synced! # Change state to Synced
+            update_isr
+          end
         end
         begin
           follower.action_loop


### PR DESCRIPTION
### WHAT is this pull request doing?

The second `full_sync` was not protected by `@sync_lock`, allowing concurrent syncs. Nests `@lock` inside `@sync_lock` so all full_sync calls are serialized.

Related to #1708, Follow-up to #1720, based on review feedback from @spuun.

