### PR TITLE
Fix MQTT subscribe permission check logic

### DIFF
--- a/spec/mqtt/permissions_spec.cr
+++ b/spec/mqtt/permissions_spec.cr
@@ -38,6 +38,34 @@ module MqttSpecs
         end
       end
 
+      it "should block subscribe when user has write-only permissions" do
+        with_server do |server|
+          server.users.create("write_only", "pass")
+          server.users.add_permission("write_only", "/", /.*/, /^$/, /.*/) # config: .*, read: ^$, write: .*
+
+          with_client_io(server) do |io|
+            connect(io, username: "write_only", password: "pass".to_slice)
+            topic_filter = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+            subscribe(io, false, topic_filters: [topic_filter])
+            io.should be_closed
+          end
+        end
+      end
+
+      it "should block subscribe when user has read-only permissions" do
+        with_server do |server|
+          server.users.create("read_only", "pass")
+          server.users.add_permission("read_only", "/", /.*/, /.*/, /^$/) # config: .*, read: .*, write: ^$
+
+          with_client_io(server) do |io|
+            connect(io, username: "read_only", password: "pass".to_slice)
+            topic_filter = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+            subscribe(io, false, topic_filters: [topic_filter])
+            io.should be_closed
+          end
+        end
+      end
+
       it "should allow operations when user has full permissions" do
         with_server do |server|
           server.users.create("full_user", "pass")

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -164,7 +164,7 @@ module LavinMQ
 
       def recieve_subscribe(packet : MQTT::Subscribe)
         if Config.instance.mqtt_permission_check_enabled?
-          if !user.can_read?(@broker.vhost.name, EXCHANGE) && !user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
+          if !user.can_read?(@broker.vhost.name, EXCHANGE) || !user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
             close_socket
             return

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -164,7 +164,7 @@ module LavinMQ
 
       def recieve_subscribe(packet : MQTT::Subscribe)
         if Config.instance.mqtt_permission_check_enabled?
-          if !user.can_read?(@broker.vhost.name, EXCHANGE) || !user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
+          unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
             close_socket
             return


### PR DESCRIPTION
### WHAT is this pull request doing?
The subscribe permission check used `&&` instead of `||`, allowing users with only read or only write permissions to subscribe. Both permissions are required: read on the exchange (to consume messages) and write on the session queue (to route messages into it). This aligns with how RabbitMQ handles MQTT subscribe permissions.

### HOW can this pull request be tested?
Run added spec 
