### PR TITLE
fix: widen x-delay from UInt32 to UInt64 to prevent overflow

### DIFF
--- a/spec/segment_position_spec.cr
+++ b/spec/segment_position_spec.cr
@@ -14,6 +14,15 @@ describe LavinMQ::SegmentPosition do
       sp.delay.should eq 15
       sp.priority.should eq 0
     end
+
+    it "should handle x-delay exceeding UInt32 max" do
+      delay = 31_536_000_000_i64 # 365 days in ms
+      headers = LavinMQ::AMQP::Table.new({"x-delay" => delay})
+      props = LavinMQ::AMQP::Properties.new(headers: headers)
+      msg = LavinMQ::Message.new(100, "test", "rk", props, 10, IO::Memory.new("body"))
+      sp = subject.make(1u32, 1u32, msg)
+      sp.delay.should eq delay
+    end
   end
 
   it "should create a SP with priority" do

--- a/src/lavinmq/segment_position.cr
+++ b/src/lavinmq/segment_position.cr
@@ -5,23 +5,23 @@ module LavinMQ
     getter segment : UInt32
     getter position : UInt32
     getter bytesize : UInt32
-    getter delay : UInt32   # used by delayed exchange queue
+    getter delay : UInt64   # used by delayed exchange queue
     getter priority : UInt8 # required for ordering in priority queues
     getter? has_dlx : Bool
 
     def_equals_and_hash @segment, @position
 
-    def initialize(@segment : UInt32, @position : UInt32, @bytesize : UInt32, @has_dlx = false, @priority = 0u8, @delay = 0u32)
+    def initialize(@segment : UInt32, @position : UInt32, @bytesize : UInt32, @has_dlx = false, @priority = 0u8, @delay = 0u64)
     end
 
     def self.make(segment : UInt32, position : UInt32, msg)
       prio = msg.properties.priority || 0u8
       has_dlx = false
-      delay = 0u32
+      delay = 0u64
       msg.properties.headers.try &.each do |key, value|
         case key
         when "x-dead-letter-exchange" then has_dlx = true
-        when "x-delay"                then delay = value.as?(Int).try(&.to_u32) || 0u32 rescue 0u32
+        when "x-delay"                then delay = value.as?(Int).try(&.to_u64) || 0u64 rescue 0u64
         end
       end
       new(segment, position, msg.bytesize.to_u32, has_dlx, prio, delay)


### PR DESCRIPTION
### WHAT is this pull request doing?

Widens the `delay` field in `SegmentPosition` from `UInt32` to `UInt64`. Large `x-delay` header values (e.g. 365 days = 31,536,000,000 ms) exceeded `UInt32::MAX` (4,294,967,295) and silently overflowed to 0, causing messages to be delivered immediately instead of being delayed.

Fixes #1781

### HOW can this pull request be tested?

A new spec (`"should handle x-delay exceeding UInt32 max"`) verifies that a 365-day delay value round-trips correctly through `SegmentPosition.make` without overflow.

Run: `make test SPEC=spec/segment_position_spec.cr`