### PR TITLE
Use segment_position.bytesize in consumer deliver loop

### DIFF
--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -81,7 +81,7 @@ module LavinMQ
           {% end %}
           queue.consume_get(@no_ack) do |env|
             deliver(env.message, env.segment_position, env.redelivered)
-            delivered_bytes &+= env.message.bytesize
+            delivered_bytes &+= env.segment_position.bytesize
             @channel.increment_deliver_count(env.redelivered, @no_ack)
           end
           if delivered_bytes > Config.instance.yield_each_delivered_bytes


### PR DESCRIPTION
### WHAT is this pull request doing?

Use the pre-computed `bytesize` stored on `SegmentPosition` instead of calling `BytesMessage#bytesize` which recomputes the value each time by summing `timestamp`, `exchange_name`, `routing_key`, `properties`, and `bodysize`.

`SegmentPosition.bytesize`  is set once at creation via `SegmentPosition.make(segment, position, msg.bytesize.to_u32)` so the value is identical.

(Noted while doing #1783)

### HOW can this pull request be tested?

Tests. Doesn't seem to make much of a difference in benchmarks though, at least not with 1 producer and 1 consumer, guessing we are "producer-bound" or this simple is a drop in the ocean?