### PR TITLE
[oauth] enable parsing permissions from multiple additional claims

### DIFF
--- a/spec/oauth_config_spec.cr
+++ b/spec/oauth_config_spec.cr
@@ -17,9 +17,9 @@ describe LavinMQ::Config do
       config.oauth_preferred_username_claims.should eq(["sub", "client_id"])
     end
 
-    it "sets default oauth_additional_scopes_key to empty array" do
+    it "sets default oauth_additional_scopes_keys to empty array" do
       config = LavinMQ::Config.new
-      config.oauth_additional_scopes_key.should be_empty
+      config.oauth_additional_scopes_keys.should be_empty
     end
 
     it "sets default oauth_scope_prefix to nil" do
@@ -80,18 +80,18 @@ describe LavinMQ::Config do
       config.oauth_preferred_username_claims.should eq(["email", "preferred_username", "sub"])
     end
 
-    it "parses additional_scopes_key" do
+    it "parses additional_scopes_keys" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
         [oauth]
         issuer_url = https://auth.example.com
-        additional_scopes_key = custom_permissions
+        additional_scopes_keys = custom_permissions
         CONFIG
       end
 
       config = LavinMQ::Config.new
       config.parse(["-c", config_file.path])
-      config.oauth_additional_scopes_key.should eq(["custom_permissions"])
+      config.oauth_additional_scopes_keys.should eq(["custom_permissions"])
     end
 
     it "parses multiple comma-separated additional_scopes_keys" do
@@ -99,13 +99,13 @@ describe LavinMQ::Config do
         file.print <<-CONFIG
         [oauth]
         issuer_url = https://auth.example.com
-        additional_scopes_key = roles, permissions
+        additional_scopes_keys = roles, permissions
         CONFIG
       end
 
       config = LavinMQ::Config.new
       config.parse(["-c", config_file.path])
-      config.oauth_additional_scopes_key.should eq(["roles", "permissions"])
+      config.oauth_additional_scopes_keys.should eq(["roles", "permissions"])
     end
 
     it "parses scope_prefix" do

--- a/spec/token_parser_spec.cr
+++ b/spec/token_parser_spec.cr
@@ -8,14 +8,14 @@ module TokenParserTestHelper
     preferred_username_claims = ["sub", "client_id"],
     resource_server_id : String? = nil,
     scope_prefix : String? = nil,
-    additional_scopes_key = [] of String,
+    additional_scopes_keys = [] of String,
   ) : LavinMQ::Auth::JWT::TokenParser
     config = LavinMQ::Config.new
     config.oauth_issuer_url = URI.parse("https://auth.example.com")
     config.oauth_preferred_username_claims = preferred_username_claims
     config.oauth_resource_server_id = resource_server_id
     config.oauth_scope_prefix = scope_prefix
-    config.oauth_additional_scopes_key = additional_scopes_key
+    config.oauth_additional_scopes_keys = additional_scopes_keys
     LavinMQ::Auth::JWT::TokenParser.new(config)
   end
 
@@ -214,9 +214,9 @@ describe LavinMQ::Auth::JWT::TokenParser do
       end
     end
 
-    describe "additional_scopes_key parsing" do
-      it "extracts scopes from additional_scopes_key string claim" do
-        parser = TokenParserTestHelper.create_token_parser(["sub"], additional_scopes_key: ["permissions"])
+    describe "additional_scopes_keys parsing" do
+      it "extracts scopes from additional_scopes_keys string claim" do
+        parser = TokenParserTestHelper.create_token_parser(["sub"], additional_scopes_keys: ["permissions"])
         payload = LavinMQ::Auth::JWT::Payload.new(
           exp: RoughTime.utc.to_unix + 3600,
           sub: "user"
@@ -227,8 +227,8 @@ describe LavinMQ::Auth::JWT::TokenParser do
         claims.permissions["myvhost"][:read].should eq(/.*/)
       end
 
-      it "extracts scopes from additional_scopes_key array claim" do
-        parser = TokenParserTestHelper.create_token_parser(["sub"], additional_scopes_key: ["permissions"])
+      it "extracts scopes from additional_scopes_keys array claim" do
+        parser = TokenParserTestHelper.create_token_parser(["sub"], additional_scopes_keys: ["permissions"])
         payload = LavinMQ::Auth::JWT::Payload.new(
           exp: RoughTime.utc.to_unix + 3600,
           sub: "user"
@@ -240,11 +240,11 @@ describe LavinMQ::Auth::JWT::TokenParser do
         claims.permissions["myvhost"][:write].should eq(/.*/)
       end
 
-      it "extracts scopes from additional_scopes_key hash claim with resource_server_id" do
+      it "extracts scopes from additional_scopes_keys hash claim with resource_server_id" do
         parser = TokenParserTestHelper.create_token_parser(
           ["sub"],
           resource_server_id: "lavinmq",
-          additional_scopes_key: ["permissions"]
+          additional_scopes_keys: ["permissions"]
         )
         payload = LavinMQ::Auth::JWT::Payload.new(
           exp: RoughTime.utc.to_unix + 3600,
@@ -259,7 +259,7 @@ describe LavinMQ::Auth::JWT::TokenParser do
       it "extracts scopes from hash claim without resource_server_id" do
         parser = TokenParserTestHelper.create_token_parser(
           ["sub"],
-          additional_scopes_key: ["permissions"]
+          additional_scopes_keys: ["permissions"]
         )
         payload = LavinMQ::Auth::JWT::Payload.new(
           exp: RoughTime.utc.to_unix + 3600,
@@ -275,7 +275,7 @@ describe LavinMQ::Auth::JWT::TokenParser do
         parser = TokenParserTestHelper.create_token_parser(
           ["sub"],
           resource_server_id: "lavinmq",
-          additional_scopes_key: ["permissions"]
+          additional_scopes_keys: ["permissions"]
         )
         payload = LavinMQ::Auth::JWT::Payload.new(
           exp: RoughTime.utc.to_unix + 3600,
@@ -288,7 +288,7 @@ describe LavinMQ::Auth::JWT::TokenParser do
       end
 
       it "extracts scopes from multiple additional_scopes_keys" do
-        parser = TokenParserTestHelper.create_token_parser(["sub"], additional_scopes_key: ["roles", "permissions"])
+        parser = TokenParserTestHelper.create_token_parser(["sub"], additional_scopes_keys: ["roles", "permissions"])
         payload = LavinMQ::Auth::JWT::Payload.new(
           exp: RoughTime.utc.to_unix + 3600,
           sub: "user"

--- a/spec/token_verifier_spec.cr
+++ b/spec/token_verifier_spec.cr
@@ -55,7 +55,7 @@ module JWTTestHelper
     audience : String? = nil,
     resource_server_id : String? = nil,
     scope_prefix : String? = nil,
-    additional_scopes_key = [] of String,
+    additional_scopes_keys = [] of String,
   ) : LavinMQ::Auth::JWT::TokenVerifier
     config = LavinMQ::Config.new
     config.oauth_issuer_url = URI.parse(issuer_url)
@@ -64,7 +64,7 @@ module JWTTestHelper
     config.oauth_audience = audience
     config.oauth_resource_server_id = resource_server_id
     config.oauth_scope_prefix = scope_prefix
-    config.oauth_additional_scopes_key = additional_scopes_key
+    config.oauth_additional_scopes_keys = additional_scopes_keys
 
     jwks_fetcher = MockJWKSFetcher.new
     LavinMQ::Auth::JWT::TokenVerifier.new(config, jwks_fetcher)
@@ -84,7 +84,7 @@ module JWTTestHelper
     audience : String? = nil,
     resource_server_id : String? = nil,
     scope_prefix : String? = nil,
-    additional_scopes_key = [] of String,
+    additional_scopes_keys = [] of String,
   ) : TestableTokenVerifier
     config = LavinMQ::Config.new
     config.oauth_issuer_url = URI.parse(issuer_url)
@@ -93,7 +93,7 @@ module JWTTestHelper
     config.oauth_audience = audience
     config.oauth_resource_server_id = resource_server_id
     config.oauth_scope_prefix = scope_prefix
-    config.oauth_additional_scopes_key = additional_scopes_key
+    config.oauth_additional_scopes_keys = additional_scopes_keys
 
     jwks_fetcher = MockJWKSFetcher.new
     TestableTokenVerifier.new(config, jwks_fetcher)

--- a/src/lavinmq/auth/jwt/token_claim.cr
+++ b/src/lavinmq/auth/jwt/token_claim.cr
@@ -61,7 +61,7 @@ module LavinMQ
             scopes.concat(scope_str.split)
           end
 
-          @config.oauth_additional_scopes_key.each do |scopes_key|
+          @config.oauth_additional_scopes_keys.each do |scopes_key|
             if claim = payload[scopes_key]?
               scopes.concat(extract_scopes_from_claim(claim))
             end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -357,8 +357,8 @@ module LavinMQ
       property oauth_resource_server_id : String? = nil
       @[IniOpt(section: "oauth", ini_name: preferred_username_claims)]
       property oauth_preferred_username_claims : Array(String) = ["sub", "client_id"]
-      @[IniOpt(section: "oauth", ini_name: additional_scopes_key)]
-      property oauth_additional_scopes_key = Array(String).new
+      @[IniOpt(section: "oauth", ini_name: additional_scopes_keys)]
+      property oauth_additional_scopes_keys = Array(String).new
       @[IniOpt(section: "oauth", ini_name: scope_prefix)]
       property oauth_scope_prefix : String? = nil
       @[IniOpt(section: "oauth", ini_name: verify_aud)]


### PR DESCRIPTION
### Context

Supported in rmq since 4.1. Figured it wasn't a huge change to add it here. But crystal team can decide if it makes sense to add it. 
I would however argue that it is a bit confusing that the config setting is called additional_scopes_key (singular) when we support a list. But no strong opinions.

In rmq this config setting it is a string separated by blank spaces. Since other config settings are separated by commas in lavinmq I chose to do the same here to keep things consequent in the ini-config.

### WHAT is this pull request doing?

Changes additional_scopes_key from string to array and traverses the token with the claims found in the config.

### HOW can this pull request be tested?

Specs.
Tested manually by adding hardcoded claims on my keycloak client that issues the jwt.
lmq config
```
[main]
auth_backends = oauth
log_level = debug

[oauth]
issuer = http://localhost:8080/realms/master
additional_scopes_key = additional_scope1,additional_scope2
preferred_username_claims = sub
verify_aud = false
```
`bin/lavinmq --data-dir ./tmp/data -c tmp/lavinmq.ini`
