### PR TITLE
Fix flaky config specs caused by STDERR.reopen

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -440,22 +440,11 @@ describe LavinMQ::Config do
         default_password = +pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+
       CONFIG
       end
-      stderr_file = File.tempfile("stderr")
-      old_stderr = STDERR.dup
-      file = File.open(stderr_file.path, "w")
-      begin
-        STDERR.reopen(file)
-        config = LavinMQ::Config.new
-        argv = ["-c", config_file.path]
-        config.parse(argv)
-      ensure
-        STDERR.reopen(old_stderr)
-        old_stderr.close
-        file.close
-      end
-      File.read(stderr_file.path).should match(/is deprecated/)
-    ensure
-      stderr_file.try &.delete
+      io = IO::Memory.new
+      config = LavinMQ::Config.new(io)
+      argv = ["-c", config_file.path]
+      config.parse(argv)
+      io.to_s.should match(/is deprecated/)
     end
 
     it "should log warning for cli options" do
@@ -464,22 +453,11 @@ describe LavinMQ::Config do
         [main]
       CONFIG
       end
-      stderr_file = File.tempfile("stderr")
-      old_stderr = STDERR.dup
-      file = File.open(stderr_file.path, "w")
-      begin
-        STDERR.reopen(file)
-        config = LavinMQ::Config.new
-        argv = ["-c", config_file.path, "--default-password", "8Yw8kj5HkhfRxQ/3kbTAO/nmgqGpkvMsGDbUWXA6+jTF3JP3"]
-        config.parse(argv)
-      ensure
-        STDERR.reopen(old_stderr)
-        old_stderr.close
-        file.close
-      end
-      File.read(stderr_file.path).should match(/is deprecated/)
-    ensure
-      stderr_file.try &.delete
+      io = IO::Memory.new
+      config = LavinMQ::Config.new(io)
+      argv = ["-c", config_file.path, "--default-password", "8Yw8kj5HkhfRxQ/3kbTAO/nmgqGpkvMsGDbUWXA6+jTF3JP3"]
+      config.parse(argv)
+      io.to_s.should match(/is deprecated/)
     end
 
     it "should forward ini option values to the new property" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -35,7 +35,7 @@ init_config
 # Allow creating custom config objects for specs
 module LavinMQ
   class Config
-    def initialize
+    def initialize(@io : IO = STDERR)
     end
 
     def self.instance=(instance)
@@ -231,13 +231,5 @@ class SpecExit < Exception
 
   def initialize(@code)
     super "Exiting with code #{@code}"
-  end
-end
-
-module LavinMQ
-  # Allow creating new Config object without using the singleton
-  class Config
-    def initialize
-    end
   end
 end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -14,12 +14,13 @@ module LavinMQ
     include Options
     @@instance : Config = self.new
     getter sni_manager : SNIManager = SNIManager.new
+    @io : IO = STDERR
 
     def self.instance : LavinMQ::Config
       @@instance
     end
 
-    private def initialize
+    private def initialize(@io : IO = STDERR)
     end
 
     # Parse configuration from environment, command line arguments and configuration file.
@@ -82,7 +83,10 @@ module LavinMQ
           %}
           # Create Option object with CLI args and a block that parses and stores the value
           # when the option is encountered during command line parsing
-          sections[:{{section_id}}][:options] << Option.new({{parser_arg.splat}}, {{cli_opt[:deprecated]}}) do |value|
+          sections[:{{section_id}}][:options] << Option.new({{parser_arg.splat}}) do |value|
+            {% if cli_opt[:deprecated] %}
+              @io.puts "WARNING: {{cli_opt[:deprecated].id}}"
+            {% end %}
             self.{{ivar.name.id}} = parse_value(value, {{value_parser}})
           end
         {% end %}
@@ -163,11 +167,11 @@ module LavinMQ
         when "http_tls_ca_cert"     then host.http_tls_ca_cert = v
         when "http_tls_keylog_file" then host.http_tls_keylog_file = v
         else
-          STDERR.puts "WARNING: Unrecognized configuration 'sni:#{hostname}/#{config}'"
+          @io.puts "WARNING: Unrecognized configuration 'sni:#{hostname}/#{config}'"
         end
       end
       if host.tls_cert.empty?
-        STDERR.puts "WARNING: SNI host '#{hostname}' missing required tls_cert"
+        @io.puts "WARNING: SNI host '#{hostname}' missing required tls_cert"
       else
         @sni_manager.add_host(host)
       end
@@ -200,15 +204,15 @@ module LavinMQ
         {% for var in ivars_in_section %}
          when "{{var[:ini_name]}}"
          {% if (deprecated = var[:deprecated]) %}
-           STDERR.puts "WARNING: Config {{var[:ini_name]}} is deprecated, use {{deprecated.id}} instead"
+           @io.puts "WARNING: Config {{var[:ini_name]}} is deprecated, use {{deprecated.id}} instead"
          {% end %}
          self.{{var[:var_name]}} = parse_value(v, {{var[:transform]}})
         {% end %}
      else
-       STDERR.puts "WARNING: Unknown setting '#{name}' in section [{{section.id}}]"
+       @io.puts "WARNING: Unknown setting '#{name}' in section [{{section.id}}]"
       end
     rescue ex
-      STDERR.puts "ERROR: Failed to handle value for '#{name}' in [{{section.id}}]: #{ex.message}"
+      @io.puts "ERROR: Failed to handle value for '#{name}' in [{{section.id}}]: #{ex.message}"
       abort
     end
   {% end %}
@@ -331,11 +335,11 @@ module LavinMQ
     struct Option
       include Comparable(Option)
 
-      def self.new(short_flag : String, long_flag : String, description : String, deprecation_warn_msg : String?, &block : Proc(String, Nil))
-        new(short_flag, long_flag, description, deprecation_warn_msg, block)
+      def self.new(short_flag : String, long_flag : String, description : String, &block : Proc(String, Nil))
+        new(short_flag, long_flag, description, block)
       end
 
-      protected def initialize(@short_flag : String, @long_flag : String, @description : String, @deprecation_warn_msg : String?, @set_value : Proc(String, Nil))
+      protected def initialize(@short_flag : String, @long_flag : String, @description : String, @set_value : Proc(String, Nil))
       end
 
       def <=>(other : Option)
@@ -362,9 +366,6 @@ module LavinMQ
 
       private def do_setup_parser(parser, *args)
         parser.on(*args) do |val|
-          if msg = @deprecation_warn_msg
-            STDERR.puts "WARNING: #{msg}"
-          end
           @set_value.call(val)
         end
       end


### PR DESCRIPTION
## Summary
- Add `@io` constructor param to `Config` (defaults to `STDERR`) and route all warning/error output through it
- Specs that verify warning text now pass `IO::Memory` instead of using `STDERR.reopen`
- Remove duplicate `Config.initialize` reopening in `spec_helper.cr`
- Simplify `Option` struct by removing `@deprecation_warn_msg` and `@io` fields

## Root cause
`STDERR.reopen` in the "log warning" specs corrupted Crystal's event loop fd registration for fd 2, causing intermittent `File not open for writing` errors in other config specs under `--order random`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)