### PR TITLE
Handle 404 errors gracefully when viewing deleted entities in UI

### DIFF
--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -94,6 +94,7 @@ const prefetchHandler = () => {
 
 const prefetch = prefetchHandler()
 document.getElementById('ch-prefetch').appendChild(prefetch.el)
+let channelUpdateInterval = null
 function updateChannel () {
   HTTP.request('GET', channelUrl).then(item => {
     Chart.update(chart, item.message_stats)
@@ -118,7 +119,12 @@ function updateChannel () {
       chMode.replaceChildren(confirmSpan)
     }
     document.getElementById('ch-global-prefetch').textContent = Helpers.formatNumber(item.global_prefetch_count)
+  }).catch(e => {
+    if (e.status === 404) {
+      clearInterval(channelUpdateInterval)
+      DOM.showEntityNotFound('Channel', channel, 'channels')
+    }
   })
 }
 updateChannel()
-setInterval(updateChannel, 5000)
+channelUpdateInterval = setInterval(updateChannel, 5000)

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -14,6 +14,7 @@ document.title = `Connection ${connection} | LavinMQ`
 document.querySelector('#pagename-label').textContent = connection
 
 const connectionUrl = `api/connections/${connection}`
+let connectionUpdateInterval = null
 function updateConnection (all) {
   HTTP.request('GET', connectionUrl).then(item => {
     const stats = { send_details: item.send_oct_details, receive_details: item.recv_oct_details }
@@ -71,10 +72,15 @@ function updateConnection (all) {
         document.getElementById('channels-section').style.display = 'block'
       }
     }
+  }).catch(e => {
+    if (e.status === 404) {
+      clearInterval(connectionUpdateInterval)
+      DOM.showEntityNotFound('Connection', connection, 'connections')
+    }
   })
 }
 updateConnection(true)
-setInterval(updateConnection, 5000)
+connectionUpdateInterval = setInterval(updateConnection, 5000)
 const channelsDataSource = new UrlDataSource(connectionUrl + '/channels', { useQueryState: false })
 const tableOptions = {
   dataSource: channelsDataSource,

--- a/static/js/datasource.js
+++ b/static/js/datasource.js
@@ -151,11 +151,12 @@ class DataSource {
     }).catch(err => {
       this._enqueueReload()
       if (err.status === 401) { return }
-      if (err.message) {
-        this.emit('error', err.message)
-      } else {
-        this.emit('error', err)
+      if (err.status === 404) {
+        this.emit('not_found')
+        return
       }
+      const message = err.message || err.reason || String(err)
+      this.emit('error', message)
     })
   }
 

--- a/static/js/dom.js
+++ b/static/js/dom.js
@@ -70,9 +70,44 @@ const button = {
   }
 }
 
+/**
+ * Show a "not found" message when an entity has been deleted.
+ * Replaces the main page content with a friendly message and a link back to the list page.
+ * @param {string} entityType - The type of entity, e.g. "Exchange", "Queue", "Connection"
+ * @param {string} entityName - The name of the entity
+ * @param {string} listUrl - The URL to the list page, e.g. "exchanges", "queues"
+ */
+function showEntityNotFound (entityType, entityName, listUrl) {
+  const main = document.querySelector('main')
+  if (!main) return
+  main.textContent = ''
+  main.classList.add('main-grid')
+
+  const section = document.createElement('section')
+  section.classList.add('card', 'cols-12')
+
+  const heading = document.createElement('h2')
+  heading.textContent = `${entityType} not found`
+  section.appendChild(heading)
+
+  const message = document.createElement('p')
+  message.textContent = `The ${entityType.toLowerCase()} "${entityName}" no longer exists. It may have been deleted.`
+  message.style.margin = '1em 0'
+  section.appendChild(message)
+
+  const link = document.createElement('a')
+  link.href = listUrl
+  link.textContent = `Back to ${listUrl}`
+  link.classList.add('btn', 'btn-outlined')
+  section.appendChild(link)
+
+  main.appendChild(section)
+}
+
 export {
   jsonToText,
   parseJSON,
   toast,
-  button
+  button,
+  showEntityNotFound
 }

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -15,6 +15,7 @@ const chart = Chart.render('chart', 'msgs/s')
 document.title = exchange + ' | LavinMQ'
 
 const exchangeUrl = HTTP.url`api/exchanges/${vhost}/${exchange}`
+let exchangeUpdateInterval = null
 function updateExchange (all) {
   HTTP.request('GET', exchangeUrl).then(item => {
     Chart.update(chart, item.message_stats)
@@ -51,10 +52,15 @@ function updateExchange (all) {
         document.getElementById('e-policy').appendChild(policyLink)
       }
     }
+  }).catch(e => {
+    if (e.status === 404) {
+      clearInterval(exchangeUpdateInterval)
+      DOM.showEntityNotFound('Exchange', exchange, 'exchanges')
+    }
   })
 }
 updateExchange(true)
-setInterval(updateExchange, 5000)
+exchangeUpdateInterval = setInterval(updateExchange, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(exchangeUrl + '/bindings/source', { useQueryState: false }),

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -15,9 +15,9 @@ function request (method, path, options = {}) {
   return window.fetch(path, opts)
     .then(response => {
       if (!response.ok) {
-        const error = { status: response.status, reason: response.statusText, is_error: true }
+        const error = { status: response.status, reason: response.statusText, is_error: true, message: response.statusText }
         return response.json()
-          .then(json => { error.reason = json.reason; return error })
+          .then(json => { error.reason = json.reason; error.message = json.reason || error.message; return error })
           .finally(() => { standardErrorHandler(error) })
       } else { return response.json().catch(() => null) }
     })

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -89,6 +89,7 @@ function handleQueueState (state) {
 
 const chart = Chart.render('chart', 'msgs/s')
 const queueUrl = HTTP.url`api/queues/${vhost}/${queue}`
+let queueUpdateInterval = null
 function updateQueue (all) {
   HTTP.request('GET', queueUrl + '?consumer_list_length=' + consumerListLength)
     .then(item => {
@@ -154,10 +155,15 @@ function updateQueue (all) {
           qArgs.appendChild(div)
         }
       }
+    }).catch(e => {
+      if (e.status === 404) {
+        clearInterval(queueUpdateInterval)
+        DOM.showEntityNotFound('Queue', queue, 'queues')
+      }
     })
 }
 updateQueue(true)
-setInterval(updateQueue, 5000)
+queueUpdateInterval = setInterval(updateQueue, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(queueUrl + '/bindings', { useQueryState: false }),

--- a/static/js/stream.js
+++ b/static/js/stream.js
@@ -78,6 +78,7 @@ function handleQueueState (state) {
 
 const chart = Chart.render('chart', 'msgs/s')
 const queueUrl = HTTP.url`api/queues/${vhost}/${queue}`
+let streamUpdateInterval = null
 function updateQueue (all) {
   HTTP.request('GET', queueUrl + '?consumer_list_length=' + consumerListLength)
     .then(item => {
@@ -132,10 +133,15 @@ function updateQueue (all) {
           qArgs.appendChild(div)
         }
       }
+    }).catch(e => {
+      if (e.status === 404) {
+        clearInterval(streamUpdateInterval)
+        DOM.showEntityNotFound('Stream', queue, 'queues')
+      }
     })
 }
 updateQueue(true)
-setInterval(updateQueue, 5000)
+streamUpdateInterval = setInterval(updateQueue, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(queueUrl + '/bindings', { useQueryState: false }),

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -35,7 +35,10 @@ function renderTable (id, options = {}, renderRow) {
   dataSource.on('update', updateTable)
   dataSource.on('error', error => {
     console.log(error)
-    toggleDisplayError(id, 'Error fetching data: ' + error.detail)
+    toggleDisplayError(id, 'Error fetching data: ' + (error.detail || error))
+  })
+  dataSource.on('not_found', () => {
+    toggleDisplayError(id, 'This resource no longer exists. It may have been deleted.')
   })
   dataSource.reload()
 

--- a/static/js/user.js
+++ b/static/js/user.js
@@ -14,6 +14,10 @@ function updateUser () {
       document.getElementById('tags').textContent = item.tags
       document.getElementById('hasPassword').textContent = hasPassword
       tagHelper(item.tags)
+    }).catch(e => {
+      if (e.status === 404) {
+        DOM.showEntityNotFound('User', user, 'users')
+      }
     })
 }
 

--- a/static/js/vhost.js
+++ b/static/js/vhost.js
@@ -11,6 +11,10 @@ HTTP.request('GET', vhostUrl).then(item => {
   document.getElementById('messages_ready').textContent = item.messages_ready.toLocaleString()
   document.getElementById('messages_unacknowledged').textContent = item.messages_unacknowledged.toLocaleString()
   document.getElementById('messages_total').textContent = item.messages.toLocaleString()
+}).catch(e => {
+  if (e.status === 404) {
+    DOM.showEntityNotFound('Virtual host', vhost, 'vhosts')
+  }
 })
 
 function fetchLimits () {


### PR DESCRIPTION
## Summary

Fixes #889

When an entity (exchange, queue, connection, etc.) is deleted while its management UI detail page is open, the UI previously showed the unhelpful error "Something went wrong: Error fetching data: [object Object]". This PR makes the UI handle 404 responses gracefully:

- **Entity detail pages** now catch 404 errors, stop the periodic refresh interval, and replace the page content with a clear "not found" message and a link back to the entity list page
- **Table data sources** now emit a distinct `not_found` event on 404, which the table renders as a user-friendly message instead of the generic error
- **Error serialization** is fixed so error objects always have a `message` property (preventing `[object Object]` in string concatenation)

## Root cause

The error object created in `http.js` on non-OK responses had no `message` property. When the datasource caught this error and tried to emit it, the object was passed through to `toggleDisplayError()` which concatenated it into a string, producing `[object Object]`. Additionally, none of the entity detail pages (exchange.js, queue.js, etc.) had `.catch()` handlers for their periodic API fetch calls.

## Files changed

- `static/js/http.js` - Add `message` property to error objects
- `static/js/datasource.js` - Emit `not_found` event on 404; ensure error messages are always strings
- `static/js/table.js` - Handle `not_found` event; fix error display fallback
- `static/js/dom.js` - Add `showEntityNotFound()` helper function
- `static/js/exchange.js` - Handle 404 on entity fetch
- `static/js/queue.js` - Handle 404 on entity fetch
- `static/js/connection.js` - Handle 404 on entity fetch
- `static/js/channel.js` - Handle 404 on entity fetch
- `static/js/vhost.js` - Handle 404 on entity fetch
- `static/js/user.js` - Handle 404 on entity fetch
- `static/js/stream.js` - Handle 404 on entity fetch

## Test plan

- [ ] Open an exchange detail page, delete the exchange via AMQP, verify the UI shows "Exchange not found" with a link to the exchanges list
- [ ] Open a queue detail page, delete the queue, verify the UI shows "Queue not found" with a link to the queues list
- [ ] Verify the same behavior for connections, channels, vhosts, users, and streams
- [ ] Verify the bindings table on exchange/queue pages shows "This resource no longer exists" instead of `[object Object]`
- [ ] Verify normal (non-404) errors still display correctly
- [ ] Run `npx standard static/js` to verify linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)