### PR TITLE
Add software documentation the the LavinMQ repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+docs/img/**/*.png filter=lfs diff=lfs merge=lfs -text
+docs/img/**/*.jpg filter=lfs diff=lfs merge=lfs -text
+docs/img/**/*.svg filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/docs/
 /lib/
 /bin/
 /node_modules/

--- a/docs/alternate-exchange.md
+++ b/docs/alternate-exchange.md
@@ -1,0 +1,89 @@
+
+Unroutable messages are an issue in a number of ways. They slow down processing times if applications make multiple attempts at delivery. Unroutable messages can also monopolize the system because they must be logged, which takes up resources. There are methods to deal with unrouted messages, which must eventually be handled or dropped.
+
+### What is the LavinMQ alternate exchange?
+
+LavinMQ lets you define an alternate exchange to apply logic to unroutable messages.
+
+### What benefits does LavinMQ alternate exchange have?
+
+It is possible to avoid the complete loss of a message by properly handling unroutable messages.
+
+### How should I use LavinMQ alternate exchange?
+
+No matter how careful you are, mistakes can happen. For example, a client may accidentally or maliciously route messages using non-existent routing keys. To avoid complications from lost information, an easy, safe backup is to collect unroutable messages in an LavinMQ alternate exchange.
+
+### What happens to unroutable messages in LavinMQ?
+
+To avoid the complete loss of a message, LavinMQ handles unroutable messages in two ways based on the mandatory flag setting within the message header:
+
+1. The server either returns the message when the flag is set to `true` or
+2. Silently drops the message when set to `false`.
+
+Applications can log returned messages, but logging does not provide a mechanism for dealing with an unreachable exchange or queue.
+
+Whether messages return or not, unroutable messages can:
+
+- Be returned to a broken application that constantly resends them.
+- Be the result of malicious activity aimed at causing LavinMQ to become unresponsive.
+- Cause the loss of mission-critical data
+
+<div class="border border-[#414040] rounded-xl px-8 py-0">
+
+<p class="mb-8">
+<strong>Example</strong>: Think of a hospital that uses LavinMQ to help store patient information in a database. Medical devices typically push vital data to a small server for processing, which then forwards the information to the cloud for storage. In this case, LavinMQ can be used to push data to the cloud and be employed to facilitate streaming.
+</p>
+<p>
+Should messages drop before they end up in LavinMQ, doctors could lose vital information. This loss could impact diagnosis and treatment. The situation could become even worse if the system breaks and overloads the resources handling messages related to more than one patient.
+</p>
+</div>
+
+Set an alternate exchange using policies or within arguments when declaring an exchange.
+
+<!-- img -->
+
+The alternate exchange attaches to one or more primary exchanges. Set the exchange type to fanout to ensure that rejected messages always route to the alternate queue. Be advised that there is no way to catch invalid exchange names outside of the mandatory flag.
+
+## Creating the Alternate Exchange
+
+Defining an alternate exchange is no different than defining any other part of your topology. The primary exchange forwards the message to the alternate exchange, which sends it to the alternate queues.
+
+Create a fanout exchange and attach a queue:
+
+{% highlight python %}
+conn_str = os.environ["AMQP_URI"]
+params = pika.URLParameters(conn_str)
+connection = pika.BlockingConnection(params)
+channel = connection.channel()
+
+channel.exchange_declare("alt_exchange", "fanout")
+channel.queue_declare("alt_queue")
+channel.queue_bind("alt_queue", "alt_exchange")
+{% endhighlight %}
+
+Any message sent to the _alt_exchange_ winds up in the _alt_queue_. Since we use a fanout exchange, the message ends up in all queues attached to `alt_exchange`.
+
+## Attaching the Alternate Exchange
+
+Use policies, the UI, or message headers to set the alternate exchange. You must use the command line to attach an alternate exchange after declaring the primary exchange.
+
+Use message arguments to set the exchange:
+
+{% highlight python %}
+args = {"alternate-exchange": "alt_exchange"}
+channel.exchange_declare("primary_exchange", "direct", arguments=args)
+{% endhighlight %}
+
+Alternately, use the command line to specify the alternate exchange:
+
+{% highlight shell %}
+lavinmqctl set*policy AE “primary*\*” ‘{“alternate-exchange”: “alt_exchange”}’
+{% endhighlight %}
+
+LavinMQ sends all messages from the `primary_exchange` to the `alt_exchange` when the routing key is invalid. Unrouted messages end up in the `alt_queue`.
+
+## What happens when the mandatory flag is set with an alternate exchange?
+
+There is still a chance that messages won’t be routed if an alternate exchange is provided. For instance, the service may be unreachable, the alternate queue may not be specified correctly, or a non-existent exchange might be specified.
+
+Setting the mandatory flag will catch these unrouted messages. Keep in mind that, if the message routes to the alternate exchange, LavinMQ marks the message as delivered.

--- a/docs/amqp-bindings.md
+++ b/docs/amqp-bindings.md
@@ -71,7 +71,7 @@ routing_key = "test"
 channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=routing_key)
 ```
 
-Read more about how different [exchanges](/documentation/amqp-exchanges) are using routing keys.
+Read more about how different [exchanges](amqp-exchanges.md) are using routing keys.
 
 ### Header attributes
 
@@ -79,7 +79,7 @@ Headers can be added to a message to provide additional context and control how 
 
 A headers exchange is a type of exchange that routes messages based on these headers instead of the routing key. In a headers exchange, the routing logic is determined by the presence and values of headers in the message.
 
-When using the [header exchange](/documentation/amqp-exchanges#headers-exchange), an argument called `x-match` is used as part of the binding. The message's headers are matched to the binding's headers. This header specifies whether all headers must match or just one.
+When using the [header exchange](amqp-exchanges.md#headers-exchange), an argument called `x-match` is used as part of the binding. The message's headers are matched to the binding's headers. This header specifies whether all headers must match or just one.
 
 - The `x-match` header can have two values: `all` or `any`.
   - `all`: The message must match all the headers specified in the binding.

--- a/docs/amqp-bindings.md
+++ b/docs/amqp-bindings.md
@@ -1,0 +1,86 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a binding?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          A binding connects a queue to an exchange, specifying how messages should be routed based on the defined routing keys. It determines which messages a queue receives from an exchange.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What is a routing key?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        A routing key is a string that helps the broker route messages to the right queue. Think of it as a label that matches messages with their intended queues.
+      </p>
+    </div>
+  </div>
+</div>
+
+In order to route messages from an exchange to a queue there needs to be a binding between the two.
+
+1. Ensure the exchange and queue exist: The exchange acts as a message router, while the queue stores messages.
+2. Attach the queue to the exchange: Establish a link between the queue and the exchange. A routing key may be needed for the binding depending on the exchange type.
+
+Example: Bind a queue to an exchange.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+exchange_name = 'my_exchange'
+channel.exchange_declare(exchange=exchange_name, exchange_type='direct')
+
+queue_name = 'my_queue'
+channel.queue_declare(queue=queue_name)
+
+channel.queue_bind(exchange=exchange_name, queue=queue_name)
+```
+
+### Routing keys
+
+Bindings can include an optional routing key, while messages have their routing keys. When a message arrives at the exchange, the exchange checks its routing key against the routing keys of the binding. If there’s a match, the message is delivered to the corresponding queue(s).
+
+Example: Bind a queue to an exchange using a defined routing key.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+exchange_name = 'my_exchange'
+channel.exchange_declare(exchange=exchange_name, exchange_type='direct')
+
+queue_name = 'my_queue'
+channel.queue_declare(queue=queue_name)
+
+routing_key = "test"
+channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=routing_key)
+```
+
+Read more about how different [exchanges](/documentation/amqp-exchanges) are using routing keys.
+
+### Header attributes
+
+Headers can be added to a message to provide additional context and control how it is routed.
+
+A headers exchange is a type of exchange that routes messages based on these headers instead of the routing key. In a headers exchange, the routing logic is determined by the presence and values of headers in the message.
+
+When using the [header exchange](/documentation/amqp-exchanges#headers-exchange), an argument called `x-match` is used as part of the binding. The message's headers are matched to the binding's headers. This header specifies whether all headers must match or just one.
+
+- The `x-match` header can have two values: `all` or `any`.
+  - `all`: The message must match all the headers specified in the binding.
+  - `any`: The message must match at least one of the headers specified in the binding.

--- a/docs/amqp-connections-and-channels.md
+++ b/docs/amqp-connections-and-channels.md
@@ -1,0 +1,85 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a connection?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          A (TCP-)connection is a link between the client and the LavinMQ broker that performs
+          underlying networking tasks, including initial authentication, IP resolution, and
+          networking.
+        </p>
+				<img alt="LavinMQ connection start" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-one.png" />
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What is a channel?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>A channel acts as a virtual connection inside a TCP connection.</p>
+			<img alt="LavinMQ channel" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-two.png" />
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect3" id="accordion3">
+        What is the role of channels in the AMQP protocol?
+      </button>
+    </h3>
+    <div id="sect3" class="accordion-content" role="region" aria-labelledby="accordion3">
+      <p>
+				Every AMQP protocol-related operation occurs over a channel. A channel reuses a
+				connection, avoiding the need to reauthorize and open a new TCP stream. Channels
+				use resources more efficiently than opening and closing connections.
+			</p>
+    </div>
+  </div>
+</div>
+
+A connection is created by:
+
+1. Establishing a physical TCP connection to the target server.
+2. The client resolves the hostname to one or more IP addresses.
+3. The receiving server authenticates the client.
+4. A connection is now established.
+
+<img alt="LavinMQ channel" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-three.png" />
+
+**Example:** Establishing a connection
+
+{% highlight python %}
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+{% endhighlight %}
+
+LavinMQ supports IPv4, IPv6, and encrypted TLS (SSL) connections. For most clients, TLS is easy to use; replace amqp:// with amqps:// in the URL.
+
+Connections must be established before creating a channel to send messages or manage queues.
+
+### Channel
+
+Every AMQP protocol-related operation occurs over a channel, such as sending messages, creating an exchange, or handling queue creation and maintenance. AMQP allows one TCP/IP connection to multiplex into several “lightweight” channels. Channels are resource-efficient since they reuse existing channels and minimize the need for resource-heavy openings and closings of new TCP channels.
+
+Closing a connection closes all associated channels.
+
+<img alt="LavinMQ channel" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-four.png" />
+
+A channel can be opened right after successfully opening a connection.
+
+**Example:** Opening a channel
+
+{% highlight python %}
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+{% endhighlight %}

--- a/docs/amqp-connections-and-channels.md
+++ b/docs/amqp-connections-and-channels.md
@@ -12,7 +12,7 @@
           underlying networking tasks, including initial authentication, IP resolution, and
           networking.
         </p>
-				<img alt="LavinMQ connection start" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-one.png" />
+				<img alt="LavinMQ connection start" class="border border-[#414040]" src="img/docs/amqp-connections-and-channels-one.png" />
     </div>
   </div>
 
@@ -24,7 +24,7 @@
     </h3>
     <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
       <p>A channel acts as a virtual connection inside a TCP connection.</p>
-			<img alt="LavinMQ channel" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-two.png" />
+			<img alt="LavinMQ channel" class="border border-[#414040]" src="img/docs/amqp-connections-and-channels-two.png" />
     </div>
   </div>
 
@@ -51,7 +51,7 @@ A connection is created by:
 3. The receiving server authenticates the client.
 4. A connection is now established.
 
-<img alt="LavinMQ channel" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-three.png" />
+<img alt="LavinMQ channel" class="border border-[#414040]" src="img/docs/amqp-connections-and-channels-three.png" />
 
 **Example:** Establishing a connection
 
@@ -71,7 +71,7 @@ Every AMQP protocol-related operation occurs over a channel, such as sending mes
 
 Closing a connection closes all associated channels.
 
-<img alt="LavinMQ channel" class="border border-[#414040]" src="/img/docs/amqp-connections-and-channels-four.png" />
+<img alt="LavinMQ channel" class="border border-[#414040]" src="img/docs/amqp-connections-and-channels-four.png" />
 
 A channel can be opened right after successfully opening a connection.
 

--- a/docs/amqp-exchanges.md
+++ b/docs/amqp-exchanges.md
@@ -1,0 +1,290 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is an exchange?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          An exchange receives messages from producers and routes them to the correct queues using bindings and routing keys based on predefined rules.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What benefits do exchanges have?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        Exchanges provide flexible message routing by applying specified rules, making it easy to direct messages to one or more queues based on the routing key and the type of exchange.
+      </p>
+    </div>
+  </div>
+</div>
+
+LavinMQ supports four types of exchanges, each routing messages differently based on binding configurations and parameters: Direct, Topic, Fanout, and Header exchanges <internal links down the page>. Default exchanges are automatically created when the server starts, but clients also have the option to define custom exchanges.
+
+## Setting up exchanges
+
+1. **Declare the exchange:** Define the exchange's name and specify its exchange type (e.g., fanout, direct, topic), which determines how it routes messages.
+2. **Declare the queue.**
+3. **Establish a binding between the exchange and the queue.**
+4. **Publish messages:** Send a message to the exchange, which routes it to the appropriate queue(s).
+5. **Delete the exchange:** Remove the exchange when it's no longer needed.
+
+**Example**: Declaring a fanout exchange, a queue, creating a binding between them, and finally deleting the exchange:
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+channel.exchange_declare(exchange='notifications', exchange_type='fanout')
+channel.queue_declare(queue='notification_queue')
+channel.queue_bind(exchange='notifications', queue='notification_queue')
+
+channel.basic_publish(exchange='notifications', routing_key='', body='New notification from LavinMQ!')
+
+channel.exchange_delete(exchange='notifications')
+
+connection.close()
+```
+
+## Direct Exchange
+
+A direct exchange routes messages to a specific queue based on a matching routing key. The routing key in the message is compared with the routing keys defined in the bindings. When they match, the message is delivered to the corresponding queue.
+
+**Example:** Declare a direct exchange named `direct_exchange` and publish a message to it.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+channel.exchange_declare(exchange='direct_exchange', exchange_type='direct')
+channel.queue_declare(queue='direct_queue')
+channel.queue_bind(exchange='direct_exchange', queue='direct_queue', routing_key='direct_key')
+
+channel.basic_publish(exchange='direct_exchange', routing_key='direct_key', body='Message to direct_exchange')
+
+channel.exchange_delete(exchange='direct_exchange')
+
+connection.close()
+```
+
+The default direct exchange in an AMQP broker is named `amq.direct`.
+
+### Default exchange (nameless direct exchange)
+
+The default direct exchange is a nameless exchange, often referred to by an empty string (`""`). When using this exchange, messages are routed to queues whose names match the message's routing key, as queues are automatically bound to it based on their names.
+
+**Example**: Publish a message to the default exchange.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='queue1')
+channel.basic_publish(exchange='', routing_key='queue1', body='Hello, queue1!')
+
+connection.close()
+```
+
+## Topic Exchange
+
+A topic exchange routes messages to one or more queues based on the routing key. The routing key in the message is compared against the routing key patterns defined in the bindings. Messages with routing keys that match the binding patterns are routed to the corresponding queues, where they remain until a consumer retrieves them or they are removed for other reasons.
+
+The topic exchange supports strict routing key matching, like a direct exchange, but will also perform wild-card matching using `*` and `#` as placeholders. Routing keys must delimit the list of words by a period.
+
+- The asterisk (`*`) is a wildcard for precisely one word.
+- The hash (`#`) is a wildcard for zero or more words.
+
+**Example**: Declare a topic exchange, create a queue, bind them with a routing key pattern (`*.error`), and publish a message with a matching routing key (`app.error`). The messages will be routed to the queue.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+channel.exchange_declare(exchange='logs', exchange_type='topic')
+channel.queue_declare(queue='log_queue')
+channel.queue_bind(exchange='logs', queue='log_queue', routing_key='*.error')
+channel.basic_publish(exchange='logs', routing_key='app.error', body='An error.')
+
+connection.close()
+```
+
+The topic exchange and AMQP broker must provide `amq.topic`.
+
+## Fanout Exchange
+
+A fanout exchange routes and copies messages to all queues bound to it, disregarding the routing key. Fanout exchanges are helpful when the same message must be sent to multiple queues, where consumers may process the message differently.
+
+**Example**: Declare a fanout exchange.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+channel.exchange_declare(exchange='logs', exchange_type='fanout')
+
+connection.close()
+```
+
+The fanout exchange and AMQP broker must provide `amq.fanout`.
+
+## Headers Exchange
+
+Messages in a headers exchange are routed based on header values, rather than routing keys, using optional arguments. A message matches if the header's value equals the value specified in the routing key on the binding, defined by the `x-match` argument.
+
+The `x-match` argument uses the binding to determine whether headers should match. The message's headers are compared with the binding's headers, and the `x-match` specifies whether all headers must match or just one.
+
+- The `x-match` header can have two values: `all` or `any`.
+  - `all`: The message header must match all the headers specified in the binding.
+  - `any`: The message header must match at least one of the headers specified in the binding.
+
+**Example**: Declare a headers exchange and set up a binding. In this example, the message will only be routed to the `my_queue` if it contains both `header1` with `value1` and `header2` with `value2` because of the `x-match: all` condition.
+
+<!-- prettier-ignore-start -->
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+channel = connection.channel()
+
+channel.exchange_declare(exchange='headers_exchange', exchange_type='headers')
+channel.queue_declare(queue='my_queue')
+channel.queue_bind(exchange='headers_exchange', queue='my_queue', arguments={
+    'x-match': 'all',
+    'header1': 'value1',
+    'header2': 'value2'
+})
+channel.basic_publish(
+    exchange='headers_exchange',
+    routing_key='',
+    body='Message with headers',
+    properties=pika.BasicProperties(headers={'header1': 'value1', 'header2': 'value2'})
+)
+
+connection.close()
+```
+<!-- prettier-ignore-end -->
+
+The headers Exchange an AMQP broker must provide `amq.headers`.
+
+## Exchange properties
+
+An exchange is created with properties. These properties must be set individually for each exchange and cannot be applied using policies.
+
+### Exchange Name
+
+Every exchange must have a name when declared. If no name is provided, most client libraries will raise an error. Some libraries may allow temporary exchanges with a randomly or automatically assigned name.
+
+Names starting with the `amq.` prefix are reserved for internal use and cannot be used for user-defined exchanges.
+
+Example: Declare a named exchange.
+
+```python
+channel.exchange_declare(exchange='direct_ex', exchange_type='direct')
+```
+
+### Exchange Type
+
+Exchange types define how messages are routed to queues:
+
+- **`direct`**: Routes messages with a specific routing key.
+- **`fanout`**: Routes messages to all bound queues (ignores routing keys).
+- **`topic`**: Routes messages based on a pattern in the routing key.
+- **`headers`**: Routes messages based on header values.
+
+**Example:** Declare exchanges.
+
+```python
+channel.exchange_declare(exchange='direct_ex', exchange_type='direct')
+channel.exchange_declare(exchange='ex', exchange_type='fanout')
+channel.exchange_declare(exchange='topic_ex', exchange_type='topic')
+channel.exchange_declare(exchange='headers_ex', exchange_type='headers')
+```
+
+### Durable Exchanges
+
+Durable exchanges remain intact even after a server restart, ensuring continued availability and reducing the risk of data loss.
+
+**Example:** Declare a durable direct exchange.
+
+```python
+channel.exchange_declare(exchange='durable_exchange', exchange_type='direct', durable=True)
+```
+
+### Auto-delete Exchanges
+
+Auto-delete exchanges are automatically removed when no queues remain bound to them, freeing up system resources.
+
+**Example:** Declare an auto-delete fanout exchange.
+
+```python
+channel.exchange_declare(exchange='auto_delete_exchange', exchange_type='fanout', auto_delete=True)
+```
+
+LavinMQ ignores the `auto-delete` field if the exchange already exists.
+
+### Internal Exchanges
+
+Internal exchanges are designed for internal use within the messaging system and are not intended for direct interaction with external components.
+
+The internal exchange should be set if the exchange is going to be used in the exchange to exchange bindings.
+
+### Delayed Exchanges
+
+Delayed exchanges introduce a delay before delivering messages, enabling delayed processing or scheduling of tasks. Read more in the [Delayed Exchanges documentation](/documentation/delayed-message).
+
+### Exchange arguments (optional properties)
+
+The specifications of AMQP 0.9.1 enable support for various features called [arguments](/documentation/arguments-and-properties). Depending on the argument, their settings can be changed after the exchange declaration.
+
+It is recommended that exchange arguments are set using policies to configure multiple queues simultaneously and ensure they are updated automatically when the policy definition changes.
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Argument</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Alternate Exchange <br/>(<code>x-alternate-exchange</code>: String)</td>
+					<td>If messages to this exchange cannot otherwise be routed, send them to the alternate exchange named here.</td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+## Dead Letter Exchange
+
+A queue declared with the x-dead-letter-exchange property will send rejected messages, negatively acknowledged (nacked) without a requeue setting, or expired (due to TTL) to the specified dead-letter-exchange. For more information, read about the [Dead Letter Exchange](/documentation/dead-letter-exchange).
+
+## Exchange to Exchange bindings
+
+Bindings can be created between exchanges in LavinMQ.
+
+**Example**: Create an exchange to exchange binding.
+
+```python
+channel.exchange_bind(destination='destination_exchange', source='source_exchange')
+```

--- a/docs/amqp-exchanges.md
+++ b/docs/amqp-exchanges.md
@@ -248,11 +248,11 @@ The internal exchange should be set if the exchange is going to be used in the e
 
 ### Delayed Exchanges
 
-Delayed exchanges introduce a delay before delivering messages, enabling delayed processing or scheduling of tasks. Read more in the [Delayed Exchanges documentation](/documentation/delayed-message).
+Delayed exchanges introduce a delay before delivering messages, enabling delayed processing or scheduling of tasks. Read more in the [Delayed Exchanges documentation](delayed-message.md).
 
 ### Exchange arguments (optional properties)
 
-The specifications of AMQP 0.9.1 enable support for various features called [arguments](/documentation/arguments-and-properties). Depending on the argument, their settings can be changed after the exchange declaration.
+The specifications of AMQP 0.9.1 enable support for various features called [arguments](arguments-and-properties.md). Depending on the argument, their settings can be changed after the exchange declaration.
 
 It is recommended that exchange arguments are set using policies to configure multiple queues simultaneously and ensure they are updated automatically when the policy definition changes.
 
@@ -277,7 +277,7 @@ It is recommended that exchange arguments are set using policies to configure mu
 
 ## Dead Letter Exchange
 
-A queue declared with the x-dead-letter-exchange property will send rejected messages, negatively acknowledged (nacked) without a requeue setting, or expired (due to TTL) to the specified dead-letter-exchange. For more information, read about the [Dead Letter Exchange](/documentation/dead-letter-exchange).
+A queue declared with the x-dead-letter-exchange property will send rejected messages, negatively acknowledged (nacked) without a requeue setting, or expired (due to TTL) to the specified dead-letter-exchange. For more information, read about the [Dead Letter Exchange](dead-letter-exchange.md).
 
 ## Exchange to Exchange bindings
 

--- a/docs/amqp-messages.md
+++ b/docs/amqp-messages.md
@@ -1,0 +1,169 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a message?
+    	</button>
+    </h3>
+  	<div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+      <p>
+				An AMQP message is the data transported from a producer to a consumer through the LavinMQ message broker. It can for example contain information that tells a system to perform a task, reports on a finished task, or simply carries data. Every message consists of a payload and a set of attributes.
+			</p>
+    </div>
+  </div>
+</div>
+
+<lottie-player src="/animations/lavinmq-animation.json" background="transparent" speed="1" style="width: 100%; height: auto" loop autoplay></lottie-player>
+
+## Message Components
+
+An AMQP message is built from two essential parts: the payload and a set of attributes. The payload is the actual data, while the attributes are the metadata that tell the broker how to handle it.
+
+### Message payload
+This is the actual data to send, it can be any binary format. The broker does not inspect or modify the payload; it only transports it.
+
+#### Payload encoding 
+Payload encoding is a key used by some client tools and APIs, like the LavinMQ HTTP API, to define how the payload should be interpreted before it is sent to the broker. This key specifies whether the payload should be handled as a `string` (UTF-8 encoded) or as `base64`. Payload encoding is not part of the standard AMQP protocol. 
+
+### Delivery mode
+In LavinMQ, every message sent is persistent by default. This ensures that all messages are saved to disk and will survive a broker restart, guaranteeing message durability.
+
+### Routing key 
+The routing key is a message attribute that the exchange looks at when deciding how to route the message to one or more queues, depending on its type. 
+
+### Attributes 
+These are the meta-information that tell the broker how to handle the message. This includes both standard properties and custom headers. Properties are a predefined set of fields from the AMQP protocol, such as content-type and delivery-mode.
+
+#### [Properties]
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-gray-300 conf-table">
+      <tr>
+        <td class="font-semibold">content_type</td>
+        <td>
+        	Describes the content of the message payload, using a MIME type (e.g., <code class="language-plaintext">application/json</code>, <code class="language-plaintext">text/plain</code>). Content type is used by applications, not core LavinMQ.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">content_encoding</td>
+        <td>
+        	Specifies the encoding of the payload (e.g., <code class="language-plaintext">gzip</code>, <code class="language-plaintext">deflate</code>). Content encoding is used by applications, not core LavinMQ.
+					<br/>
+        	<br/>
+        	Default: <code class="language-plaintext">application/json</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">expiration</td>
+        <td>
+					A string representing the message's time-to-live (TTL) in milliseconds. 
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">priority</td>
+        <td>
+					A number from 0 to 9 to set message priority. Read more about [message priority](/documentation/message-priority).
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">message_id</td>
+        <td>
+        A unique identifier for the message.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">timestamp</td>
+        <td>
+					Application-provided timestamp.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">type</td>
+        <td>
+        The name of the message type, such as a command or event name.
+        </td>
+      </tr>
+			<tr>
+        <td class="font-semibold">user_id</td>
+        <td>
+					The ID of the user who published the message.
+        </td>
+			</tr>	
+			<tr>
+        <td class="font-semibold">app_id</td>
+        <td>
+					The name of the application that published the message.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">correlation_id</td>
+        <td>
+					Used to correlate a response message with a request message.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">reply_to</td>
+        <td>
+					The name of a queue where the consumer should send a reply. This property is essential for implementing a request-response pattern, allowing a client to receive a specific response to a message it has sent.
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+#### Custom headers
+Custom headers are a flexible key-value map for adding application-specific metadata.
+
+## Example message
+
+<!-- prettier-ignore -->
+
+{% highlight shell %}
+{% raw %}
+{
+  "properties": {
+    "content_type": "application/json",
+    "content_encoding": "text/plain"
+  },
+  "routing_key": "my-key",
+  "payload": "my-body",
+  "payload_encoding": "string"
+}
+{% endraw %}
+{% endhighlight %}
+
+
+### Message acknowledgements
+
+Messages in transit between LavinMQ and the consumer might get lost and have
+to be re-sent. This can occur when a connection fails or during other events
+that disconnect the receiving service (consumer) from LavinMQ. The use of
+consumer acknowledgments assures that messages have been delivered. When it
+comes to message publishing, a publish confirm is the same concept.
+
+Read more about
+[consumer acknowledgments](/documentation/consumer-acknowledgements).
+
+### Message ordering in LavinMQ
+
+Messages in LavinMQ are placed onto the queue in the sequential order in
+which they are received. The first message is placed in position 1, the second
+message in position 2, and so on. Messages are then consumed from the head of
+the queue, meaning that message 1 gets consumed first. This is called the FIFO
+method (first in first out). 
+
+Read more about [message ordering](/documentation/message-ordering) in
+LavinMQ.
+
+### Details on the message store in LavinMQ
+
+All routed messages in LavinMQ are written directly to the disk into
+something called a Message Store. The Message Store is a series of files
+(segments). A routed message is located in the Message Store, with a reference
+from the queue’s index to the [message store](/documentation/message-store).
+
+### Message size
+The default message size limit in LavinMQ is 128 MB. This limit is on the message payload and can be configured.
+It's generally recommended to keep messages small. Larger messages can consume more memory and disk resources, potentially affecting broker performance and stability.
+Read more about [message configurations](/documentation/configuration-files).

--- a/docs/amqp-messages.md
+++ b/docs/amqp-messages.md
@@ -1,4 +1,3 @@
-
 <div class="accordion">
   <div class="accordion-item">
     <h3>
@@ -14,28 +13,34 @@
   </div>
 </div>
 
-<lottie-player src="/animations/lavinmq-animation.json" background="transparent" speed="1" style="width: 100%; height: auto" loop autoplay></lottie-player>
+<!--  -->
 
 ## Message Components
 
 An AMQP message is built from two essential parts: the payload and a set of attributes. The payload is the actual data, while the attributes are the metadata that tell the broker how to handle it.
 
 ### Message payload
+
 This is the actual data to send, it can be any binary format. The broker does not inspect or modify the payload; it only transports it.
 
-#### Payload encoding 
-Payload encoding is a key used by some client tools and APIs, like the LavinMQ HTTP API, to define how the payload should be interpreted before it is sent to the broker. This key specifies whether the payload should be handled as a `string` (UTF-8 encoded) or as `base64`. Payload encoding is not part of the standard AMQP protocol. 
+#### Payload encoding
+
+Payload encoding is a key used by some client tools and APIs, like the LavinMQ HTTP API, to define how the payload should be interpreted before it is sent to the broker. This key specifies whether the payload should be handled as a `string` (UTF-8 encoded) or as `base64`. Payload encoding is not part of the standard AMQP protocol.
 
 ### Delivery mode
+
 In LavinMQ, every message sent is persistent by default. This ensures that all messages are saved to disk and will survive a broker restart, guaranteeing message durability.
 
-### Routing key 
-The routing key is a message attribute that the exchange looks at when deciding how to route the message to one or more queues, depending on its type. 
+### Routing key
 
-### Attributes 
+The routing key is a message attribute that the exchange looks at when deciding how to route the message to one or more queues, depending on its type.
+
+### Attributes
+
 These are the meta-information that tell the broker how to handle the message. This includes both standard properties and custom headers. Properties are a predefined set of fields from the AMQP protocol, such as content-type and delivery-mode.
 
 #### [Properties]
+
 <div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
   <div style="overflow: auto;">
     <table class="divide-y divide-gray-300 conf-table">
@@ -57,13 +62,13 @@ These are the meta-information that tell the broker how to handle the message. T
       <tr>
         <td class="font-semibold">expiration</td>
         <td>
-					A string representing the message's time-to-live (TTL) in milliseconds. 
+					A string representing the message's time-to-live (TTL) in milliseconds.
         </td>
       </tr>
       <tr>
         <td class="font-semibold">priority</td>
         <td>
-					A number from 0 to 9 to set message priority. Read more about [message priority](/documentation/message-priority).
+					A number from 0 to 9 to set message priority. Read more about [message priority](message-priority.md).
         </td>
       </tr>
       <tr>
@@ -89,7 +94,7 @@ These are the meta-information that tell the broker how to handle the message. T
         <td>
 					The ID of the user who published the message.
         </td>
-			</tr>	
+			</tr>
 			<tr>
         <td class="font-semibold">app_id</td>
         <td>
@@ -113,12 +118,12 @@ These are the meta-information that tell the broker how to handle the message. T
 </div>
 
 #### Custom headers
+
 Custom headers are a flexible key-value map for adding application-specific metadata.
 
 ## Example message
 
 <!-- prettier-ignore -->
-
 {% highlight shell %}
 {% raw %}
 {
@@ -133,7 +138,6 @@ Custom headers are a flexible key-value map for adding application-specific meta
 {% endraw %}
 {% endhighlight %}
 
-
 ### Message acknowledgements
 
 Messages in transit between LavinMQ and the consumer might get lost and have
@@ -143,7 +147,7 @@ consumer acknowledgments assures that messages have been delivered. When it
 comes to message publishing, a publish confirm is the same concept.
 
 Read more about
-[consumer acknowledgments](/documentation/consumer-acknowledgements).
+[consumer acknowledgments](consumer-acknowledgements.md).
 
 ### Message ordering in LavinMQ
 
@@ -151,9 +155,9 @@ Messages in LavinMQ are placed onto the queue in the sequential order in
 which they are received. The first message is placed in position 1, the second
 message in position 2, and so on. Messages are then consumed from the head of
 the queue, meaning that message 1 gets consumed first. This is called the FIFO
-method (first in first out). 
+method (first in first out).
 
-Read more about [message ordering](/documentation/message-ordering) in
+Read more about [message ordering](message-ordering.md) in
 LavinMQ.
 
 ### Details on the message store in LavinMQ
@@ -161,9 +165,10 @@ LavinMQ.
 All routed messages in LavinMQ are written directly to the disk into
 something called a Message Store. The Message Store is a series of files
 (segments). A routed message is located in the Message Store, with a reference
-from the queue’s index to the [message store](/documentation/message-store).
+from the queue’s index to the [message store](message-store.md).
 
 ### Message size
+
 The default message size limit in LavinMQ is 128 MB. This limit is on the message payload and can be configured.
 It's generally recommended to keep messages small. Larger messages can consume more memory and disk resources, potentially affecting broker performance and stability.
-Read more about [message configurations](/documentation/configuration-files).
+Read more about [message configurations](configuration-files.md).

--- a/docs/amqp-queues.md
+++ b/docs/amqp-queues.md
@@ -1,0 +1,217 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a queue?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          An AMQP queue is a buffer where messages are held until a consuming client retrieves them for processing. Messages remain in the queue until consumed or removed due to expiration, purging, deletion, or conditions such as reaching a size limit. In LavinMQ, all messages sent to a queue are persistently stored on disk. Queues deliver messages in a first-in, first-out (FIFO) order.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What features do queues hold?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        A queue serves as a temporary storage area for messages, acting as a buffer before they are consumed. When created, queues can be configured with various attributes that determine their lifecycle and behavior. For instance, an auto-delete queue is automatically removed when its last connection closes, while an exclusive queue is restricted to a single connection and is deleted once that connection ends.
+      </p>
+    </div>
+  </div>
+</div>
+
+LavinMQ supports two types of queues: standard queues and stream queues. Standard queues are designed for short-term message storage, where messages are discarded once handled. If multiple message processing times are required, LavinMQ offers stream queues. In stream queues, messages are not deleted after consumption, allowing multiple consumers to read the same message and enabling message replay. Read the [Stream queues documentation](/documentation/streams) for more information.
+
+## Using a queue
+
+When setting up a message queue, begin by declaring it with a name. If the queue does not already exist, it will be created.
+
+The sending service declares the queue, and the LavinMQ server confirms the declaration by responding `declare-ok`. The service then connects a consumer to the message queue. Messages can now be sent via the queue from one service (producer) to another (consumer). The consumer can explicitly disconnect from a queue or disconnect by closing the channel and/or connection.
+
+**Example**: Declare a durable queue.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+# Declare a durable queue
+channel.queue_declare(queue='test', durable=True)
+
+connection.close()
+```
+
+## Queue properties
+
+A queue can be created with some given queue properties. Queue properties cannot be applied with policies and must be enabled per queue. These properties are available in LavinMQ:
+
+- Name
+- Durable
+- Exclusive
+- Auto-delete
+- Arguments
+
+## Queue Name
+
+A queue can have a given name, if no name is specified, most client libraries assign a random name to the queue. Queue names starting with the `amq.` prefix are reserved for internal use and cannot be used for user-defined queues.
+
+Example: Declare a queue with the queue name `the_queue_name`.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='the_queue_name', durable=True)
+```
+
+## Durable queues
+
+A queue can be marked as durable, which specifies whether it should persist a LavinMQ restart. To create a durable queue, specify the property `durable` as `True` during the queue's creation as done in the example above.
+
+**Example**: Declare a durable queue.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='the_queue_name', durable=True)
+```
+
+## Exclusive queues
+
+Setting the properties to `exclusive` is useful when limiting a queue to only one consumer. Exclusive queues can only be used by one connection, meaning that all actions to and from that queue happen over and follow the preset settings of one specific connection. When the connection closes, the exclusive queue is deleted.
+
+**Example**: Declare an exclusive queue.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='test', exclusive=True)
+```
+
+## Auto-delete queues
+
+A queue can be declared with the `auto-delete` property. This is useful when queues should not stay open when the final connection to the queue closes. The auto-delete property requires at least one connected consumer to succeed. Otherwise, it will not be deleted.
+
+Note: Different consumer and broker communication methods can impact the auto-delete property. For example, the `basic.get` method gives direct access to a queue instead of setting up a consumer, so consuming a message with `basic.get` will not affect `auto_delete`.
+
+**Example**: Declare an auto-delete queue.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='test', auto_delete=True)
+
+connection.close()
+```
+
+## Queue arguments (optional properties)
+
+The specifications of AMQP 0.9.1 enable support for various features called arguments. Depending on the argument, their settings can be changed after the queue declaration.
+
+It is recommended that queue arguments are set using policies to configure multiple queues simultaneously and ensure they are updated automatically when the policy definition changes.
+
+Read more about [policies](/documentation/policies).
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Argument</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><span class="font-semibold">Auto Expire</span> <br/>(<code class="language-plaintext highlighter-rouge">x-expires</code> : Int)</td>
+					<td>Sets the time (in milliseconds) after which an <strong>idle queue</strong> (one without consumers) is automatically deleted.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Max Length</span> <br/>(<code class="language-plaintext highlighter-rouge">x-max-length</code> : Int)</td>
+					<td>Limits the <strong>number of messages</strong> a queue can hold. If exceeded, messages are dropped based on the overflow policy.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Message TTL</span> <br/>(<code class="language-plaintext highlighter-rouge">x-message-ttl</code> : Int)</td>
+					<td>Defines how long (in milliseconds) a message can stay in the queue before being automatically removed.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Delivery Limit</span> <br/>(<code class="language-plaintext highlighter-rouge">x-delivery-limit</code> : Int)</td>
+					<td>Specifies the <strong>maximum number of delivery attempts</strong> for a message before it is discarded or sent to a dead-letter exchange.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Overflow Behaviour</span> <br/>(<code class="language-plaintext highlighter-rouge">x-overflow</code> : String)</td>
+					<td>Determines what happens when a queue reaches its max length: By default this is set to <code class="language-plaintext highlighter-rouge">"drop-head"</code> (removes oldest messages). Also available is <code class="language-plaintext highlighter-rouge">"reject-publish"</code> (rejects new messages).</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Dead Letter Exchange</span> <br/>(<code class="language-plaintext highlighter-rouge">x-dead-letter-exchange</code> : String)</td>
+					<td>Specifies an <strong>exchange</strong> where messages are sent when they expire, exceed delivery attempts, or are rejected.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Dead Letter Routing Key</span> <br/>(<code class="language-plaintext highlighter-rouge">x-dead-letter-routing-key</code> : String)</td>
+					<td>Defines a <strong>custom routing key</strong> for messages sent to the dead-letter exchange.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Max Priority</span> <br/>(<code class="language-plaintext highlighter-rouge">x-max-priority</code> : Int)</td>
+					<td>Enables <strong>message prioritization</strong> with a priority range between <strong>1 and 255</strong>. Read more about message priority <a href="/documentation/message-priority">here</a>.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Stream Queue</span> <br/>(<code class="language-plaintext highlighter-rouge">x-queue-type=stream</code>)</td>
+					<td>Turns the queue into a <strong>stream queue</strong>, storing messages for history-based retrieval instead of traditional message queuing.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Max Age</span> <br/>(<code class="language-plaintext highlighter-rouge">x-max-age</code> : String)</td>
+					<td>Limits how long messages are <strong>retained</strong> in a stream queue. Older messages are automatically deleted.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Message Deduplication</span> <br/>(<code class="language-plaintext highlighter-rouge">x-deduplication-enabled</code> : Bool)</td>
+					<td>Enables deduplication to avoid storing duplicate messages.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Deduplication Cache Size</span> <br/>(<code class="language-plaintext highlighter-rouge">x-cache-size</code> : Int)</td>
+					<td>Sets how many messages to store for deduplication checks. A larger cache uses more memory.</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Deduplication Cache TTL</span> <br/>(<code class="language-plaintext highlighter-rouge">x-cache-ttl</code> : Int)</td>
+					<td>Cache entry time-to-live in milliseconds (default: unlimited).</td>
+				</tr>
+				<tr>
+					<td><span class="font-semibold">Deduplication Header</span> <br/>(<code class="language-plaintext highlighter-rouge">x-deduplication-header</code> : String)</td>
+					<td>Specifies what header to guard for deduplication, defaults to x-deduplication-header.</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+## Pausing a queue
+
+Pausing a queue will pause all consumers. All clients will remain connected but receive no messages from the queue. The “pause queue” option can be found in queue details in the LavinMQ management interface or via the HTTP API.
+
+Pausing a queue using RabbitMQ HTTP API:
+
+`curl -X PUT [http://guest:guest@localhost:15672/api/queues/vhost_name/queue_name/pause](http://guest:guest@localhost:15672/api/queues/vhost/queue/pause)`
+
+Resuming a queue using RabbitMQ HTTP API:
+
+`curl -X PUT [http://guest:guest@localhost:15672/api/queues/vhost_name/queue_name/](http://guest:guest@localhost:15672/api/queues/vhost/queue/pause)resume`
+
+![Management Interface pause queue](/img/docs/pause-queue.png)

--- a/docs/amqp-queues.md
+++ b/docs/amqp-queues.md
@@ -27,7 +27,7 @@
   </div>
 </div>
 
-LavinMQ supports two types of queues: standard queues and stream queues. Standard queues are designed for short-term message storage, where messages are discarded once handled. If multiple message processing times are required, LavinMQ offers stream queues. In stream queues, messages are not deleted after consumption, allowing multiple consumers to read the same message and enabling message replay. Read the [Stream queues documentation](/documentation/streams) for more information.
+LavinMQ supports two types of queues: standard queues and stream queues. Standard queues are designed for short-term message storage, where messages are discarded once handled. If multiple message processing times are required, LavinMQ offers stream queues. In stream queues, messages are not deleted after consumption, allowing multiple consumers to read the same message and enabling message replay. Read the [Stream queues documentation](streams.md) for more information.
 
 ## Using a queue
 
@@ -129,7 +129,7 @@ The specifications of AMQP 0.9.1 enable support for various features called argu
 
 It is recommended that queue arguments are set using policies to configure multiple queues simultaneously and ensure they are updated automatically when the policy definition changes.
 
-Read more about [policies](/documentation/policies).
+Read more about [policies](policies.md).
 
 <div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
   <div style="overflow: auto;">
@@ -171,7 +171,7 @@ Read more about [policies](/documentation/policies).
 				</tr>
 				<tr>
 					<td><span class="font-semibold">Max Priority</span> <br/>(<code class="language-plaintext highlighter-rouge">x-max-priority</code> : Int)</td>
-					<td>Enables <strong>message prioritization</strong> with a priority range between <strong>1 and 255</strong>. Read more about message priority <a href="/documentation/message-priority">here</a>.</td>
+					<td>Enables <strong>message prioritization</strong> with a priority range between <strong>1 and 255</strong>. Read more about message priority <a href="message-priority.md">here</a>.</td>
 				</tr>
 				<tr>
 					<td><span class="font-semibold">Stream Queue</span> <br/>(<code class="language-plaintext highlighter-rouge">x-queue-type=stream</code>)</td>
@@ -214,4 +214,4 @@ Resuming a queue using RabbitMQ HTTP API:
 
 `curl -X PUT [http://guest:guest@localhost:15672/api/queues/vhost_name/queue_name/](http://guest:guest@localhost:15672/api/queues/vhost/queue/pause)resume`
 
-![Management Interface pause queue](/img/docs/pause-queue.png)
+![Management Interface pause queue](img/docs/pause-queue.png)

--- a/docs/amqp-the-protocol.md
+++ b/docs/amqp-the-protocol.md
@@ -1,0 +1,66 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is the Advanced Message Queuing Protocol?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p><a href="https://www.amqp.org/">AMQP</a> is a binary protocol, designed to handle large amounts of data and is typically the protocol that is used for message-oriented middleware. It allows messages to be sent asynchronously, meaning they don't need to be processed immediately. LavinMQ supports all AMQP client libraries that are available for nearly every programming language.</p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        Why is AMQP used in LavinMQ?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>AMQP enables advanced messaging patterns like work queues, publish-subscribe, and routing, which make it an ideal choice for LavinMQ. It ensures reliable, asynchronous communication across different platforms, guarantees message delivery, and supports scalability, making it a trusted choice for building flexible and resilient messaging systems.</p>
+    </div>
+  </div>
+</div>
+
+LavinMQ extends the open standard AMQP 0.9.1 specification. AMQP is one of two protocols supported by LavinMQ.
+
+### Main concepts in AMQP
+
+In AMQP 0-9-1, producers send messages to an exchange. These [messages](/documentation/amqp-messages) are routed from the exchange to a queue based on exchange types and routing keys, forming the core structure of its messaging model. Consumers then retrieve messages from the queues.
+
+<img title="AMQP protocol" src="/img/docs/amqp-protocol-illustration.png" class="border border-[#414040]"/>
+
+### Queues
+
+A queue provides a place to store messages, acting as a buffer before they are consumed. Before use, a queue must be declared with a specified name or assigned a random one by the broker. During creation, queues can be configured with various attributes that define their lifecycle and behaviour. For example, an auto-delete queue is automatically removed when its last connection closes. In contrast, an exclusive queue can only be used by a single connection and is deleted when that connection ends.
+
+Learn more about how to create a [queue](/documentation/amqp-queues), [queue properties](/documentation/amqp-queues#queue-properties), and [arguments](/documentation/amqp-queues#queue-arguments-optional-properties).
+
+### Exchange types and bindings
+
+A message is routed to a queue depending on the exchange type and bindings between the exchange and the queue. For a queue to receive messages, it must be bound to at least one exchange. LavinMQ provides four main exchange types - direct exchange, fanout exchange, topic exchange, and header exchange.
+
+During creation, an exchange can be declared with several attributes. For instance, it can be marked as durable to survive a broker restart, or it can be marked as auto-delete, meaning that it’s automatically deleted when the last queue is unbound. A binding is a relation between a queue and an exchange consisting of rules that the exchange uses (among other things) to route messages to queues.
+
+Learn more about [exchange types](/documentation/amqp-exchanges) and [bindings](/documentation/amqp-bindings) and [how to create them.](/documentation/amqp-exchanges#the-four-exchange-types)
+
+### Message and content
+
+A message is a package sent from a publisher (sending client) to LavinMQ. Once LavinMQ receives it, the message is passed through an **exchange**, which decides where the message should go based on specific rules. The message is then stored in a **queue**, waiting to be picked up by a **consumer** (receiving client). Each message contains a set of headers, defining properties such as life duration, durability, and priority.
+
+AMQP 0.9.1 includes a built-in message acknowledgment feature that confirms message delivery and processing.
+
+Read more about [messages](/documentation/amqp-messages).
+
+### Connections and channels
+
+A **connection** is like a direct link between your application and LavinMQ over TCP/IP. **Channels** are like virtual pathways within that link, through which messages are actually sent and received. One connection can support multiple channels, allowing your application to send and receive multiple messages at once, without needing separate physical connections.
+
+The documentation provides more information about [connections and channels and their relationships](/documentation/amqp-connections-and-channels).
+
+### Virtual Hosts
+
+Think of **virtual hosts (vhosts)** as separate namespaces within LavinMQ where applications can run independently. Each vhost is like its own private area where **queues** and **exchanges** are created, and these resources don’t overlap with other vhosts. This separation helps control who can access what: users are given permission to specific vhosts, so they can only interact with the resources in their assigned space. This way, you can keep different applications isolated and secure within the same broker.
+
+Learn more about [vhosts](/documentation/amqp-vhost).

--- a/docs/amqp-the-protocol.md
+++ b/docs/amqp-the-protocol.md
@@ -27,15 +27,15 @@ LavinMQ extends the open standard AMQP 0.9.1 specification. AMQP is one of two p
 
 ### Main concepts in AMQP
 
-In AMQP 0-9-1, producers send messages to an exchange. These [messages](/documentation/amqp-messages) are routed from the exchange to a queue based on exchange types and routing keys, forming the core structure of its messaging model. Consumers then retrieve messages from the queues.
+In AMQP 0-9-1, producers send messages to an exchange. These [messages](amqp-messages.md) are routed from the exchange to a queue based on exchange types and routing keys, forming the core structure of its messaging model. Consumers then retrieve messages from the queues.
 
-<img title="AMQP protocol" src="/img/docs/amqp-protocol-illustration.png" class="border border-[#414040]"/>
+<img title="AMQP protocol" src="img/docs/amqp-protocol-illustration.png" class="border border-[#414040]"/>
 
 ### Queues
 
 A queue provides a place to store messages, acting as a buffer before they are consumed. Before use, a queue must be declared with a specified name or assigned a random one by the broker. During creation, queues can be configured with various attributes that define their lifecycle and behaviour. For example, an auto-delete queue is automatically removed when its last connection closes. In contrast, an exclusive queue can only be used by a single connection and is deleted when that connection ends.
 
-Learn more about how to create a [queue](/documentation/amqp-queues), [queue properties](/documentation/amqp-queues#queue-properties), and [arguments](/documentation/amqp-queues#queue-arguments-optional-properties).
+Learn more about how to create a [queue](amqp-queues.md), [queue properties](amqp-queues.md#queue-properties), and [arguments](amqp-queues.md#queue-arguments-optional-properties).
 
 ### Exchange types and bindings
 
@@ -43,7 +43,7 @@ A message is routed to a queue depending on the exchange type and bindings betwe
 
 During creation, an exchange can be declared with several attributes. For instance, it can be marked as durable to survive a broker restart, or it can be marked as auto-delete, meaning that it’s automatically deleted when the last queue is unbound. A binding is a relation between a queue and an exchange consisting of rules that the exchange uses (among other things) to route messages to queues.
 
-Learn more about [exchange types](/documentation/amqp-exchanges) and [bindings](/documentation/amqp-bindings) and [how to create them.](/documentation/amqp-exchanges#the-four-exchange-types)
+Learn more about [exchange types](amqp-exchanges.md) and [bindings](amqp-bindings.md) and [how to create them.](amqp-exchanges.md#the-four-exchange-types)
 
 ### Message and content
 
@@ -51,16 +51,16 @@ A message is a package sent from a publisher (sending client) to LavinMQ. Once L
 
 AMQP 0.9.1 includes a built-in message acknowledgment feature that confirms message delivery and processing.
 
-Read more about [messages](/documentation/amqp-messages).
+Read more about [messages](amqp-messages.md).
 
 ### Connections and channels
 
 A **connection** is like a direct link between your application and LavinMQ over TCP/IP. **Channels** are like virtual pathways within that link, through which messages are actually sent and received. One connection can support multiple channels, allowing your application to send and receive multiple messages at once, without needing separate physical connections.
 
-The documentation provides more information about [connections and channels and their relationships](/documentation/amqp-connections-and-channels).
+The documentation provides more information about [connections and channels and their relationships](amqp-connections-and-channels.md).
 
 ### Virtual Hosts
 
 Think of **virtual hosts (vhosts)** as separate namespaces within LavinMQ where applications can run independently. Each vhost is like its own private area where **queues** and **exchanges** are created, and these resources don’t overlap with other vhosts. This separation helps control who can access what: users are given permission to specific vhosts, so they can only interact with the resources in their assigned space. This way, you can keep different applications isolated and secure within the same broker.
 
-Learn more about [vhosts](/documentation/amqp-vhost).
+Learn more about [vhosts](amqp-vhost.md).

--- a/docs/amqp-vhost.md
+++ b/docs/amqp-vhost.md
@@ -1,0 +1,69 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a vhost?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          A vhost in LavinMQ is a logical container that groups connections, exchanges, queues, bindings, user permissions, and other resources within LavinMQ. Each vhost is isolated, allowing management and control of resources separately within the server.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What benefits does a vhost offer?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        A vhost in LavinMQ helps separate different applications on the same server. Multiple development instances can exist on the same LavinMQ server.
+      </p>
+    </div>
+  </div>
+</div>
+
+When a client establishes a connection to the LavinMQ server, it specifies the vhost in which it operates, for example `amqp://myuser:mypassword@localhost:5672/myvhost`
+
+<img src="/img/docs/lavinmq-vhost-example.png" class="border border-[#414040]" alt="LavinMQ vhost" />
+
+Resources such as exchanges and queues are named entities inside the vhost container, making each vhost function as a LavinMQ mini-server. When configuring LavinMQ, at least one vhost is required; by default, it is named “/”.
+
+Vhosts do not share exchanges or queues, and users, policies, and other settings are unique to each vhost.
+
+### Using vhosts in LavinMQ
+
+To create a vhost in LavinMQ, use the management interface or the HTTP API. A newly created vhost always has a default set of exchanges, no other entities, and no user permissions.
+
+### LavinMQ HTTP API
+
+1. Create a vhost:
+
+   ```
+   curl -X PUT http://username:password@localhost:15672/api/vhosts/vhost_name
+   ```
+
+   Replace `vhost_name` with the desired virtual host name.
+
+2. Grant a user access to the host:
+
+   ```
+   curl -X PUT http://username:password@localhost:15672/api/permissions/vhost_name/username \
+   -d '{"configure":".*", "write":".*", "read":".*"}' \
+   -H "Content-Type: application/json"
+   ```
+
+   Replace `vhost_name` with the vhost name, `username` with the user's name, and modify the regex pattern (`".*"`) to restrict permissions.
+
+### LavinMQ Management Interface
+
+1. Log in to the LavinMQ management interface.
+2. Navigate to the Virtual hosts section.
+3. Enter a vhost name and adjust permissions.
+4. Click _Add virtual host_ to create it.
+
+<img class="border border-[#414040]" alt="Management Interface vhost" src="/img/docs/docs-dm/vhost-dm.png" />

--- a/docs/amqp-vhost.md
+++ b/docs/amqp-vhost.md
@@ -29,7 +29,7 @@
 
 When a client establishes a connection to the LavinMQ server, it specifies the vhost in which it operates, for example `amqp://myuser:mypassword@localhost:5672/myvhost`
 
-<img src="/img/docs/lavinmq-vhost-example.png" class="border border-[#414040]" alt="LavinMQ vhost" />
+<img src="img/docs/lavinmq-vhost-example.png" class="border border-[#414040]" alt="LavinMQ vhost" />
 
 Resources such as exchanges and queues are named entities inside the vhost container, making each vhost function as a LavinMQ mini-server. When configuring LavinMQ, at least one vhost is required; by default, it is named “/”.
 
@@ -66,4 +66,4 @@ To create a vhost in LavinMQ, use the management interface or the HTTP API. A ne
 3. Enter a vhost name and adjust permissions.
 4. Click _Add virtual host_ to create it.
 
-<img class="border border-[#414040]" alt="Management Interface vhost" src="/img/docs/docs-dm/vhost-dm.png" />
+<img class="border border-[#414040]" alt="Management Interface vhost" src="img/docs/vhost-dm.png" />

--- a/docs/amqp-websocket.md
+++ b/docs/amqp-websocket.md
@@ -93,4 +93,4 @@ client.on('message', function (topic, message) {
 
 ### WebSocket tutorial
 Dive in with our hands-on guide to get started with WebSockets in LavinMQ.
-Try out the [websocket tutorial](/documentation/websocket-tutorial).
+Try out the [websocket tutorial](https://lavinmq.com/documentation/websocket-tutorial).

--- a/docs/amqp-websocket.md
+++ b/docs/amqp-websocket.md
@@ -1,0 +1,96 @@
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="ws-sect1" id="ws-accordion1">
+        What are WebSockets?
+      </button>
+    </h3>
+    <div id="ws-sect1" class="accordion-content" role="region" aria-labelledby="ws-accordion1">
+        <p>
+          WebSockets are like a phone call for your web browser. Instead of hanging up and redialing for every message (like a standard website), a WebSocket opens one continuous connection. This lets applications like live charts or chat apps instantly send and receive data without delay
+        </p>
+        <p>  
+          WebSockets are a protocol that enables a persistent, full-duplex communication channel over a single TCP connection. Unlike HTTP, which follows a request–response model, WebSockets allow both the client and the server to send messages to each other at any time. 
+        </p>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        Why are WebSockets important in LavinMQ?
+      </button>
+    </h3>
+      <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+        <p>
+          WebSockets make it possible for applications to communicate with LavinMQ in real time directly from environments where AMQP libraries may not be available, such as web browsers. WebSockets are well suited for real-time applications such as chat systems, live dashboards, online games, and IoT messaging.
+           This expands LavinMQ’s reach beyond traditional backend systems and makes it easier to integrate messaging into modern, interactive applications.
+        </p>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="ws-sect3" id="ws-accordion3">
+        How does LavinMQ support WebSockets?
+      </button>
+    </h3>
+      <div id="ws-sect3" class="accordion-content" role="region" aria-labelledby="ws-accordion3">
+        <p>
+          LavinMQ provides native support for WebSockets by exposing a persistent, full-duplex communication channel over a standard HTTP(S) port. Through WebSockets, applications can publish messages, consume from queues, and use exchanges in the same way as with traditional AMQP connections. Authentication, access control, and routing all work consistently, so WebSocket clients benefit from the same security and reliability features as other LavinMQ protocols.
+        </p>
+    </div>
+  </div>
+</div>
+LavinMQ offers support for Websockets via: _AMQP and MQTT over Websockets_.
+
+LavinMQ provides the WebSockets functionality through the `WebsocketProxy` module, which acts as a bridge between WebSocket clients and the standard TCP servers. Authentication, authorization, and routing work the same way as with regular AMQP or MQTT connections.
+
+The protocol is determined by the WebSocket endpoint path:
+
+- MQTT over WebSockets → connections to the `/mqtt` or `/ws/mqtt` are treated as MQTT.
+
+- AMQP over WebSockets → all other WebSocket connections are treated as AMQP.
+
+This design makes it possible for LavinMQ to serve both messaging protocols through the same WebSocket interface, enabling real-time applications, IoT devices, and browser-based clients to connect without additional libraries or plugins.
+
+### Example (AMQP over WebSockets)
+
+{% highlight javascript %}
+const WebSocket = require('ws');
+const ws = new WebSocket('ws://your-lavinmq-server/');
+
+ws.onopen = () => {
+  console.log('Connected to LavinMQ via AMQP/WebSocket');
+  // Perform protocol-specific actions like declaring a queue
+  // and subscribing to it.
+};
+
+ws.onmessage = (event) => {
+  console.log('Received message:', event.data);
+};
+{% endhighlight %}
+
+### Example (MQTT over WebSockets)
+
+{% highlight javascript %}
+const mqtt = require('mqtt');
+const MQTT_URL = "wss://<host>/mqtt";
+const client = mqtt.connect('MQTT_URL');
+
+client.on('connect', function () {
+  console.log('Connected to LavinMQ via MQTT/WebSocket');
+  client.subscribe('mytopic', function (err) {
+    if (!err) {
+      console.log('Subscribed to my/topic');
+    }
+  });
+});
+
+client.on('message', function (topic, message) {
+  console.log(`Received message on topic "${topic}": ${message.toString()}`);
+});
+{% endhighlight %}
+
+
+### WebSocket tutorial
+Dive in with our hands-on guide to get started with WebSockets in LavinMQ.
+Try out the [websocket tutorial](/documentation/websocket-tutorial).

--- a/docs/amqps-tls.md
+++ b/docs/amqps-tls.md
@@ -1,0 +1,36 @@
+
+LavinMQ supports TLS 1.2 and 1.3, both for AMQPS and HTTPS.
+
+If a valid certificate and key are available, LavinMQ will listen on port `5671`
+for AMQPS and port `15671` for HTTPS.
+
+The location of the valid certificate and key could be configured in the
+`lavinmq.ini` file as shown below:
+
+### Default config
+
+```ini
+[main]
+tls_cert = /etc/lavinmq/cert.pem
+tls_key = /etc/lavinmq/key.pem
+tls_min_version = 1.2
+
+[mgmt]
+tls_port = 15671
+
+[amqp]
+tls_port = 5671
+```
+
+### Reloading certificates
+
+Send a `HUP` signal to reload certificate if files have changed e.g. renewed.
+Existing connections will not be interrupted, and new TLS connections will be
+served the new certificate.
+
+## Wrap up
+
+You can configure TLS in LavinMQ to ensure a secure and robust
+communication environment. LavinMQ supports both TLS 1.2 and 1.3, for AMQPS and HTTPS.
+LavinMQ requires valid certificate and key for TLS to work. You can configure the location
+of these certificates and keys in the `lavinmq.ini` file.

--- a/docs/arguments-and-properties.md
+++ b/docs/arguments-and-properties.md
@@ -1,0 +1,79 @@
+
+LavinMQ has arguments and properties that can be used to define behaviors. Properties are defined by the AMQP protocol and included in LavinMQ. Arguments can be any key-value pair and are used for feature extensions. Some properties are mandatory while others are optional. All arguments are optional.
+
+### What is a Property in LavinMQ?
+
+Properties are specified in the AMQP protocol 0.9.1. An example of a property for a queue is “passive”, “durable” and “exclusive”.
+
+### What is an Argument in LavinMQ?
+
+An argument is an optional feature for defining behaviors, implemented by the LavinMQ server. These arguments are also known as x-arguments and can sometimes be changed after queue declaration. An example of an argument for messages and queues are “TTL”.
+
+### What Benefits do Arguments and Properties have?
+
+Defining properties and arguments can be beneficial, and in some cases crucial. Properties and Arguments do provide an easy and secure approach to keeping your LavinMQ instance tidy and healthy - a way to minimize unnecessary resource usage or letting a faulty client cause issues by publishing millions of messages to a single queue.
+
+## Properties and Arguments
+
+Properties and Arguments can be defined for [Queues](/documentation/amqp-queues), [Exchanges](/documentation/amqp-exchanges), and [Messages](/documentation/amqp-the-protocol#message-and-content) in LavinMQ.
+
+Properties are specified in the AMQP protocol 0.9.1. and implemented by LavinMQ.
+
+Arguments are additional, optional features to the mandatory properties. Some Arguments can be dynamically changed after the creation of the queue or exchange.
+
+### Queue Properties and Arguments
+
+Examples of Queue properties are “passive”, which determines if the queue already exists, and “durable” which tell if the queue remains when a server restarts.
+
+Example Queue Arguments are [“x-max-priority”](/documentation/message-priority), which is setting a maximum number of priorities, and “x-message-ttl” which is setting managing queue TTL.
+
+### Exchange Properties and Arguments
+
+<!-- See Exchange Properties and Arguments can be found here. -->
+
+Examples of Exchange properties are “durable”, which tells if the exchange remains when a server restarts, and “internal” which tells that the exchange can not be used directly by publishers.
+
+Example Exchange Arguments are “x-dead-letter-exchange” and “x-dead-letter-routing-key” used by the dead letter exchange.
+
+## Set arguments and properties
+
+A property can be set while creating the queue, code-wise, via the management interface, or via policies.
+
+### Code example
+
+A queue’s arguments are normally set on a per queue basis when the queue is declared by the client. How the arguments are set varies from client to client.
+
+A queue can be marked as durable, which specifies if the queue should survive an LavinMQ restart. Setting a queue property as durable only means that the queue definition will survive a restart, not the messages in it. Create a durable queue by specifying durable as `True` during the creation of the queue.
+
+Code example of how to declare a durable queue:
+
+{% highlight python %}
+channel.queue_declare(queue='test', durable=True)
+{% endhighlight %}
+
+Dead letter exchanges are no different than other exchanges except added arguments. Code example of how to apply arguments for an exchange:
+
+{% highlight python %}
+channel.queue_declare("test_queue", arguments={
+"x-dead-letter-exchange": "dlx_exchange", "x-dead-letter-routing-key": "dlx_key"})
+{% endhighlight %}
+
+### Via the LavinMQ Management Interface
+
+A queue or exchange can be created via the Management Interface. A message can also be sent through the management interface.
+
+When manually creating a queue through the [LavinMQ Web Management Interface](/documentation/management-interface-overview) the arguments are set in a free text field and can be added to it with quick links. Properties can be set as true or false.
+
+<img src="/img/docs/docs-dm/add-queue-dm-2x.png" style="margin-bottom: 8px;" alt="Setting  arguments via Management Interface" class="border border-gray-200 rounded-xl"/> <small class="mt-2 block text-center">Illustration of a queue created with the durability property set to true, and two arguments, x-max-length and x-message-ttl</small>
+
+<img src="/img/docs/docs-dm/publish-message-dm-2x.png" style="margin-bottom: 8px;" alt="Setting  arguments via Management Interface" class="border border-gray-200 rounded-xl"/> <small class="mt-2 block text-center">Illustration of a message published with TTL expiration set to 36000000 milliseconds</small>
+
+## Arguments and Policies
+
+Arguments can also be set using [Policies](/documentation/policies).
+
+To set arguments, the use of policies is recommended. Policies make it possible to configure arguments for one or many queues at once, and the queues will all be updated when you’re updating the policy definition. To reduce the overhead work of configuring every single queue and exchange with arguments, the use of policies are perfect. Policies enable a way to configure multiple queues or exchanges in a consistent way, reducing the risk for sloppy mistakes in the configuration. A queue can only be applied by one policy simultaneously, but there is a priority system along with the regex recognition in order to manage several policies.
+
+![Setting arguments through policies](/img/docs/lavinmq-arguments-policy.jpg)
+
+![Updating argument through policies](/img/docs/lavinmq-policy-argument-update.jpg)

--- a/docs/arguments-and-properties.md
+++ b/docs/arguments-and-properties.md
@@ -15,7 +15,7 @@ Defining properties and arguments can be beneficial, and in some cases crucial. 
 
 ## Properties and Arguments
 
-Properties and Arguments can be defined for [Queues](/documentation/amqp-queues), [Exchanges](/documentation/amqp-exchanges), and [Messages](/documentation/amqp-the-protocol#message-and-content) in LavinMQ.
+Properties and Arguments can be defined for [Queues](amqp-queues.md), [Exchanges](amqp-exchanges.md), and [Messages](amqp-the-protocol.md#message-and-content) in LavinMQ.
 
 Properties are specified in the AMQP protocol 0.9.1. and implemented by LavinMQ.
 
@@ -25,7 +25,7 @@ Arguments are additional, optional features to the mandatory properties. Some Ar
 
 Examples of Queue properties are “passive”, which determines if the queue already exists, and “durable” which tell if the queue remains when a server restarts.
 
-Example Queue Arguments are [“x-max-priority”](/documentation/message-priority), which is setting a maximum number of priorities, and “x-message-ttl” which is setting managing queue TTL.
+Example Queue Arguments are [“x-max-priority”](message-priority.md), which is setting a maximum number of priorities, and “x-message-ttl” which is setting managing queue TTL.
 
 ### Exchange Properties and Arguments
 
@@ -62,18 +62,18 @@ channel.queue_declare("test_queue", arguments={
 
 A queue or exchange can be created via the Management Interface. A message can also be sent through the management interface.
 
-When manually creating a queue through the [LavinMQ Web Management Interface](/documentation/management-interface-overview) the arguments are set in a free text field and can be added to it with quick links. Properties can be set as true or false.
+When manually creating a queue through the [LavinMQ Web Management Interface](management-interface-overview.md) the arguments are set in a free text field and can be added to it with quick links. Properties can be set as true or false.
 
-<img src="/img/docs/docs-dm/add-queue-dm-2x.png" style="margin-bottom: 8px;" alt="Setting  arguments via Management Interface" class="border border-gray-200 rounded-xl"/> <small class="mt-2 block text-center">Illustration of a queue created with the durability property set to true, and two arguments, x-max-length and x-message-ttl</small>
+<img src="img/docs/add-queue-dm-2x.png" style="margin-bottom: 8px;" alt="Setting  arguments via Management Interface" class="border border-gray-200 rounded-xl"/> <small class="mt-2 block text-center">Illustration of a queue created with the durability property set to true, and two arguments, x-max-length and x-message-ttl</small>
 
-<img src="/img/docs/docs-dm/publish-message-dm-2x.png" style="margin-bottom: 8px;" alt="Setting  arguments via Management Interface" class="border border-gray-200 rounded-xl"/> <small class="mt-2 block text-center">Illustration of a message published with TTL expiration set to 36000000 milliseconds</small>
+<img src="img/docs/publish-message-dm-2x.png" style="margin-bottom: 8px;" alt="Setting  arguments via Management Interface" class="border border-gray-200 rounded-xl"/> <small class="mt-2 block text-center">Illustration of a message published with TTL expiration set to 36000000 milliseconds</small>
 
 ## Arguments and Policies
 
-Arguments can also be set using [Policies](/documentation/policies).
+Arguments can also be set using [Policies](policies.md).
 
 To set arguments, the use of policies is recommended. Policies make it possible to configure arguments for one or many queues at once, and the queues will all be updated when you’re updating the policy definition. To reduce the overhead work of configuring every single queue and exchange with arguments, the use of policies are perfect. Policies enable a way to configure multiple queues or exchanges in a consistent way, reducing the risk for sloppy mistakes in the configuration. A queue can only be applied by one policy simultaneously, but there is a priority system along with the regex recognition in order to manage several policies.
 
-![Setting arguments through policies](/img/docs/lavinmq-arguments-policy.jpg)
+![Setting arguments through policies](img/docs/lavinmq-arguments-policy.jpg)
 
-![Updating argument through policies](/img/docs/lavinmq-policy-argument-update.jpg)
+![Updating argument through policies](img/docs/lavinmq-policy-argument-update.jpg)

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,0 +1,148 @@
+
+<!-- prettier-ignore-start -->
+
+LavinMQ 2.0 and above supports clustering to ensure high availability for your messaging infrastructure. It achieves this by integrating with etcd, a distributed key-value store based on the [Raft consensus algorithm](/blog/lavinmq-high-availability). Consequently, LavinMQ can now run in either cluster or standalone mode. This configuration can be adjusted in the `/etc/lavinmq/lavinmq.ini` file.
+
+## What is clustering in LavinMQ?
+
+Clustering in LavinMQ creates a leader node and one or more follower nodes. The leader tracks changes—like published messages, acknowledgments, and metadata updates—by recording them in a log. This log, which represents the shared state as a sequence of actions, is replicated to follower nodes in real-time. LavinMQ ensures that these actions are consistently processed across the entire cluster.
+
+![Clustering in LavinMQ](/img/blog/2024-09-10-high-availability/illustration-1-3.svg)
+
+## When can I use clustering?
+
+This feature is ideal for minimizing downtime and prioritizing data safety. By distributing data across multiple nodes, follower nodes can immediately take over if the leader node fails.
+
+## Benefits of clustering
+
+With clustering, LavinMQ offers key benefits:
+
+- <b>Data Redundancy:</b> Messages are replicated to follower nodes, safeguarding against data loss.
+
+- <b>High Availability:</b> Automatic leader election enables quick recovery from failures, reducing disruptions.
+
+## How to set up clustering in LavinMQ
+
+While LavinMQ checks for the possibility of becoming a leader, etcd handles the actual leader election process. LavinMQ and etcd can be on separate machines, allowing you to have a dedicated etcd cluster that supports multiple LavinMQ clusters or nodes. Alternatively, you can set up etcd on each node in your LavinMQ cluster.
+
+This guide explains how to set up etcd on each LavinMQ node.
+
+### Step 1: Decide on the number of nodes in your cluster.
+
+Before setting up your cluster, determine the number of nodes you will include. The recommended minimum for a fault-tolerant cluster is three nodes, and we recommend using an odd number of nodes.
+
+### Step 2: Download and install the etcd binary
+
+Next, download and install the etcd binary on each node in your cluster. You can find the latest etcd releases [here](https://github.com/etcd-io/etcd/releases){:target="\_blank"}. LavinMQ requires at least etcd version 3.4.
+
+We also provide `.deb` packages for simple installation.
+
+```
+curl -fsSL https://packagecloud.io/cloudamqp/etcd/gpgkey | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/cloudamqp_etcd.gpg
+. /etc/os-release
+echo "deb https://packagecloud.io/cloudamqp/etcd/any any main" | sudo tee /etc/apt/sources.list.d/cloudamqp_etcd.list
+apt-get update
+apt-get install etcd
+```
+
+### Step 3: Configure etcd nodes
+
+You need to specify the cluster members on each etcd node. This configuration step enables the nodes to recognize and communicate with each other, forming the cluster. See the code snippet below for an example etcd config for the first node of a three-node cluster.
+
+`/etc/etcd/etcd.conf.yml`
+
+```
+name: my-server-name-01
+data-dir: /var/lib/etcd/
+listen-peer-urls: http://0.0.0.0:2380
+listen-client-urls: http://0.0.0.0:2379
+initial-advertise-peer-urls: http://my-server-name-01.cloudamqp.com:2380
+advertise-client-urls: http://my-server-name-01.cloudamqp.com:2379
+initial-cluster-token: my-cluster-token
+initial-cluster-state: new
+initial-cluster: my-server-name-01=http://my-server-name-01.cloudamqp.com:2380,my-server-name-02=http://my-server-name-02.cloudamqp.com:2380,my-server-name-03=http://my-server-name-03.cloudamqp.com:2380
+```
+
+For the second and third nodes in the cluster, change the `initial-cluster-state` to existing. Also, change name, `initial-advertise-peer-urls`, and `advertise-client-urls` to match your node.
+
+### Step 4: Install LavinMQ
+
+LavinMQ releases are hosted in packagecloud. First, you will need a key to access the repository. Execute the following commands in a terminal:
+
+```
+curl -fsSL https://packagecloud.io/cloudamqp/lavinmq/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/lavinmq.gpg > /dev/null
+. /etc/os-release
+echo "deb [signed-by=/usr/share/keyrings/lavinmq.gpg] https://packagecloud.io/cloudamqp/lavinmq/$ID $VERSION_CODENAME main" | sudo tee /etc/apt/sources.list.d/lavinmq.list
+```
+
+Now, LavinMQ is ready to be installed. Execute the following commands in a terminal:
+
+```
+sudo apt-get update
+sudo apt-get install lavinmq
+```
+
+[Read our LavinMQ installation guide](/documentation/installation-guide) for more information.
+
+### Step 5: Configure LavinMQ
+
+You need to enable clustering in the LavinMQ config. You can do this either by updating your `lavinmq.ini` config or by providing options when starting LavinMQ.
+
+```
+[clustering]
+enabled = true
+bind = 0.0.0.0
+port = 5679
+advertised_uri = tcp://my-server-name-01.internal.cloudamqp.com:5679
+```
+
+<div class="mt-4"></div>
+
+```
+lavinmq
+--clustering
+--clustering-bind=0.0.0.0
+--clustering-port=5679
+--clustering-advertised-uri=tcp://my-server-name-01.internal.cloudamqp.com:5679
+```
+
+<b>Note:</b> LavinMQ by default looks for etcd at `127.0.0.1:2379`. However, that can be changed by providing `--clustering-etcd-endpoints` when starting LavinMQ or setting `etcd_endpoints` in the `clustering` segment of the LavinMQ config.
+
+#### etcd Authentication and Security
+
+LavinMQ supports authenticated and encrypted connections to etcd for secure cluster coordination:
+
+- **Basic Auth:** Include credentials in etcd_endpoints using the format `user:password@host:port`
+- **HTTPS/TLS:** Use the `https://` prefix in etcd_endpoints for encrypted connections
+- **Example with Basic Auth:** `etcd_endpoints = admin:secret@localhost:2379`
+- **Example with HTTPS:** `etcd_endpoints = https://secure-etcd.example.com:2379`
+
+These security features ensure that cluster coordination traffic is protected and only authorized LavinMQ nodes can participate in the cluster.
+
+### Step 6: Start etcd and let LavinMQ connect.
+
+LavinMQ nodes query etcd for the current cluster status. Start by bringing the etcd nodes online. You can pass a config file to etcd, otherwise default configurations will be used.
+
+```
+etcd --config-file=/path-to-config-file
+```
+
+Once the etcd cluster is running, start the LavinMQ nodes. You can also pass a config file to LavinMQ:
+
+```
+lavinmq --config-file=/path-to-config-file
+```
+
+On starting, a LavinMQ node checks if it can become the leader. If a leader already exists, the node enters follower mode and begins replicating data from the leader.
+
+### Step 7: Start sending data.
+
+Time to start publishing messages to your LavinMQ cluster. [Get started with LavinMQ](/documentation/getting-started) using the various resources we have curated for you.
+
+### Optional: Configure your cluster's DNS
+
+We recommend configuring your DNS to point to all nodes in your cluster. If a client connects to a follower, LavinMQ will forward that traffic to the leader node.
+
+By using etcd with LavinMQ 2.0, you can create a reliable and highly-available messaging system. Once set up, your cluster will handle server outages and keep your data consistent. This way, LavinMQ ensures your messaging infrastructure is fault tolerant.
+
+<!-- prettier-ignore-end -->

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,13 +1,12 @@
-
 <!-- prettier-ignore-start -->
 
-LavinMQ 2.0 and above supports clustering to ensure high availability for your messaging infrastructure. It achieves this by integrating with etcd, a distributed key-value store based on the [Raft consensus algorithm](/blog/lavinmq-high-availability). Consequently, LavinMQ can now run in either cluster or standalone mode. This configuration can be adjusted in the `/etc/lavinmq/lavinmq.ini` file.
+LavinMQ 2.0 and above supports clustering to ensure high availability for your messaging infrastructure. It achieves this by integrating with etcd, a distributed key-value store based on the [Raft consensus algorithm](https://lavinmq.com/blog/lavinmq-high-availability). Consequently, LavinMQ can now run in either cluster or standalone mode. This configuration can be adjusted in the `/etc/lavinmq/lavinmq.ini` file.
 
 ## What is clustering in LavinMQ?
 
 Clustering in LavinMQ creates a leader node and one or more follower nodes. The leader tracks changes—like published messages, acknowledgments, and metadata updates—by recording them in a log. This log, which represents the shared state as a sequence of actions, is replicated to follower nodes in real-time. LavinMQ ensures that these actions are consistently processed across the entire cluster.
 
-![Clustering in LavinMQ](/img/blog/2024-09-10-high-availability/illustration-1-3.svg)
+![Clustering in LavinMQ](img/docs/illustration-1-3.svg)
 
 ## When can I use clustering?
 
@@ -82,7 +81,7 @@ sudo apt-get update
 sudo apt-get install lavinmq
 ```
 
-[Read our LavinMQ installation guide](/documentation/installation-guide) for more information.
+[Read our LavinMQ installation guide](https://lavinmq.com/documentation/installation-guide) for more information.
 
 ### Step 5: Configure LavinMQ
 
@@ -137,7 +136,7 @@ On starting, a LavinMQ node checks if it can become the leader. If a leader alre
 
 ### Step 7: Start sending data.
 
-Time to start publishing messages to your LavinMQ cluster. [Get started with LavinMQ](/documentation/getting-started) using the various resources we have curated for you.
+Time to start publishing messages to your LavinMQ cluster. [Get started with LavinMQ](https://lavinmq.com/documentation/getting-started) using the various resources we have curated for you.
 
 ### Optional: Configure your cluster's DNS
 

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -1,0 +1,713 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is the LavinMQ configuration file?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>Most settings in LavinMQ can be tuned using the configuration file. The structure of the configuration file is <a href="https://en.wikipedia.org/wiki/INI_file" target="_blank">INI</a> and comprises key-value pairs for properties and sections that organize the properties. The sections are split into four; one [main] section for general settings, one for the LavinMQ Management Interface [mgmt], one for amqp settings [amqp], one for MQTT settings [mqtt], one for clustering settings [clustering]. The syntax can be explained as:
+        <ul>
+          <li>One setting uses one line</li>
+          <li>Lines are structured Key = Value</li>
+          <li>Any line starting with the ; character indicates a comment</li>
+        </ul>
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        Where is the configuration file located?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>The default configuration file location is <code class="language-plaintext">/etc/lavinmq/lavinmq.ini</code></p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect3" id="accordion3">
+        How do config changes take effect?
+      </button>
+    </h3>
+    <div id="sect3" class="accordion-content" role="region" aria-labelledby="accordion3">
+      <p>Changes to the configuration file will be applied after a restart of LavinMQ.</p>
+    </div>
+  </div>
+</div>
+
+The tables below outline the different settings available for LavinMQ by section, including their default values and examples.
+
+### [main]
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-[#414040] conf-table">
+      <tr>
+        <td class="font-semibold">consumer_timeout</td>
+        <td>
+        Default consumer timeout for acks.
+        <br/>
+        <br/>
+        Default:
+        <code>consumer_timeout = nil (UInt64?)</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">data_dir</td>
+        <td>
+          The path of the data directory where all data is stored.
+          <br/>
+          <br/>
+          Default: <code>data_dir = /var/lib/lavinmq (String)</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">data_dir_lock</td>
+        <td>
+          Use file lock in the data directory
+          <br/>
+          <br/>
+          Default: <code>data_dir_lock = true</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">default_consumer_prefetch</td>
+        <td>
+        Default prefetch value for consumers if not set by consumer.
+        <br/>
+        <br/>
+        Default:
+        <code>default_consumer_prefetch = 65535</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">default_password</td>
+        <td>
+        Hashed password for default user. Use <code>lavinmqctl hash_password</code> or <code>/api/auth/hash_password</code> to generate password hash.
+        <br/>
+        <br/>
+        Default:
+        <code>default_password = +pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">default_user</td>
+        <td>
+        Default user.
+        <br/>
+        <br/>
+        Default:
+        <code>default_user = guest</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">default_user_only_loopback</td>
+        <td>
+        Limit default user to only connect from loopback address (127.0.0.1). Replaces the deprecated <code>guest_only_loopback</code> option.
+        <br/>
+        <br/>
+        Default:
+        <code>default_user_only_loopback = true</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">free_disk_min</td>
+        <td>
+          The minimum value of free disk space in bytes before LavinMQ starts to control flow.
+          <br/>
+          <br/>
+          Default:
+          <code>free_disk_min = 0</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">free_disk_warn</td>
+        <td>
+        The minimum value of free disk space in bytes before LavinMQ warns about low disk space.
+        <br/>
+        <br/>
+        Default:
+        <code>free_disk_warn = 0</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">guest_only_loopback</td>
+        <td>
+        <strong>DEPRECATED:</strong> This option is deprecated as of v2.2.0 and will be removed in the next major version. Use <code>default_user_only_loopback</code> instead, which has identical functionality but supports the new configurable default user feature.
+        <br/>
+        <br/>
+        Limit guest user to only connect from loopback address.
+        <br/>
+        <br/>
+        Default:
+        <code>guest_only_loopback = true</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">log_exchange</td>
+        <td>
+          Enable log exchange
+          <br/>
+          <br/>
+          Default: <code>log_exchange = false</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">log_file</td>
+        <td>
+          Path to file log file. If no path is set, log is written to STDOUT.
+          <br/>
+          <br/>
+          Default: <code>log_file = nil</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">log_level</td>
+        <td>
+          Controls how detailed the log should be. The level can be one of:
+          <ul>
+            <li>
+              none  (nothing is logged)
+            </li>
+            <li>
+              fatal (only fatal errors are logged)
+            </li>
+            <li>
+              error (fatal and errors are logged)
+            </li>
+            <li>
+              warn (fatal, errors and warnings are logged)
+            </li>
+            <li>
+              info (fatal, errors, warnings, and info messages are logged)
+            </li>
+            <li>
+              debug (all messages are logged).
+            </li>
+          </ul>
+          <br/>
+          <br/>
+          Default: <code>log_level = info</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">max_deleted_definitions</td>
+        <td>
+        Number of deleted queues, unbinds etc that compacts the definitions file.
+        <br/>
+        <br/>
+        Default:
+        <code>max_deleted_definitions = 8192</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">segment_size</td>
+        <td>
+        Size of segment files.
+        <br/>
+        <br/>
+        Default:
+        <code>segment_size = 8388608</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">set_timestamp</td>
+        <td>
+          Boolean value for setting the timestamp property.
+          <br/>
+          <br/>
+          Default:
+          <code>set_timestamp = false</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">socket_buffer_size</td>
+        <td>
+          Socket buffer size in bytes.
+          <br/>
+          <br/>
+          Default:
+          <code>socket_buffer_size = 16384</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">stats_interval</td>
+        <td>
+          Statistics collection interval in milliseconds.
+          <br/>
+          <br/>
+          Default: <code>stats_interval = 5000</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">stats_log_size</td>
+        <td>
+          Number of entries in the statistics log file before oldest entry removed.
+          <br/>
+          <br/>
+          Default:
+          <code>stats_log_size = 120</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tcp_keepalive</td>
+        <td>
+          tcp_keepalive settings as a tuple, {idle, interval, probes/count}.
+          <br/>
+          <br/>
+          Default:
+          <code>tcp_keepalive = {60, 10, 3}</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tcp_nodelay</td>
+        <td>
+          Boolean value for disabling Nagle's algorithm, and sending the data as
+          soon as it's available.
+          <br/>
+          <br/>
+          Default:
+          <code>tcp_nodelay = false</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tcp_recv_buffer_size</td>
+        <td>
+          TCP receive buffer size.
+          <br/>
+          <br/>
+          Default:
+          <code>tcp_recv_buffer_size = nil</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tcp_send_buffer_size</td>
+        <td>
+          TCP send buffer size.
+          <br/>
+          <br/>
+          Default:
+          <code>tcp_send_buffer_size = nil</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tls_cert</td>
+        <td>
+          TLS certificate (including chain).
+          <br/>
+          <br/>
+          Default:
+          <code>tls_cert = nil</code>
+          <br/>
+          Example:
+          <code>tls_cert = /etc/lavinmq/cert.pem</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tls_key</td>
+        <td>
+          Private key for the TLS certificate.
+          <br/>
+          <br/>
+          Default:
+          <code>tls_key = nil</code>
+          <br />
+          Example:
+          <code>ls_key = /etc/lavinmq/key.pem</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tls_ciphers</td>
+        <td>
+          List of TLS ciphers to allow
+          <br/>
+          <br/>
+          Example:
+          <code>tls_ciphers = nil</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tls_min_version</td>
+        <td>
+          Minimum allowed TLS version. Allowed options:
+          <ul>
+            <li>
+              1.0
+            </li>
+            <li>
+              1.1
+            </li>
+            <li>
+              1.2
+            </li>
+            <li>
+              1.3
+            </li>
+          </ul>
+          <br/>
+          Default: <code>tls_min_version = 1.2</code>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+### [mgmt]
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-gray-300 conf-table">
+      <tr>
+        <td class="font-semibold">bind</td>
+        <td>
+          IP address that the HTTP server will listen on.
+          <br/>
+          <br/>
+          Default:
+          <code>bind = 127.0.0.1</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">port</td>
+        <td>
+          Port used for connections.
+          <br/>
+          <br/>
+          Default:
+          <code>port = 15672</code>
+        </td>
+      </tr>
+      <!--<tr>
+        <td class="font-bold">systemd_socket_name</td>
+        <td>
+          Default:
+          <code>systemd_socket_name = lavinmq-http.socket</code>
+        </td>
+      </tr>-->
+      <tr>
+        <td class="font-semibold">tls_port</td>
+        <td>
+          Port used for TLS connections.
+          <br/>
+          <br/>
+          Default:
+          <br/>
+          <code>tls_port = -1 (disabled)</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">unix_path</td>
+        <td>
+          UNIX path to listen to
+          <br/>
+          <br/>
+          Default:
+          <code>unix_path = /tmp/lavinmq-http.sock</code>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+### [amqp]
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-gray-300 conf-table">
+      <tr>
+        <td class="font-semibold">bind</td>
+        <td>
+          IP address that both the AMQP and HTTP servers will listen on.
+          <br/>
+          <br/>
+          Default:
+          <code>bind = 127.0.0.1</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">channel_max</td>
+        <td>
+          Maximum number of channels to negotiate with clients. Setting to 0 means
+          an unlimited number of channels.
+          <br/>
+          <br/>
+          Default:
+          <code>channel_max = 2048</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">frame_max</td>
+        <td>
+          Maximum frame size in bytes.
+          <br/>
+          <br/>
+          Default:
+          <code>frame_max = 1048576</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">heartbeat</td>
+        <td>
+          Timeout value in seconds suggested by the server during connection
+          negotiation. If set to 0 on both server and client, heartbeats are
+          disabled.
+          <br/>
+          <br/>
+          Default:
+          <code>Heartbeat = 0</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">max_message_size</td>
+        <td>
+        The maximum message size in bytes.
+        <br/>
+        <br/>
+        Default: <code>max_message_size = 128 * 1024²</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">port</td>
+        <td>
+          Port used for AMQP connections
+          <br/>
+          <br/>
+          Default:
+          <code>port = 5672</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">systemd_socket_name</td>
+        <td>
+          Default:
+          <code>systemd_socket_name = lavinmq-amqp.socket</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tcp_proxy_protocol</td>
+        <td>
+          Boolean value for PROXY protocol on amqp tcp connections
+          <br/>
+          <br/>
+          Default:
+          <code>tcp_proxy_protocol = false</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tls_port</td>
+        <td>
+          Port used for TLS (AMQPS) connections
+          <br/>
+          <br/>
+          Default:
+          <code>tls_port = -1 (disabled)</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">unix_path</td>
+        <td>
+          UNIX path to listen to
+          <br/>
+          <br/>
+          Default:
+          <code>unix_path = /tmp/lavinmq.sock</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">unix_proxy_protocol</td>
+        <td>
+          Boolean value for PROXY protocol on unix domain socket connections
+          <br/>
+          <br/>
+          Default:
+          <code>unix_proxy_protocol = true</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-bold">max_consumers_per_channel</td>
+        <td>
+          Maximum number of consumers allowed per AMQP channel. For unlimited consumers per channel set this value to 0.
+          <br/>
+          <br/>
+          Default:
+          <code>max_consumers_per_channel = 0</code>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+### [mqtt]
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-gray-300 conf-table">
+      <tr>
+        <td class="font-semibold">bind</td>
+        <td>
+          IP address that AMQP, MQTT, and HTTP servers will listen on.
+          <br/>
+          <br/>
+          Default:
+          <code>bind = 127.0.0.1</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">port</td>
+        <td>
+          Port for non-TLS MQTT connections.
+          <br/>
+          <br/>
+          Default:
+          <code>port = 1883</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">tls_port</td>
+        <td>
+          Port for TLS-enabled MQTT connections
+          <br/>
+          <br/>
+          Default:
+          <br/>
+          <code>tls-port = -1 (disabled)</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">unix_path</td>
+        <td>
+          UNIX path to listen to
+          <br/>
+          <br/>
+          Default:
+          <code>unix_path = /tmp/lavinmq-mqtt.sock</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">max_inflight_messages</td>
+        <td>
+          Maximum number of messages in flight simultaneously.
+          <br/>
+          <br/>
+          Default:
+          <code>65535</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">permission_check_enabled</td>
+        <td>
+          Enable permission checks for MQTT publish and subscribe operations. When enabled, publishing (including will messages) requires write permission on the MQTT exchange, and subscribing requires read permission on the MQTT exchange or write permission on the client's session queue.
+          <br/>
+          <br/>
+          Available since v2.5.0.
+          <br/>
+          <br/>
+          Default:
+          <code>permission_check_enabled = false</code>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+### [clustering]
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-gray-300 conf-table">
+      <tr>
+        <td class="font-semibold">advertised_uri</td>
+        <td>
+        Advertised URI for the clustering server.
+        <br/>
+        <br/>
+        Default: <code>advertised_uri = nil</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">bind</td>
+        <td>
+        Listen for clustering followers on this address.
+        <br/>
+        <br/>
+        Default: <code>bind = 127.0.0.1</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">enabled</td>
+        <td>
+        Enable clustering.
+        <br/>
+        <br/>
+        Default: <code>enabled = false</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">etcd_endpoints</td>
+        <td>
+        Comma separated host:port pairs
+        <br/>
+        <br/>
+        Default: <code>etcd_endpoints = localhost:2379</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">etcd_prefix</td>
+        <td>
+        Key prefix used in etcd.
+        <br/>
+        <br/>
+        Default: <code>etcd_prefix = lavinmq</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">max_unsynced_actions</td>
+        <td>
+        Maximum number of unsynced actions.
+        <br/>
+        <br/>
+        Default: <code>max_unsynced_actions = 8192</code>
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">port</td>
+        <td>
+        Listen for clustering followers on this port.
+        <br/>
+        <br/>
+        Default: <code>port = 5679</code>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+## Example configuration file
+
+An example configuration file can be found in the LavinMQ repo on [GitHub.](https://github.com/cloudamqp/lavinmq/blob/main/extras/lavinmq.ini)
+
+```bash
+[main]
+data_dir = /var/lib/lavinmq
+default_user_only_loopback = true
+log_level = info
+
+[mgmt]
+bind = 0.0.0.0
+port = 15672
+tls_port = 15671
+unix_path = /tmp/lavinmq-http.sock
+
+[amqp]
+bind = 0.0.0.0
+port = 5672
+tcp_proxy_protocol = false
+tls_port = 5671
+unix_path = /tmp/lavinmq.sock
+unix_proxy_protocol = true
+```

--- a/docs/consistent-hash-exchange.md
+++ b/docs/consistent-hash-exchange.md
@@ -1,0 +1,66 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is Consistent Hash Exchange?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>The Consistent Hash Exchange routes messages using the publisher's routing key and a hashing process. This ensures that messages related to the same identifier are always sent to the same consumer, keeping a predictable order and maintaining causal relationships.</p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        When should I use Consistent Hash Exchange?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>Manually distributing messages can be complex, as publishers often lack visibility into the number of queues and their bindings. Messages are typically distributed sequentially, but to prevent long queues, data is often spread across multiple queues or handled by several consumers. However, this distribution can lead to the loss of order.</p>
+      <p>In contrast, messages sent to a consistent hash exchange are distributed to bound queues based on the hash computed from the routing key or header value. This method ensures that messages sharing the same computed hash—such as those linked to a specific booking ID or client ID—are directed to the same queue, thereby maintaining causal order for that ID as long as the bindings remain unchanged.</p>
+    </div>
+  </div>
+</div>
+
+The routing key value determines how messages are distributed across bound queues based on their computed hash. Queues can be dynamically added or removed at runtime, allowing flexible scaling while maintaining message order for specific keys.
+
+1. **Declare queues.** In this case, two queues (`q1` and `q2`) are declared with durability.
+2. **Define the exchange.** Declare a consistent hash exchange (`ce`), which will handle the routing of messages based on the hash of the routing key.
+3. **Bind each queue to the exchange using a routing key.** The routing key on the binding must be set as a numeric value, which determines how many times the queue is added to the hash ring. This acts like a weight, impacting the likelihood of a queue receiving messages. A queue with a higher binding key value is present more frequently in the hash ring and is therefore more likely to be selected.
+
+   Here, `q2` is added to the hash ring twice as many times as `q1`, meaning it has a higher chance of receiving messages—but the actual distribution depends on the hash function applied to the published routing keys.
+
+4. **Publishing messages:** When a message is published, its routing key is hashed, and the exchange selects a queue based on its position in the hash ring.
+
+   Since `user123` always hashes to the same value, this message will be routed to the same queue, ensuring that messages for a given user remain ordered. If more queues are added dynamically, the distribution of messages may shift, but messages for the same routing key will continue to be routed consistently.
+
+**Example:** Set up a consistent hash exchange in LavinMQ to route messages based on the routing key's hash.
+
+<!-- prettier-ignore-start -->
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='q1', durable=True)
+channel.queue_declare(queue='q2', durable=True)
+
+channel.exchange_declare(exchange="ce", exchange_type="x-consistent-hash", durable=True)
+
+channel.queue_bind(exchange="ce", queue='q1', routing_key="1")
+channel.queue_bind(exchange="ce", queue='q2', routing_key="2")
+
+channel.basic_publish(
+    exchange="ce",
+    routing_key="user123",  # Routing key for hashing
+    body="Message for user123",
+)
+
+connection.close()
+```
+
+<!-- prettier-ignore-end -->

--- a/docs/consumer-acknowledgements.md
+++ b/docs/consumer-acknowledgements.md
@@ -1,0 +1,143 @@
+
+Messages in transit between LavinMQ and the consumer might get lost and have to be re-sent. This can occur when a connection fails or during other events that disconnect the receiving service (consumer) from LavinMQ. The use of consumer acknowledgements assures that messages have been delivered. When it comes to message publishing, a publish confirm is the same concept.
+
+### What are Consumer Acknowledgements?
+
+Consumer acknowledgements (acks) provide notice if and when messages between LavinMQ and the consumer have been sent to or received and handled by the intended destination. The response of a consumer acknowledgement setting can also trigger actions that may re-queue and resend messages if needed. There are many ways of using consumer acks, depending on the desired result.
+
+### What benefits do Consumer Acknowledgments have?
+
+If for some reason, the consumer cannot process a message, the use of consumer acknowledgement can prevent a message loss by letting another available consumer receive and handle it, or retrying the process at a later time. Once an acknowledgement is received by LavinMQ, the message can be discarded from the queue.
+
+### When should I use Consumer Acknowledgments?
+
+The use of consumer acknowledgements may be seen as a data safety measure that helps secure your service from unnoticed message loss or protecting services or applications that can not afford to lose any messages.
+
+## Ensure that the message has been sent from LavinMQ
+
+For LavinMQ to securely deliver messages to a consumer, the LavinMQ broker needs to understand when a message is considered successfully sent.
+A message can be considered successfully delivered in two ways, _Manual Acknowledgement_, and _Automatic Acknowledgement_.
+
+### Manual Acknowledgement in LavinMQ
+
+One way for LavinMQ to receive message delivery confirmation is when an explicit acknowledgment is received from the consumer. This means that LavinMQ considers the message to be successfully sent once it has been consumed and acked by a consumer. Manual Acks are the default setting for consumer acknowledgements in LavinMQ.
+
+### Automatic Acknowledgment in LavinMQ
+
+Another way for LavinMQ to be noticed about message delivery is via Automatic Acknowledgment. This means that Acks are received once the message is sent out and written to a TCP socket. LavinMQ considers the message to be successfully sent once it has left the broker. Automatic acknowledgements are enabled by setting `auto_ack` to `True`:
+
+{% highlight python %}
+default.channel.basic_consume('hello', callback, auto_ack=True)
+{% endhighlight %}
+
+Notice that _Automatic Acknowledgement_ should be considered as unsafe, as an unexpected message loss in case of connection failure to the consumer might result in a message being dropped after leaving LavinMQ. Because of this, this setup is not suitable for all workloads.
+
+## Consumer Acknowledgement settings
+
+When a message is consumed it removes the segment-position from the queue's in-memory array and writes the segment-position to an "ack" file.
+
+The manually sent acknowledgement can be positive or negative.
+
+- `basic.ack` is used for _positive acknowledgements_
+- `basic.nack` is used for _negative acknowledgements_
+- `basic.reject` is used for _negative acknowledgements_ but can not nack bulk messages
+
+### Positive acknowledgments
+
+A positive acknowledgment simply instructs LavinMQ to register a message as delivered and the message can be discarded from the queue.
+
+### Negative Acknowledgments
+
+During times when a consumer is unable to process a delivered message immediately, but other consuming services might be able to, it may be a good option to requeue the message and hand it over for another consumer to handle it.
+
+With setting `basic.reject` or `basic.nack`, LavinMQ will either drop or requeue the messages depending on the desired behavior, which is controlled by the requeue field:
+
+{% highlight python %}
+// requeue the delivery
+channel.basicReject(deliveryTag, true);
+{% endhighlight %}
+
+The broker will requeue the delivery with the specified tag when the field is set to true.
+
+### Difference between Basic.reject and Basic.nack
+
+Basic react was in the original AMQP specification, while basic.nack is an LavinMQ extension, allowing for multiple message negative acknowledgments.
+
+### Requeues and Redelivers with LavinMQ
+
+A requeued message is placed back into its original position in the queue if possible, and can therefore immediately be ready for redelivery. If for some reason all consumers requeue messages and are unable to process the deliveries, they create a requeue/redelivery loop.
+
+Redelivered messages are trackable and can be either scheduled for;
+
+1. Requeuing after a potential delay or
+2. Forever rejected and discarded from the loop after x number of times.
+
+LavinMQ detects deviant behaviors of consumers. For example, if the consumer is unavailable to send acks due to connection loss. LavinMQ understands that the message wasn't fully processed and will re-queue the message for other available services to consume, ensuring that no messages are lost even in case of a consumer failure.
+
+### Prevent react loops and poisonous messages in LavinMQ
+
+LavinMQ implements an x-delivery-limit policy that prevents unacked messages from staying in a loop without ever being acknowledged. Messages that are always returned can cause trouble for the service if they grow in numbers.
+
+It is possible to keep track of unsuccessful delivery attempts though the x-delivery-count header. Removed messages can either be removed completely or sent to a dead letter exchange.
+
+### Ack or nack one or many messages
+
+By setting delivery tags, and using the multiple field setting, message acknowledgements for messages using the same channel can be acknowledged.
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Example 1</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Delivery tags 2, 3, 4, 5</td>
+        </tr>
+        <tr>
+					<td>delivery_tag set to 5</td>
+        </tr>
+        <tr>
+          <td><code>Multiple</code> field <code>true</code></td>
+        </tr>
+        <tr>
+          <td><strong>Result: All tags from 2 to 5 acknowledged.</strong></td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Example 2</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Delivery tags 2, 3, 4, 5</td>
+        </tr>
+        <tr>
+					<td>delivery_tag set to 5</td>
+        </tr>
+        <tr>
+          <td><code>Multiple</code> field <code>false</code></td>
+        </tr>
+        <tr>
+          <td><strong>Result: Tags 2, 3, and 4 stay unacknowledged.</strong></td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+The delivery tag is sent while sending the ack/nack. This code will requeue all unacknowledged deliveries up to the delivery tag:
+
+{% highlight python %}
+channel.basicNack(deliveryTag, true, true);
+{% endhighlight %}

--- a/docs/consumer-cancellation.md
+++ b/docs/consumer-cancellation.md
@@ -1,0 +1,69 @@
+
+It is easy to kill an LavinMQ consumer by destroying the channel but this leaves messages undelivered. Performing LavinMQ consumer cancellation the right way requires handling shutdown gracefully.
+
+An LavinMQ consumer waits for messages interacts with the broker, and processes received data. There is an extensive amount of communication between the two components. Message acknowledgement and prefetching require a degree of communication. Brokers, consumers, and publishers interact in an intricate dance over exchanges and queues. A graceful shutdown means responding to any communications, processing messages in transit, and then terminating the connection gracefully.
+
+## Cancelling a LavinMQ Consumer
+
+The official way to cancel a consumer in LavinMQ is over its own channel or connection. Externally stopping the process often leads to delays and can cause messages to drop or redeliver.
+
+Using the _basic.cancel_ command built into AMQP allows your consumer to finish processing messages in flight. It also tells the broker to stop sending messages to the target. This form of graceful shutdown gives you a powerful tool to avoid unexpected bugs.
+
+## Handling Cancel Commands
+
+LavinMQ libraries allow you to easily implement logic to terminate consumers. Clients in Java, .Net, Python, Rust, and many other languages expose the basic cancel command for this purpose. Call the command from a client or the consumer itself.
+
+The process is similar for most clients. The Java client includes a specific cancellation handler. You can do the same in Pika’s asyncio consumer by overriding the following methods:
+
+<!-- prettier-ignore-start -->
+
+{% highlight python %}
+{% raw %}
+def start_consuming(self):
+        self.add_on_cancel_callback()
+        self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
+
+def on_consumer_canceled(self):
+        LOGGER.info('Consumer Cancelled')
+{% endraw %}
+{% endhighlight %}
+
+The _on_consumer_canceled_ method provides a custom callback for dealing with standard cancellations.
+
+## Cancelling the Consumer
+You can cancel a consumer after receiving a certain message or store the tag in a way that it can be accessed by your entire system. The
+(basic_consume)[https://pika.readthedocs.io/en/stable/modules/channel.html] method in Pika allows you to create a custom tag as well.
+
+{% highlight python %}
+{% raw %}
+  class MyAsyncConsumer:
+
+      def __init__(self):
+          self._channel = None
+
+     def handle_message(self, _unused_channel, basic_deliver, properties, body):
+         print(“Handling Message”)
+
+      def start_consuming(self):
+          self_channel.basic_consume(“my_queue”, self.handle_message), consumer_tag=”my_custom_tag”)
+
+{% endraw %}
+{% endhighlight %}
+
+You can now cancel the consumer from the same or a different client using the tag _my_custom_tag_:
+
+{% highlight python %}
+{% raw %}
+  def handle_cancel(msg):
+    print(“Canceled”)
+
+  channel.basic_cancel(“my_consumer_tag”)
+{% endraw %}
+{% endhighlight %}
+
+In some clients, it is possible to avoid receiving a response from the broker with no-wait. However, if using a publisher, more messages may be passed to the consumer if not handled carefully. Pika does not offer this option.
+
+## LavinMQ Consumer Cancellation the Right Way
+An LavinMQ consumer does not operate in a vacuum. There are many factors that influence how a consumer runs. Gracefully terminate the consumer to avoid lost messages and other complications. Using the basic.cancel command is a best practice you should not avoid.
+
+<!-- prettier-ignore-end -->

--- a/docs/consumer-priorities.md
+++ b/docs/consumer-priorities.md
@@ -1,0 +1,68 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is consumer priority?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          When consumers connected to LavinMQ have different priorities, messages are delivered first to those with higher priority and <a href="#consumer-capacity">available capacity</a>. Lower-priority consumers receive messages only when higher-priority ones are blocked.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        When to use consumer priority?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>A typical scenario where consumer priority proves beneficial is resource management. Assign higher priorities to consumers with greater computing power or available resources, enabling efficient handling of critical tasks.</p>
+    </div>
+  </div>
+</div>
+
+Assign priority to a consumer by setting the `x-priority` argument in the `basic.consume` method to an integer value. If no value is specified, the priority is 0. Higher numbers indicate higher priority, with both positive and negative numbers available.
+
+<!-- prettier-ignore-start -->
+
+**Example:** Set the priority on a consumer to 10
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+		print(f"[✅]  { msg }")
+		ch.basic_ack(delivery_tag=method.delivery_tag)
+
+channel.basic_consume(
+    "test_queue",
+    callback,
+    auto_ack=False,
+    arguments**=**{
+      'x-priority':10
+    }
+)
+connection.close()
+```
+
+### Consumer capacity
+
+A consumer has _capacity_ when ready to receive a message. It becomes blocked when it can't, such as when the prefetch limit of unacknowledged messages is reached.
+<br />A consumer is either ready or blocked at any given moment.
+
+### Multiple consumers with the same priority
+
+If multiple consumers share the same priority, LavinMQ sends messages to the first consumer bound to the queue by default, rather than using a round-robin approach. To ensure fair message distribution among same-priority consumers, set the prefetch value to 1.
+
+### Single active consumers and priority consumers
+
+When the single active consumer feature is enabled, priority consumers cannot be used on that queue.
+
+<!-- prettier-ignore-end -->

--- a/docs/dead-letter-exchange.md
+++ b/docs/dead-letter-exchange.md
@@ -1,0 +1,110 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is the Dead Letter Exchange?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>The Dead Letter Exchange (DLX) can handle messages that cannot be delivered due to:</p>
+        <ul>
+          <li>Negative acknowledgment or rejection with requeuing disabled.</li>
+          <li>Expiration due to TTL.</li>
+          <li>Exceeding queue length limits.</li>
+        </ul>
+        <p>Instead of being lost, these messages are published to the DLX, which then routes them to a queue for later processing.</p>
+        <img src="/img/docs/dead-letter-exchange-illustration.png" class="border border-[#414040]" />
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What benefits does the Dead Letter Exchange have?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>Queues attached to a Dead Letter Exchange collect undeliverable messages, preventing message loss and allowing further handling based on the desired outcome.</p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect3" id="accordion3">
+        When to use the Dead Letter Exchange?
+      </button>
+    </h3>
+    <div id="sect3" class="accordion-content" role="region" aria-labelledby="accordion3">
+      <p>Use a Dead Letter Exchange for messages that cannot be processed immediately but still require handling. This prevents message loss and allows for inspection or retries.</p>
+    </div>
+  </div>
+</div>
+
+Dead Letter Exchanges are similar to regular exchanges. They are declared as basic exchanges and can be used for any exchange type.
+
+1. **Declare a Dead Letter Exchange.** In this example, it's named `dlx_exchange`.
+2. **Declare the Dead Letter Queue.** In this example, it's named `dlx_queue`.
+3. **Bind the Dead Letter Exchange to the Dead Letter Queue.**
+4. **Declare the main queue.** Once the Dead Letter Exchange is set up, it can be used by any queue that needs to handle messages that may become undeliverable. Declare the main queue with the `x-dead-letter-exchange` argument and a routing key.
+5. **Publish a message.** This example adds a TTL to the message, ensuring it moves to the Dead Letter Queue once the TTL expires.
+
+<!-- prettier-ignore-start -->
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.exchange_declare(exchange='dlx_exchange', exchange_type='direct')
+
+channel.queue_declare(queue='dlx_queue', durable=True)
+channel.queue_bind(exchange='dlx_exchange', queue='dlx_queue', routing_key='dlx_key')
+
+channel.queue_declare(
+    queue="main_queue",
+    arguments={
+        "x-dead-letter-exchange": "dlx_exchange",
+        "x-dead-letter-routing-key": "dlx_key"
+    }
+)
+
+channel.basic_publish(
+    exchange='',
+    routing_key='main_queue',
+    body='Hello, DLX with TTL!',
+    properties=pika.BasicProperties(
+        expiration='5000'  # Expire the message after 5sec.
+    )
+)
+```
+
+### Publish a message with a DLX Header:
+
+A message can be published to the main queue with `x-dead-letter-exchange` and `x-dead-letter-routing-key` arguments in the headers. These headers do not trigger dead-lettering but provide routing information. Dead-lettering occurs only if the main queue’s DLX settings are activated.
+
+```python
+channel.basic_publish(
+    exchange='',
+    routing_key='main_queue',
+    body='Message with DLX headers!',
+    properties=pika.BasicProperties(
+        headers={
+            'x-dead-letter-exchange': 'dlx_exchange',
+            'x-dead-letter-routing-key': 'dlx_key'
+        }
+    )
+)
+```
+
+### Define a policy that applies to any matching queues:
+
+```python
+lavinmqctl set_policy dead_lettering ".*" '{"dead-letter-exchange":"dlx_exchange", "x-dead-letter-routing-key": "dead_routing_key"}' --apply-to queues
+```
+
+The policy would attach the dead letter exchange, `dlx_exchange` to all queues. Using the lavinmqctl is just one way of defining policies. Read the [documentation on policies](/documentation/policies) for more information on other approaches.
+
+
+<!-- prettier-ignore-end -->

--- a/docs/dead-letter-exchange.md
+++ b/docs/dead-letter-exchange.md
@@ -14,7 +14,7 @@
           <li>Exceeding queue length limits.</li>
         </ul>
         <p>Instead of being lost, these messages are published to the DLX, which then routes them to a queue for later processing.</p>
-        <img src="/img/docs/dead-letter-exchange-illustration.png" class="border border-[#414040]" />
+        <img src="img/docs/dead-letter-exchange-illustration.png" class="border border-[#414040]" />
     </div>
   </div>
 
@@ -104,7 +104,7 @@ channel.basic_publish(
 lavinmqctl set_policy dead_lettering ".*" '{"dead-letter-exchange":"dlx_exchange", "x-dead-letter-routing-key": "dead_routing_key"}' --apply-to queues
 ```
 
-The policy would attach the dead letter exchange, `dlx_exchange` to all queues. Using the lavinmqctl is just one way of defining policies. Read the [documentation on policies](/documentation/policies) for more information on other approaches.
+The policy would attach the dead letter exchange, `dlx_exchange` to all queues. Using the lavinmqctl is just one way of defining policies. Read the [documentation on policies](policies.md) for more information on other approaches.
 
 
 <!-- prettier-ignore-end -->

--- a/docs/delayed-message.md
+++ b/docs/delayed-message.md
@@ -29,7 +29,7 @@ LavinMQ can delay message delivery by adding a controlled waiting period between
 
 When a delayed exchange is declared, LavinMQ automatically creates an internal queue that stores the delayed messages. This internal queue is configured with a `dead-letter-exchange` argument that handles message routing once the delay period expires.
 
-![Delayed Exchange](/img/docs/docs-dm/delayed-exchange.png)
+![Delayed Exchange](img/docs/delayed-exchange.png)
 
 When a message is published to a delayed exchange, it is routed to an internal queue and stored with a delay specified in the message header, using the `x-delay` header. The internal queue assigns a Time-to-Live (TTL) equal to the value of `x-delay`. The message remains in the queue during this TTL until the delay period expires. Unlike a traditional FIFO queue, where messages are processed in order, this internal queue prioritises messages based on their individual delay values. This means messages can expire independently, without waiting for other messages to expire first. After expiration, the internal queue re-publishes the message to a dead-letter exchange set up to match the delayed exchange. Since the message is re-published with no delay, it will be routed directly to the queues bound to the routing key.
 

--- a/docs/delayed-message.md
+++ b/docs/delayed-message.md
@@ -1,0 +1,112 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a delayed message exchange?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>A <strong>delayed message exchange</strong> in LavinMQ temporarily holds messages for a specified delay period before routing them to their destination. This delay is set using the <code class="language-plaintext">x-delay</code> header in the message.</p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        When to use the delayed message exchange?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>Use it when you need to control message delivery timing, such as in scheduled tasks, retry attempts, or time-sensitive workflows.</p>
+    </div>
+  </div>
+</div>
+
+## Delayed message exchange
+
+LavinMQ can delay message delivery by adding a controlled waiting period between the time an exchange receives a message and when it is routed to its queue.
+
+When a delayed exchange is declared, LavinMQ automatically creates an internal queue that stores the delayed messages. This internal queue is configured with a `dead-letter-exchange` argument that handles message routing once the delay period expires.
+
+![Delayed Exchange](/img/docs/docs-dm/delayed-exchange.png)
+
+When a message is published to a delayed exchange, it is routed to an internal queue and stored with a delay specified in the message header, using the `x-delay` header. The internal queue assigns a Time-to-Live (TTL) equal to the value of `x-delay`. The message remains in the queue during this TTL until the delay period expires. Unlike a traditional FIFO queue, where messages are processed in order, this internal queue prioritises messages based on their individual delay values. This means messages can expire independently, without waiting for other messages to expire first. After expiration, the internal queue re-publishes the message to a dead-letter exchange set up to match the delayed exchange. Since the message is re-published with no delay, it will be routed directly to the queues bound to the routing key.
+
+### Using the delayed exchange
+
+**Example: Declaring a delayed exchange in LavinMQ**
+
+To configure a delayed exchange, you must specify the `x-delayed-type` argument, which indicates the underlying exchange type. LavinMQ supports allexchange types (`direct`, `fanout`, `topic`, and `headers`) for delayed messaging. This flexibility allows delayed exchanges can seamlessly integrate with various routing mechanisms.
+
+<!-- prettier-ignore-start -->
+
+For example:
+
+```ruby
+require "amqp-client"
+require "amq-protocol"
+
+# Connect to LavinMQ
+connection = AMQP::Client::Connection.new("amqp://localhost")
+channel = connection.channel
+
+# Define the exchange details
+exchange_name = "delayed_fanout_exchange"
+exchange_type = "x-delayed-message"
+arguments = {
+  "x-delayed-type" => "fanout"  # Specify the underlying exchange type
+}
+
+# Declare the delayed exchange
+channel.exchange_declare(
+  exchange: exchange_name,
+  type: exchange_type,
+  durable: true,
+  arguments: arguments
+)
+
+puts "Delayed exchange '#{exchange_name}' declared successfully."
+
+# Close the channel and connection
+channel.close
+connection.close
+```
+
+This example declares an exchange named “`delayed_fanout_exchange`” that uses the fanout strategy. Messages will be delayed by the specified duration in the message before being broadcast to all queues bound to this exchange.
+
+**Example: Publish a message to LavinMQ**
+
+To publish a message with a delay, include the delay time in the `x-delay` header when sending the message:
+
+```ruby
+require "amqp-client"
+require "amq-protocol"
+
+# Connect to LavinMQ
+connection = AMQP::Client::Connection.new("amqp://localhost")
+channel = connection.channel
+
+message = "This is a delayed message for LavinMQ."
+headers = {
+  "x-delay" => 2500_i64  # Delay in milliseconds, required as Int64
+}
+
+# Publish the message to the delayed exchange
+channel.basic_publish(
+  exchange: exchange_name,
+  routing_key: "", # Fanout exchanges ignore the routing key
+  body: message,
+  properties: AMQP::Client::BasicProperties.new(headers: headers)
+)
+
+puts "Message published to LavinMQ with a 2,500ms delay."
+
+# Close the channel and connection
+channel.close
+connection.close
+```
+
+The target queue attached to the delayed_route receives the message after 2500 milliseconds. Set the header for whichever delay is needed.
+
+<!-- prettier-ignore-end -->

--- a/docs/docker-compose-cluster.md
+++ b/docs/docker-compose-cluster.md
@@ -1,0 +1,134 @@
+
+<!-- prettier-ignore-start -->
+
+This guide will help you set up a 3-node LavinMQ cluster with [Docker Compose](https://docs.docker.com/compose/). 
+
+This will set up a development cluster with 3 LavinMQ nodes and 1 etcd node. LavinMQ uses etcd to track which nodes are in-sync. Note that we suggest running multiple etcd nodes in a production environment. For more information on clustering, see the [clustering docs](/documentation/clustering).
+
+## Configuration
+
+docker-compose.yml
+{% highlight yaml %}
+{% raw %}
+name: lavinmq-cluster
+services:
+  lavinmq1:
+    image: cloudamqp/lavinmq:latest
+    hostname: lavinmq1
+    container_name: lavinmq1
+    ports:
+      - 5672:5672
+      - 5679:5679
+      - 15672:15672
+    volumes:
+      - lavinmq-data:/var/lib/lavinmq/data
+    configs:
+      - source: lavinmq_config
+        target: /etc/lavinmq/lavinmq.ini
+    depends_on:
+      etcd:
+        condition: service_healthy
+    networks:
+      - network
+
+  lavinmq2:
+    image: cloudamqp/lavinmq:latest
+    hostname: lavinmq2
+    container_name: lavinmq2
+    ports:
+      - 5673:5672
+      - 15679:5679
+      - 25672:15672
+    volumes:
+      - lavinmq-data:/var/lib/lavinmq/data
+    configs:
+      - source: lavinmq_config
+        target: /etc/lavinmq/lavinmq.ini
+    depends_on:
+      etcd:
+        condition: service_healthy
+    networks:
+      - network
+
+  lavinmq3:
+    image: cloudamqp/lavinmq:latest
+    hostname: lavinmq3
+    container_name: lavinmq3
+    ports:
+      - 5674:5672
+      - 25679:5679
+      - 35672:15672
+    volumes:
+      - lavinmq-data:/var/lib/lavinmq/data
+    configs:
+      - source: lavinmq_config
+        target: /etc/lavinmq/lavinmq.ini
+    depends_on:
+      etcd:
+        condition: service_healthy
+    networks:
+      - network
+
+  etcd:
+    image: gcr.io/etcd-development/etcd:v3.6.5
+    container_name: etcd
+    ports:
+      - 2379:2379
+      - 2380:2380
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd
+      - --data-dir=/var/lib/etcd/data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd:2380
+      - --advertise-client-urls=http://etcd:2379
+      - --initial-cluster=etcd=http://etcd:2380
+      - --initial-cluster-state=new
+      - --initial-cluster-token=etcd-cluster-0
+    volumes:
+      - etcd-data:/var/lib/etcd/data
+    networks:
+      - network
+    healthcheck:
+      test: [ "CMD", "etcdctl", "--endpoints=http://localhost:2379", "endpoint", "health" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    environment:
+      - ETCDCTL_API=3
+
+configs:
+  lavinmq_config:
+    content: |
+        [clustering]
+        enabled = true
+        bind = 0.0.0.0
+        etcd_endpoints = etcd:2379
+
+networks:
+  network:
+    driver: bridge
+
+volumes:
+  lavinmq-data:
+  etcd-data:
+
+{% endraw %}
+{% endhighlight %}
+
+
+## Running the cluster
+
+Start the containers by running:
+{% highlight shell %}
+{% raw %}
+docker compose up
+{% endraw %}
+{% endhighlight %}
+
+You can now start publishing and consuming messages at `amqp://guest:guest@localhost`, and access the management UI by visiting `http://localhost:15672`
+
+Visit [cloudamqp/lavinmq](https://hub.docker.com/r/cloudamqp/lavinmq) on Docker Hub to learn more.
+
+<!-- prettier-ignore-end -->

--- a/docs/docker-compose-cluster.md
+++ b/docs/docker-compose-cluster.md
@@ -3,7 +3,7 @@
 
 This guide will help you set up a 3-node LavinMQ cluster with [Docker Compose](https://docs.docker.com/compose/). 
 
-This will set up a development cluster with 3 LavinMQ nodes and 1 etcd node. LavinMQ uses etcd to track which nodes are in-sync. Note that we suggest running multiple etcd nodes in a production environment. For more information on clustering, see the [clustering docs](/documentation/clustering).
+This will set up a development cluster with 3 LavinMQ nodes and 1 etcd node. LavinMQ uses etcd to track which nodes are in-sync. Note that we suggest running multiple etcd nodes in a production environment. For more information on clustering, see the [clustering docs](clustering.md).
 
 ## Configuration
 

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -101,7 +101,7 @@ The federation functionality comes as standard on LavinMQ, so there is no need t
 - A federation link
 - The policy that matches the queues/exchanges that should be federated.
 
-![Federation add upstream](/img/docs/docs-dm/add-new-upstream-dm-2x.png)
+![Federation add upstream](img/docs/add-new-upstream-dm-2x.png)
 
 Here is a list of all configuration with descriptions related to federations:
 
@@ -114,7 +114,7 @@ Here is a list of all configuration with descriptions related to federations:
     - connect to server-name, with credentials and SSL
   - `amqps://server-name?cacertfile=/path/to/cacert.pem&certfile=/path/to/cert .pem&keyfile=/path/to/key.pem&verify=verify_peer &fail_if_no_peer_cert=true&auth_mechanism=external`
     - connect to server-name, with SSL and EXTERNAL authentication
-- [Prefetch](/documentation/prefetch) is the maximum number of unacknowledged
+- [Prefetch](prefetch.md) is the maximum number of unacknowledged
   messages that will be in flight at one time.
 - Reconnection delay is the time in seconds to wait after a network link goes
   down before trying to reconnection.
@@ -148,7 +148,7 @@ on broker B (the downstream server). Configuring the federation can be done via
 the LavinMQ Management Interface or the HTTP API, but in this example, we
 will focus on the LavinMQ Management Interface.
 
-![Federation example](/img/docs/lavinmq-federation-example.jpg)
+![Federation example](img/docs/lavinmq-federation-example.jpg)
 
 When configuring the federation, we will enable messages to be moved or copied
 from cluster A to cluster B. In this example, we will create a queue named
@@ -168,7 +168,7 @@ downstream server.
     Configure the federation link on the downstream server (B) by going to the
     LavinMQ Management Interface and click on the tab Federation and fill in
     the section <em>Add a new upstream</em>.<br/>
-    <img src="/img/docs/docs-dm/add-new-upstream-v2-dm-2x.png" alt="Federation add upstream example" class="border border-[#414040]">
+    <img src="img/docs/add-new-upstream-v2-dm-2x.png" alt="Federation add upstream example" class="border border-[#414040]">
   </li>
   <li>
     Create a policy on the downstream server (B) that matches the
@@ -179,7 +179,7 @@ downstream server.
     apply to an upstream set or a single upstream of exchanges and/or queues. In
     this example we apply to all upstreams, federation-upstream-set is set to all.
     <br/>
-    <img src="/img/docs/docs-dm/add-policy-dm-2x.png" alt="Update federation policy" class="border border-[#414040]">
+    <img src="img/docs/add-policy-dm-2x.png" alt="Update federation policy" class="border border-[#414040]">
   </li>
   <li>
     We then need to create queues, exchanges, and bindings for the downstream

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -1,0 +1,221 @@
+
+Federation is used to transfer messages between brokers, which can be useful in
+a number of scenarios. This documentation will outline when to use federation,
+what the difference is between queue federation and exchange federation, and how
+to configure it.
+
+### What is a federation?
+
+Federation is used to transfer messages between brokers. It will transfer
+messages from one broker called the upstream to another broker called the
+downstream. There are two ways of configuring a federation, via queue federation
+or exchange federation.
+
+### What is the difference between queue federation and exchange federation?
+
+- Queue federation is used when you want to transfer messages from a queue to
+  another queue on another node or cluster, i.e. messages are moved and not
+  copied. Exchange federation is used when you want to copy messages from an
+  exchange to another exchange on another node or cluster.
+- With queue federation, messages are only transferred where there are
+  underutilized consumers, always preferring local consumers to remote ones.
+  With exchange federation messages are always federated, no matter where the
+  consumers are connected.
+- Exchange federation will pass on bindings from the downstream to the upstreams
+  when possible, whereas queue federation will not.
+
+### What does downstream and upstream mean?
+
+Upstream servers are where messages are originally published. Downstream servers
+are where messages get forwarded to.
+
+### When should I use federation?
+
+Federation has several use-cases:
+
+- collect messages in a central cluster from multiple clusters
+- distribute the load from one queue to other clusters
+- migrating to another cluster without stopping all producers/consumers
+- a hot-standby with relatively up-to-date data
+
+### How does the federation connect?
+
+The federation will connect to all its upstream queues or exchanges using
+AMQP 0-9-1. The URI used to connect can be in any of the formats:
+
+```
+amqp://user:password@server-name/my-vhost
+```
+
+<p style="margin-top: -24px;">
+connect to server-name, with credentials and specified virtual host
+</p>
+
+```
+amqps://user:password@server-name?cacertfile=/path/to/cacert.pem&certfile=/path/to/cert.pem&keyfile=/path/to/key.pem&verify=verify_peer
+```
+
+<p style="margin-top: -24px;">
+connect to server-name, with credentials and SSL
+</p>
+
+```
+amqps://server-name?cacertfile=/path/to/cacert.pem&certfile=/path/to/cert.pem&keyfile=/path/to/key.pem&verify=verify_peer&fail_if_no_peer_cert=true&auth_mechanism=external
+```
+
+<p style="margin-top: -24px;">
+connect to server-name, with SSL and EXTERNAL authentication
+</p>
+
+## Queue Federation
+
+Queue federation connects an upstream queue to transfer messages to a downstream
+queue when there are consumers on the downstream queue. Consumers and publishers
+can be moved in any order and the messages will not be duplicated. The federated
+queue will only receive messages when it has run out of messages locally,
+consumers are connected, and the upstream queue has messages that are not being
+consumed.
+
+## Exchange Federation
+
+In a normal scenario, messages are published to an exchange and then routed to
+the queue(s). With the use of an exchange federation, it is possible to get
+LavinMQ to distribute those messages to another cluster. This means that
+messages arriving in the federated exchanges will also be forwarded to the
+downstream clusters. Exchange federation consumes messages from an upstream
+cluster and republishes them on its own local exchange as if the messages
+published on the upstream cluster were published on the local cluster.
+
+The federation will create a queue on the upstream cluster, bind it to the
+exchange being federated, and then consume from that queue to republish the
+messages on the local exchange. If the connection between the two federated
+clusters is broken messages will queue up on the upstream queue and when the
+server reconnects again it will transfer all messages that were published during
+the network outage.
+
+## Configure a federation
+
+The federation functionality comes as standard on LavinMQ, so there is no need to activate the functionality. Federations are always configured on the downstream servers, and you need to configure:
+
+- One or more upstreams where the messages will come from.
+- A federation link
+- The policy that matches the queues/exchanges that should be federated.
+
+![Federation add upstream](/img/docs/docs-dm/add-new-upstream-dm-2x.png)
+
+Here is a list of all configuration with descriptions related to federations:
+
+- Virtual host the federation will be created in
+- Name of the federation
+- URI of the upstream server, in any of the format:
+  - `amqp://user:password@server-name/my-vhost`
+    - connect to server-name, with credentials and specified virtual host
+  - `amqps://user:password@server-name?cacertfile=/path/to/cacert.pem&certfile=/path/to/     cert.pem&keyfile=/path/to/key.pem&verify=verify_peer`
+    - connect to server-name, with credentials and SSL
+  - `amqps://server-name?cacertfile=/path/to/cacert.pem&certfile=/path/to/cert .pem&keyfile=/path/to/key.pem&verify=verify_peer &fail_if_no_peer_cert=true&auth_mechanism=external`
+    - connect to server-name, with SSL and EXTERNAL authentication
+- [Prefetch](/documentation/prefetch) is the maximum number of unacknowledged
+  messages that will be in flight at one time.
+- Reconnection delay is the time in seconds to wait after a network link goes
+  down before trying to reconnection.
+- Ack mode is how messages will be acknowledged:
+  - `on-confirm`<br/>
+    Messages are acknowledged to the upstream broker when they have been
+    confirmed by the downstream server. Messages are not lost in the case of
+    network errors and broker failures.
+  - `on-publish`<br/>
+    Messages are acknowledged to the upstream broker after they have been
+    published to the downstream server. Handles network errors without losing
+    messages, but may lose messages in the event of broker failures.
+  - `no-ack`<br/>
+    Message acknowledgements are not used. Can lose messages in the event of
+    network or broker failures.
+- Exchange is the name of the upstream exchange.
+- Expires is the time in milliseconds when the federation link will be
+  removed. Leave this blank for the link to never expire.
+- Message TTL is how long the upstream should hold undelivered messages in
+  the event of a network outage or backlog. Leaving this blank means forever.
+- Queue is the name of the upstream queue. The default is using the same name
+  as the federated queue.
+- Consumers tag is used when consuming from upstream.
+
+## Examples
+
+In this example, we will work with two different LavinMQ clusters, located
+in two different physical locations. Broker A will be the upstream server and
+broker B will be the downstream server. We start by configuring the federation
+on broker B (the downstream server). Configuring the federation can be done via
+the LavinMQ Management Interface or the HTTP API, but in this example, we
+will focus on the LavinMQ Management Interface.
+
+![Federation example](/img/docs/lavinmq-federation-example.jpg)
+
+When configuring the federation, we will enable messages to be moved or copied
+from cluster A to cluster B. In this example, we will create a queue named
+`federation.queue` on both the upstream and the downstream server. We will also
+create a federated exchange called ‘federation.exchange’ and bind the exchange
+on the upstream server to the federated link on the downstream server. Messages
+published to the exchange on the upstream server will be routed to
+the `federation.queue` and they will also be copied to the exchange on the
+downstream server, as well as routed to the `federation.queue` on the
+downstream server.
+
+<ol class="flex flex-col space-y-4">
+  <li>
+    Start by getting the URL for the upstream server, for example <code class="language-plaintext highlighter-rouge">amqp://user:password@server-name/my-vhost</code>
+  </li>
+  <li>
+    Configure the federation link on the downstream server (B) by going to the
+    LavinMQ Management Interface and click on the tab Federation and fill in
+    the section <em>Add a new upstream</em>.<br/>
+    <img src="/img/docs/docs-dm/add-new-upstream-v2-dm-2x.png" alt="Federation add upstream example" class="border border-[#414040]">
+  </li>
+  <li>
+    Create a policy on the downstream server (B) that matches the
+    queues/exchanges that should be federated. Navigate to Policies and fill in the
+    section Add/update policy. The pattern argument is a regular expression used to
+    match exchange or queue names. In this case, we will tell the policy to federate
+    all queues and exchanges whose names begin with "federation.". A policy can
+    apply to an upstream set or a single upstream of exchanges and/or queues. In
+    this example we apply to all upstreams, federation-upstream-set is set to all.
+    <br/>
+    <img src="/img/docs/docs-dm/add-policy-dm-2x.png" alt="Update federation policy" class="border border-[#414040]">
+  </li>
+  <li>
+    We then need to create queues, exchanges, and bindings for the downstream
+    server (B). The fastest and easiest way to set up this is by using any
+    programming language, but it can also be done directly from the LavinMQ
+    Management interface.
+    <ul>
+      <li>Define a queue, in this example named <code class="language-plaintext highlighter-rouge">federation.queue</code>.
+      </li>
+      <li>
+        Create an exchange, in this example named <code class="language-plaintext highlighter-rouge">federation.exchange</code>.
+      </li>
+      <li>
+        Bind the exchange to the queue, in this example bind
+        the <code class="language-plaintext highlighter-rouge">federation.exchange</code> to the <code class="language-plaintext highlighter-rouge">federation.queue</code>.
+      </li>
+      <li>
+        Check that the federation.exchange has a binding to the federated
+        upstream exchange.
+      </li>
+    </ul>
+  </li>
+  <li>
+    Try the federation by publishing one message to the exchange,
+  federation.exchange, on the upstream server. You will see that the message
+  moves to the <code class="language-plaintext highlighter-rouge">federation.queue</code> on the downstream server.
+  </li>
+</ol>
+
+## Conclusions
+
+- Policies are matched every time an exchange or queue is created.
+- Policies with a priority greater than 0 will take precedence.
+- The default exchange cannot be federated since it is not a standard exchange.
+
+## Read more
+
+HTTP API documentation for federation:
+[https://hostname/docs/#operation/](https://hostname/docs/#operation/)

--- a/docs/img/docs/add-new-upstream-dm-2x.png
+++ b/docs/img/docs/add-new-upstream-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aceead50810ec26fb69bdb011a3e6ba6a84008b8a4b7c322256f171514719493
+size 189607

--- a/docs/img/docs/add-new-upstream-v2-dm-2x.png
+++ b/docs/img/docs/add-new-upstream-v2-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1049742fd1036e1d575b10caab33196b8f37585718d23019d99a26ecba1f786d
+size 191020

--- a/docs/img/docs/add-policy-dm-2x.png
+++ b/docs/img/docs/add-policy-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09acc18cb4214578bf46ce2ea8d7fc2d84bb8db152df72b94cf52695346e3c23
+size 176856

--- a/docs/img/docs/add-queue-dm-2x.png
+++ b/docs/img/docs/add-queue-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e15a1c31d0afc1da048b72b4d2d4c70dbbb83fc520b1cd883425972db1821675
+size 155298

--- a/docs/img/docs/add-remove-defs-dm-2x.png
+++ b/docs/img/docs/add-remove-defs-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6582067d505c837898b40dcd2984b802bc123fdb1b49f077fa062819f2831fe7
+size 91959

--- a/docs/img/docs/add-shovel-dm-2x.png
+++ b/docs/img/docs/add-shovel-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4483cb99fa40624936c87e57f061a3babcb27e03f8bcb416b1040f0c8d7f989c
+size 193349

--- a/docs/img/docs/amqp-connections-and-channels-four.png
+++ b/docs/img/docs/amqp-connections-and-channels-four.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f183f36a37fc7ddae380eea131c733fd183363ea17f9b796060bec1c80d98e8
+size 16304

--- a/docs/img/docs/amqp-connections-and-channels-one.png
+++ b/docs/img/docs/amqp-connections-and-channels-one.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:724df1bab714ca4a81487c1cfa0ebc659d0767a170761e9fb328817fe4371dbe
+size 19076

--- a/docs/img/docs/amqp-connections-and-channels-three.png
+++ b/docs/img/docs/amqp-connections-and-channels-three.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05a613b0d8d4927e3a98fd2a6b132997056f3206be39901689672d8e953c4e8
+size 22808

--- a/docs/img/docs/amqp-connections-and-channels-two.png
+++ b/docs/img/docs/amqp-connections-and-channels-two.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8414e31190b56a6c1fe42f54272e72c1d3285229d1cb93e9b160f74c1e33ab8
+size 18171

--- a/docs/img/docs/amqp-protocol-illustration.png
+++ b/docs/img/docs/amqp-protocol-illustration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3445420b0fea5e07b2b8cda4433d9312e53e2ede09a41683f1ea84b9a587479c
+size 117268

--- a/docs/img/docs/channel-details-dm-2x.png
+++ b/docs/img/docs/channel-details-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:486b349731c369b7fca6fb0cc6feafe12e8b008f6ea08a20887f02366ef6a7b5
+size 333284

--- a/docs/img/docs/channels-dm-2x.png
+++ b/docs/img/docs/channels-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03c31a0fda84f9400bb3ed5f94bda63ad74db27c2e0b7a7eee7190b41031542d
+size 161753

--- a/docs/img/docs/connections-dm-2x.png
+++ b/docs/img/docs/connections-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fed904b9ddca094ffc48f3250f0bfef6825f9ee3be3a9e8beeea04cfb65c65bd
+size 190788

--- a/docs/img/docs/data-rates-dm-2x.png
+++ b/docs/img/docs/data-rates-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7780d562004b0fee5a3b3e97458e69a977a1432e63523c182239c0c0f88bcafc
+size 103532

--- a/docs/img/docs/dead-letter-exchange-illustration.png
+++ b/docs/img/docs/dead-letter-exchange-illustration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0520318d2629e9d9df14d5e4ec1b2d18319aa6dcc776b896842f7c5537276b2e
+size 59167

--- a/docs/img/docs/delayed-exchange.png
+++ b/docs/img/docs/delayed-exchange.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f718a46b03aa92d029d7bd89318d8fd2a97339ced7d674d78528ce946b331dc
+size 63043

--- a/docs/img/docs/exchanges-dm-2x.png
+++ b/docs/img/docs/exchanges-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbb51113fcacc2bb69326f3a506afee51f28eeeb45e1831f61688a6aef16140a
+size 255581

--- a/docs/img/docs/federation-dm-2x.png
+++ b/docs/img/docs/federation-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6630c085ae98b10d2f8835ddcc2f9be0d206447755c15c5b0cf45f8ad3097ced
+size 304118

--- a/docs/img/docs/illustration-1-3.svg
+++ b/docs/img/docs/illustration-1-3.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb84c92cf6e942edaaef05df9a4076197e70ba18161b16da948f63356c5964d9
+size 53732

--- a/docs/img/docs/lavinmq-arguments-policy.jpg
+++ b/docs/img/docs/lavinmq-arguments-policy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04e53f88c75fd42f4d02fd99b77a704e953d3aeec5b4401d8fddf7f55a2a1f43
+size 98766

--- a/docs/img/docs/lavinmq-bindings.png
+++ b/docs/img/docs/lavinmq-bindings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce427cd212012c43de1c4ed338f63c5ff67bcc84fcbedb6e424589498786e330
+size 122483

--- a/docs/img/docs/lavinmq-dead-lettering.jpg
+++ b/docs/img/docs/lavinmq-dead-lettering.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66c2c8b21ea4363ab9fc5a10647f226761cd0970c63cb81f090a078ef87d0df2
+size 54500

--- a/docs/img/docs/lavinmq-federation-example.jpg
+++ b/docs/img/docs/lavinmq-federation-example.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eacb08d4d9c0d1033400bc1bd2aa3c6fad1cfa1eb7438dace64e1669cb9b62d8
+size 96717

--- a/docs/img/docs/lavinmq-fifo-enqueue-dequeue.jpg
+++ b/docs/img/docs/lavinmq-fifo-enqueue-dequeue.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4da7a69fc61f4b122ed3af0b36d3acc9f5f87c4d214356dd7fe20499f3f21046
+size 46537

--- a/docs/img/docs/lavinmq-message-store.jpg
+++ b/docs/img/docs/lavinmq-message-store.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c49e288505bf0abb5032d186cddbe085a22eb9a03614e1901504833af3d642c
+size 99205

--- a/docs/img/docs/lavinmq-multiple-competing-consumers.jpg
+++ b/docs/img/docs/lavinmq-multiple-competing-consumers.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:469aad0c789394e0aaddef42deaabb5605306cc1dff6196394bca023e9ade44d
+size 71601

--- a/docs/img/docs/lavinmq-multiple-connections-channels.jpg
+++ b/docs/img/docs/lavinmq-multiple-connections-channels.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebec303d808d3280d0c9c8848f498c7db44e817a9e71a44ff05182314b1af168
+size 47483

--- a/docs/img/docs/lavinmq-policy-argument-update.jpg
+++ b/docs/img/docs/lavinmq-policy-argument-update.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d4daca79260029f37d0a59ce5939e3d3397507c1fecb541b3b74f9e3a0f6490
+size 92570

--- a/docs/img/docs/lavinmq-streams-offsets.png
+++ b/docs/img/docs/lavinmq-streams-offsets.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43cfdd7a9c00d7c0fbc0fb46516d2da674111d326584f2e028828460f782065d
+size 23377

--- a/docs/img/docs/lavinmq-vhost-example.png
+++ b/docs/img/docs/lavinmq-vhost-example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87400695e5aad3a414445db8d339b279b637957bcc29183aed90031ee508b453
+size 39291

--- a/docs/img/docs/message-rates-dm-2x.png
+++ b/docs/img/docs/message-rates-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c975f607df94a529609a3509d73ff9185fe3e99ecb939e53035b62cc3f74ffb
+size 119949

--- a/docs/img/docs/nodes-dm-2x.png
+++ b/docs/img/docs/nodes-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2181203231b3aefb0c121e0b3ac4aaafc2dd8d0916768e918fa1d9188dce9708
+size 601305

--- a/docs/img/docs/overview-dm-2x.png
+++ b/docs/img/docs/overview-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d87b26831fc5a95eaebec2cc8ebeeced34f0782329bda68c7ae8b208f46931cb
+size 380930

--- a/docs/img/docs/pause-queue.png
+++ b/docs/img/docs/pause-queue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ae442b80fdc80ca4cb3aa12db93f7fa8843db7a1e8ffaac28ec9123b6d1c5bf
+size 257530

--- a/docs/img/docs/policies-dm.png
+++ b/docs/img/docs/policies-dm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd07bd2142c923e1bc6ff75f22b583f938836c76971697839bdc3b518c0d8195
+size 85842

--- a/docs/img/docs/prefetch-1.png
+++ b/docs/img/docs/prefetch-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d0b437c1983a06a64a6ec115a2381230f37859a799d34f1be131cbc9ac470f1
+size 38474

--- a/docs/img/docs/prefetch-2.png
+++ b/docs/img/docs/prefetch-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04f95b8f8396a456f2432821e72fbba6f0985010b74339aa214eaca840ba01a3
+size 49186

--- a/docs/img/docs/prefetch-3.png
+++ b/docs/img/docs/prefetch-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8421fc095bf688f570245d57b7b03e0cd2771b5e163de1f74d79477e0937ca6
+size 33527

--- a/docs/img/docs/publish-message-dm-2x.png
+++ b/docs/img/docs/publish-message-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:638079c0bde3df9e8f1b991d28bb4ddd0cb8f674f39a212b6884d7e6325fe562
+size 201130

--- a/docs/img/docs/queued-messages-dm-2x.png
+++ b/docs/img/docs/queued-messages-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc892e1ac139c2b72ec4e5f8b95d9a35edb3ad151a28e17458dad4d3a580e54a
+size 149851

--- a/docs/img/docs/queues-dm-2x.png
+++ b/docs/img/docs/queues-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76c9f9b7c1100886b0920c40f4b59ba94219b9bc289063c65266dadc94a768d2
+size 248659

--- a/docs/img/docs/shovels-dm-2x.png
+++ b/docs/img/docs/shovels-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8cdfbc5d7958601f7c8c799407ff7d57a21d013c2c290ffa3427139629570d5
+size 258446

--- a/docs/img/docs/single-connection-dm-2x.png
+++ b/docs/img/docs/single-connection-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a29a0c8392fd7249943f2b62283fb1ebbcee84cc0dc9d4c13c4ccb411b761c2e
+size 473820

--- a/docs/img/docs/single-exchange-dm-2x.png
+++ b/docs/img/docs/single-exchange-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dcd824850750eaf849bc8d06d7424b5bc4d1079359bfa0d9f1df892b097514b
+size 391481

--- a/docs/img/docs/single-queue-dm-2x.png
+++ b/docs/img/docs/single-queue-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7309b51f81e533d6e21584e9bcf34d5c61245a2a60c45ccb8dcc9164fb2f8326
+size 791741

--- a/docs/img/docs/single-user-dm-2x.png
+++ b/docs/img/docs/single-user-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8d8a8ea8f126ca943770a27fc6c4b59b29bce828d9c1154ff31107b8c7553e7
+size 284275

--- a/docs/img/docs/single-vhost-dm-2x.png
+++ b/docs/img/docs/single-vhost-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:358b533b82b92db4e51172674e480c4f20a7b62468df6cc019efa96d0efc4a6a
+size 273087

--- a/docs/img/docs/users-dm-2x.png
+++ b/docs/img/docs/users-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d9d9975bf2d923c36006d6c8198a47ad17922e39fbfdc83512f400abbb13788
+size 183596

--- a/docs/img/docs/vhost-dm.png
+++ b/docs/img/docs/vhost-dm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05a3b9741a90f71e59ed9f59b78d544e88f539a46b82e8171c15179ca4dc3c23
+size 30685

--- a/docs/img/docs/vhosts-dm-2x.png
+++ b/docs/img/docs/vhosts-dm-2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6b1dc1706b3cb1a72c0af2897caf4895406e65797ef33c6900dc7e2ff5ff6a
+size 154386

--- a/docs/import-export-definitions.md
+++ b/docs/import-export-definitions.md
@@ -17,8 +17,8 @@ An exported definitions file can be used to restore the basic setup on a seconda
 
 Definitions can be exported or imported as a JSON using any of the following methods:
 
-- The [LavinMQ management interface](/documentation/management-interface-overview)
-- Using [lavinmqctl](/documentation/lavinmqctl) commands export_definitions and import_defintions
+- The [LavinMQ management interface](management-interface-overview.md)
+- Using [lavinmqctl](lavinmqctl.md) commands export_definitions and import_defintions
 - Calling the [api/definitions](https://docs.lavinmq.com/http-api.html#tag/definitions) API endpoint
 
 Note: Be aware that the exported definitions contain hashed passwords.
@@ -27,7 +27,7 @@ Note: Be aware that the exported definitions contain hashed passwords.
 
 The LavinMQ management overview tab contains two sections, namely Upload definitions and Export definitions.
 
-<img alt="Upload and export definitions in LavinMQ management interface" src="/img/docs/docs-dm/add-remove-defs-dm-2x.png" class="border border-[#414040]" />
+<img alt="Upload and export definitions in LavinMQ management interface" src="img/docs/add-remove-defs-dm-2x.png" class="border border-[#414040]" />
 
 #### Upload definitions
 

--- a/docs/import-export-definitions.md
+++ b/docs/import-export-definitions.md
@@ -1,0 +1,48 @@
+
+The LavinMQ definitions file consist of users, queues, exchanges, bindings, virtual hosts, permissions, and parameters. These definitions can be exported to a file to import into another server or used for a schema backup.
+
+### What is the definitions file?
+
+The definition file contains information and definitions of all objects in LavinMQ, like queues, exchanges, bindings, users, virtual hosts, permissions, and parameters.
+
+### Can the definitions file be exported and imported?
+
+Yes, it can be exported to a JSON object, and imported as a JSON object.
+
+### Why do I need to export the definitions file?
+
+An exported definitions file can be used to restore the basic setup on a secondary LavinMQ server. It might be used when creating a backup or moving from one AMQP-server to another.
+
+## How to export or import LavinMQ configuration
+
+Definitions can be exported or imported as a JSON using any of the following methods:
+
+- The [LavinMQ management interface](/documentation/management-interface-overview)
+- Using [lavinmqctl](/documentation/lavinmqctl) commands export_definitions and import_defintions
+- Calling the [api/definitions](https://docs.lavinmq.com/http-api.html#tag/definitions) API endpoint
+
+Note: Be aware that the exported definitions contain hashed passwords.
+
+### Using the LavinMQ management
+
+The LavinMQ management overview tab contains two sections, namely Upload definitions and Export definitions.
+
+<img alt="Upload and export definitions in LavinMQ management interface" src="/img/docs/docs-dm/add-remove-defs-dm-2x.png" class="border border-[#414040]" />
+
+#### Upload definitions
+
+Upload the definitions by clicking Choose file, then select the JSON file containing the definitions, and click upload.
+
+#### Export definitions
+
+Definitions can be exported for a specific virtual host or for the entire LavinMQ server. Select All or a specific vhost from the drop-down and click _Download_. When definitions are exported for just one virtual host, some information will be excluded from the exported file.
+
+### Using Lavinmqctl commands export_definitions and import_defintions
+
+lavinmqctl allows for definitions to be exported in JSON format using the command `lavinmqctl export_definitions`.
+
+Importing definitions is done using `lavinmqctl import_definitions <file>`
+
+### Calling the api/definitions API endpoint
+
+More information on the definitions export and import functionality can be found in the [LavinMQ API docs](https://docs.lavinmq.com/http-api.html#tag/definitions).

--- a/docs/lavinmq-ports.md
+++ b/docs/lavinmq-ports.md
@@ -1,0 +1,97 @@
+
+LavinMQ supports the following main protocols:
+
+- AMQP
+- MQTT
+- HTTP
+- Replication protocol
+
+Each protocol listens on a default port that's configurable. In the subsequent
+sections, we will look at the available ports for each protocol and how to configure
+your instance to use custom ports.
+
+## AMQP
+
+In addition to **AMQP**, LavinMQ also supports TLS 1.2 and 1.3, for **AMQPS**.
+The ports for AMQP and AMQPS are as follows:
+
+- AMQP: `5672`
+- AMQPS: `5671` - If a valid certificate and key are available.
+
+If you are running self-managed LavinMQ, you can also use custom ports for AMQP and AMQPS by
+updating the following variables in the `lavinmq.ini` file as shown below:
+
+```
+[amqp]
+bind = 0.0.0.0
+port = 3322
+tls_port = 3321
+```
+
+## MQTT
+
+In addition to **AMQP**, LavinMQ also supports **MQTT**, a lightweight publish/subscribe protocol commonly used for IoT and resource-constrained devices.
+
+LavinMQ supports both plain **MQTT** and **MQTTS** (MQTT over TLS 1.2 and 1.3).
+The default ports for MQTT and MQTTS are as follows:
+
+- MQTT: `1883`
+- MQTTS: `8883`
+
+If you are running self-managed LavinMQ, you can also use custom ports for MQTT and MQTTS by
+updating the following variables in the `lavinmq.ini` file as shown below:
+
+```
+[mqtt]
+bind = 0.0.0.0
+port = 3342
+tls_port = 3341
+```
+
+## HTTP
+
+LavinMQ exposes a number of services over HTTP, namely:
+
+- Management UI
+- HTTP API
+- Prometheus metrics endpoint
+
+In addition to **HTTP**, LavinMQ also supports TLS 1.2 and 1.3, for **HTTPS**.
+Thus, for the management interface, LavinMQ listens on the following ports:
+
+- HTTP: `15672`
+- HTTPS: `15671` - If a valid certificate and key are available.
+
+Other than the defaults above, you can also use custom ports for HTTP and HTTPS by
+updating the following variables in the `lavinmq.ini` file as shown below:
+
+```
+[mgmt]
+bind = 0.0.0.0
+port = 6644
+tls_port = 6643
+```
+
+In addition to the management interface LavinMQ also exposes a HTTP API and
+a metrics endpoint for Prometheus - both services listen on port `443`.
+
+## Replication protocol
+
+LavinMQ `>1.1.6` comes with a dedicated replication protocol for the `hot standby replication feature`. This protocol listens on the default port `5679`.
+However, this is configurable.
+
+To use a custom port, update the following variables in the `lavinmq.ini` file as shown below:
+
+```
+[replication]
+bind = 0.0.0.0
+port = 5679
+```
+
+## Wrap up
+
+In conclusion, LavinMQ supports three main protocols: AMQP, HTTP,
+and Replication protocol. Each protocol has its default port, which can be
+configured to use custom ports. By adjusting the configuration settings in
+the `lavinmq.ini` file, you can easily tailor LavinMQ to suit your specific
+port requirements for each protocol.

--- a/docs/lavinmqctl.md
+++ b/docs/lavinmqctl.md
@@ -1,0 +1,214 @@
+
+<!-- prettier-ignore-start -->
+
+### What is a command line interface?
+
+A command line interface lets you configure a program from your terminal. This has several benefits but one big advantage is that you can control your program from script files or from other programs.
+
+### What benefits does lavinmqctl offer?
+
+Being able to control LavinMQ from the command line can be very powerful, it allows you to do repetitive tasks like setting up exchanges and queues very simple. You can also use it to check the status of the broker.
+
+
+### How should I use lavinmqctl?
+Lavinmqctl can be used on your own computer or a server and you can use it against a local instance of lavinmq or a hosted one running on cloudamqp.com as it supports remote instances as well.
+
+## Usage
+
+`lavinmqctl` is a command line tool for managing an LavinMQ instance, it connects to the running instance over either unix socket or over HTTP. Default is using a unix socket, which therefore requires the instance to be running on the same machine. You can tell the tool to connect to a remote instance using HTTPS and using basic auth for authentication. When using this method the credentials to use are the same as you use when connecting an AMQP client so the same permissions is also used for `lavinmqctl`.
+
+Example of listing queues in vhost cloudamqp
+
+{% highlight shell %}
+lavinmqctl -p cloudamqp list_queues
+{% endhighlight %}
+
+## Global options
+
+Global options are available for all commands.
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Option</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>-p vhost, --vhost=vhost</td>
+          <td>Specify vhost</td>
+        </tr>
+        <tr>
+          <td>-H host, --host=host</td>
+          <td>Specify host, if skipped it will connect using the default unix socket, which require LavinMQ to be running on the same machine. <br> When connecting to a remote broker you should specify host a complete http uri like this: https://username:password@hostname.com/</td>
+        </tr>
+        <tr>
+          <td>-q, --quiet</td>
+          <td>Suppress informational messages</td>
+        </tr>
+        <tr>
+          <td>-s, --silent</td>
+          <td>Suppress informational messages and table formatting</td>
+        </tr>
+        <tr>
+          <td>-v, --version</td>
+          <td>Show version</td>
+        </tr>
+        <tr>
+          <td>-h, --help</td>
+          <td>Print all options and commands available, this can also be used for a command like “<code class="language-plaintext highlighter-rouge">lavinmqctl list_queue -h</code>” to show options for this command.</td>
+        </tr>
+        <tr>
+          <td>-f format, --format=format</td>
+          <td>Format output (text, json) default is text</td>
+        </tr>
+        <tr>
+          <td>-n node, --node=node</td>
+          <td>Does nothing, only used in CI for compatibility reasons.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+## Commands
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Command</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>status</td>
+          <td>Display server status</td>
+        </tr>
+        <tr>
+          <td>cluster_status</td>
+          <td>Display cluster status</td>
+        </tr>
+        <tr>
+          <td>add_user</td>
+          <td>Creates a new user</td>
+        </tr>
+        <tr>
+          <td>change_password</td>
+          <td>Change the user password</td>
+        </tr>
+        <tr>
+          <td>delete_user</td>
+          <td>Delete a user</td>
+        </tr>
+        <tr>
+          <td>list_users</td>
+          <td>List user names and tags</td>
+        </tr>
+        <tr>
+          <td>set_user_tags</td>
+          <td>Sets user tags</td>
+        </tr>
+        <tr>
+          <td>list_vhosts</td>
+          <td>Lists virtual hosts</td>
+        </tr>
+        <tr>
+          <td>add_vhost</td>
+          <td>Creates a virtual host</td>
+        </tr>
+        <tr>
+          <td>delete_vhost</td>
+          <td>Deletes a virtual host</td>
+        </tr>
+        <tr>
+          <td>reset_vhost</td>
+          <td>Purges all messages in all queues in the vhost and close all consumers, optionally back up the data</td>
+        </tr>
+        <tr>
+          <td>list_connections</td>
+          <td>Lists AMQP 0.9.1 connections for the node</td>
+        </tr>
+        <tr>
+          <td>close_connection</td>
+          <td>Instructs the broker to close a connection by pid</td>
+        </tr>
+        <tr>
+          <td>close_all_connections</td>
+          <td>Instructs the broker to close all connections for the specified vhost or entire node</td>
+        </tr>
+        <tr>
+          <td>list_queues</td>
+          <td>Lists queues and their properties</td>
+        </tr>
+        <tr>
+          <td>create_queue</td>
+          <td>Create queue</td>
+        </tr>
+        <tr>
+          <td>purge_queue</td>
+          <td>Purges a queue (removes all messages in it)</td>
+        </tr>
+        <tr>
+          <td>pause_queue</td>
+          <td>Pause all consumers on a queue</td>
+        </tr>
+        <tr>
+          <td>resume_queue</td>
+          <td>Resume all consumers on a queue</td>
+        </tr>
+        <tr>
+          <td>delete_queue</td>
+          <td>Delete queue</td>
+        </tr>
+        <tr>
+          <td>list_exchanges</td>
+          <td>Lists exchanges</td>
+        </tr>
+        <tr>
+          <td>create_exchange</td>
+          <td>Create exchange</td>
+        </tr>
+        <tr>
+          <td>delete_exchange</td>
+          <td>Delete exchange</td>
+        </tr>
+        <tr>
+          <td>set_policy</td>
+          <td>Sets or updates a policy</td>
+        </tr>
+        <tr>
+          <td>clear_policy</td>
+          <td>Clears (removes) a policy</td>
+        </tr>
+        <tr>
+          <td>list_policies</td>
+          <td>Lists all policies in a virtual host</td>
+        </tr>
+        <tr>
+          <td>definitions</td>
+          <td>Generate definitions json from the data directory</td>
+        </tr>
+        <tr>
+          <td>export_definitions</td>
+          <td>Exports definitions in JSON</td>
+        </tr>
+        <tr>
+          <td>import_definitions</td>
+          <td>Import definitions in JSON</td>
+        </tr>
+        <tr>
+          <td>hash_password</td>
+          <td>Hash a password</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- prettier-ignore-end -->

--- a/docs/lavinmqperf.md
+++ b/docs/lavinmqperf.md
@@ -1,0 +1,326 @@
+
+<!-- prettier-ignore-start -->
+
+`lavinmqperf` is a command-line tool designed to help you test the performance of your LavinMQ service. It allows you to spin up clients on your server and measure the performance of LavinMQ as these clients interact with it in different ways.`lavinmqperf` provides real-time updates and a summary report of the results at the end of each test.
+
+## Usage
+
+You can run `lavinmqperf` with the command line input
+
+{% highlight shell %}
+{% raw %}
+bin/lavinmqperf [protocol] [throughput | bind-churn | queue-churn | connection-churn | connection-count | queue-count] [arguments]
+{% endraw %}
+{% endhighlight %}
+
+`[protocol]` can be either `amqp` or `mqtt`, depending on which protocol you want to test. The `[throughput | bind-churn | queue-churn | connection-churn | connection-count | queue-count]` specifies the type of test you want to run. The `[arguments]` are optional parameters that allow you to customize the test.
+
+If you don't specify any protocol or arguments, `lavinmqperf` will run the tests with default AMQP settings. Please see the Parameters section below for more information.
+
+## Example
+
+Here is a simple example on how to run a throughput test with `lavinmqperf` on your local setup.
+
+First, make sure LavinMQ is running on your machine
+
+{% highlight shell %}
+{% raw %}
+crystal run src/lavinmq.cr -- -D /tmp/amqp
+{% endraw %}
+{% endhighlight %}
+
+Go to the LavinMQ repository and run
+
+{% highlight shell %}
+{% raw %}
+bin/lavinmqperf throughput -x 1 -y 2
+{% endraw %}
+{% endhighlight %}
+
+This command runs a throughput test with `lavinmqperf`, using one publisher and two consumers.
+
+## AMQP Features
+
+`lavinmqperf` supports various performance metrics to help you evaluate the performance of your LavinMQ service. The available metrics for the AMQP protocol include:
+
+#### Throughput
+
+Measures the number of messages per second that LavinMQ can sustain to publish and consume.
+
+#### Bind-churn
+
+Measures the maximum rate at which LavinMQ can bind to both a durable and a non-durable queue.
+
+#### Queue-churn
+
+Measures the maximum rate at which LavinMQ can create and delete a queue.
+
+#### Connection-churn
+
+Measures the maximum rate at which clients can connect and disconnect.
+
+#### Connection-count
+
+Measures the number of connections that LavinMQ can sustain, as well as the amount of memory used by those connections.
+
+#### Queue-count
+
+Measures the number of queues that LavinMQ can sustain.
+
+### Parameters
+
+`lavinmqperf` provides several parameters that allow you to customize the tests to your AMQP needs. Here is a table that explains the available parameters and how to set them:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Option / Flag</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Description</span></th>
+          <th><span class="font-semibold">Default Value</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>-x, --publishers=number</td>
+          <td class="border-r border-[#414040]">Number of publishers</td>
+          <td><span class="text-[#FAFAFA]">1</span></td>
+        </tr>
+        <tr>
+          <td>-y, --consumers=number</td>
+          <td class="border-r border-[#414040]">Number of consumers</td>
+          <td><span class="text-[#FAFAFA]">1</span></td>
+        </tr>
+        <tr>
+          <td>-s, --size=bytes</td>
+          <td class="border-r border-[#414040]">Size of each message</td>
+          <td><span class="text-[#FAFAFA]">16 bytes</span></td>
+        </tr>
+        <tr>
+          <td>-V, --verify</td>
+          <td class="border-r border-[#414040]">Verify the message body</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-a, --ack=messages</td>
+          <td class="border-r border-[#414040]">Ack after X consumed messages</td>
+          <td><span class="text-[#FAFAFA]">0</span></td>
+        </tr>
+        <tr>
+          <td>-c, --confirm=max-unconfirmed</td>
+          <td class="border-r border-[#414040]">Confirm publishes every X messages</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>-t, --transaction=messages</td>
+          <td class="border-r border-[#414040]">Publish messages in transactions</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>-T, --transaction=acknowledgements</td>
+          <td class="border-r border-[#414040]">Ack messages in transactions</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>-u, --queue=name</td>
+          <td class="border-r border-[#414040]">Queue name</td>
+          <td><span class="text-[#FAFAFA]">perf-test</span></td>
+        </tr>
+        <tr>
+          <td>-k, --routing-key=name</td>
+          <td class="border-r border-[#414040]">Routing key</td>
+          <td><span class="text-[#FAFAFA]">Same as queue name</span></td>
+        </tr>
+        <tr>
+          <td>-e, --exchange=name</td>
+          <td class="border-r border-[#414040]">Exchange to publish to</td>
+          <td><span class="text-[#FAFAFA]">””</span></td>
+        </tr>
+        <tr>
+          <td>-r, --rate=number</td>
+          <td class="border-r border-[#414040]">Max publish rate</td>
+          <td><span class="text-[#FAFAFA]">0</span></td>
+        </tr>
+        <tr>
+          <td>-R, --consumer-rate=number</td>
+          <td class="border-r border-[#414040]">Max consume rate</td>
+          <td><span class="text-[#FAFAFA]">0</span></td>
+        </tr>
+        <tr>
+          <td>-p, --persistent</td>
+          <td class="border-r border-[#414040]">Persistent messages</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-P, --prefetch=number</td>
+          <td class="border-r border-[#414040]">Number of messages to prefetch</td>
+          <td><span class="text-[#FAFAFA]">0 (unlimited)</span></td>
+        </tr>
+        <tr>
+          <td>-g, --poll</td>
+          <td class="border-r border-[#414040]">Poll with basic_get instead of consuming</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-j, --json</td>
+          <td class="border-r border-[#414040]">Output result as JSON</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-z, --time=seconds</td>
+          <td class="border-r border-[#414040]">Only run for X seconds</td>
+          <td><span class="text-[#FAFAFA]">Unlimited</span></td>
+        </tr>
+        <tr>
+          <td>-q, --quiet</td>
+          <td class="border-r border-[#414040]">Quiet, only print the summary</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-C, --pmessages=messages</td>
+          <td class="border-r border-[#414040]">Publish max X number of messages</td>
+          <td><span class="text-[#FAFAFA]">Unlimited</span></td>
+        </tr>
+        <tr>
+          <td>-D, --cmessages=messages</td>
+          <td class="border-r border-[#414040]">Consume max X number of messages</td>
+          <td><span class="text-[#FAFAFA]">Unlimited</span></td>
+        </tr>
+        <tr>
+          <td>--queue-args=JSON</td>
+          <td class="border-r border-[#414040]">Queue arguments as a JSON string</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>--consumer-args=JSON</td>
+          <td class="border-r border-[#414040]">Consumer arguments as a JSON string</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>--properties=JSON</td>
+          <td class="border-r border-[#414040]">Properties added to published messages</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>--random-bodies</td>
+          <td class="border-r border-[#414040]">Each message body is random</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+## MQTT Features
+
+#### Throughput
+
+Measures the number of messages per second that LavinMQ can sustain to publish and consume.
+
+### Parameters
+
+`lavinmqperf` provides several parameters that allow you to customize the tests to your MQTT needs. Here is a table that explains the available parameters and how to set them:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Option / Flag</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Description</span></th>
+          <th><span class="font-semibold">Default Value</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>-x, --publishers=number</td>
+          <td class="border-r border-[#414040]">Number of publishers</td>
+          <td><span class="text-[#FAFAFA]">1</span></td>
+        </tr>
+        <tr>
+          <td>-y, --consumers=number</td>
+          <td class="border-r border-[#414040]">Number of consumers</td>
+          <td><span class="text-[#FAFAFA]">1</span></td>
+        </tr>
+        <tr>
+          <td>-s, --size=bytes</td>
+          <td class="border-r border-[#414040]">Size of each message</td>
+          <td><span class="text-[#FAFAFA]">16 bytes</span></td>
+        </tr>
+        <tr>
+          <td>-V, --verify</td>
+          <td class="border-r border-[#414040]">Verify the message body</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-q, --qos=level</td>
+          <td class="border-r border-[#414040]">QoS level (0 or 1)</td>
+          <td><span class="text-[#FAFAFA]">0</span></td>
+        </tr>
+        <tr>
+          <td>-t, --topic=name</td>
+          <td class="border-r border-[#414040]">Topic name</td>
+          <td><span class="text-[#FAFAFA]">perf-test</span></td>
+        </tr>
+        <tr>
+          <td>-r, --rate=number</td>
+          <td class="border-r border-[#414040]">Max publish rate</td>
+          <td><span class="text-[#FAFAFA]">0</span></td>
+        </tr>
+        <tr>
+          <td>-R, --consumer-rate=number</td>
+          <td class="border-r border-[#414040]">Max consume rate</td>
+          <td><span class="text-[#FAFAFA]">0</span></td>
+        </tr>
+        <tr>
+          <td>-j, --json</td>
+          <td class="border-r border-[#414040]">Output result as JSON</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-z, --time=seconds</td>
+          <td class="border-r border-[#414040]">Only run for X seconds</td>
+          <td><span class="text-[#FAFAFA]">Unlimited</span></td>
+        </tr>
+        <tr>
+          <td>-q, --quiet</td>
+          <td class="border-r border-[#414040]">Quiet, only print the summary</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-C, --pmessages=messages</td>
+          <td class="border-r border-[#414040]">Publish max X number of messages</td>
+          <td><span class="text-[#FAFAFA]">Unlimited</span></td>
+        </tr>
+        <tr>
+          <td>-D, --cmessages=messages</td>
+          <td class="border-r border-[#414040]">Consume max X number of messages</td>
+          <td><span class="text-[#FAFAFA]">Unlimited</span></td>
+        </tr>
+        <tr>
+          <td>--random-bodies</td>
+          <td class="border-r border-[#414040]">Each message body is random</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>--retain</td>
+          <td class="border-r border-[#414040]">Set retain flag on published messages</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>--clean-session</td>
+          <td class="border-r border-[#414040]">Use clean session</td>
+          <td><span class="text-[#FAFAFA]">false</span></td>
+        </tr>
+        <tr>
+          <td>-u, --uri=uri</td>
+          <td class="border-r border-[#414040]">MQTT broker URI</td>
+          <td><span class="text-[#FAFAFA]">mqtt://localhost:1883</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- prettier-ignore-end -->

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,98 @@
+
+Logging is a crucial part of system observability, just like monitoring.
+When developers and operators encounter issues or need to assess the system's state,
+inspecting logs becomes essential.
+
+Luckily, LavinMQ offers various logging features to facilitate this process.
+To begin, let's look at where LavinMQ sends its log data to.
+
+## LavinMQ log outputs
+
+LavinMQ supports two log outputs:
+
+- Standard output(Console)
+- Log file
+
+### Standard output(console)
+
+By default LavinMQ will send its generated logs to the standard output. No configuration
+needed for this - it happens out of the box.
+
+### Log file
+
+LavinMQ can also be configured to pipe its logs to a file. This can be done by
+specifying the path to the log file in the `lavinmq.ini` file like so:
+`log_file=/path/to/log/file`
+
+In addition to the supported outputs above, logs can also be viewed/retrieved from
+LavinMQ in a number of ways:
+
+- **Managament interface:** You can download the last 1000 lines of logs from the management
+  interface under the **Logs** tab.
+- **HTTP API:** The HTTP API exposes two logs endpoints:
+  - `/:your_server_url/api/logs` for retrieving the last 1000 lines of logs
+  - `/:your_server_url/api/livelog` an [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+    endpoint that streams log data to a client over HTTP in real time
+
+## LavinMQ log levels
+
+Log levels provide a means to filter and adjust logging. They have a clear
+hierarchy, with debug as the lowest severity and critical as the highest.
+
+You can control logging verbosity on different levels by setting log levels
+for categories and outputs. More verbose log levels include more log messages,
+with debug being the most detailed and none being the least.
+
+The log levels used by LavinMQ are as follows:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Log level</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Verbosity</span></th>
+          <th><span class="font-semibold">Severity</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>debug</td>
+          <td class="border-r border-[#414040]">most verbose</td>
+          <td>lowest severity</td>
+        </tr>
+        <tr>
+          <td>info</td>
+          <td class="border-r border-[#414040]"></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>warn</td>
+          <td class="border-r border-[#414040]"></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>error</td>
+          <td class="border-r border-[#414040]"></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>fatal</td>
+          <td class="border-r border-[#414040]">least verbose</td>
+          <td>highest severity</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+The default debug level is `info`. However, this is configurable in the
+`lavinmq.ini` file like so:
+
+`log_level=warn`
+
+## Wrap up
+
+Logging is essential for system observability in LavinMQ. It offers easy
+access to logs from standard output or log files. The flexibility of log
+levels aids in effective troubleshooting and optimization.

--- a/docs/management-http-api.md
+++ b/docs/management-http-api.md
@@ -1,0 +1,2 @@
+
+[API Documentation](https://docs.lavinmq.com/http-api.html)

--- a/docs/management-interface-overview.md
+++ b/docs/management-interface-overview.md
@@ -1,0 +1,334 @@
+
+The LavinMQ Management interface is a user-friendly dashboard to monitor and handle the LavinMQ broker from a web browser. Elements such as queues, connections, channels, exchanges, users, and user permissions can be created, deleted, and listed in the browser. Other tasks include monitoring the message rate and keeping track of the number of messages in the queues. This documentation describes the functions of the LavinMQ Management Interface.
+
+Note: The columns view can be changed by clicking the +/- symbol in the top right corner. Many columns can be sorted with the arrows next to the column name as well as filtered through the name in the top left corner.
+
+### What is the LavinMQ Management Interface?
+
+The LavinMQ Management Interface is a user-friendly interface to monitor and manage an LavinMQ broker from a web browser.
+
+### What are the benefits of using the LavinMQ Management Interface?
+
+The LavinMQ Management Interface gives a quick and easy snapshot of the state of an LavinMQ broker.
+
+### How do I access the LavinMQ Management Interface?
+
+The LavinMQ Management Interface can be accessed using a Web browser at
+`http://localhost:15672` if running it locally,
+or `https://{hostname}.lmq.cloudamqp.com` if hosted by CloudAMQP.
+
+#### Default Credentials
+
+The default credentials for accessing the LavinMQ Management Interface are:
+
+- **Username:** `guest`
+- **Password:** `guest`
+
+#### Remote Access for Guest User
+
+By default, the default (`guest`) user is restricted from accessing the server from a remote host. If you want the default user to access the server remotely, follow these steps:
+
+1. **Command Line Option:** Set the flag `--default-user-only-loopback=false` when starting LavinMQ from the command line.
+2. **Configuration File:** Alternatively, you can incorporate the flag into the configuration file (`lavinmq.ini`) by setting `default_user_only_loopback = false`.´
+
+It's important to note that the default user has full access to the server. Exposing the default user to the internet can pose a security risk. It's recommended to create a user with limited permissions for remote access to mitigate potential security issues.
+
+#### Theme Selection
+
+The management interface supports both dark and light themes. Toggle between themes using the theme selector in the interface header. Your preference is saved locally and persists across sessions.
+
+## LavinMQ Management Interface Overview Tab
+
+The Overview tab shows a quick and easy snapshot of the LavinMQ state. From the top right corner, you can choose to view metrics for all vhosts, or a specific one. This is also the location to view your user login name and to logout. The LavinMQ version is found in the top left corner next to the LavinMQ logo. When a certain vhost is specified in the top right, note that the tab will show different information depending on which vhost is selected.
+
+<!-- ![LavinMQ Management Interface](/img/docs/management-interface-overview.jpg) -->
+
+<img class="border border-[#414040]" alt="LavinMQ Management Interface" src="/img/docs/docs-dm/overview-dm-2x.png" />
+
+There are a couple of sections in this view:
+
+- An overview of the number of connections, channels, consumers, exchanges, and queues as well as uptime. Click on connections, channels, exchanges, and queues to drill down to a more detailed view.
+- Graphs for the number of queued messages with ready, unacked, and total, as well as Data Rates in bytes per second and Message Rates in messages per second. The graphs will show data for the last 5 minutes or hover over them to show the metric for a specific time. Hide metrics by clicking on the name on the right side of the graph. A checkmark (&#10003;) will show if the metric is displayed in the graph.
+- Definitions export and upload section, used to export and [upload definitions](/documentation/import-export-definitions) from a file.
+
+The Queued message graph will show the total number of messages in queues and messages that are being processed by consumers.
+
+- Unacked: When a message is in the unacknowledged state, it means that a consumer is processing it but has not sent an acknowledgement to the broker yet.
+- Ready: When a message is in the ready state, it means that the message is still in a queue, waiting to be processed by a consumer.
+- Total: Shows the total amount of messages in the queue, unacknowledged and ready messages.
+
+<!-- ![LavinMQ queued messages](/img/docs/lavinmq-queued-messages.png) -->
+
+<img class="border border-[#414040]" alt="LavinMQ queued messages" src="/img/docs/docs-dm/queued-messages-dm-2x.png" />
+
+The data rates graph shows how many bytes of data are being sent and received by the broker per second.
+
+<!-- ![Data rates](/img/docs/lavinmq-data-rates.png) -->
+
+<img class="border border-[#414040]" alt="Data rates" src="/img/docs/docs-dm/data-rates-dm-2x.png" />
+
+The message rates graph shows how many messages are being published, delivered, get, acknowledged, redelivered and rejected each second.
+
+<!-- ![Message rates](/img/docs/lavinmq-message-rate.png) -->
+
+<img class="border border-[#414040]" alt="Message rates" src="/img/docs/docs-dm/message-rates-dm-2x.png" />
+
+Definitions include node and cluster objects such as vhosts, queues, users, permissions, policies, exchanges, bindings, and parameters. It is possible to upload and export definitions per vhost or for all vhosts. When the definitions are downloaded, a json file will be created. When a file is selected to be uploaded, it needs to be in json format. Definitions can be used to restore the objects listed above and be used as a backup.
+
+<!-- ![Message rates](/img/docs/lavinmq-upload-definitions.png) -->
+
+<img class="border border-[#414040]" alt="Message rates" src="/img/docs/docs-dm/add-remove-defs-dm-2x.png" />
+
+## LavinMQ Management Interface Connections
+
+This tab shows a detailed view of all connections connected to the broker. The table includes the columns:
+
+- Virtual host: the vhost where a connection operates.
+- Name the name of a connection.
+- User: Associated user.
+- State: Connection state; one of:
+  - Starting
+  - Tuning
+  - Opening
+  - running
+  - flow
+  - blocking
+  - blocked
+  - closing
+  - closed
+- TLS: boolean indicating whether the connection is secured with TLS/SSL.
+- TLS Version: SSL protocol, for example tlsv1.2.
+- Cipher: SSL cipher algorithm, for example aes_256_cbc
+- Protocol: Version of the AMQP protocol, for example 0-9-1.
+- Channels: Number of channels using a connection.
+- Channel max: Maximum number of channels allowed.
+- Heartbeat: Negotiated heartbeat value in seconds.
+- Client: Client library used.
+- Connected at: Date and time when a connection was established.
+- Sent bytes
+- Delivered bytes
+
+<!-- ![Connections](/img/docs/lavinmq-connections.png) -->
+
+<img class="border border-[#414040]" alt="Connections" src="/img/docs/docs-dm/connections-dm-2x.png" />
+
+Clicking on the name of the connection gives an even more detailed view. This view shows details for a specific connection, its client properties, data rates, channels, and a way to close the connection. From here you can also drill down further to channels
+
+<!--![Channels](/img/docs/lavinmq-channels.png) -->
+
+<img class="border border-[#414040]" alt="Channels" src="/img/docs/docs-dm/channels-dm-2x.png" />
+
+<!-- ![Connection details](/img/docs/lavinmq-connection-details.png) -->
+
+<img class="border border-[#414040]" alt="Connection details" src="/img/docs/docs-dm/single-connection-dm-2x.png" />
+
+<!-- ![Channel details](/img/docs/lavinmq-channel-information.png) -->
+
+## Channels
+
+The Channels tab shows a detailed view of all channels open. The table includes the columns:
+
+- Name the name of a channel.
+- Virtual host: the vhost where a channel operates.
+- User: Associated user.
+- Mode: the channel guarantee mode, in either confirm or transactional mode.
+- Consumers: Number of consumers retrieving messages via the channel.
+- Prefetch limit: prefetch limit for consumers, 0 if unlimited.
+- Unacked messages: number of messages that are unacked by consumers via the channel.
+
+<!-- ![Channels](/img/docs/lavinmq-channels.png) -->
+
+<img class="border border-[#414040]" alt="Channels" src="/img/docs/docs-dm/channels-dm-2x.png" />
+
+Clicking on the name of the channel gives an even more detailed view. This view will show details for a specific channel, it’s stats, message rates, and consumers. From here you can also drill down further to the consumer linked queue.
+
+<!-- ![Channels](/img/docs/lavinmq-channels.png) -->
+
+<!-- ![Channel details](/img/docs/lavinmq-channel-details.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/channel-details-dm-2x.png" />
+
+## Queues
+
+The queues tab shows a detailed view of all queues. The table includes the columns:
+
+- Virtual host: the vhost where a queue operates.
+- Name the name of a queue.
+- Features: the parameters that belong to the queue, for example durable, auto-expire, etc.
+- Policy: effective policy applied to the queue.
+- Consumers: number of consumers connected to the queue.
+- State: The state of the queue, normally "running”.
+- Ready: Number of messages ready to be delivered to clients.
+- Unacked: Number of messages delivered to clients but not yet acknowledged.
+- Total: Sum of ready and unacknowledged messages.
+- Publish rate: Message rate for publishing to the queue.
+- Delivery rate: Message rate for delivering from the queue.
+- Ack rate: Message rate for consumers acknowledging messages.
+
+Queues have different parameters and arguments depending on how they were created. The features column shows the parameters that belong to the queue. It could be features like:
+
+- Durable (ensures that LavinMQ will never lose the queue),
+- Message TTL (how long a message published to a queue can live before it is discarded),
+- Auto Expire (how long a queue can be unused before it is automatically deleted),
+- Max Length (how many (ready) messages a queue can contain before it starts to drop them) and
+- Max Length Bytes (the total body size for ready messages a queue can contain before it starts to drop them).
+
+You can also create a queue from this view.
+
+<!-- ![Channel details](/img/docs/lavinmq-queues.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/queues-dm-2x.png" />
+
+Clicking on the name of the queue gives a more detailed view. This view will show details for a specific queue, message stats, arguments, message rates, consumers, and bindings. It will give you options to add a binding to the queue, publish a message, get messages, move messages, pause, delete and purge.
+
+From here you can also drill down further to exchanges and consumer channels as well as cancel a consumer and delete a binding.
+
+<!-- ![Channel details](/img/docs/lavinmq-queues-details.png)
+
+![Channel details](/img/docs/lavinmq-bindings.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/single-queue-dm-2x.png" />
+
+## Exchanges
+
+The Exchanges tab shows a detailed view of all exchanges. The table includes the columns:
+
+- Virtual host: the vhost where an exchange operates.
+- Name: the name of an exchange.
+- Type: the exchange type such as direct, topic, headers, fanout.
+- Features: Show the parameters for the exchange (e.g. D stand for durable, and AD for auto-delete)
+- Policy: policy applied to the exchange.
+
+Features and types can be specified when the exchange is created. In this list there are some amq.\* exchanges that are created by default. You can also add an exchange from this view.
+
+<!-- ![Channel details](/img/docs/lavinmq-exchanges.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/exchanges-dm-2x.png" />
+
+Clicking on the name of the exchange gives a more detailed view. This view shows details for a specific exchange, message rates, and bindings. It will give you options to add a binding from this exchange, publish a message, and delete the exchange.
+
+<!-- ![Channel details](/img/docs/lavinmq-exchanges-details.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/single-exchange-dm-2x.png" />
+
+## Users
+
+The Users tab shows a detailed view of all users. The table includes the columns:
+
+- Name: name of the user.
+- Tags: tags assigned to the user.
+- Can access virtual hosts: list of vhosts the user has access to
+- Has password: boolean for if the user has a password or not.
+
+Users can be added from the management interface and assigned permissions using
+tags and vhosts.
+
+<!-- ![Channel details](/img/docs/lavinmq-users.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/users-dm-2x.png" />
+
+### Create a user in LavinMQ Management Interface
+
+First, create a user with a password and permission tags, then click on the name of the user to set detailed permissions. From the detailed view you can set missions to a specific vhost, and the subsequent read, write and configure access the user should have to that vhost. Delete permissions by clicking the Clear button. Or you can update a user’s password and remove tags as well as delete the user.
+
+<!-- ![Channel details](/img/docs/lavinmq-user-details.png) -->
+
+<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/single-user-dm-2x.png" />
+
+## Virtual hosts
+
+Virtual hosts (vhosts), are like a virtual machine for a physical server, allowing for multiple secure application operations through virtual rather than physical separation. As the separation is virtual, it is important to remember that the vhosts are not physically separated from each other and therefore they might affect each other’s performance. Vhosts do not share exchanges or queues between them, and users, policies, etc. are unique to each vhost. The Virtual hosts’ tab shows a detailed view of all vhosts. The table includes the columns:
+
+- Name: name of the virtual host.
+- Users: users having access to the virtual host.
+- Ready: number of messages in a ready state.
+- Unacked: number of messages in unacked state.
+- Total: total number of messages in ready and unacked state.
+
+You can create a vhost from this view, or click on the name of an already existing vhost to show more details.
+
+<!-- ![virtual host](/img/docs/lavinmq-vhost.png) -->
+
+<img class="border border-[#414040]" alt="Virtual host" src="/img/docs/docs-dm/vhosts-dm-2x.png" />
+
+<!-- ![virtual host details](/img/docs/lavinmq-vhost-details.png) -->
+
+<img class="border border-[#414040]" alt="Virtual host details" src="/img/docs/docs-dm/single-vhost-dm-2x.png" />
+
+### Vhost Limits API
+
+Configure resource limits per virtual host using the HTTP API to prevent runaway resource consumption and connection leaks:
+
+- **Set limit:** `PUT /api/vhost-limits/{vhost}/{name}` with JSON body containing limit definitions. Name should be either `max-connections` or `max-queues`
+  - Example: `{"value": 1000}`
+- **View limits:** `GET /api/vhost-limits/{vhost}` includes current limits in the response
+- **Remove limit:** `DELETE /api/vhost-limits/{vhost}/{name}` 
+
+These limits help maintain system stability by controlling possible queue or connection leaks on a per-vhost basis.
+
+## Nodes
+
+The Nodes tab shows information about the server on which LavinMQ is running, such as:
+
+- Server details (name, uptime, number of cores, memory usage, average CPU usage, and disk usage)
+- Stats (connections, channels, queues, file descriptors)
+- Memory usage
+- IOPS (read and write)
+- CPU usage (user, system, and total)
+- Connection churn (created and closed)
+- Channel churn (created and closed)
+- Queue churn (declared and deleted)
+
+<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-nodes.png) -->
+
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/nodes-dm-2x.png" />
+
+## Policies
+
+Policies are used to control arguments for groups of queues and exchanges. A policy can match one or several queues and exchanges based on a regex pattern.
+The Policies tab shows a detailed view of all policies. The table includes the columns:
+
+- Virtual host: the vhost where a policy operates.
+- Name: name of the policy.
+- Pattern: regular expression for matching resources where the policy will apply.
+- Apply to: which types of objects the policy should apply to. Possible values are queues, exchanges, or all.
+- Definition: the definition of the policy, as a JSON term.
+- Priority: the priority of the policy as an integer. Higher numbers indicate greater precedence.
+
+<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-policy.png) -->
+
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/policies-dm.png" />
+
+### Create a policy
+
+Create a policy by selecting the vhost where the policy should be applied, a name, a regex pattern for matching queues and/or exchanges, the definitions, and priority. The definitions field is where you define what arguments the queues and/or exchanges should get, in JSON format.
+Click on the definition names below the definition field to get an explanation and populate the field. Make sure you change the word “value” to the value you want to apply.
+Only one policy can be applied to a queue and/or exchange at a certain time, so here is where the priority comes in, i.e. the policy with the greatest priority applies. To apply several definitions to one queue and/or exchange, create a policy with multiple definitions. This view is also where a policy can be deleted.
+
+The shovels tab shows a detailed view of all shovels created and has an option to create new shovels. Shovels are used to move messages from a source to a destination. The source and destination can be in the same broker, or between different brokers.
+
+For more information on how to create a shovel, go to
+[the Shovel Documentation](/documentation/shovel)
+
+<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-shovel.png) -->
+
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/shovels-dm-2x.png" />
+
+## Federation
+
+The federation tab shows a detailed view of all federations created and has an option to create new federations.
+
+Federation is used to transfer messages between brokers. It transfers messages from one broker to another broker. There are two ways of configuring a federation, via queue federation or exchange federation.
+
+For more information on how to create a federation, go to
+[the Federation Documentation](/documentation/federation)
+
+<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-federation.png) -->
+
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/federation-dm-2x.png" />
+
+## HTTP API
+
+The HTTP API is used to programmatically manage all aspects of LavinMQ.
+Complete documentation can be found here
+[HTTP API](https://docs.lavinmq.com/http-api.html).

--- a/docs/management-interface-overview.md
+++ b/docs/management-interface-overview.md
@@ -41,15 +41,15 @@ The management interface supports both dark and light themes. Toggle between the
 
 The Overview tab shows a quick and easy snapshot of the LavinMQ state. From the top right corner, you can choose to view metrics for all vhosts, or a specific one. This is also the location to view your user login name and to logout. The LavinMQ version is found in the top left corner next to the LavinMQ logo. When a certain vhost is specified in the top right, note that the tab will show different information depending on which vhost is selected.
 
-<!-- ![LavinMQ Management Interface](/img/docs/management-interface-overview.jpg) -->
+<!-- ![LavinMQ Management Interface](img/docs/management-interface-overview.jpg) -->
 
-<img class="border border-[#414040]" alt="LavinMQ Management Interface" src="/img/docs/docs-dm/overview-dm-2x.png" />
+<img class="border border-[#414040]" alt="LavinMQ Management Interface" src="img/docs/overview-dm-2x.png" />
 
 There are a couple of sections in this view:
 
 - An overview of the number of connections, channels, consumers, exchanges, and queues as well as uptime. Click on connections, channels, exchanges, and queues to drill down to a more detailed view.
 - Graphs for the number of queued messages with ready, unacked, and total, as well as Data Rates in bytes per second and Message Rates in messages per second. The graphs will show data for the last 5 minutes or hover over them to show the metric for a specific time. Hide metrics by clicking on the name on the right side of the graph. A checkmark (&#10003;) will show if the metric is displayed in the graph.
-- Definitions export and upload section, used to export and [upload definitions](/documentation/import-export-definitions) from a file.
+- Definitions export and upload section, used to export and [upload definitions](import-export-definitions.md) from a file.
 
 The Queued message graph will show the total number of messages in queues and messages that are being processed by consumers.
 
@@ -57,27 +57,27 @@ The Queued message graph will show the total number of messages in queues and me
 - Ready: When a message is in the ready state, it means that the message is still in a queue, waiting to be processed by a consumer.
 - Total: Shows the total amount of messages in the queue, unacknowledged and ready messages.
 
-<!-- ![LavinMQ queued messages](/img/docs/lavinmq-queued-messages.png) -->
+<!-- ![LavinMQ queued messages](img/docs/lavinmq-queued-messages.png) -->
 
-<img class="border border-[#414040]" alt="LavinMQ queued messages" src="/img/docs/docs-dm/queued-messages-dm-2x.png" />
+<img class="border border-[#414040]" alt="LavinMQ queued messages" src="img/docs/queued-messages-dm-2x.png" />
 
 The data rates graph shows how many bytes of data are being sent and received by the broker per second.
 
-<!-- ![Data rates](/img/docs/lavinmq-data-rates.png) -->
+<!-- ![Data rates](img/docs/lavinmq-data-rates.png) -->
 
-<img class="border border-[#414040]" alt="Data rates" src="/img/docs/docs-dm/data-rates-dm-2x.png" />
+<img class="border border-[#414040]" alt="Data rates" src="img/docs/data-rates-dm-2x.png" />
 
 The message rates graph shows how many messages are being published, delivered, get, acknowledged, redelivered and rejected each second.
 
-<!-- ![Message rates](/img/docs/lavinmq-message-rate.png) -->
+<!-- ![Message rates](img/docs/lavinmq-message-rate.png) -->
 
-<img class="border border-[#414040]" alt="Message rates" src="/img/docs/docs-dm/message-rates-dm-2x.png" />
+<img class="border border-[#414040]" alt="Message rates" src="img/docs/message-rates-dm-2x.png" />
 
 Definitions include node and cluster objects such as vhosts, queues, users, permissions, policies, exchanges, bindings, and parameters. It is possible to upload and export definitions per vhost or for all vhosts. When the definitions are downloaded, a json file will be created. When a file is selected to be uploaded, it needs to be in json format. Definitions can be used to restore the objects listed above and be used as a backup.
 
-<!-- ![Message rates](/img/docs/lavinmq-upload-definitions.png) -->
+<!-- ![Message rates](img/docs/lavinmq-upload-definitions.png) -->
 
-<img class="border border-[#414040]" alt="Message rates" src="/img/docs/docs-dm/add-remove-defs-dm-2x.png" />
+<img class="border border-[#414040]" alt="Message rates" src="img/docs/add-remove-defs-dm-2x.png" />
 
 ## LavinMQ Management Interface Connections
 
@@ -108,21 +108,21 @@ This tab shows a detailed view of all connections connected to the broker. The t
 - Sent bytes
 - Delivered bytes
 
-<!-- ![Connections](/img/docs/lavinmq-connections.png) -->
+<!-- ![Connections](img/docs/lavinmq-connections.png) -->
 
-<img class="border border-[#414040]" alt="Connections" src="/img/docs/docs-dm/connections-dm-2x.png" />
+<img class="border border-[#414040]" alt="Connections" src="img/docs/connections-dm-2x.png" />
 
 Clicking on the name of the connection gives an even more detailed view. This view shows details for a specific connection, its client properties, data rates, channels, and a way to close the connection. From here you can also drill down further to channels
 
-<!--![Channels](/img/docs/lavinmq-channels.png) -->
+<!--![Channels](img/docs/lavinmq-channels.png) -->
 
-<img class="border border-[#414040]" alt="Channels" src="/img/docs/docs-dm/channels-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channels" src="img/docs/channels-dm-2x.png" />
 
-<!-- ![Connection details](/img/docs/lavinmq-connection-details.png) -->
+<!-- ![Connection details](img/docs/lavinmq-connection-details.png) -->
 
-<img class="border border-[#414040]" alt="Connection details" src="/img/docs/docs-dm/single-connection-dm-2x.png" />
+<img class="border border-[#414040]" alt="Connection details" src="img/docs/single-connection-dm-2x.png" />
 
-<!-- ![Channel details](/img/docs/lavinmq-channel-information.png) -->
+<!-- ![Channel details](img/docs/lavinmq-channel-information.png) -->
 
 ## Channels
 
@@ -136,17 +136,17 @@ The Channels tab shows a detailed view of all channels open. The table includes 
 - Prefetch limit: prefetch limit for consumers, 0 if unlimited.
 - Unacked messages: number of messages that are unacked by consumers via the channel.
 
-<!-- ![Channels](/img/docs/lavinmq-channels.png) -->
+<!-- ![Channels](img/docs/lavinmq-channels.png) -->
 
-<img class="border border-[#414040]" alt="Channels" src="/img/docs/docs-dm/channels-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channels" src="img/docs/channels-dm-2x.png" />
 
 Clicking on the name of the channel gives an even more detailed view. This view will show details for a specific channel, it’s stats, message rates, and consumers. From here you can also drill down further to the consumer linked queue.
 
-<!-- ![Channels](/img/docs/lavinmq-channels.png) -->
+<!-- ![Channels](img/docs/lavinmq-channels.png) -->
 
-<!-- ![Channel details](/img/docs/lavinmq-channel-details.png) -->
+<!-- ![Channel details](img/docs/lavinmq-channel-details.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/channel-details-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/channel-details-dm-2x.png" />
 
 ## Queues
 
@@ -175,19 +175,19 @@ Queues have different parameters and arguments depending on how they were create
 
 You can also create a queue from this view.
 
-<!-- ![Channel details](/img/docs/lavinmq-queues.png) -->
+<!-- ![Channel details](img/docs/lavinmq-queues.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/queues-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/queues-dm-2x.png" />
 
 Clicking on the name of the queue gives a more detailed view. This view will show details for a specific queue, message stats, arguments, message rates, consumers, and bindings. It will give you options to add a binding to the queue, publish a message, get messages, move messages, pause, delete and purge.
 
 From here you can also drill down further to exchanges and consumer channels as well as cancel a consumer and delete a binding.
 
-<!-- ![Channel details](/img/docs/lavinmq-queues-details.png)
+<!-- ![Channel details](img/docs/lavinmq-queues-details.png)
 
-![Channel details](/img/docs/lavinmq-bindings.png) -->
+![Channel details](img/docs/lavinmq-bindings.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/single-queue-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/single-queue-dm-2x.png" />
 
 ## Exchanges
 
@@ -201,15 +201,15 @@ The Exchanges tab shows a detailed view of all exchanges. The table includes the
 
 Features and types can be specified when the exchange is created. In this list there are some amq.\* exchanges that are created by default. You can also add an exchange from this view.
 
-<!-- ![Channel details](/img/docs/lavinmq-exchanges.png) -->
+<!-- ![Channel details](img/docs/lavinmq-exchanges.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/exchanges-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/exchanges-dm-2x.png" />
 
 Clicking on the name of the exchange gives a more detailed view. This view shows details for a specific exchange, message rates, and bindings. It will give you options to add a binding from this exchange, publish a message, and delete the exchange.
 
-<!-- ![Channel details](/img/docs/lavinmq-exchanges-details.png) -->
+<!-- ![Channel details](img/docs/lavinmq-exchanges-details.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/single-exchange-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/single-exchange-dm-2x.png" />
 
 ## Users
 
@@ -223,17 +223,17 @@ The Users tab shows a detailed view of all users. The table includes the columns
 Users can be added from the management interface and assigned permissions using
 tags and vhosts.
 
-<!-- ![Channel details](/img/docs/lavinmq-users.png) -->
+<!-- ![Channel details](img/docs/lavinmq-users.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/users-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/users-dm-2x.png" />
 
 ### Create a user in LavinMQ Management Interface
 
 First, create a user with a password and permission tags, then click on the name of the user to set detailed permissions. From the detailed view you can set missions to a specific vhost, and the subsequent read, write and configure access the user should have to that vhost. Delete permissions by clicking the Clear button. Or you can update a user’s password and remove tags as well as delete the user.
 
-<!-- ![Channel details](/img/docs/lavinmq-user-details.png) -->
+<!-- ![Channel details](img/docs/lavinmq-user-details.png) -->
 
-<img class="border border-[#414040]" alt="Channel details" src="/img/docs/docs-dm/single-user-dm-2x.png" />
+<img class="border border-[#414040]" alt="Channel details" src="img/docs/single-user-dm-2x.png" />
 
 ## Virtual hosts
 
@@ -247,13 +247,13 @@ Virtual hosts (vhosts), are like a virtual machine for a physical server, allowi
 
 You can create a vhost from this view, or click on the name of an already existing vhost to show more details.
 
-<!-- ![virtual host](/img/docs/lavinmq-vhost.png) -->
+<!-- ![virtual host](img/docs/lavinmq-vhost.png) -->
 
-<img class="border border-[#414040]" alt="Virtual host" src="/img/docs/docs-dm/vhosts-dm-2x.png" />
+<img class="border border-[#414040]" alt="Virtual host" src="img/docs/vhosts-dm-2x.png" />
 
-<!-- ![virtual host details](/img/docs/lavinmq-vhost-details.png) -->
+<!-- ![virtual host details](img/docs/lavinmq-vhost-details.png) -->
 
-<img class="border border-[#414040]" alt="Virtual host details" src="/img/docs/docs-dm/single-vhost-dm-2x.png" />
+<img class="border border-[#414040]" alt="Virtual host details" src="img/docs/single-vhost-dm-2x.png" />
 
 ### Vhost Limits API
 
@@ -279,9 +279,9 @@ The Nodes tab shows information about the server on which LavinMQ is running, su
 - Channel churn (created and closed)
 - Queue churn (declared and deleted)
 
-<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-nodes.png) -->
+<!-- ![Nodes in LavinMQ](img/docs/lavinmq-nodes.png) -->
 
-<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/nodes-dm-2x.png" />
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="img/docs/nodes-dm-2x.png" />
 
 ## Policies
 
@@ -295,9 +295,9 @@ The Policies tab shows a detailed view of all policies. The table includes the c
 - Definition: the definition of the policy, as a JSON term.
 - Priority: the priority of the policy as an integer. Higher numbers indicate greater precedence.
 
-<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-policy.png) -->
+<!-- ![Nodes in LavinMQ](img/docs/lavinmq-policy.png) -->
 
-<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/policies-dm.png" />
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="img/docs/policies-dm.png" />
 
 ### Create a policy
 
@@ -308,11 +308,11 @@ Only one policy can be applied to a queue and/or exchange at a certain time, so 
 The shovels tab shows a detailed view of all shovels created and has an option to create new shovels. Shovels are used to move messages from a source to a destination. The source and destination can be in the same broker, or between different brokers.
 
 For more information on how to create a shovel, go to
-[the Shovel Documentation](/documentation/shovel)
+[the Shovel Documentation](shovel.md)
 
-<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-shovel.png) -->
+<!-- ![Nodes in LavinMQ](img/docs/lavinmq-shovel.png) -->
 
-<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/shovels-dm-2x.png" />
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="img/docs/shovels-dm-2x.png" />
 
 ## Federation
 
@@ -321,11 +321,11 @@ The federation tab shows a detailed view of all federations created and has an o
 Federation is used to transfer messages between brokers. It transfers messages from one broker to another broker. There are two ways of configuring a federation, via queue federation or exchange federation.
 
 For more information on how to create a federation, go to
-[the Federation Documentation](/documentation/federation)
+[the Federation Documentation](federation.md)
 
-<!-- ![Nodes in LavinMQ](/img/docs/lavinmq-federation.png) -->
+<!-- ![Nodes in LavinMQ](img/docs/lavinmq-federation.png) -->
 
-<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="/img/docs/docs-dm/federation-dm-2x.png" />
+<img class="border border-[#414040]" alt="Nodes in LavinMQ" src="img/docs/federation-dm-2x.png" />
 
 ## HTTP API
 

--- a/docs/message-deduplication.md
+++ b/docs/message-deduplication.md
@@ -1,0 +1,50 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is message deduplication?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>Message deduplication prevents duplicate messages from being enqueued, reducing unnecessary processing and storage.</p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        When to enable message deduplication?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>Enable deduplication when you need to prevent redundant processing, reduce storage usage, or ensure messages are delivered only once.</p>
+    </div>
+  </div>
+</div>
+
+## Message deduplication
+
+LavinMQ supports message deduplication at both exchange and queue levels:
+
+- **Exchange-level deduplication**: When enabled, duplicate messages are not forwarded to bound queues.
+- **Queue-level deduplication**: Messages are routed as usual but are not stored in the queue if already seen. This ensures correct routing while avoiding increased "Unroutable message" statistics.
+
+## Using message deduplication
+
+To enable deduplication, set the following arguments:
+
+- `x-message-deduplication` (bool) – Enables deduplication.
+- `x-cache-size` (int) – Defines how many messages to store for deduplication checks. A larger cache uses more memory.
+
+Optional settings:
+
+- `x-cache-ttl` (int) – Cache entry time-to-live in milliseconds (default: unlimited).
+- `x-deduplication-header` (string) – The message header used for deduplication (default: `x-deduplication-header`).
+
+The deduplication cache is stored in memory, meaning:
+
+- A larger cache increases memory usage.
+- The cache is lost on broker restarts or leadership transfers in a cluster.
+
+This allows LavinMQ to filter out duplicate messages while maintaining proper routing behavior.

--- a/docs/message-ordering.md
+++ b/docs/message-ordering.md
@@ -1,0 +1,45 @@
+
+Messages in LavinMQ are placed onto the queue in the sequential order in which they are received. The first message is placed in position 1, the second message in position 2, and so on. Messages are then consumed from the head of the queue, meaning that message 1 gets consumed first. This is called the FIFO method (first in first out). A message received by the broker is _enqueued_ (added to the queue). If there is a consumer subscribed to the queue, a message is _dequeued_ (removed from the queue) when it is sent to the consumer.
+
+![LavinMQ FIFO - First in, First out](/img/docs/lavinmq-fifo-enqueue-dequeue.jpg)
+
+## Factors that influence message ordering
+
+Even though LavinMQ and the AMQP protocol follow the FIFO method, message ordering might be altered by configurations or application design. Here are several scenarios that affect message ordering:
+
+### Message redeliveries
+
+> These redeliveries happen automatically after negative consumer acknowledgments and channel closures.
+
+Order processing can be broken when messages are redelivered. Causes of message redelivery include: a consumer nacks or rejects a message, a consumer’s connection or channel is closed. In these cases, the message will be returned to the front of the queue and LavinMQ will then send it to the next available consumer. It is possible that consumers have already processed messages that were initially behind the redelivered messages in the queue.
+
+The amount of resends for unhandled messages can be adjusted, to prevent the queue from filling up. `x-delivery-limit` is configurable as a policy or queue argument. If the x-delivery-limit is set, the message will be dead-lettered or deleted after X amount of redeliveries.
+Every redeliver of a message to a consumer is counted. When the redelivery count exceeds the given limit, the message is `dead-lettered` or deleted.
+
+![LavinMQ Message Redelivery](/img/docs/lavinmq-dead-lettering.jpg)
+
+### Multiple competing consumers
+
+In a case where there are multiple receiving services, or more than one consumer for the queue, dequeued messages will be sent to consumers in FIFO order. If all of the consumers have equal priorities (see below for a discussion on consumer priority), they will be picked to receive messages on a round-robin basis.
+
+In the illustration below, chronological message processing is not guaranteed. Messages 1, 2, and 3 are directed to different consumers, and LavinMQ cannot force the consumer that received message 1 to finish processing it before the other consumer processes message 2 (and the same for the consumer processing message 3).
+
+![LavinMQ multiple consumers](/img/docs/lavinmq-multiple-competing-consumers.jpg)
+
+### Multiple connections or channels
+
+Publishing applications can assume that messages published on a single channel will be enqueued in their published order. When publishing happens on multiple connections or channels, their messages will be routed concurrently and interleaved. See the illustration below.
+
+![LavinMQ FIFO - First in, First out](/img/docs/lavinmq-multiple-connections-channels.jpg)
+
+### Message priority
+
+LavinMQ allows special messages to be sent with a [higher priority](/documentation/message-priority) than normal messages. This can be useful in cases such as an urgent alarm or a task that must be handled immediately. These designated messages are placed at the head of the queue and will be directed to the next available consumer. This configuration overrides the FIFO message ordering.
+
+Note: Setting a Redelivery-limit (_x-delivery-limit_) will ensure that messages are only delivered X times according to the configuration mentioned above.
+
+## Conclusion
+
+LavinMQ can guarantee message order under special conditions only. Messages come from a single channel and are routed to a single consumer channel. If either channel is closed or messages are rejected, message ordering is not maintained.
+
+Important messages can be enqueued at the front of the queue so that they are processed before ‘standard’ messages.

--- a/docs/message-ordering.md
+++ b/docs/message-ordering.md
@@ -1,7 +1,7 @@
 
 Messages in LavinMQ are placed onto the queue in the sequential order in which they are received. The first message is placed in position 1, the second message in position 2, and so on. Messages are then consumed from the head of the queue, meaning that message 1 gets consumed first. This is called the FIFO method (first in first out). A message received by the broker is _enqueued_ (added to the queue). If there is a consumer subscribed to the queue, a message is _dequeued_ (removed from the queue) when it is sent to the consumer.
 
-![LavinMQ FIFO - First in, First out](/img/docs/lavinmq-fifo-enqueue-dequeue.jpg)
+![LavinMQ FIFO - First in, First out](img/docs/lavinmq-fifo-enqueue-dequeue.jpg)
 
 ## Factors that influence message ordering
 
@@ -16,7 +16,7 @@ Order processing can be broken when messages are redelivered. Causes of message 
 The amount of resends for unhandled messages can be adjusted, to prevent the queue from filling up. `x-delivery-limit` is configurable as a policy or queue argument. If the x-delivery-limit is set, the message will be dead-lettered or deleted after X amount of redeliveries.
 Every redeliver of a message to a consumer is counted. When the redelivery count exceeds the given limit, the message is `dead-lettered` or deleted.
 
-![LavinMQ Message Redelivery](/img/docs/lavinmq-dead-lettering.jpg)
+![LavinMQ Message Redelivery](img/docs/lavinmq-dead-lettering.jpg)
 
 ### Multiple competing consumers
 
@@ -24,17 +24,17 @@ In a case where there are multiple receiving services, or more than one consumer
 
 In the illustration below, chronological message processing is not guaranteed. Messages 1, 2, and 3 are directed to different consumers, and LavinMQ cannot force the consumer that received message 1 to finish processing it before the other consumer processes message 2 (and the same for the consumer processing message 3).
 
-![LavinMQ multiple consumers](/img/docs/lavinmq-multiple-competing-consumers.jpg)
+![LavinMQ multiple consumers](img/docs/lavinmq-multiple-competing-consumers.jpg)
 
 ### Multiple connections or channels
 
 Publishing applications can assume that messages published on a single channel will be enqueued in their published order. When publishing happens on multiple connections or channels, their messages will be routed concurrently and interleaved. See the illustration below.
 
-![LavinMQ FIFO - First in, First out](/img/docs/lavinmq-multiple-connections-channels.jpg)
+![LavinMQ FIFO - First in, First out](img/docs/lavinmq-multiple-connections-channels.jpg)
 
 ### Message priority
 
-LavinMQ allows special messages to be sent with a [higher priority](/documentation/message-priority) than normal messages. This can be useful in cases such as an urgent alarm or a task that must be handled immediately. These designated messages are placed at the head of the queue and will be directed to the next available consumer. This configuration overrides the FIFO message ordering.
+LavinMQ allows special messages to be sent with a [higher priority](message-priority.md) than normal messages. This can be useful in cases such as an urgent alarm or a task that must be handled immediately. These designated messages are placed at the head of the queue and will be directed to the next available consumer. This configuration overrides the FIFO message ordering.
 
 Note: Setting a Redelivery-limit (_x-delivery-limit_) will ensure that messages are only delivered X times according to the configuration mentioned above.
 

--- a/docs/message-priority.md
+++ b/docs/message-priority.md
@@ -49,7 +49,7 @@ queue = channel.queue("bunny_queue", arguments: {"x-max-priority" => 3})
 
 ### Consumer Interaction
 
-Consumers do not take the message priority into account, and simply process messages in the given order. A consumer connected to an empty queue will process all messages coming into it regardless of priorities. Using [prefetch](/documentation/prefetch) (*basic.qos*) can limit the number of messages sent out for delivery and still make the opportunity for the queue to prioritize incoming messages.
+Consumers do not take the message priority into account, and simply process messages in the given order. A consumer connected to an empty queue will process all messages coming into it regardless of priorities. Using [prefetch](prefetch.md) (*basic.qos*) can limit the number of messages sent out for delivery and still make the opportunity for the queue to prioritize incoming messages.
 
 ## Learning and tips
 

--- a/docs/message-priority.md
+++ b/docs/message-priority.md
@@ -1,0 +1,58 @@
+
+Certain messages that publishers send have a higher priority than others, such as an urgent alarm or a task that needs to be handled right away. LavinMQ allows for message priority, meaning that designated messages are placed at the head of the queue and get handled immediately.
+
+### What is Message priority?
+
+Message priorities in LavinMQ ensure that messages of different priorities are handled according to the level of importance. Both the message itself and the queue need to be configured to achieve message priority.
+
+### What benefits does Message Priority have?
+
+Message priority is used to ensure that messages of high priority are handled as fast as possible.
+
+## Description
+
+A queue's priority range is specified when the queue is created, and a message priority is specified when the message is published to this queue.
+
+### Defining Message Priorities
+
+Publishers specify message priority using the priority field in message properties, which becomes effective when the message is published to the queue. The priority range of messages is specified in numbers between 0 and 255. Larger numbers indicate higher priority. If no priority property is set, messages are treated as if priority is 0. If the number is set over 255, they will be handled with maximum priority.
+
+Here follow an example of how to publish a message with priority 8, in Ruby:
+
+<!-- prettier-ignore-start -->
+
+{% highlight ruby %}
+exchange.publish("hello",
+         :routing_key => queue_name,
+         :priority    => 8)
+{% endhighlight %}
+
+### Messaging with priority settings
+
+This scenario explains the message flow when message priority is enabled: 
+
+1. A publisher sends a message of high priority to a queue using the priority field of *basic.properties*
+2. The prioritized message is added to the same queue (defined as a priority queue) as other messages
+3. The prioritized message will be placed at the head of the queue immediately due to the given priority level.
+
+NOTE: Messages with a priority sent to a queue that is not defined as a priority queue will be treated as messages without priorities. 
+
+### Defining Queue Priorities 
+
+To apply message priority, the queue must be defined as a *priority queue*. Setting a queue's priority range must be done when the queue is created. After declaring a queue, the number of priorities cannot be changed. A priority queue is declared via the *x-max-priority* queue argument, where this argument should, as for messages, be between 1 and 255.
+
+Here follow an example of how to declare a queue with a max priority level of 3, in Ruby:
+
+{% highlight ruby %}
+queue = channel.queue("bunny_queue", arguments: {"x-max-priority" => 3})
+{% endhighlight %}
+
+### Consumer Interaction
+
+Consumers do not take the message priority into account, and simply process messages in the given order. A consumer connected to an empty queue will process all messages coming into it regardless of priorities. Using [prefetch](/documentation/prefetch) (*basic.qos*) can limit the number of messages sent out for delivery and still make the opportunity for the queue to prioritize incoming messages.
+
+## Learning and tips
+
+* Use priority queues with care if you have specified a Queue Length Limit that discards messages from the head of the queue. In that case; make sure that you are not reaching the limit of messages for a priority queue. Messages discarded from the head of the queue might be your most important message, and they will, in this case, be dropped when a low priority message enters the queue.
+
+<!-- prettier-ignore-end -->

--- a/docs/message-store.md
+++ b/docs/message-store.md
@@ -1,0 +1,54 @@
+
+All routed messages in LavinMQ are written directly to the disk, into something called a _Message Store_. The Message Store is a series of files (segments). A routed message is located in the Message Store, with a reference from the queue’s index to the message store.
+
+![Message Store in LavinMQ](/img/docs/lavinmq-message-store.jpg)
+
+A routed message is a message that is not dropped by the exchange, including messages that are routed via alternate exchanges. Once a message is routed to a queue the segment number, the position in that segment, and some other metadata are written to its queues index and then placed in the queue.
+
+When LavinMQ starts up, it allocates [memory-mapped files](https://en.wikipedia.org/wiki/Memory-mapped_file) for message segments using the [mmap](https://en.wikipedia.org/wiki/Mmap) syscall. However, to prevent unnecessary memory usage, we unmap these files and free up the allocated memory when they are not in use. When a file needs to be accessed, we map it again with mmap and use only the memory needed for that specific segment. This keeps the memory footprint very low and allows LavinMQ to sustain unbound queue lengths. Apart from this, messages are copied directly to the OS caching layer without the need for syscalls making the writing very fast even for very small messages.
+
+### How are messages handled by LavinMQ?
+
+Routed messages are appended to the message store and also written to the queue index for a queue. Messages in the message store are deleted when no queue index has a reference to a position in the message store.
+
+### How are messages stored in the Message Store?
+
+Each incoming message is appended to the last segment and prefixed with a timestamp, that includes its exchange name, routing key, and message headers.
+
+### How are messages stored in the Message Queue?
+
+A message in the Message Queue is simply a reference from the queue’s index to the Message Store.
+
+## Built in Crystal
+
+LavinMQ is written in [Crystal](https://crystal-lang.org/), a modern language built on the LLVM, that has a Ruby-like syntax and uses an event loop library for IO. It is also garbage collected, adopts a CSP-like [concurrency model](https://crystal-lang.org/docs/guides/concurrency.html), and compiles down to a single binary. You can liken it to Go, but with a nicer syntax.
+
+## Message store on disk
+
+Each queue is backed by a message store on disk in a series of files (segments) that can grow to 8MB each. Each incoming message is appended to the last segment, prefixed with a timestamp, its exchange name, routing key, and message headers.
+
+When a message is routed to a queue, the segment number and the position in that segment are written to each queue's queue index. The queue index is just an [in-memory array](https://crystal-lang.org/api/Deque.html) of segment numbers and file positions and some metadata. In the case of durable queues, the message index is also appended to a file.
+
+### Consume a message from the message store
+
+When a message is consumed, LavinMQ removes the segment-position from the segment. It also writes the segment-position to an "ack" file. That way the queue index will be restored on boot by reading all the segment-position information stored in the queue index file, then excluding all the segment-position read information from the "ack" file. The queue index is rewritten when the "ack" file becomes 16 MB, that is, every 16 _ 1024 _ 1024 / 8 = 2097152 message. Then the current in-memory queue index is written to a new file and the "ack" file is truncated.
+
+Segments in the queues's message store are deleted when no queue index is a reference to a position in that segment.
+
+## Definitions file
+
+Declarations of queues, exchanges, and bindings are written to a definitions file (if the target is durable), and encoded with the AMQP frame they came in as. Periodically this file is garbage collected by writing only the current in-memory state to the file (getting rid of all delete events). This file is read on boot to restore all definitions.
+
+## Storage of users, vhosts, policies
+
+All non-AMQP objects like users, vhosts, policies, etc. are stored in JSON files. Most often these types of objects do not have a high turnover rate. JSON, in this case, makes it easy for operators to modify things when the server is not running if needed.
+
+In the data directory, `users.json` and `vhosts.json` are stored, and each vhost has a directory in which definitions.amqp (encoded as AMQP frames), policies.json and the messages named such as msgs.0000000124 are stored as well. Each vhost directory is named after the sha1 hash of its real name. The same goes for the queue directories in the vhost directory. The queue directories only have two files, _ack_, and _enq_.
+
+### Publish
+
+`Client#read_loop` reads from the socket, it calls `Channel#start_publish` for the `Basic.Publish` frame and `Channel#add_content` for Body frames. When all content has been received (and appended to an _IO::Memory object_) it calls `VHost#publish` with a Message struct. `VHost#publish` finds all matching queues, writes the message to the message store, and then calls `Queue#publish` with the segment position. `Queue#publish` writes to the queue index file (if it's a durable queue).
+
+### Consume
+
+When `Client#read_loop` receives a `Basic.Consume` frame, it will create a Consumer class and add it to the queue's list of consumers. The Queue got a _deliver_loop_ fiber that will loop over the list of consumers and deliver a message to each.

--- a/docs/message-store.md
+++ b/docs/message-store.md
@@ -1,7 +1,7 @@
 
 All routed messages in LavinMQ are written directly to the disk, into something called a _Message Store_. The Message Store is a series of files (segments). A routed message is located in the Message Store, with a reference from the queue’s index to the message store.
 
-![Message Store in LavinMQ](/img/docs/lavinmq-message-store.jpg)
+![Message Store in LavinMQ](img/docs/lavinmq-message-store.jpg)
 
 A routed message is a message that is not dropped by the exchange, including messages that are routed via alternate exchanges. Once a message is routed to a queue the segment number, the position in that segment, and some other metadata are written to its queues index and then placed in the queue.
 

--- a/docs/mqtt-in-lavinmq.md
+++ b/docs/mqtt-in-lavinmq.md
@@ -1,0 +1,338 @@
+
+<div class="accordion">
+	<div class="accordion-item">
+		<h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+				What is the MQTT Protocol
+			</button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+      <p>
+        <a href="https://mqtt.org/">MQTT</a>, which stands for Message Queuing Telemetry Transport, is a lightweight, publish-subscribe messaging protocol. It's designed for machine-to-machine (M2M) and Internet of Things (IoT) communication. Developed with resource-constrained devices in mind, MQTT is designed for situations where network bandwidth is limited and power consumption needs to be minimized. This makes it ideal for remote sensors, embedded systems, and mobile applications with intermittent connectivity.
+      </p>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        Why is MQTT used in LavinMQ
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        LavinMQ is a lightweight message broker, and MQTT's small code footprint and focus on efficiency make it a perfect match. By supporting MQTT, LavinMQ can serve as a robust and scalable platform for IoT and mobile applications, such as our [Real-time temperature monitoring with LavinMQ project](/iot). It ensures asynchronous communication across different devices, making it a trusted choice for building flexible and resilient messaging systems.
+      </p>
+    </div>
+  </div>
+</div>
+
+<!-- prettier-ignore-start -->
+
+## MQTT Protocol Overview
+
+MQTT operates on a client-server model and uses TCP/IP for all communication. By default, the protocol uses specific ports: 1883 for unencrypted connections and 8883 for secure, encrypted connections over TLS/SSL (MQTTS).
+
+To establish a connection to a LavinMQ broker, the following information is needed:
+
+* Host/broker address: The domain name or IP address of the LavinMQ server.
+
+* Port: The port number (1883 for unencrypted or 8883 for MQTTS).
+
+* Credentials: Username and password for authentication.
+LavinMQ supports MQTT 3.1.0 and 3.1.1 clients and there are many client libraries for nearly every programming language. While they all follow the same protocol, their syntax and usage will differ a bit. The examples that follow are all in Crystal for the client library [mqtt-client.cr](https://github.com/cloudamqp/mqtt-client.cr).
+
+## Connecting to LavinMQ with MQTT
+
+The following table outlines the MQTT protocol and the required arguments for each packet type.
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Packet type</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Required Fields</span></th>
+          <th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Connect</td>
+					<td class="border-r border-[#414040]"><code>client_id</code>, <code>username</code>, <code>password</code></td>
+          <td>Starts a session by authenticating and connecting the client to the broker.</td>
+				</tr>
+        <tr>
+					<td>Subscribe</td>
+					<td class="border-r border-[#414040]"><code>topic</code>, <code>qos</code></td>
+          <td>Subscribes to a specific topic.</td>
+				</tr>
+        <tr>
+					<td>Unsubscribe</td>
+					<td class="border-r border-[#414040]"><code>topic</code></td>
+          <td>Unsubscribes to a specific topic.</td>
+				</tr>
+        <tr>
+					<td>Publish</td>
+					<td class="border-r border-[#414040]"><code>topic</code>, <code>qos</code></td>
+          <td>Sends a message to a specific topic.</td>
+				</tr>
+        <tr>
+					<td>Puback</td>
+					<td class="border-r border-[#414040]"><code>message_id</code></td>
+          <td>Acknowledges receipt of a message (QoS 1).</td>
+				</tr>
+        <tr>
+					<td>Disconnect</td>
+					<td class="border-r border-[#414040]">N/A</td>
+          <td>Ends the session gracefully.</td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+
+
+### Steps to Connect:
+
+1. Send a **CONNECT** packet to LavinMQ's MQTT listener on port `1883`.
+2. Include the following fields in the CONNECT packet:
+   - `client_id`: A unique identifier for the client.
+   - `username` and `password`: For authentication.
+   - `clean_session`: Boolean to specify whether to start a clean session.
+   - `will`: An optional field for a Last Will and Testament message.
+   - `qos`: Quality of Service level.
+
+### Connecting to a Specific Virtual Host
+
+By default, MQTT clients connect to the default virtual host configured in LavinMQ (typically "/"). To connect a user to a specific vhost, use the following username format:
+
+```
+vhost:username
+```
+
+For example, to connect user "guest" to the vhost "production", set the username field to:
+
+```
+production:guest
+```
+
+If no colon (`:`) and vhost is present in the username, the connection will use the default vhost specified by the `default_mqtt_vhost` configuration variable.
+
+### Example Using `mqtt-client.cr`:
+
+**Default vhost connection:**
+
+```ruby
+require "mqtt-client"
+require "mqtt-protocol"
+
+will = MQTT::Client::Message.new("connect", "body".to_slice, 1_u8, false)
+
+client = MQTT::Client.new("localhost", 1883, user: "guest", password: "guest", client_id: "hello", clean_session: false, will: will)
+
+# Application logic goes here.
+
+client.disconnect
+```
+
+**Connecting to a specific vhost:**
+
+```ruby
+require "mqtt-client"
+require "mqtt-protocol"
+
+will = MQTT::Client::Message.new("connect", "body".to_slice, 1_u8, false)
+
+# Connect to the "production" vhost as user "guest"
+client = MQTT::Client.new("localhost", 1883, user: "production:guest", password: "guest", client_id: "hello", clean_session: false, will: will)
+
+# Application logic goes here.
+
+client.disconnect
+```
+
+### Quality of Service (QoS)
+
+QoS defines the guarantee level for message delivery:
+
+- **0 (At most once)**: No acknowledgment is required; the message may be lost.
+- **1 (At least once)**: Requires acknowledgment (Puback); may result in duplicates of messages.
+
+### Will
+
+The **Will** argument specifies a message to be sent by the broker to a chosen topic if the client disconnects unexpectedly. Fields include:
+
+- `will_topic`: Topic for the Will message.
+- `will_message`: Content of the Will message.
+- `will_qos`: QoS level for the Will message.
+- `will_retain`: Whether the Will message should be retained.
+
+### Clean session
+
+The `clean_session` flag determines whether to establish a persistent or transient session:
+
+- **True**: The broker will not retain session information, such as subscriptions or undelivered messages, after the client disconnects.
+- **False**: The session is persistent, and the broker retains subscriptions and undelivered messages, enabling the client to resume where it left off.
+
+Persistent sessions benefit clients who need to reconnect frequently while maintaining continuity. However, transient sessions are lightweight and suitable for clients that only need real-time interactions without history.
+
+## Subscribing and Unsubscribing
+
+### Example: Subscribe to a Topic
+
+```ruby
+require "mqtt-client"
+require "mqtt-protocol"
+
+client = MQTT::Client.new("localhost", 1883, user: "guest", password: "guest", client_id: "hello", clean_session: false)
+
+client.on_message do |msg|
+  puts "Got a message, on topic #{msg.topic}: #{String.new(msg.body)}"
+end
+
+client.subscribe("my/topic")
+
+# Application logic goes here.
+
+client.unsubscribe("my/topic")
+```
+
+## Publishing and Acknowledging Messages
+
+### Example: Publish a Message
+
+Disclaimer: It's not possible to publish messages to a topic that no session has subscribed to yet.
+
+```ruby
+require "mqtt-client"
+require "mqtt-protocol"
+
+client = MQTT::Client.new("localhost", 1883, user: "guest", password: "guest", client_id: "hello", clean_session: false)
+
+client.publish("my/topic", "Hello World")
+```
+
+### Example: Acknowledge a Published Message (Puback)
+
+```ruby
+require "mqtt-client"
+require "mqtt-protocol"
+
+client = MQTT::Client.new("localhost", 1883, user: "guest", password: "guest", client_id: "hello", clean_session: false)
+
+client.on_message do |msg|
+  puts "Got a message, on topic #{msg.topic}: #{String.new(msg.body)}"
+  client.puback("my/topic", msg.id)
+end
+
+client.subscribe("my/topic", qos: 1)
+```
+
+## Retained Messages
+
+Retained messages are stored by the broker and delivered to new subscribers on a topic when they subscribe. To send a retained message:
+
+### Example: Send a Retained Message
+
+```ruby
+require "mqtt-client"
+require "mqtt-protocol"
+
+client = MQTT::Client.new("localhost", 1883, user: "guest", password: "guest", client_id: "hello", clean_session: false)
+
+client.publish("my/topic", "Hello World", retain: true)
+```
+
+---
+
+## MQTT Client Permissions
+
+By default, LavinMQ only checks user credentials when an MQTT client connects. To also enforce resource permissions on publish and subscribe operations, enable `permission_check_enabled` in the `[mqtt]` configuration section:
+
+```ini
+[mqtt]
+permission_check_enabled = true
+```
+
+When enabled, MQTT clients use the same authorization model as AMQP clients:
+
+- **Publish operations:** Require **write** permission on the MQTT exchange (`mqtt.default`)
+- **Subscribe operations:** Require **read** permission on the MQTT exchange or **write** permission on the client's session queue (`mqtt.<client_id>`)
+- **Will messages:** Require **write** permission on the MQTT exchange
+
+If a client lacks the required permissions, the connection is closed.
+
+LavinMQ does not currently support fine-grained, per-topic permissions for MQTT. Access is granted or denied at the exchange level.
+
+## Clustering with MQTT
+
+In a clustered setup, LavinMQ replicates retained messages across nodes. To ensure followers forward MQTT traffic to the leader, configure the following settings:
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Config variable</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code>unix_path</code></td>
+					<td>UNIX path to listen for MQTT traffic, e.g., <br /> <code>/tmp/lavinmq-mqtt.sock</code>.</td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+## New Configuration Variables
+
+The following variables control MQTT behavior in LavinMQ:
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Variable</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code>bind</code></td>
+					<td>IP address that AMQP, MQTT, and HTTP servers will listen on.</td>
+				</tr>
+        <tr>
+					<td><code>port</code></td>
+					<td>Port for non-TLS MQTT connections. <br />Default: <code>1883</code>.</td>
+				</tr>
+        <tr>
+					<td><code>tls_port</code></td>
+					<td>Port for TLS-enabled MQTT connections. <br />Default: <code>8883</code>.</td>
+				</tr>
+        <tr>
+					<td><code>unix_path</code></td>
+					<td>UNIX socket path for MQTT. <br />Example: <code>/tmp/lavinmq-mqtt.sock</code>.</td>
+				</tr>
+        <tr>
+					<td><code>max_inflight_messages</code></td>
+					<td>Maximum number of messages in flight simultaneously. <br />Default: <code>65535</code>.</td>
+				</tr>
+        <tr>
+					<td><code>default_vhost</code></td>
+					<td>Specifies the default virtual host (vhost) for MQTT connections. Default: "/"</td>
+				</tr>
+        <tr>
+					<td><code>permission_check_enabled</code></td>
+					<td>Enables resource permission checks on MQTT publish and subscribe operations. When disabled (the default), only authentication is checked at connection time. Default: <code>false</code>. Available since v2.5.0.</td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- prettier-ignore-end -->

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,7 +1,7 @@
 
-In order to ensure uniformly configured queues and exchanges, LavinMQ (AMQP) includes the ability to define Policies and [Arguments](/documentation/arguments-and-properties). The specifications of the AMQP protocol (0.9.1) enables support for various features, called Arguments. Depending on which argument you implement, changes can be made to their settings after the queue declaration. Arguments define certain configurations, such as message and queue TTL, different consumer priorities, and queue length limit. Policies make it possible to configure arguments for one or many queues and exchanges at once, and the queues/exchanges will all be updated when the policy definition is updated. Policies can be changed at any time, and changes will affect all matching queues and exchanges.
+In order to ensure uniformly configured queues and exchanges, LavinMQ (AMQP) includes the ability to define Policies and [Arguments](arguments-and-properties.md). The specifications of the AMQP protocol (0.9.1) enables support for various features, called Arguments. Depending on which argument you implement, changes can be made to their settings after the queue declaration. Arguments define certain configurations, such as message and queue TTL, different consumer priorities, and queue length limit. Policies make it possible to configure arguments for one or many queues and exchanges at once, and the queues/exchanges will all be updated when the policy definition is updated. Policies can be changed at any time, and changes will affect all matching queues and exchanges.
 
-![LavinMQ Arguments Policy](/img/docs/lavinmq-arguments-policy.jpg)
+![LavinMQ Arguments Policy](img/docs/lavinmq-arguments-policy.jpg)
 
 ### What is a policy?
 
@@ -19,7 +19,7 @@ A policy can be set when you want to apply a TTL on a set of queues. Policies co
 
 A policy is applied when the pattern, a [regular expression](https://en.wikipedia.org/wiki/Regular_expression), matches a queue or exchange. As soon as a policy is created it will be applied to the matching queues and/or exchanges and its arguments will be amended to the definitions. As the match occurs continuously changes can easily be applied to multiple queues that are up and running. For example, if a TTL is to be set on a group of queues, or if multiple queues are to be deleted or purged at once. A policy is also applied every time an exchange or queue is created if a match exists. Only one policy can be matched to every queue or exchange at once, but one policy may be set to apply multiple arguments.
 
-Policies are created per vhost, with a pattern that defines where it will be applied and a parameter that defines what the policy will do. The parameter is entered as a key (the parameter name) and a value (the parameter value), also called a key-value pair. Policies can be set from a terminal using [lavinmqctl](/documentation/lavinmqctl) or by using the [HTTP API](https://docs.lavinmq.com/http-api.html#tag/policies) or [Web Management Interface](/documentation/management-interface-overview).
+Policies are created per vhost, with a pattern that defines where it will be applied and a parameter that defines what the policy will do. The parameter is entered as a key (the parameter name) and a value (the parameter value), also called a key-value pair. Policies can be set from a terminal using [lavinmqctl](lavinmqctl.md) or by using the [HTTP API](https://docs.lavinmq.com/http-api.html#tag/policies) or [Web Management Interface](management-interface-overview.md).
 
 ## How to create and view policies
 
@@ -45,11 +45,11 @@ Filling the name, patterns, and definition fields is mandatory. Note that below 
 
 A priority should be used if multiple policies are used where the patterns overlap.
 
-<img class="border border-[#414040]" src="/img/docs/docs-dm/policies-dm.png"/>
+<img class="border border-[#414040]" src="img/docs/policies-dm.png"/>
 
 ## Policies in lavinmqctl
 
-The following commands are available for policies via [lavinmqctl](/documentation/lavinmqctl).
+The following commands are available for policies via [lavinmqctl](lavinmqctl.md).
 
 #### List Policies
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,95 @@
+
+In order to ensure uniformly configured queues and exchanges, LavinMQ (AMQP) includes the ability to define Policies and [Arguments](/documentation/arguments-and-properties). The specifications of the AMQP protocol (0.9.1) enables support for various features, called Arguments. Depending on which argument you implement, changes can be made to their settings after the queue declaration. Arguments define certain configurations, such as message and queue TTL, different consumer priorities, and queue length limit. Policies make it possible to configure arguments for one or many queues and exchanges at once, and the queues/exchanges will all be updated when the policy definition is updated. Policies can be changed at any time, and changes will affect all matching queues and exchanges.
+
+![LavinMQ Arguments Policy](/img/docs/lavinmq-arguments-policy.jpg)
+
+### What is a policy?
+
+Policies can be advantageously used to apply queue or exchange arguments to more than one created queue/exchange.
+
+### What benefits do policies have?
+
+When using policies, argument configurations and updates don't have to be done for every single queue or exchange. Policies simply ensure that all matching queues or exchanges come with the desirable preset arguments, suitable for their purpose, and also ensures that updates of one single argument are applied on all queues or exchanges bound to it.
+
+### How can policies be used?
+
+A policy can be set when you want to apply a TTL on a set of queues. Policies could be used when you want to delete single or multiple queues at once, or when you want to delete all messages from a queue.
+
+## Policies in LavinMQ
+
+A policy is applied when the pattern, a [regular expression](https://en.wikipedia.org/wiki/Regular_expression), matches a queue or exchange. As soon as a policy is created it will be applied to the matching queues and/or exchanges and its arguments will be amended to the definitions. As the match occurs continuously changes can easily be applied to multiple queues that are up and running. For example, if a TTL is to be set on a group of queues, or if multiple queues are to be deleted or purged at once. A policy is also applied every time an exchange or queue is created if a match exists. Only one policy can be matched to every queue or exchange at once, but one policy may be set to apply multiple arguments.
+
+Policies are created per vhost, with a pattern that defines where it will be applied and a parameter that defines what the policy will do. The parameter is entered as a key (the parameter name) and a value (the parameter value), also called a key-value pair. Policies can be set from a terminal using [lavinmqctl](/documentation/lavinmqctl) or by using the [HTTP API](https://docs.lavinmq.com/http-api.html#tag/policies) or [Web Management Interface](/documentation/management-interface-overview).
+
+## How to create and view policies
+
+To create a policy we will define the following:
+
+- Name of the policy
+- The vhost it lives in, default is /
+- A pattern or exact match to determine which queues or exchanges it applies to
+- A definition consisting of one or several key-value pairs
+- A priority, how it will be applied in relation to other policies, default is 0
+
+Policies can be viewed and created from either of the following:
+
+- The LavinMQ management interface
+- A terminal using lavinmqctl
+- The HTTP API
+
+## Policies in the LavinMQ management interface
+
+Policies are listed under “policies” in the LavinMQ menu. On the same page in the Add/update section, a new policy can be created.
+
+Filling the name, patterns, and definition fields is mandatory. Note that below the definitions box a selection of keys are listed that can be added to the policy by clicking them. Values have to be added to the definitions box for every key added.
+
+A priority should be used if multiple policies are used where the patterns overlap.
+
+<img class="border border-[#414040]" src="/img/docs/docs-dm/policies-dm.png"/>
+
+## Policies in lavinmqctl
+
+The following commands are available for policies via [lavinmqctl](/documentation/lavinmqctl).
+
+#### List Policies
+
+List policies by using the command<br/> `lavinmqctl list_policies -p vhostname`
+
+#### Create Policies
+
+Create a policy by using the command <br/> `lavinmqctl set_policy <name> <pattern> <definition>`
+
+| Example                                                                                                             |
+| :------------------------------------------------------------------------------------------------------------------ |
+| <code class="language-plaintext highlighter-rouge">lavinmqctl set_policy Policy2 '.\*' '{"message-ttl": 60}'</code> |
+
+To specify vhost, priority, and exchange/queue-application use the following syntax<br/>
+`lavinmqctl set_policy <name> <pattern> <definition> -p <vhost> --apply-o <queues|exchanges> --priority 8`
+
+| Example                                                                                                                                                                                                                         |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <code class="language-plaintext highlighter-rouge">lavinmqctl set_policy Policy5 &#x27;queue_A&#x27; &#x27;{&#x22;message-ttl&#x22;: 60}&#x27; -p<br class="hidden lg:inline"/> zyxhvjpx --apply-to queues --priority 10</code> |
+
+#### Delete Policies
+
+Deleting policies is done with the command<br/> `lavinmqctl clear_policy <name>`
+
+| Example                                                                                          |
+| :----------------------------------------------------------------------------------------------- |
+| <code class="language-plaintext highlighter-rouge">sudo lavinmqctl clear_policy 'Policy1'</code> |
+
+## Policies with the HTTP API
+
+The following commands are available for policies via [LavinMQ HTTP Api](https://docs.lavinmq.com/http-api.html#tag/policies).
+
+#### List Policies
+
+Policies can be listed with the following API call<br/>`curl -u USERNAME:PASSWORD -X GET https://SERVERNAME.lmq.cloudamqp.com/api/policies`
+
+#### Create Policies
+
+Policies can be added with the following API call<br/>`curl -XPUT -u USERNAME:PASSWORD --header "Content-Type: application/json" --data '{"pattern":"[PATTERN]","definition":{"key":value},"apply-to":"[queues|exchanges]"}' https://host/api/policies/[VHOST]/[POLICYNAME]`
+
+#### Delete Policies
+
+Policies can be deleted with the following API call <br/>`curl -u USERNAME:PASSWORD -X DELETE https://host/api/policies/[VHOST]/[POLICYNAME]`

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -1,0 +1,63 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is the LavinMQ prefetch?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+            Prefetch controls how many messages a consumer can receive before acknowledging them. Once a consumer receives the specified number of unacknowledged prefetched messages, the broker pauses delivery until at least one message is acknowledged.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What benefits does LavinMQ prefetch have?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>LavinMQ prefetch controls how many messages a consumer can receive before acknowledging them, preventing messages from piling up at the client. By limiting unacknowledged messages, it ensures consumers process data efficiently without getting overwhelmed. This keeps all consumers actively engaged, balancing the workload and optimizing resource usage.</p>
+      <img class="border border-[#414040]" src="/img/docs/prefetch-1.png" />
+      <img class="border border-[#414040]" src="/img/docs/prefetch-2.png" />
+    </div>
+  </div>
+</div>
+
+LavinMQ offers two types of prefetch options:
+
+- **Channel Prefetch** – This option limits the number of unacknowledged messages across all channels. It helps control the overall message flow within the connection.
+- **Consumer Prefetch** – This option limits the number of unacknowledged messages per consumer.
+
+Prefetch settings apply only when consuming messages from a queue (not when using the `get` method) and only if explicit acknowledgments are required. Pre-fetched messages are not re-queued or delivered to other consumers; they remain assigned to the current consumer and are marked as unacknowledged until processed.
+
+By default, LavinMQ sets the prefetch limit to 65,535 (2¹⁶) messages. This value can be configured using the `default_consumer_prefetch` setting.
+
+### Using prefetch
+
+The `basic.qos` channel property (Quality of Service) sets the prefetch count. The **`basic_qos`** method includes a `global` flag. Setting this flag to:
+
+- **`false`** applies the prefetch count to each consumer individually (consumer prefetch).
+- **`true`** applies the prefetch count to all consumers on the channel (channel prefetch).
+
+An unbounded prefetch can be set by `basic_qos(0)`.
+
+Example: Limit the number of unacknowledged messages per consumer to three.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.queue_declare(queue='task_queue', durable=True)
+
+channel.basic_qos(prefetch_count=3, global=False)
+```
+
+![LavinMQ Prefetch example](/img/docs/prefetch-3.png)
+
+Looking for help on setting the prefetch value? Check out our blog, ["How to set the correct prefetch value in LavinMQ"](/blog/correct-prefetch-value), for more information.

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -21,8 +21,8 @@
     </h3>
     <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
       <p>LavinMQ prefetch controls how many messages a consumer can receive before acknowledging them, preventing messages from piling up at the client. By limiting unacknowledged messages, it ensures consumers process data efficiently without getting overwhelmed. This keeps all consumers actively engaged, balancing the workload and optimizing resource usage.</p>
-      <img class="border border-[#414040]" src="/img/docs/prefetch-1.png" />
-      <img class="border border-[#414040]" src="/img/docs/prefetch-2.png" />
+      <img class="border border-[#414040]" src="img/docs/prefetch-1.png" />
+      <img class="border border-[#414040]" src="img/docs/prefetch-2.png" />
     </div>
   </div>
 </div>
@@ -58,6 +58,6 @@ channel.queue_declare(queue='task_queue', durable=True)
 channel.basic_qos(prefetch_count=3, global=False)
 ```
 
-![LavinMQ Prefetch example](/img/docs/prefetch-3.png)
+![LavinMQ Prefetch example](img/docs/prefetch-3.png)
 
-Looking for help on setting the prefetch value? Check out our blog, ["How to set the correct prefetch value in LavinMQ"](/blog/correct-prefetch-value), for more information.
+Looking for help on setting the prefetch value? Check out our blog, ["How to set the correct prefetch value in LavinMQ"](https://lavinmq.com/blog/correct-prefetch-value), for more information.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,0 +1,451 @@
+
+Generally, monitoring is the process of tracking a system's behavior through
+health checks and metrics over time. It helps detect anomalies, such as
+unavailability, unusual loads, resource exhaustion, or deviations from normal
+behavior. This ensures early identification of issues for prompt action to maintain
+optimal performance and stability.
+
+While the LavinMQ's management interface provides an easy to use built-in monitoring
+solution, it is not ideal for long term metric collection, storage and visualisation.
+
+This is where support for Prometheus in LavinMQ comes in.
+
+## What is Prometheus?
+
+In a nutshell, Prometheus is a monitoring tool that collects and stores metrics from
+different systems using a simple scraping method. It saves the data in a database and
+allows users to analyze it using a user-friendly query language called PromQL.
+
+## When can I use Prometheus with LavinMQ
+
+You can integrate Prometheus with LavinMQ:
+
+- If you need a more long term metric collection and storage solution
+- If you need to adopt an external monitoring solution and by extension separate the
+  system being monitored from the monitoring system.
+
+## How does LavinMQ support Prometheus?
+
+Every LavinMQ installation/instance ships with two metrics endpoints ouf of the box.
+These endpoints expose data in a Prometheus-compatible format. To integrate
+Prometheus with LavinMQ, you simply point your Prometheus scraper to these
+endpoints:
+
+- **`/metrics`:** This endpoint returns aggregate metrics of all the metrics emitting objects
+- **`/metrics/detailed`:** This returns the metric for each metric emitting object depending
+  on the query parameters it's passed.
+
+### /metrics
+
+Typically, Prometheus and other compatible solutions assume that metrics are accessible
+at the `/metrics` path. LavinMQ, by default, provides aggregated metrics on this endpoint.
+
+As mentioned earlier, this endpoint returns a combined metrics for all the metrics emitting
+objects defined in your LavinMQ server. Metrics emitting objects here refers to connections,
+channels, queues, and consumers amongst others.
+
+The table below lists all the relevant metrics returned from this endpoint. |
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Metric</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>lavinmq_connections_opened_total</td>
+          <td>Total number of connections opened</td>
+        </tr>
+        <tr>
+          <td>lavinmq_connections_closed_total</td>
+          <td>Total number of connections closed or terminated</td>
+        </tr>
+        <tr>
+          <td>lavinmq_channels_opened_total</td>
+          <td>Total number of channels opened</td>
+        </tr>
+        <tr>
+          <td>lavinmq_channels_closed_total</td>
+          <td>Total number of channels closed</td>
+        </tr>
+        <tr>
+          <td>lavinmq_queues_declared_total</td>
+          <td>Total number of queues declared</td>
+        </tr>
+        <tr>
+          <td>lavinmq_queues_deleted_total</td>
+          <td>Total number of queues deleted</td>
+        </tr>
+        <tr>
+          <td>lavinmq_process_open_fds</td>
+          <td>Open file descriptors</td>
+        </tr>
+        <tr>
+          <td>lavinmq_process_open_tcp_sockets</td>
+          <td>Open TCP sockets</td>
+        </tr>
+        <tr>
+          <td>lavinmq_disk_space_available_bytes</td>
+          <td>Disk space available in bytes</td>
+        </tr>
+        <tr>
+          <td>lavinmq_process_max_fds</td>
+          <td>Open file descriptors limit</td>
+        </tr>
+        <tr>
+          <td>lavinmq_resident_memory_limit_bytes</td>
+          <td>Memory high watermark in bytes</td>
+        </tr>
+        <tr>
+          <td>lavinmq_connections</td>
+          <td>Connections currently open</td>
+        </tr>
+        <tr>
+          <td>lavinmq_channels</td>
+          <td>Channels currently open</td>
+        </tr>
+        <tr>
+          <td>lavinmq_consumers</td>
+          <td>Consumers currently connected</td>
+        </tr>
+        <tr>
+          <td>lavinmq_queues</td>
+          <td>Queues available</td>
+        </tr>
+        <tr>
+          <td>lavinmq_queue_messages_ready</td>
+          <td>Messages ready to be delivered to consumers</td>
+        </tr>
+        <tr>
+          <td>lavinmq_queue_messages_unacked</td>
+          <td>Messages delivered to consumers but not yet acknowledged</td>
+        </tr>
+        <tr>
+          <td>lavinmq_queue_messages</td>
+          <td>Sum of ready and unacknowledged messages - total queue depth</td>
+        </tr>
+        <tr>
+          <td>lavinmq_global_messages_delivered_total</td>
+          <td>Total number of messages delivered to consumers</td>
+        </tr>
+        <tr>
+          <td>lavinmq_global_messages_redelivered_total</td>
+          <td>Total number of messages redelivered to consumers</td>
+        </tr>
+        <tr>
+          <td>lavinmq_global_messages_acknowledged_total</td>
+          <td>Total number of messages acknowledged by consumers</td>
+        </tr>
+        <tr>
+          <td>lavinmq_global_messages_confirmed_total</td>
+          <td>Total number of messages confirmed to publishers</td>
+        </tr>
+        <tr>
+          <td>lavinmq_deliver_no_ack</td>
+          <td>Number of messages delivered with auto-acknowledgment (no_ack=true)</td>
+        </tr>
+        <tr>
+          <td>lavinmq_get_no_ack</td>
+          <td>Number of messages retrieved via Basic.Get with auto-acknowledgment</td>
+        </tr>
+        <tr>
+          <td>lavinmq_uptime</td>
+          <td>Server uptime in seconds</td>
+        </tr>
+        <tr>
+          <td>lavinmq_cpu_system_time_total</td>
+          <td>Total CPU system time</td>
+        </tr>
+        <tr>
+          <td>lavinmq_rss_bytes</td>
+          <td>Memory RSS in bytes</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_heap_size_bytes</td>
+          <td>Heap size in bytes (including the area unmapped to OS)</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_free_bytes</td>
+          <td>Total bytes contained in free and unmapped blocks</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_unmapped_bytes</td>
+          <td>Amount of memory unmapped to OS</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_since_recent_collection_allocated_bytes</td>
+          <td>Number of bytes allocated since the recent GC</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_before_recent_collection_allocated_bytes_total</td>
+          <td>Number of bytes allocated before the recent GC (value may wrap)</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_non_candidate_bytes</td>
+          <td>Number of bytes not considered candidates for GC</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_cycles_total</td>
+          <td>Garbage collection cycle number (value may wrap)</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_marker_threads</td>
+          <td>Number of marker threads (excluding the initiating one)</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_since_recent_collection_reclaimed_bytes</td>
+          <td>Approximate number of reclaimed bytes after recent GC</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_before_recent_collection_reclaimed_bytes_total</td>
+          <td>Approximate number of bytes reclaimed before the recent GC (value may wrap)</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_since_recent_collection_explicitly_freed_bytes</td>
+          <td>Number of bytes freed explicitly since the recent GC</td>
+        </tr>
+        <tr>
+          <td>lavinmq_gc_from_os_obtained_bytes_total</td>
+          <td>Total amount of memory obtained from OS, in bytes</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+All the metrics returned from this endpoint are prefixed with `lavinmq` by default.
+However, this is customisable - just pass the the query param `prefix`
+with your custom prefix like so: `/metrics?prefix=prometheus`.
+
+### /metrics/detailed
+
+As opposed to returning aggregate metrics, this endpoint allows
+filtering metrics per object via query params. This way, you only get
+the metrics you need.
+
+By default, this endpoint returns nothing until you pass a filter/query
+param.
+
+With this endpoint, you can either pass one ore **family** values or one or more
+**vhost** values. Let's cover each of them one at a time.
+
+#### family:
+
+In the context of these metrics, every entity on a LavinMQ node
+belongs to a family. E.g all queues belong to the queue family, connections to the
+connection family and so on and so forth. The _family_ query parameter essentially
+allows you retrieve metrics for a specific group of objects(queues, connections, channels etc).
+
+For example, if you want to grab metrics on queues only, you will pass
+the following values to the family parameter:
+
+`/metrics/detailed?family=queue_coarse_metrics`
+
+LavinMQ supports the following family values:
+
+##### `queue_coarse_metrics`
+
+In this group, every metric points to a particular queue through its label.
+As a result, the size of the response here grows in direct proportion to the
+number of queues hosted on the node.
+
+Thus, passing this value to the family query param will return the following metrics
+for each queue defined on your LavinMQ node:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Metric</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>lavinmq_detailed_queue_messages_ready</td>
+          <td>Messages ready to be delivered to consumers</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_queue_messages_unacked</td>
+          <td>Messages delivered to consumers but not yet acknowledged</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_queue_messages</td>
+          <td>Sum of ready and unacknowledged messages - total queue depth</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+**Deprecated Metric Names:**
+
+The following queue metric names are deprecated and will be removed in the next major version. Please migrate to the new metric names:
+
+- **DEPRECATED:** `ready` → Use `messages_ready` instead
+- **DEPRECATED:** `ready_bytes` → Use `message_bytes_ready` instead
+- **DEPRECATED:** `unacked` → Use `messages_unacknowledged` instead
+- **DEPRECATED:** `unacked_bytes` → Use `message_bytes_unacknowledged` instead
+
+##### `connection_churn_metrics`
+
+This retrieves generic metrics on connection. Passing this value to the family query
+param will return the following metrics:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Metric</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>lavinmq_detailed_consumers_added_total</td>
+          <td>Total number of consumers added</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_consumers_removed_total</td>
+          <td>Total number of consumers removed</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_connections_opened_total</td>
+          <td>Total number of connections opened</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_connections_closed_total</td>
+          <td>Total number of connections closed or terminated</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_channels_opened_total</td>
+          <td>Total number of channels opened</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_channels_closed_total</td>
+          <td>Total number of channels closed</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_queues_declared_total</td>
+          <td>Total number of queues declared</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_queues_deleted_total</td>
+          <td>Total number of queues deleted</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+##### `queue_consumer_count`
+
+This metric serves a valuable purpose by promptly identifying consumer-related
+issues, such as when no consumers are online. That's why it's made available
+separately for easy access and monitoring.
+
+Passing this value to the family query param will return just one metric:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Metric</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>lavinmq_detailed_queue_consumers</td>
+          <td>Consumers on a queue</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+##### `connection_coarse_metrics`
+
+Passing this value to the family query param will return the following metrics:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Metric</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>lavinmq_detailed_connection_incoming_bytes_total</td>
+          <td>Total number of bytes received on a connection</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_connection_outgoing_bytes_total</td>
+          <td>Total number of bytes sent on a connection</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_connection_process_reductions_total</td>
+          <td>Total number of connection process reductions</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+##### `channel_metrics`
+
+Passing this value to the family query param will return the following metrics:
+
+<div class="bg-[#181818] mt-6 border mb-8 border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Metric</span></th>
+					<th><span class="font-semibold">Description</span></th>
+				</tr>
+			</thead>
+			<tbody>
+        <tr>
+          <td>lavinmq_detailed_channel_consumers</td>
+          <td>Consumers on a channel</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_channel_messages_unacked</td>
+          <td>Delivered but not yet acknowledged messages</td>
+        </tr>
+        <tr>
+          <td>lavinmq_detailed_channel_prefetch</td>
+          <td>Total limit of unacknowledged messages for all consumers on a channel</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+#### vhost:
+
+Family values would allow you retrieve metrics for a group of objects on a node.
+For example, the `queue_coarse_metrics` will return metrics for all the queues
+defined on a node. But what if you just want metrics for all the queues defined
+in a specific vhost?
+
+You can do that with the `vhost` query param like so:
+
+`/metrics/detailed?vhost=vhost-name&family=queue_coarse_metrics`
+
+The query above will return metrics for the queues in the specified vhost only.
+
+**Note:** All the metrics returned from the `/metrics/detailed` endpoint are prefixed with `lavinmq_detailed`.
+However, this is customisable - again, just pass the the query param `prefix`
+with your custom prefix like so: `/metrics/detailed?prefix=prometheus`.

--- a/docs/publisher-confirms.md
+++ b/docs/publisher-confirms.md
@@ -1,7 +1,7 @@
 
 <!-- prettier-ignore-start -->
 
-Messages in transit might get lost if the broker goes down before LavinMQ has the chance to receive it. This can happen in the event of a connection failure or during a broker restart. Sometimes you want these messages to be retransmitted from the publisher to the LavinMQ server. Publish confirm lets the client knows when to retransmit messages. [Consumer acknowledgements](/documentation/consumer-acknowledgements) are the same concept but on the consumer side; the client confirms when it has received a message from the LavinMQ.
+Messages in transit might get lost if the broker goes down before LavinMQ has the chance to receive it. This can happen in the event of a connection failure or during a broker restart. Sometimes you want these messages to be retransmitted from the publisher to the LavinMQ server. Publish confirm lets the client knows when to retransmit messages. [Consumer acknowledgements](consumer-acknowledgements.md) are the same concept but on the consumer side; the client confirms when it has received a message from the LavinMQ.
 
 ### What is Publisher Confirms?
 

--- a/docs/publisher-confirms.md
+++ b/docs/publisher-confirms.md
@@ -1,0 +1,45 @@
+
+<!-- prettier-ignore-start -->
+
+Messages in transit might get lost if the broker goes down before LavinMQ has the chance to receive it. This can happen in the event of a connection failure or during a broker restart. Sometimes you want these messages to be retransmitted from the publisher to the LavinMQ server. Publish confirm lets the client knows when to retransmit messages. [Consumer acknowledgements](/documentation/consumer-acknowledgements) are the same concept but on the consumer side; the client confirms when it has received a message from the LavinMQ.
+
+### What is Publisher Confirms?
+
+LavinMQ can acknowledge that a message has been received, with the use of publisher confirms.
+### What benefits do Publisher Confirms have?
+
+The client can ensure that a message has been received by LavinMQ.
+
+### When should I use Publisher Confirms?
+
+Use publisher confirms when you must not lose messages and when you want to ensure that LavinMQ has received the message sent by the publisher.
+
+## Ensure that LavinMQ has received a message
+
+Publisher confirms are not enabled by default. It can be enabled by turning on delivery confirms on the channel, which tells LavinMQ and the client to start counting messages:
+
+{% highlight python %}
+channel.confirm_delivery()
+{% endhighlight %}
+
+Once a channel is in confirm mode, the publisher should expect to receive `basic.ack`. LavinMQ can confirm messages as it handles them by sending a basic.ack on the same channel. The delivery-tag field contains the sequence number of the confirmed message.
+
+{% highlight python %}
+try:
+  channel.basic_publish(exchange='test',
+                        routing_key='test',
+                        body='Hello World!',
+                        properties=pika.BasicProperties(content_type='text/plain', delivery_mode=1)):
+  print('Message publish was confirmed')
+  except pika.exceptions.UnroutableError:
+  print('Message could not be confirmed')
+{% endhighlight %}
+
+The basic.ack is sent when a message reaches LavinMQ and has been accepted by all the queues. The broker may also set the multiple field in basic.ack to indicate that all messages up to and including the one with the sequence number have been handled.
+
+Note: A persistent message is confirmed when written to disk or ack:ed on all the queues it was delivered to.
+
+## Negative Acknowledgment
+When LavinMQ is unable to handle messages successfully, it can reply with a `basic.nack`. Fields in a basic.nack correspond with those in a basic.ack, and the requeue field is ignored. When LavinMQ nacks one or more messages, this indicates to the client that it was unable to process the messages and will not retry. At that point, the client may choose to republish them or take some other action.
+
+<!-- prettier-ignore-end -->

--- a/docs/publishers-and-consumers.md
+++ b/docs/publishers-and-consumers.md
@@ -1,0 +1,140 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a publisher?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          A publisher refers to a client application or system that creates and sends messages to LavinMQ, generating information or events to be distributed to other systems. When applications send messages, they _publish_ or _produce_ them.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What is a consumer?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        A consumer connects to LavinMQ to retrieve and process messages. It acts as a receiver, handling messages published by a producer. Designed for asynchronous processing, it fetches and works on messages independently, without real-time interaction with the publisher.
+      </p>
+    </div>
+  </div>
+</div>
+
+## Publishing messages
+
+To publish messages, clients establish a connection with LavinMQ. This connection serves as a pathway for communication between the client and the message broker. Within this connection, clients create a channel, which is a virtual communication pathway that allows them to interact with the message broker. For more information, refer to the documentation on [connections and channels](/documentation/amqp-connections-and-channels).
+
+**Example:** Clients can start publishing messages once the connection and channel are established.
+
+<!-- prettier-ignore-start -->
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+channel.queue_declare(
+   queue="test_queue",
+   durable=True,
+)
+channel.basic_publish(
+	exchange="", # Use the default exchange
+	routing_key="test_queue",
+	body="Hello World"
+)
+
+connection.close()
+```
+
+- Messages are sent to an [exchange](/documentation/amqp-exchanges), not directly to a queue.
+- The exchange receives messages from publishers and routes them to the correct queue(s) based on [bindings](/documentation/amqp-bindings).
+- The routing key, set by the publisher, determines the message's destination.
+
+Refer to the documentation on [exchanges](/documentation/amqp-exchanges) and [queues](/documentation/amqp-queues) for more information.
+
+### Publishing to a non-existing exchange
+
+If a message is published to a non-existing exchange, the message broker typically discards the message. This happens because the exchange is responsible for routing messages, so if it doesn’t exist, there is no way for the message to reach its intended destination. However, an [Alternate Exchange](/documentation/alternate-exchange) can be configured to handle undelivered messages.
+
+### The publisher lifecycle
+
+Publishers can be short-lived or long-lived. In a short-lived scenario, a publisher connects, publishes messages, and disconnects. In most cases, publishers are long-lived, maintaining a persistent connection, reusing the same channel, and publishing throughout the application's lifetime.
+
+## Consuming messages
+
+To consume messages, clients connect to LavinMQ and create channels. Once connected, clients subscribe to specific queues to receive messages. A user-defined handler (function or object based on the client library) processes messages when delivered.
+
+**Example:** A consumer subscribes to a queue named `test_queue` and uses a handler called `call_back`:
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+		print(f"[✅]  { msg }")
+
+channel.basic_consume(
+    "test_queue",
+    callback,
+    auto_ack=True,
+)
+connection.close()
+```
+
+### Consumer tag
+
+Consumer tags uniquely identify each consumer, allowing the message broker to manage their state and correctly handle actions like acknowledgments or rejections. When a subscription is successful, a subscription identifier (consumer tag) is returned, which can later be used to cancel the consumer if needed.
+
+### Consumer exclusivity
+
+Consumer exclusivity assigns one consumer as the sole processor for a specific queue, ensuring only that consumer handles messages. If the exclusive consumer disconnects or stops, the application must register a new consumer to continue processing.
+
+**Example:** Consumer exclusivity
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+		print(f"[✅]  { msg }")
+		ch.basic_ack(delivery_tag=method.delivery_tag)
+
+channel.basic_consume(
+    "ex_queue",
+    callback,
+    auto_ack=False,
+    exclusive**=**True
+
+)
+connection.close()
+```
+
+### Consuming from non-existing queues
+
+If a consumer tries to consume from a queue that doesn’t exist, LavinMQ typically responds with a `404, "NOT_FOUND"` error, indicating that the queue is unavailable. In this case, the consumer needs to ensure that the queue exists before attempting to consume from it.
+
+### The Consumer lifecycle
+
+Consumers are designed to be persistent, receiving multiple messages over time. They are typically registered at application startup and remain active once the connection is established, often throughout the application's lifetime.
+
+### More resources on consumers
+
+For more information about consumers and their various applications, refer to the following resources:
+
+- [Single Active Consumer](/documentation/single-active-consumer)
+- [Consumer priorities](/documentation/consumer-priorities)
+- [The Competing Consumer Pattern](/documentation/task-queue-python)
+
+<!-- prettier-ignore-end -->

--- a/docs/publishers-and-consumers.md
+++ b/docs/publishers-and-consumers.md
@@ -29,7 +29,7 @@
 
 ## Publishing messages
 
-To publish messages, clients establish a connection with LavinMQ. This connection serves as a pathway for communication between the client and the message broker. Within this connection, clients create a channel, which is a virtual communication pathway that allows them to interact with the message broker. For more information, refer to the documentation on [connections and channels](/documentation/amqp-connections-and-channels).
+To publish messages, clients establish a connection with LavinMQ. This connection serves as a pathway for communication between the client and the message broker. Within this connection, clients create a channel, which is a virtual communication pathway that allows them to interact with the message broker. For more information, refer to the documentation on [connections and channels](amqp-connections-and-channels.md).
 
 **Example:** Clients can start publishing messages once the connection and channel are established.
 
@@ -54,15 +54,15 @@ channel.basic_publish(
 connection.close()
 ```
 
-- Messages are sent to an [exchange](/documentation/amqp-exchanges), not directly to a queue.
-- The exchange receives messages from publishers and routes them to the correct queue(s) based on [bindings](/documentation/amqp-bindings).
+- Messages are sent to an [exchange](amqp-exchanges.md), not directly to a queue.
+- The exchange receives messages from publishers and routes them to the correct queue(s) based on [bindings](amqp-bindings.md).
 - The routing key, set by the publisher, determines the message's destination.
 
-Refer to the documentation on [exchanges](/documentation/amqp-exchanges) and [queues](/documentation/amqp-queues) for more information.
+Refer to the documentation on [exchanges](amqp-exchanges.md) and [queues](amqp-queues.md) for more information.
 
 ### Publishing to a non-existing exchange
 
-If a message is published to a non-existing exchange, the message broker typically discards the message. This happens because the exchange is responsible for routing messages, so if it doesn’t exist, there is no way for the message to reach its intended destination. However, an [Alternate Exchange](/documentation/alternate-exchange) can be configured to handle undelivered messages.
+If a message is published to a non-existing exchange, the message broker typically discards the message. This happens because the exchange is responsible for routing messages, so if it doesn’t exist, there is no way for the message to reach its intended destination. However, an [Alternate Exchange](alternate-exchange.md) can be configured to handle undelivered messages.
 
 ### The publisher lifecycle
 
@@ -133,8 +133,8 @@ Consumers are designed to be persistent, receiving multiple messages over time. 
 
 For more information about consumers and their various applications, refer to the following resources:
 
-- [Single Active Consumer](/documentation/single-active-consumer)
-- [Consumer priorities](/documentation/consumer-priorities)
-- [The Competing Consumer Pattern](/documentation/task-queue-python)
+- [Single Active Consumer](single-active-consumer.md)
+- [Consumer priorities](consumer-priorities.md)
+- [The Competing Consumer Pattern](https://lavinmq.com/documentation/task-queue-python)
 
 <!-- prettier-ignore-end -->

--- a/docs/queue-length-limit.md
+++ b/docs/queue-length-limit.md
@@ -3,7 +3,7 @@ A policy can be set to limit the number of messages stored in a queue. This can 
 
 ## Policy for Max Queue length
 
-The maximum length allowed for a queue can be configured by setting a [policy](/documentation/policies). Policies can be set from a terminal using [lavinmqctl](/documentation/lavinmqctl) or by using the [HTTP API](https://docs.lavinmq.com/http-api.html) or [Web Management Interface](/documentation/management-interface-overview).
+The maximum length allowed for a queue can be configured by setting a [policy](policies.md). Policies can be set from a terminal using [lavinmqctl](lavinmqctl.md) or by using the [HTTP API](https://docs.lavinmq.com/http-api.html) or [Web Management Interface](management-interface-overview.md).
 
 The policy must be given a name and a pattern or exact match to determine which queues should have this policy. Additional options can be set including the number of messages or the total size of stored messages and how to handle messages published beyond the limit.
 
@@ -11,7 +11,7 @@ The policy must be given a name and a pattern or exact match to determine which 
 
 The Overflow setting determines what happens when messages beyond the allowed limit are sent to the queue. The options are to dequeue messages from the head of the queue (‘drop-head’) or to reject the message (‘reject-publish’). The default configuration for overflow is ‘drop-head’.
 
-If the queue has a [dead-letter policy](/documentation/policies) and overflow is set to ‘drop-head’, the dequeued messages will be sent to the dead letter queue. Otherwise, the dequeued messages will be deleted. In the case of ‘reject-publish’, new messages published to the queue that exceed the limit messages will be rejected.
+If the queue has a [dead-letter policy](policies.md) and overflow is set to ‘drop-head’, the dequeued messages will be sent to the dead letter queue. Otherwise, the dequeued messages will be deleted. In the case of ‘reject-publish’, new messages published to the queue that exceed the limit messages will be rejected.
 
 ## Max Queue Length
 
@@ -23,7 +23,7 @@ Alternatively, the queue can be limited by the size of the message data queue in
 
 ## Example Policies
 
-Using the [lavinmqctl cli](/documentation/lavinmqctl), we can set a max length queue policy for a queue. For this example, we want the policy to apply to a single queue (so we match the full queue name, ‘IT/Helpdesk/Requests’), to limit the number of messages in the queue to 1,000, and to reject messages published that exceed this limit. The policy name will be set to MessageCountLimit:
+Using the [lavinmqctl cli](lavinmqctl.md), we can set a max length queue policy for a queue. For this example, we want the policy to apply to a single queue (so we match the full queue name, ‘IT/Helpdesk/Requests’), to limit the number of messages in the queue to 1,000, and to reject messages published that exceed this limit. The policy name will be set to MessageCountLimit:
 
 {% highlight shell %}
 avalanchmqctl set_policy MessageCountLimit "IT/Helpdesk/Requests" \

--- a/docs/queue-length-limit.md
+++ b/docs/queue-length-limit.md
@@ -1,0 +1,44 @@
+
+A policy can be set to limit the number of messages stored in a queue. This can improve the server stability in the case where one of the server’s queues has an increasing number of enqueued messages. Otherwise, a single continuously growing queue may take down the entire server.
+
+## Policy for Max Queue length
+
+The maximum length allowed for a queue can be configured by setting a [policy](/documentation/policies). Policies can be set from a terminal using [lavinmqctl](/documentation/lavinmqctl) or by using the [HTTP API](https://docs.lavinmq.com/http-api.html) or [Web Management Interface](/documentation/management-interface-overview).
+
+The policy must be given a name and a pattern or exact match to determine which queues should have this policy. Additional options can be set including the number of messages or the total size of stored messages and how to handle messages published beyond the limit.
+
+## Overflow
+
+The Overflow setting determines what happens when messages beyond the allowed limit are sent to the queue. The options are to dequeue messages from the head of the queue (‘drop-head’) or to reject the message (‘reject-publish’). The default configuration for overflow is ‘drop-head’.
+
+If the queue has a [dead-letter policy](/documentation/policies) and overflow is set to ‘drop-head’, the dequeued messages will be sent to the dead letter queue. Otherwise, the dequeued messages will be deleted. In the case of ‘reject-publish’, new messages published to the queue that exceed the limit messages will be rejected.
+
+## Max Queue Length
+
+Max queue length is simply the number of messages allowed in the queue at any given time. Messages sent to a queue that has reached this limit will be handled according to the ‘Overflow’ policy explained above.
+
+## Max Length Bytes
+
+Alternatively, the queue can be limited by the size of the message data queue in bytes. When the data exceeds this amount, the handling described method by the Overflow setting is applied until the limit is no longer exceeded.
+
+## Example Policies
+
+Using the [lavinmqctl cli](/documentation/lavinmqctl), we can set a max length queue policy for a queue. For this example, we want the policy to apply to a single queue (so we match the full queue name, ‘IT/Helpdesk/Requests’), to limit the number of messages in the queue to 1,000, and to reject messages published that exceed this limit. The policy name will be set to MessageCountLimit:
+
+{% highlight shell %}
+avalanchmqctl set_policy MessageCountLimit "IT/Helpdesk/Requests" \
+ '{"max-length":1000,"overflow":"reject-publish"}'
+{% endhighlight %}
+
+For the second example, we want to apply the policy to all queues that start with the string ‘watchdog’, and we will limit the queue size to 1 MB, and drop messages at the head of the queue. The name of the policy will be set to WatchDogLimit. In this case, we will use the HTTP API:
+
+{% highlight shell %}
+curl -XPUT -u USERNAME:PWD --header "Content-Type: application/json"
+--data ‘{"pattern":"^watchdog", "definition":{"max-length-bytes":1000, "overflow":"drop-head"}, "apply-to":"queues","priority":1}’ http://{AvMQ_HOSTNAME:15672}/api/policies/{VHOST}/WatchDogLimit
+{% endhighlight %}
+
+Note that here we have also set the priority of the policy as well as specified that the pattern is only applied to queues.
+
+## Conclusion
+
+Note that here we have also set the priority of the policy as well as specified that the pattern is only applied to queues.

--- a/docs/reliable-delivery-overview.md
+++ b/docs/reliable-delivery-overview.md
@@ -20,7 +20,7 @@ This feedback mechanism assures the producer that messages have been reliably
 accepted by LavinMQ.
 
 For more information, you can read our documentation on
-[publisher confirms](/documentation/publisher-confirms).
+[publisher confirms](publisher-confirms.md).
 
 ## Consumer Acknowledgements
 
@@ -31,7 +31,7 @@ isn't received, LavinMQ assumes something went wrong and the message is left in
 the queue.
 
 For more information, you can read our documentation on
-[consumer acknowledgements](/documentation/consumer-acknowledgements).
+[consumer acknowledgements](consumer-acknowledgements.md).
 
 ## Durable Queues and Persistent Messages
 
@@ -50,7 +50,7 @@ Transactions in LavinMQ offer the highest level of message persistence guarantee
 
 To learn more about transactions in LavinMQ and how they offer the highest level
 of message durability guarantee compared to pubisher confirms and consumer
-acknowledgements, check out our documentation on [transactions](/documentation/transactions).
+acknowledgements, check out our documentation on [transactions](transactions.md).
 
 ## Wrap up
 

--- a/docs/reliable-delivery-overview.md
+++ b/docs/reliable-delivery-overview.md
@@ -1,0 +1,59 @@
+
+In LavinMQ, reliable message delivery is vital to prevent message
+loss in specific scenarios like server failures, network interruptions,
+or high message traffic.
+
+To ensure data safety, LavinMQ offers various mechanisms for reliable message
+delivery. You can achieve this by employing one or a combination of the
+following methods:
+
+- Publisher Confirms
+- Consumer Acknowledgements
+- Durable Queues and Persistent Messages
+- Transactions
+
+## Publisher Confirms
+
+When using publisher confirms, the producer (publisher) receives acknowledgments
+from LavinMQ after successfully delivering messages to the intended queues.
+This feedback mechanism assures the producer that messages have been reliably
+accepted by LavinMQ.
+
+For more information, you can read our documentation on
+[publisher confirms](/documentation/publisher-confirms).
+
+## Consumer Acknowledgements
+
+On the other hand, when consumers consume messages from a queue,
+they can also send an acknowledgement to LavinMQ confirming the
+successful processing of messages. If an acknowledgment
+isn't received, LavinMQ assumes something went wrong and the message is left in
+the queue.
+
+For more information, you can read our documentation on
+[consumer acknowledgements](/documentation/consumer-acknowledgements).
+
+## Durable Queues and Persistent Messages
+
+Declaring queues as "durable" ensures that they survive server restarts,
+safeguarding your messages from loss.
+
+In LavinMQ, messages are persistent by default. LavinMQ would generally ignore the
+`delivery_mode` argument, if passed.
+
+## Transactions
+
+Even though publisher confirms and consumer acknowledgements offer some
+level of message persistence guarantee in LavinMQ, that guarante is not 100%.
+
+Transactions in LavinMQ offer the highest level of message persistence guarantee.
+
+To learn more about transactions in LavinMQ and how they offer the highest level
+of message durability guarantee compared to pubisher confirms and consumer
+acknowledgements, check out our documentation on [transactions](/documentation/transactions).
+
+## Wrap up
+
+By leveraging these methods in LavinMQ, you can establish a robust and
+reliable message delivery system, preventing data loss and ensuring your
+messaging infrastructure performs optimally even in challenging circumstances.

--- a/docs/remote-procedure-call.md
+++ b/docs/remote-procedure-call.md
@@ -61,7 +61,6 @@ In the code shown above is a callback queue added for every RPC request, which
 might be confusing since it's not clear to which request the response belongs.
 A `correlation_id` (a unique value) can therefore be sent with every request.
 
-![]()
 
 {% highlight python %}
 channel.basic_publish(

--- a/docs/remote-procedure-call.md
+++ b/docs/remote-procedure-call.md
@@ -1,0 +1,210 @@
+
+<!-- prettier-ignore-start -->
+
+In an RPC (Remote Procedure Call), a client sends a request to run a function
+and any related arguments to a program located on another server. The remote
+server runs the task and sends back the response. The compiled code includes a
+stub that acts as a representative of the remote procedure code. The stub
+receives the request while the program is running and the procedure call has
+been issued. It forwards it to a client program in the local computer, while the
+initiating program waits until it receives a response.
+
+The RPC process works somewhat differently in LavinMQ. There is no stub
+available. The program will not stall if you use a non-blocking consumer.
+Instead, your client sends a message to the broker containing the reply-to
+header. The target server processes the request and sends data back to the
+server. Then, in regular pub/sub fashion, your consumer receives the
+response.
+
+### What is LavinMQ RPC?
+
+The reply-to header in LavinMQ lets you create applications that communicate
+with one another over a special form of RPC.
+
+### How does RPC work in LavinMQ?
+
+After a client sends the request to a server, the server gives a response
+message in return. The client sends a callback queue address with its request in
+order to receive a response. One queue receives the response while another
+consumer handles the reply.
+
+Another way to handle RPC in LavinMQ is by using direct reply-to, which
+passes a response directly to the client, avoiding having to create a response
+queue to wait on.
+
+### When to Use RPC in LavinMQ?
+
+RPC using the LavinMQ direct reply-to header allows you to create responsive
+applications since you can perform tasks remotely from your mobile and desktop
+applications.
+
+## LavinMQ RPC
+
+There are different RPC options in LavinMQ. One is to let the client send a
+request message and let a server reply with a response message, sent into a
+specified queue. This queue is called a callback or response queue. The name of
+this queue must be sent as an address in the request message sent from the
+client:
+
+{% highlight python %}
+channel.basic_publish(
+  exchange='',
+  routing_key='rpc_queue',
+  properties=pika.BasicProperties(
+    reply_to = response_queue,
+  ),
+  body=request
+)
+{% endhighlight %}
+
+In the code shown above is a callback queue added for every RPC request, which
+might be confusing since it's not clear to which request the response belongs.
+A `correlation_id` (a unique value) can therefore be sent with every request.
+
+![]()
+
+{% highlight python %}
+channel.basic_publish(
+  exchange='',
+  routing_key='rpc_queue',
+  properties=pika.BasicProperties(
+    reply_to = response_queue,
+    correlation_id = correlation_id
+  ),
+  body=request
+)
+{% endhighlight %}
+
+Workflow of RPC callback queues in LavinMQ:
+
+- The client creates an exclusive callback_queue.
+- The client sends a message containing the reply queue, the callback queue
+  along with the correlation_id. The value of the correlation_id is set to a
+  unique value at every request.
+- Next, the request is sent to `rpc_queue`.
+- The RPC worker/consumer, i.e. the remote server, is waiting for requests on
+  that queue (rpc_queue) and handles the request once received.
+- The result is sent back to the broker by the remote server using the `reply_to`
+  field to know which queue it belongs in. The response goes to the response_queue.
+- The callback queue is where the client/consumer waits for data.
+
+{% highlight python %}
+callback_queue = channel.queue_declare(queue='', exclusive=True)
+
+channel.basic_publish(
+  exchange='',
+  routing_key='rpc_queue',
+  properties=pika.BasicProperties(
+    reply_to = callback_queue,
+    correlation_id = correlation_id
+  ),
+  body=request
+)
+{% endhighlight %}
+
+As mentioned earlier, you can also handle RPC in LavinMQ by using direct reply-to.
+
+## What is Direct Reply-to?
+
+LavinMQ allows you to pass a response directly to the client, avoiding
+creating a response queue to wait on. To do so, set `reply-to`
+to `amq.direct.reply-to`. Send a message in `no-ack` mode. LavinMQ
+generates a special name that the target server sees as the routing key. The
+remote machine then publishes the result to the default exchange. No queue is
+created in the process. A direct reply allows you to avoid maintaining a
+long-lived queue. It also lets you avoid creating short-lived queues that
+utilize memory.
+
+### Using Direct Reply-to in LavinMQ
+
+To use the direct reply feature, use the reply-to header with the
+`amq.direct.reply-to` queue. In this RPC example, we send a simple ping
+request to a remote machine.
+
+Start by consuming from the `amq.direct.reply-to` queue on your client to
+avoid missing the response:
+
+{% highlight python %}
+def client_consumer_callback(ch, method, properties, body):
+  msg = body.decode('utf-8')
+
+  if msg in "Hello from Consumer":
+    print("TARGET MACHINE IS ACTIVE")
+    global RECEIVED_HELLO
+    RECEIVED_HELLO = True
+  else:
+    print("RECEIVED UNEXPECTED MESSAGE")
+    ch.close()
+    channel.consume("amq.direct.reply-to", on_message_callback=client_consumer_callback)
+{% endhighlight %}
+
+The consumer checks that the response message contains a greeting from the
+server.
+
+Next, create another consumer to mimic a remote computer:
+
+{% highlight python %}
+def consumer_callback(ch, method, properties, body):
+  msg = body.decode('utf-8')
+
+  if msg in "Hello World":
+    basic_props = BasicProperties()
+    ch.basic_publish(exchange='', routing_key=properties.reply_to, properties=basic_props, body="Hello from Consumer")
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+  else:
+    print("RECEIVED UNEXPECTED MESSAGE")
+    channel.consume("amq.direct.reply-to", on_message_callback=consumer_callback)
+{% endhighlight %}
+
+This consumer receives the request, checks that the message contains Hello World, and sends back the greeting. Notice that both consumers subscribe to amq.direct.reply-to.
+
+Finally, send a message to the queue using the `reply-to` header:
+
+{% highlight python %}
+basic_props = BasicProperties(
+    reply_to="amq.direct.reply-to"
+)
+
+channel.basic_publish(
+    exchange='',
+    routing_key='',
+    properties=basic_props,
+    body="Hello World"
+)
+{% endhighlight %}
+
+You can use this method to fetch data or perform tasks such as registering users
+on a mobile application. We created a simple health check.
+
+RPC differs somewhat from the traditional publisher-subscriber model LavinMQ
+is known for. No queues are created and the process sends information directly
+to the client using a direct reply.
+
+When using RPC this way:
+
+- Try to establish a connection to the client using the generated name on a
+  disposal channel to see if the client still exists
+- Set the immediate flag to false when publishing
+- Start consuming from the amq.lavinmq.reply-to before publishing your
+  message
+- Set the mandatory flag if using amq.lavinmq.reply-to to create error logs
+- Do not set the mandatory flag when using a direct-reply if using
+  `amq.lavinmq.reply-to.*` as your queue
+
+These tips allow you to know when something goes wrong. They also help you
+handle issues without losing messages.
+
+---
+
+**NOTE:**
+LavinMQ supports the use of `amq.rabbitmq.reply-to` to allow for compatibility with other brokers.
+
+---
+
+## Wrap up
+
+In conclusion, LavinMQ provides efficient support for Remote Procedure Calls (RPC), allowing applications to communicate with one another seamlessly. Unlike traditional RPC systems that use stubs, LavinMQ simplifies the process by eliminating the need for stubs and providing alternative mechanisms for RPC.
+
+When using LavinMQ for RPC, clients can send requests to servers, and the servers respond with the desired data or results. The reply-to header plays a crucial role in this process, enabling clients to specify where they expect the response. The response can be received through a callback queue or, alternatively, by utilizing the direct reply-to feature. Direct reply-to streamlines the process by directly passing the response to the client, eliminating the need for maintaining long-lived or short-lived queues.
+
+<!-- prettier-ignore-end -->

--- a/docs/shovel.md
+++ b/docs/shovel.md
@@ -1,0 +1,213 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is a shovel?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          A shovel is a mechanism in LavinMQ used to transfer messages from one broker to another, such as between different servers. It can be configured to move messages between the following:
+        </p>
+        <ul>
+          <li>One exchange to another exchange</li>
+          <li>One exchange to a queue</li>
+          <li>One queue to an exchange</li>
+          <li>One queue to another queue</li>
+        </ul>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        How does a shovel work?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>
+        A shovel connects to the source and destination, authenticates, then consumes and republishes messages. If a failure occurs, it automatically retries.
+      </p>
+    </div>
+  </div>
+</div>
+
+<!-- prettier-ignore-start -->
+
+A shovel can be created and managed through the LavinMQ [HTTP API](https://docs.lavinmq.com/docs/#/operations/GetShovels) or the LavinMQ management console.
+
+## API
+
+To create a shovel using the LavinMQ API, send a `POST` request to the `/api/parameters/shovel/` endpoint with the required configuration.
+
+**Example:** API - create a shovel
+
+```python
+POST http://<rabbitmq-server>/api/parameters/shovel/<vhost>/<shovel-name>
+```
+
+**Example:** Payload
+
+```json
+{
+  "component": "shovel",
+  "name": "my_shovel",
+  "value": {
+    "src-uri": "amqp://source-server",
+    "src-type": "queue", // Source type (queue or exchange)
+    "src-queue": "source-queue", // Source queue name (use src-exchange for exchanges)
+    "dest-uri": "amqp://destination-server",
+    "dest-type": "queue", // Destination type (queue or exchange)
+    "dest-queue": "destination-queue",
+    "ack-mode": "on-confirm"
+  }
+}
+```
+
+In this example:
+
+- The shovel moves messages from the `source-queue` on the source server to the `destination-queue` on the destination server.
+- `src-type` and `dest-type` define the type of the source and destination: either queue or exchange.
+  - If `src-type` is queue, use `src-queue` to specify the source queue.
+  - If `src-type` is exchange, use `src-exchange` to specify the source exchange.
+  - Similarly, for the `dest-type`, if it's queue, use `dest-queue`; if it's exchange, use `dest-exchange`.
+- The `ack-mode`is set to`on-confirm`, ensuring messages are acknowledged once they are confirmed by the destination.
+- The `prefetch-count` is set to `100`, controlling how many messages can be prefetched at once before acknowledging them.
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-[#414040] conf-table">
+      <tr>
+        <td class="font-semibold">Virtual host</td>
+        <td>
+          Any vhost chosen
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Name (shovel-name)</td>
+        <td>
+          The name of the shovel
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+Full API documentation can be found in the HTTP API for [parameters for components](https://docs.lavinmq.com/docs/#/operations/GetShovels) and [main](https://docs.lavinmq.com/docs/#/operations/GetShovels).
+
+### Source
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-[#414040] conf-table">
+      <tr>
+        <td class="font-semibold">URI (src-uri)</td>
+        <td>
+          The URI for the source server (e.g., <code>amqp://source-server</code>).
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Type (src-type)</td>
+        <td>
+          Select whether the source is a “queue” or an “exchange”.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Endpoint queue (src-queue)</td>
+        <td>
+          Source queue
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Endpoint exchange (src-exchange)</td>
+        <td>
+          This can be used instead of <code>src-queue</code> if source type is "exchange”.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Prefetch (prefetch-count)</td>
+        <td>
+          How many messages to be prefetched.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Auto delete (auto-delete)</td>
+        <td>
+          When enabled, the shovel will transfer all messages from the queue and delete itself once done. If set to <code>false</code>, it will persist until explicitly removed.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Routing key (dest-routing-key)</td>
+        <td>
+          The routing key is only needed when shoveling messages to an exchange and controlling the routing.
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+### Destination
+
+<div class="bg-[#181818] border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+    <table class="divide-y divide-[#414040] conf-table">
+      <tr>
+        <td class="font-semibold">URI (dest-uri)</td>
+        <td>
+          The URI for the destination server (e.g., <code>amqp://destination-server</code>).
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Type (dest-type)</td>
+        <td>
+          Select whether the destination is a “queue” or an “exchange”.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Endpoint queue (dest-queue)</td>
+        <td>
+          Destination queue
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Endpoint exchange (dest-exchange)</td>
+        <td>
+          This can be used instead of dest-queue if destination type is "exchange”.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Reconnect delay (reconnect-delay)</td>
+        <td>
+          Delay in seconds before attempting to reconnect in case of failure.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-semibold">Ack mode (ack-mode)</td>
+        <td>
+          Set the acknowledgment mode (e.g., <code>on-confirm</code> or <code>none</code>).
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+#### Webhooks as a destination
+
+LavinMQ shovels also support setting an HTTP target as the destination (`dest-uri`). This functionality, called webhooks, allows messages to be forwarded to an HTTP endpoint instead of another AMQP broker. This is particularly useful for integrating with external systems or services that expose HTTP APIs.
+
+For more details on webhooks, refer to the [webhooks documentation](/documentation/webhooks).
+
+### Pausing a shovel
+
+To pause a shovel, you can use the LavinMQ management console or the API.
+
+To pause a shovel using the API, send a `PUT` request to the `/api/shovel/<vhost>/<shovel-name>/pause` endpoint.
+
+**Example:** API - pause a shovel
+
+```python
+PUT http://<rabbitmq-server>/api/shovel/<vhost>/<shovel-name>/pause
+```
+
+<!-- prettier-ignore-end -->

--- a/docs/shovel.md
+++ b/docs/shovel.md
@@ -196,7 +196,7 @@ Full API documentation can be found in the HTTP API for [parameters for componen
 
 LavinMQ shovels also support setting an HTTP target as the destination (`dest-uri`). This functionality, called webhooks, allows messages to be forwarded to an HTTP endpoint instead of another AMQP broker. This is particularly useful for integrating with external systems or services that expose HTTP APIs.
 
-For more details on webhooks, refer to the [webhooks documentation](/documentation/webhooks).
+For more details on webhooks, refer to the [webhooks documentation](webhooks.md).
 
 ### Pausing a shovel
 

--- a/docs/single-active-consumer.md
+++ b/docs/single-active-consumer.md
@@ -1,0 +1,97 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What is the Single Active Consumer?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>A Single Active Consumer permits only one consumer to process messages from a specific queue. If the active consumer becomes unavailable, the queue automatically fails to the next available consumer.</p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        What benefits does the Single Active Consumer have?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <ul>
+        <li>Guarantees that messages are processed in the exact order they arrive in the queue.</li>
+        <li>Ensures a single consumer executes a task at a time.</li>
+        <li>Eliminates conflicts from multiple consumers processing the same message.</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect3" id="accordion3">
+        When to use a Single Active Consumer?
+      </button>
+    </h3>
+    <div id="sect3" class="accordion-content" role="region" aria-labelledby="accordion3">
+      <ul>
+        <li>Maintaining event order is critical (e.g., when processing ticket requests).</li>
+        <li>Preventing conflicts from parallel processing is necessary.</li>
+        <li>Tasks require exclusive, sequential execution.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+Single Active Consumer can be enabled when declaring a queue, with the **`x-single-active-consumer`** argument set to `True`.
+
+<!-- prettier-ignore-start -->
+
+**Example:** Declaring a queue with a single active consumer
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+channel.queue_declare(
+    queue="sac",
+    durable=True,
+    arguments={"x-single-active-consumer":True}
+)
+
+connection.close()
+```
+
+For a queue with single active consumer enabled, registering consumers results in the following:
+
+- The first consumer registered with the queue becomes the *single active consumer*.
+- If the active consumer becomes unavailable, the queue selects the next consumer from the pool in connection order.
+
+### Consumer Exclusivity vs Single Active Consumer
+
+A Single Active Consumer is not the only way to ensure that a single consumer processes messages from a queue. Consumer Exclusivity offers an alternative. It assigns one consumer as the sole processor for a specific queue, ensuring only one consumer handles messages. However, if the exclusive consumer disconnects or stops, the application must register a new consumer to continue processing—unlike the Single Active Consumer, which automatically fails over to the next available consumer.
+
+**Example:** Consumer exclusivity
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+		print(f"[✅]  { msg }")
+		ch.basic_ack(delivery_tag=method.delivery_tag)
+
+channel.basic_consume(
+    "ex_queue",
+    callback,
+    auto_ack=False,
+    exclusive**=**True
+
+)
+connection.close()
+
+```
+<!-- prettier-ignore-end -->

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -84,9 +84,9 @@ connection.close()
 
 In addition to the **`x-queue-type`** argument, Streams support three additional queue arguments that can be specified at queue declaration or via a policy.
 
-- **`x-max-length`** - Sets the maximum number of messages allowed in the stream at any given time. See [**retention**](/documentation/streams#data-retention). Default: not set.
-- **`x-max-length-bytes`** - Sets the maximum size of the Stream in bytes. See [**retention**](/documentation/streams#data-retention). Default: not set.
-- **`x-max-age`** - This argument will control how long a message survives in a LavinMQ Stream. The unit of this configuration could either be in years (Y), months (M), days (D), hours (h), minutes (m), or seconds (s). See [**retention**](/documentation/streams#data-retention). Default: not set.
+- **`x-max-length`** - Sets the maximum number of messages allowed in the stream at any given time. See [**retention**](streams.md#data-retention). Default: not set.
+- **`x-max-length-bytes`** - Sets the maximum size of the Stream in bytes. See [**retention**](streams.md#data-retention). Default: not set.
+- **`x-max-age`** - This argument will control how long a message survives in a LavinMQ Stream. The unit of this configuration could either be in years (Y), months (M), days (D), hours (h), minutes (m), or seconds (s). See [**retention**](streams.md#data-retention). Default: not set.
 
 ### 3. Consuming from the stream
 
@@ -163,7 +163,7 @@ connection.close()
 
 Offsets in Streams serve a similar purpose as indexes in arrays. To start reading from a specific index in a Stream, simply specify an offset in the consumer query. Essentially, every message in a Stream has an offset. For instance, the following image illustrates how messages and their corresponding offsets would appear in a given Stream:
 
-![Streams](/img/docs/lavinmq-streams-offsets.png)
+![Streams](img/docs/lavinmq-streams-offsets.png)
 
 ## Data retention
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -1,0 +1,427 @@
+
+<div class="accordion">
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect1" id="accordion1">
+        What are LavinMQ Streams?
+      </button>
+    </h3>
+    <div id="sect1" class="accordion-content" role="region" aria-labelledby="accordion1">
+        <p>
+          LavinMQ Streams buffer messages from producers for consumers, like traditional queues. However, unlike queues, streams are immutable; messages can't be erased; they can only be read. While retention settings offer some control, Streams are designed for long-term message storage. This allows consumers to subscribe and read the same message multiple times.
+        </p>
+    </div>
+  </div>
+
+  <div class="accordion-item">
+    <h3>
+      <button class="accordion-header" aria-expanded="false" aria-controls="sect2" id="accordion2">
+        When to use LavinMQ Streams?
+      </button>
+    </h3>
+    <div id="sect2" class="accordion-content" role="region" aria-labelledby="accordion2">
+      <p>Streams are great for:</p>
+      <ul>
+        <li><strong>Fan-out architectures:</strong> Where many consumers need to read the same message. Implementing a fan-out arrangement with LavinMQ Streams is remarkably straightforward. Merely declare a Stream and bind as many consumers as required.
+        </li>
+        <li><strong>Replay & time-travel:</strong> Where consumers need to re-read the same message or start reading from any point in the Stream.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- prettier-ignore-start -->
+
+Client applications could talk to a Stream via an AMQP client library, just as they do with queues. Like queues, there are three steps to working with LavinMQ Streams:
+
+1. Declare a Stream
+2. Publish messages to the Stream
+3. Consume messages from the Stream
+
+### 1. Declaring a stream
+
+Streams are declared with the AMQP client libraries the same way queues are created. Set the **`x-queue-type`** queue argument to **`stream`**, and provide this argument at declaration time. Also make sure to declare the Stream with **`durable=true`** . LavinMQ does not allow the creation of non-durable Streams.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+channel.queue_declare(
+    queue='test_stream',
+    durable=True,
+    arguments={"x-queue-type": "stream"}
+)
+
+connection.close()
+```
+
+### 2. Publishing to the stream
+
+As an example, below, the previous snippet has been extended to publish a message to the **`test_stream`** declared.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+channel.queue_declare(
+    queue="test_stream",
+    durable=True,
+    arguments={"x-queue-type": "stream"}
+)
+
+channel.basic_publish(
+	exchange="", # Use the default exchange
+	routing_key="test_stream",
+	body="Hello World"
+)
+
+connection.close()
+```
+
+In addition to the **`x-queue-type`** argument, Streams support three additional queue arguments that can be specified at queue declaration or via a policy.
+
+- **`x-max-length`** - Sets the maximum number of messages allowed in the stream at any given time. See [**retention**](/documentation/streams#data-retention). Default: not set.
+- **`x-max-length-bytes`** - Sets the maximum size of the Stream in bytes. See [**retention**](/documentation/streams#data-retention). Default: not set.
+- **`x-max-age`** - This argument will control how long a message survives in a LavinMQ Stream. The unit of this configuration could either be in years (Y), months (M), days (D), hours (h), minutes (m), or seconds (s). See [**retention**](/documentation/streams#data-retention). Default: not set.
+
+### 3. Consuming from the stream
+
+Three key things to note about consuming messages from a Stream queue:
+
+- An offset can be specified to start reading from any point in the Stream.
+- Consuming messages in LavinMQ Streams requires setting the QoS prefetch.
+- LavinMQ does not allow consuming messages from a Stream with **`auto_ack=True`**
+
+As mentioned, when consuming from a Stream , clients have the ability to specify a starting point by using an offset. The **`x-stream-offset`** consumer argument controls this behaviour.
+
+LavinMQ supports the following offset values:
+
+- **`first`**: This starts reading from the beginning of the Stream, **`offset 1`**.
+- **`last`**: This starts reading from the beginning of the last segment file.
+- **`next`**: Initiates reading from the latest offset once the consumer is initiated - essentially, the **`next`** offset won’t attempt to read all the messages present in the Stream prior to the consumer’s activation.
+- **A specific numerical offset value**: Clients can specify an exact offset to attach to the log. If the specified offset does not exist, it will be adjusted to either the start or end of the log accordingly.
+- **Timestamp:** This value represents a specific point in time to attach to the log.
+
+**Note:** Connecting a consumer to a Stream that already contains messages, without specifying an offset, will configure the consumer to read from beginning of the stream.
+
+**Example**: Sets the consumers prefetch to 100 and reads from the **`test_stream`** via two approaches:
+
+- Reading from the 5000th offset
+- Reading from the first message in the Stream.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+		print(f"[✅]  { msg }")
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+channel.basic_qos(prefetch_count=100)
+
+# Reading from the beginning of the Stream.
+channel.basic_consume(
+    "test_stream",
+    callback,
+    auto_ack=False,
+    arguments={"x-stream-offset": 1}
+)
+connection.close()
+```
+
+<div class="my-6"></div>
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+		print(f"[✅]  { msg }")
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+channel.basic_qos(prefetch_count=100)
+
+# Reading from the 5000th offset
+channel.basic_consume(
+    "test_stream",
+    callback,
+    auto_ack=False,
+    arguments={"x-stream-offset": 5000}
+)
+connection.close()
+```
+
+## Offsets
+
+Offsets in Streams serve a similar purpose as indexes in arrays. To start reading from a specific index in a Stream, simply specify an offset in the consumer query. Essentially, every message in a Stream has an offset. For instance, the following image illustrates how messages and their corresponding offsets would appear in a given Stream:
+
+![Streams](/img/docs/lavinmq-streams-offsets.png)
+
+## Data retention
+
+A stream can be configured to discard old messages using data retention settings. Retention settings allow a Stream to automatically remove messages once they exceed a specified size or age.
+
+Message truncation involves deleting an entire segment file. Instead of storing messages in a single large file, LavinMQ uses smaller 8MB files called segment files. When truncation occurs, a segment file and all its messages are deleted.
+
+**Note:** Retention is evaluated per segment. A Stream applies retention limits only when an existing segment file reaches its maximum size (default: 8MB) and is closed in favour of a new one.
+
+A Stream’s retention strategy can be configured using a **size-based**, **time-based**, or combined approach.
+
+### Size-based retention strategy
+
+Here, the Stream is set up to discard segment files once the total size or number of messages in the Stream reaches a specified upper limit. Setting up the sized-based retention strategy requires providing any of the following arguments when declaring the Stream:
+
+- **`x-max-length-bytes`**
+- **`x-max-length`**
+
+Example: Setting stream capacity to one thousand messages.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+channel.queue_declare(
+    queue='test_stream',
+    durable=True,
+    arguments={"x-queue-type": "stream", "x-max-length": 1000}
+)
+
+connection.close()
+```
+
+In the example above, if the Stream reaches the 1000 message limit, old segment files are deleted until the limit is met.
+
+### Time-based retention strategy
+
+The Stream truncates segment files exceeding a set age. To enable time-based retention, specify **`x-max-age`** when declaring the Stream or via policy.
+
+Units: years (Y), months (M), days (D), hours (h), minutes (m), or seconds (s).
+
+**Example**: Expire messages that have been in the queue longer than 30 days
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+channel.queue_declare(
+    queue='test_stream',
+    durable=True,
+    arguments={"x-queue-type": "stream", "x-max-age": "30D"}
+)
+
+connection.close()
+```
+
+The snippet demonstrates a time-based retention strategy, where segment files older than 30 days are discarded.
+
+### Automatic offset tracking
+
+When consuming from a stream, it is possible to configure LavinMQ to handle tracking of offsets. Offset tracking helps a consumer remember where it left off in a stream.
+
+For example, if a consumer has processed messages up to position 5000, that means it has successfully handled everything before that point. If it stops and later comes back online, it can resume from position 5001 instead of starting over.
+
+**How it works**
+
+Offset tracking can be enabled in two ways:
+
+1. By setting **`x-stream-offset = null`** .
+2. Or by setting **`x-stream-automatic-offset-tracking = true`**.
+
+In both cases, setting the  **`consumer tag`**  is _required_.
+
+When setting **`x-stream-offset = null`**, the consumer will start reading the stream from the beginning at first connection. At a later reconnect the consumer will resume from where it left off automatically.
+
+It is also possible to combine the automatic tracking with all possible **`x-stream-offset`** values by providing both a valid **`x-stream-offset`** and setting **`x-stream-automatic-offset-tracking = true`**. In this case, the consumer will start reading the stream from the provided **`x-stream-offset`** at first connection. At a later reconnect the consumer will resume from where it left off automatically.
+
+**Important:** When a message is acknowledged, the tracked offset is set to the offset of the **latest message delivered** to the consumer, not the offset of the specific message being acknowledged. To avoid skipping messages, consumers using automatic offset tracking should process messages **sequentially with a prefetch (QoS) of 1**. If the consumer disconnects after receiving multiple prefetched messages but before acknowledging all of them, the unacknowledged messages will be skipped upon reconnection.
+
+For use cases requiring parallel processing or higher prefetch values, manage offsets manually using the `x-stream-offset` consumer argument instead.
+
+The snippet below shows a consumer script with **`x-stream-automatic-offset-tracking`** set to **`true`** and consumer **`tag`** set to **`test-consumer`**.
+
+```python
+import pika
+
+connection = pika.BlockingConnection(pika.URLParameters('host-url'))
+channel = connection.channel()
+
+def callback(ch, method, properties, msg):
+    print(f"[✅]  { msg }")
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+channel.basic_qos(prefetch_count=1)
+
+channel.basic_consume(
+    "test_stream",
+    callback,
+    auto_ack=False,
+    consumer_tag="**test-consumer"**
+    arguments={"x-stream-automatic-offset-tracking": true}
+)
+
+connection.close()
+```
+
+Server side tracking can be disabled at any point by reconnecting the consumer and providing a valid value for **`x-stream-offset`** (and not providing **`x-stream-automatic-offset-tracking`**).
+
+### Stream filtering
+
+LavinMQ Streams support server-side filtering, allowing consumers to receive only the messages they need without scanning the entire stream. This reduces network usage and improves efficiency, making it easier to work with specific data.
+
+**How it works**
+
+When publishing messages to a stream, you can add filter values in several ways:
+
+1. By setting the **`x-stream-filter-value`** header on the message
+2. By using any other message header as a filter criterion
+
+When consuming from a stream, you can filter messages by providing the **`x-stream-filter`** argument. This filter can be:
+
+- A string (comma-separated values)
+- An `AMQP::Table` of filter key-value pairs
+- An array combination of the above options
+
+For example, to publish a message with filter values:
+
+```python
+# Publishing with x-stream-filter-value header
+properties = pika.BasicProperties(
+    headers={"x-stream-filter-value": "application1,info"}
+)
+channel.basic_publish(exchange="", routing_key="test_stream", properties=properties, body="Hello World")
+
+# Publishing with custom headers that can be filtered against
+properties = pika.BasicProperties(
+    headers={"log_level": "error", "service": "payment-api"}
+)
+channel.basic_publish(exchange="", routing_key="test_stream", properties=properties, body="Hello World")
+```
+
+Consuming messages with filters: 
+```python
+channel.basic_consume(
+    "test_stream",
+    callback,
+    auto_ack=False,
+    arguments={"x-stream-filter": "application1,info"}
+)
+```
+
+When consuming, you can filter in multiple ways:
+
+```python
+# Filtering by x-stream-filter header values
+arguments = {"x-stream-filter": "application1,info"}
+
+# Filtering by specific header fields
+arguments = {"x-stream-filter": {"log_level": "error", "service": "payment-api"}}
+
+# To receive messages without a specific filter
+arguments = {"x-stream-match-unfiltered": True}
+```
+
+You can also control how multiple filters are matched by setting the **`x-filter-match-type`** argument:
+- **`all`** (default): Message must match all provided filters
+- **`any`**: Message must match at least one provided filter
+
+```python
+# Message must match either log_level OR service
+arguments = {
+    "x-stream-filter": {
+        "log_level": "error",
+        "service": "payment-api",
+    },
+    "x-filter-match-type": "any"
+}
+```
+
+If no filter is provided when consuming, all messages in the stream are returned as if no filters existed.
+
+### Feature comparison with queues
+
+Due to their design and intended use cases, Streams lack some features found in normal queues.The table below compares queues vs streams.
+
+<div class="bg-[#181818] mt-6 border border-[#414040] text-[#FAFAFA] overflow-hidden">
+  <div style="overflow: auto;">
+		<table class="divide-y divide-gray-300 conf-table">
+			<thead>
+				<tr>
+					<th><span class="font-semibold">Features</span></th>
+					<th class="border-r border-[#414040]"><span class="font-semibold">Queue</span></th>
+          <th><span class="font-semibold">Stream</span></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Non-durability</td>
+					<td class="border-r border-[#414040]">Queues can be non-durable</td>
+          <td>A stream must be durable. <code>durable: false</code> will fail.</td>
+				</tr>
+        <tr>
+					<td>Exclusivity</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported</td>
+				</tr>
+        <tr>
+					<td>Consumer priority</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported. <code>x-priority</code> argument will fail.</td>
+				</tr>
+        <tr>
+					<td>Single Active Consumer</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported. <code>x-single-active-consumer</code> argument will fail.</td>
+				</tr>
+        <tr>
+					<td>Consumer acknowledgement</td>
+					<td class="border-r border-[#414040]">Not required</td>
+          <td>Consumers must acknowledge messages when reading from Streams. <code>noAck: true</code> will fail.</td>
+				</tr>
+        <tr>
+					<td>Dead Letter Exchange</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported. <code>x-dead-letter-exchange</code> argument will fail.</td>
+				</tr>
+        <tr>
+					<td>Per-message TTL</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported. <code>x-expires</code> will fail.</td>
+				</tr>
+        <tr>
+					<td>Delivery limit</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported. <code>x-delivery-limit</code> will fail.</td>
+				</tr>
+        <tr>
+					<td>Reject on overflow</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported. <code>x-overflow</code> will fail.</td>
+				</tr>
+        <tr>
+					<td>Channel Prefetch</td>
+					<td class="border-r border-[#414040]">Not required</td>
+          <td>A consumer must specify its channel prefetch.</td>
+				</tr>
+        <tr>
+					<td>Global Prefetch</td>
+					<td class="border-r border-[#414040]">Supported</td>
+          <td>Not supported</td>
+				</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- prettier-ignore-end -->

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,0 +1,232 @@
+
+<!-- prettier-ignore-start -->
+
+Even though publisher confirms and consumer acknowledgements offer some
+level of message persistence guarantee in LavinMQ, that guarante is not 100%.
+And beyond just reliable message persistence, publisher confirms are limited
+in some ways.
+
+This is true because:
+
+- When using publisher confirms in LavinMQ, the server acknowledges the producer 
+upon receiving the message and writing it to a file, but in a volatile way. So there
+is no guarantee that messages would survive a server crash or disk error.
+
+- In LavinMQ, consumer acknowledgements confirm successful message processing. 
+Once acknowledged, the message gets removed from the queue. However, if the 
+LavinMQ server crashes before receiving the acknowledgment, the processed message 
+remains in the queue and may be redelivered to the consumer - resulting in duplicate 
+processing.
+
+- Traditional message publishing in LavinMQ lacks a roll-back mechanism after 
+publishing. This limitation affects scenarios where you might need to trigger 
+a database update(for example) after message publishing and roll back the message 
+published if the update fails.
+
+Transactions in LavinMQ help mitigate the above listed challenges.
+
+## What are transactions?
+The concept of a transaction in LavinMQ is quite similar to a transaction in relational
+databases.
+
+Transactions in LavinMQ allow a producer to publish one or more messages in transaction 
+mode, then commit these messages to the server or roll back all the published messages. 
+Similarly, a consumer can send one or more acknowledgements in transaction mode then commit
+these acknowledements or roll back.
+
+In fact, you can even take this a step further and combine AMQP actions with other
+things. For example, you can publish one or more messages, trigger a database update
+or a network request to some API and only commit the publishes if the database
+update or the network request passes. If the request or database update fails then you
+roll-back.
+
+In transaction mode, published messages are temporarily sent to the server 
+but not saved until you perform a commit. Upon committing, the LavinMQ server 
+writes the messages to disk and returns a `commit-ok` to the client. Alternatively, 
+if you no longer wish to save the published messages on the server, you can opt 
+for a roll-back instead of a commit.
+
+## When can I use transactions?
+You can use transactions in LavinMQ in the following scenarios:
+
+- You can use transactions in scenarios where you want the highest possible
+persistence guarantee.
+
+- You can use transactions when publishing messages and making calls to 
+an external service to ensure that the messages are saved on the server only if 
+the external service call succeeds.
+
+## Usage
+To demonstrate working with transactions in LavinMQ we will consider
+a use case.
+
+Imagine a scenario where you want to publish some messages then trigger
+a database update. You only want the messages to be saved on the server
+only when the database update goes through.
+
+For the purpose of this tutorial we will not be doing an actual database
+update, we will just simulate it.
+
+To begin, create your AMQP connection and channel as you normally would.
+We are using Pika, the Python client.
+
+{% highlight python %}
+{% raw %}
+# transactions_producer.py
+
+import pika, os, random
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Access the CLOUDAMQP_URL environment variable and parse it (fallback to localhost)
+url = os.environ.get('CLOUDAMQP_URL', 'amqp://guest:guest@localhost:5672/%2f')
+
+# Create a connection
+params = pika.URLParameters(url)
+connection = pika.BlockingConnection(params)
+print("[✅] Connection over channel established")
+
+channel = connection.channel() # start a channel
+
+{% endraw %}
+{% endhighlight %}
+
+Next, we need to set the channel to use transaction mode with:
+`channel.tx_select()`
+
+Next, you declare your queue and publish messages as you normally would:
+
+{% highlight python %}
+{% raw %}
+channel.queue_declare(queue="transactions") # Declare a queue
+def send_to_queue(channel, routing_key, body):
+  channel.basic_publish(
+        exchange='',
+        routing_key=routing_key,
+        body=body
+  )
+  print(f"[📥] Message sent to queue #{body}")
+
+# Publish messages
+send_to_queue(
+    channel=channel, routing_key="transactions", body="Hello World"
+)
+send_to_queue(
+    channel=channel, routing_key="transactions", body="Hello World"
+)
+send_to_queue(
+    channel=channel, routing_key="transactions", body="Hello World"
+)
+{% endraw %}
+{% endhighlight %}
+
+Next, to simulate an update to a database, we will define a function that
+randonmly generates numbers between 0 - 10. If the generated number is even,
+then we say the database update went through and we commit the transaction.
+Otherwise we say the database update failed and we roll back the transaction.
+
+{% highlight python %}
+{% raw %}
+def db_update_successful():
+    num = random.randrange(0, 10)
+    
+    if num % 2 == 0:
+        print(f"[✅] Number: {num} - Database update PASSED, commiting the transaction...")
+        return True
+    
+    print(f"[❎] Number: {num} -  Database update FAILED, rolling back the transaction...")
+    return False
+  
+# Commit or roll back published messages based on the outcome of database update
+if db_update_successful():
+   channel.tx_commit()
+else:
+   channel.tx_rollback
+
+try:
+  connection.close()
+  print("[❎] Connection closed")
+except Exception as e:
+  print(f"Error: #{e}")
+{% endraw %}
+{% endhighlight %}
+
+### Putting everything together
+{% highlight python %}
+{% raw %}
+# transactions_producer.py
+
+import pika, os, random
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Access the CLOUDAMQP_URL environment variable and parse it (fallback to localhost)
+url = os.environ.get('CLOUDAMQP_URL', 'amqp://guest:guest@localhost:5672/%2f')
+
+# Create a connection
+params = pika.URLParameters(url)
+connection = pika.BlockingConnection(params)
+print("[✅] Connection over channel established")
+
+channel = connection.channel() # start a channel
+channel.tx_select() # start channel in transactions mode
+
+channel.queue_declare(queue="transactions") # Declare a queue
+def send_to_queue(channel, routing_key, body):
+  channel.basic_publish(
+        exchange='',
+        routing_key=routing_key,
+        body=body
+  )
+  print(f"[📥] Message sent to queue #{body}")
+
+# Publish messages
+send_to_queue(
+    channel=channel, routing_key="transactions", body="Hello World"
+)
+send_to_queue(
+    channel=channel, routing_key="transactions", body="Hello World"
+)
+send_to_queue(
+    channel=channel, routing_key="transactions", body="Hello World"
+)
+
+def db_update_successful():
+    num = random.randrange(0, 10)
+    
+    if num % 2 == 0:
+        print(f"[✅] Number: {num} - Database update PASSED, commiting the transaction...")
+        return True
+    
+    print(f"[❎] Number: {num} -  Database update FAILED, rolling back the transaction...")
+    return False
+  
+# Commit or roll back published messages based on outcome of data
+if db_update_successful():
+   channel.tx_commit()
+else:
+   channel.tx_rollback
+
+try:
+  connection.close()
+  print("[❎] Connection closed")
+except Exception as e:
+  print(f"Error: #{e}")
+  
+{% endraw %}
+{% endhighlight %}
+
+If you run the script above, published messages will only be saved
+on the server if the generated number is even - you can monitor this
+from the admin view.
+
+## Wrap up
+In conclusion, transactions in LavinMQ provide a powerful and flexible 
+solution for ensuring reliable message processing and data integrity. 
+Generally, transactions address challenges such as potential message loss 
+during server crashes, duplicate message processing, and the need for roll-back 
+mechanisms after publishing or sending acknowledgements to the server.
+
+<!-- prettier-ignore-end -->

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,7 +1,7 @@
 
 **Note:** It is hard to talk about webhooks in LavinMQ without referencing shovel.
 Thus, we highly recommend that you go through our
-[guide on shovel](/documentation/shovel) first, if you are not familiar with it,
+[guide on shovel](shovel.md) first, if you are not familiar with it,
 before going through this guide.
 
 Shovels in other brokers like RabbitMQ only allow moving messages between queues
@@ -34,10 +34,10 @@ destination as the HTTP endpoint capable of receiving POST requests.
 
 The image below demonstrates what this would look like:
 
-<img alt="LavinMQ Webhook" src="/img/docs/docs-dm/add-shovel-dm-2x.png" class="border border-[#414040]"/>
+<img alt="LavinMQ Webhook" src="img/docs/add-shovel-dm-2x.png" class="border border-[#414040]"/>
 
 If you are not familiar with what each field does in the image above,
-again, we encourage you to go through our [guide on shovel](/documentation/shovel).
+again, we encourage you to go through our [guide on shovel](shovel.md).
 
 In summary, we are trying to create a shovel named
 `webhookShovel`. The **source** section is where we specify the LavinMQ server

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,64 @@
+
+**Note:** It is hard to talk about webhooks in LavinMQ without referencing shovel.
+Thus, we highly recommend that you go through our
+[guide on shovel](/documentation/shovel) first, if you are not familiar with it,
+before going through this guide.
+
+Shovels in other brokers like RabbitMQ only allow moving messages between queues
+to queues, queues to exchanges(and vice-versa), and exchanges to exchanges.
+
+While LavinMQ supports that as well, it takes this a step further
+with webhooks.
+
+## What is a webhook?
+
+Generally speaking, a webhook allows different software services to
+instantly communicate and share data with each other. With a webhook,
+one application can send data in real-time to another application whenever
+something happens in the first application..
+
+Now, let's tie this to LavinMQ...
+
+In LavinMQ, the webhook feature enables your LavinMQ server to communicate
+with a HTTP server. More specifically, by configuring a webhook, you can
+set up LavinMQ to forward every published message from an exchange or a queue
+to a designated HTTP endpoint. It's almost like making
+a `HTTP POST` request from your LavinMQ server to a HTTP server for every
+new message received.
+
+## How does a webhook work in LavinMQ?
+
+To configure webhook in LavinMQ, simply create a "shovel" and specify the
+LavinMQ server, the source exchange/queue for grabbing messages, and the
+destination as the HTTP endpoint capable of receiving POST requests.
+
+The image below demonstrates what this would look like:
+
+<img alt="LavinMQ Webhook" src="/img/docs/docs-dm/add-shovel-dm-2x.png" class="border border-[#414040]"/>
+
+If you are not familiar with what each field does in the image above,
+again, we encourage you to go through our [guide on shovel](/documentation/shovel).
+
+In summary, we are trying to create a shovel named
+`webhookShovel`. The **source** section is where we specify the LavinMQ server
+and the specific queue or exchange where we want our shovel to grab messages from.
+
+In our case, we want our shovel to grab messages from the `webhook-queue`, that's
+declared in the LavinMQ server whose URL we specified in the URI field.
+
+Similarly, the **destination** section is where we specify the HTTP endpoint
+where we want messages forwarded to. The
+`Type` and `Endpoint` fields are automatically disabled once LavinMQ detects a valid
+HTTP URL.
+
+For your HTTP endpoint, you can grab a URL from [webhook.site](https://webhook.site/)
+and use it to test things out.
+
+## Wrap up
+
+While LavinMQ allows moving messages between queues and exchanges with shovels,
+it even takes this a step further with webhooks. With webhooks in LavinMQ, you can
+effortlessly configure your server to forward every published message from an exchange or a
+queue to a designated HTTP endpoint. This feature expands LavinMQ's capabilities beyond
+traditional brokers, enabling you to easily integrate and exchange data with
+non-amqp applications.


### PR DESCRIPTION
### WHAT is this pull request doing?
Move LavinMQ software documentation to this repository. 
Add documentation images to docs/img/docs/ with git LFS tracking via `.gitattributes`. Fix internal links between docs to use relative `.md` references and convert blog/tutorial reference links to full https://lavinmq.com URLs.


### HOW can this pull request be tested?

Preview the `.md` file