### PR TITLE
Require specs for all code changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,3 +25,4 @@ Standard library sources: `crystal env CRYSTAL_PATH` shows compiler search paths
 ## Key Patterns
 - Avoid allocations in hot paths (message publishing and delivery)
 - SEGFAULTs due to use of MFiles after close is a common source of bugs
+- All code changes must have corresponding specs. New features need specs, bug fixes need regression specs.

--- a/.claude/review-criteria.md
+++ b/.claude/review-criteria.md
@@ -4,6 +4,7 @@ Report only issues you are confident about:
 - Performance issues (especially allocations in hot paths)
 - Missing error handling
 - Crystal anti-patterns
+- Missing specs (all code changes must have corresponding specs)
 
 Quality bar:
 - Only report issues you'd block a PR for. Skip stylistic nits and minor suggestions.


### PR DESCRIPTION
## Summary
- Add spec requirement to CLAUDE.md key patterns: all code changes must have corresponding specs
- Add "missing specs" to review-criteria.md so it gets flagged during code review