### PR TITLE
fix: print usage on unexpected arguments in lavinmqperf

### DIFF
--- a/src/lavinmqperf/perf.cr
+++ b/src/lavinmqperf/perf.cr
@@ -17,6 +17,7 @@ module LavinMQPerf
       @parser.on("-v", "--version", "Show version") { @io.puts LavinMQ::VERSION; exit 0 }
       @parser.on("--build-info", "Show build information") { @io.puts BUILD_INFO; exit 0 }
       @parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
+      @parser.unknown_args { |args| abort "Unexpected argument: #{args.join(", ")}\n\n#{@parser}" unless args.empty? }
       @parser.on("--uri=URI", "URI to connect to (default #{@uri})") do |v|
         @uri = URI.parse(v)
       end
@@ -24,7 +25,6 @@ module LavinMQPerf
 
     def run(args = ARGV)
       @parser.parse(args)
-      abort "Unexpected argument: #{args.join(", ")}\n\n#{@parser}" unless args.empty?
     end
 
     macro build_flags


### PR DESCRIPTION
### WHAT is this pull request doing?
Abort run if unexpected arguments are provided. 

Stupid users (me) need help. I got confused why stuff worked when it defaulted to localhost behind the scenes, but real cause of error was that I forgot to pass option flags :) 

### HOW can this pull request be tested?

Prior (connecting to default localhost)
```
lavinmqperf throughput amqp://nouser:nopw@nodomain.com:5672/test
Publish rate: 1519814 msgs/s Consume rate: 1519778 msgs/s
...
```
After
```
bin/lavinmqperf throughput amqp://nouser:nopw@nodomain.com:5672/test
Unexpected argument: amqp://nouser:nopw@nodomain.com:5672/test

Usage: bin/lavinmqperf [protocol] [throughput | bind-churn | queue-churn | connection-churn | connection-count | queue-count] [arguments]
    -h, --help                       Show this help
....
```