### PR TITLE
Add sorting to bindings tables

### DIFF
--- a/views/exchange.ecr
+++ b/views/exchange.ecr
@@ -46,9 +46,9 @@
         <table id="bindings-table" class="table">
           <thead>
             <tr>
-              <th class="left">Type</th>
-              <th class="left">To</th>
-              <th class="left">Binding key</th>
+              <th data-sort-key="destination_type" class="left">Type</th>
+              <th data-sort-key="destination" class="left">To</th>
+              <th data-sort-key="routing_key" class="left">Binding key</th>
               <th class="left">Arguments</th>
               <th></th>
             </tr>

--- a/views/queue.ecr
+++ b/views/queue.ecr
@@ -115,8 +115,8 @@
           <table id="bindings-table" class="table">
             <thead>
               <tr>
-                <th class="left">From</th>
-                <th class="left">Binding key</th>
+                <th data-sort-key="source" class="left">From</th>
+                <th data-sort-key="routing_key" class="left">Binding key</th>
                 <th class="left">Arguments</th>
                 <th></th>
               </tr>

--- a/views/stream.ecr
+++ b/views/stream.ecr
@@ -98,8 +98,8 @@
           <table id="bindings-table" class="table">
             <thead>
               <tr>
-                <th class="left">From</th>
-                <th class="left">Binding key</th>
+                <th data-sort-key="source" class="left">From</th>
+                <th data-sort-key="routing_key" class="left">Binding key</th>
                 <th class="left">Arguments</th>
                 <th></th>
               </tr>


### PR DESCRIPTION
## Summary
- Add `data-sort-key` attributes to bindings table headers on the exchange, queue, and stream views
- Enables column sorting for Type, To/From, and Binding key columns, consistent with other tables in the management UI

Closes #1785

## Test plan
- [x] Open exchange detail page, verify bindings table columns are sortable by clicking headers
- [x] Open queue detail page, verify bindings table columns are sortable
- [x] Open stream detail page, verify bindings table columns are sortable
- [x] Confirm sort order toggles between ascending and descending