### PR TITLE
Align exchange type error message with RabbitMQ

### DIFF
--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -71,11 +71,12 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should require a known type" do
       with_http_server do |http, _|
-        body = %({ "type": "tut" })
+        unknown_type = "tut"
+        body = %({ "type": "#{unknown_type}" })
         response = http.put("/api/exchanges/%2f/faulty", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
-        body["reason"].as_s.should match(/invalid exchange type/)
+        body["reason"].as_s.should match(/unknown exchange type '#{unknown_type}'/)
       end
     end
 

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -661,7 +661,7 @@ module LavinMQ
         AMQP::FederationExchange.new(vhost, name, arguments)
       when "x-consistent-hash"
         AMQP::ConsistentHashExchange.new(vhost, name, durable, auto_delete, internal, arguments)
-      else raise Error::ExchangeTypeError.new("invalid exchange type '#{type}'")
+      else raise Error::ExchangeTypeError.new("unknown exchange type '#{type}'")
       end
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

The discrepancy with RabbitMQ was reported in https://github.com/cloudamqp/amqp-client.rb/issues/76#issue-3975821977.

Relevant RabbitMQ implementation: https://github.com/rabbitmq/rabbitmq-server/blob/v4.2.4/deps/rabbit/src/rabbit_exchange.erl#L173-L175

The old message, regarding invalid exchange type, seem to happen in RabbitMQ when a plugin registers the exchange type name but its module isn't loaded — for example, a plugin was installed and registered the type atom, but then was disabled or failed to start, leaving the atom in the VM but no module in the registry. This case is not really applicable in LavinMQ.

### HOW can this pull request be tested?

Specs, I tightened them up a tad bit.