### PR TITLE
fix: restore CLI opts removed in config rewrite

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -264,6 +264,9 @@ describe LavinMQ::Config do
       "--http-bind=172.16.0.1",
       "--http-port=15673",
       "--http-unix-path=/tmp/http.sock",
+      "--mqtt-bind=10.0.0.2",
+      "--mqtt-port=1884",
+      "--mqtts-port=8884",
       "--mqtt-unix-path=/tmp/mqtt.sock",
       "--https-port=15675",
       "--cert=/etc/ssl/cert.pem",
@@ -297,6 +300,9 @@ describe LavinMQ::Config do
     config.http_bind.should eq "172.16.0.1"
     config.http_port.should eq 15673
     config.http_unix_path.should eq "/tmp/http.sock"
+    config.mqtt_bind.should eq "10.0.0.2"
+    config.mqtt_port.should eq 1884
+    config.mqtts_port.should eq 8884
     config.mqtt_unix_path.should eq "/tmp/mqtt.sock"
     config.https_port.should eq 15675
     config.tls_cert_path.should eq "/etc/ssl/cert.pem"
@@ -399,6 +405,23 @@ describe LavinMQ::Config do
       ENV.delete("LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS")
       ENV.delete("LAVINMQ_CLUSTERING_PORT")
     end
+  end
+
+  it "accepts deprecated [http] section as alias for [mgmt]" do
+    config_file = File.tempfile do |file|
+      file.print <<-CONFIG
+        [main]
+        data_dir = /tmp/lavinmq-spec
+        [http]
+        port = 15699
+      CONFIG
+    end
+    io = IO::Memory.new
+    config = LavinMQ::Config.new(io)
+    argv = ["-c", config_file.path]
+    config.parse(argv)
+    config.http_port.should eq 15699
+    io.to_s.should match(/\[http\] is deprecated/)
   end
 
   it "will not parse ini sections that do not exist" do

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -116,6 +116,9 @@ module LavinMQ
         when {{section}}
           parse_section({{section}}, settings)
         {% end %}
+        when "http"
+          @io.puts "WARNING: Config section [http] is deprecated, use [mgmt] instead"
+          parse_section("mgmt", settings)
         when .starts_with?("sni:") then parse_sni(section[4..], settings)
         when "replication"
           abort("#{file}: [replication] is deprecated and replaced with [clustering], see the README for more information")

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -28,7 +28,7 @@ module LavinMQ
       @[CliOpt("-b BIND", "--bind=BIND", "IP address that both the AMQP and HTTP servers will listen on (default: 127.0.0.1)", ->parse_bind(String), section: "bindings")]
       property bind = "127.0.0.1"
 
-      @[CliOpt("-p PORT", "--port=PORT", "AMQP port to listen on (default: 5672)", section: "bindings")]
+      @[CliOpt("-p PORT", "--amqp-port=PORT", "AMQP port to listen on (default: 5672)", section: "bindings")]
       @[IniOpt(ini_name: port, section: "amqp")]
       @[EnvOpt("LAVINMQ_AMQP_PORT")]
       property amqp_port = 5672
@@ -54,12 +54,15 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_AMQPS_PORT")]
       property amqps_port = 5671
 
+      @[CliOpt("", "--mqtt-bind=BIND", "IP address that the MQTT server will listen on (default: 127.0.0.1)", section: "bindings")]
       @[IniOpt(ini_name: bind, section: "mqtt")]
       property mqtt_bind = "127.0.0.1"
 
+      @[CliOpt("", "--mqtt-port=PORT", "MQTT port to listen on (default: 1883)", section: "bindings")]
       @[IniOpt(ini_name: port, section: "mqtt")]
       property mqtt_port = 1883
 
+      @[CliOpt("", "--mqtts-port=PORT", "MQTTS port to listen on (default: 8883)", section: "bindings")]
       @[IniOpt(ini_name: tls_port, section: "mqtt")]
       property mqtts_port = 8883
 


### PR DESCRIPTION
## Summary
- Restore `--amqp-port`, `--mqtt-bind`, `--mqtt-port`, and `--mqtts-port` CLI flags unintentionally removed/renamed in #917
- Accept deprecated `[http]` INI section as alias for `[mgmt]` with deprecation warning
- Add spec coverage for restored flags and `[http]` section alias