### PR TITLE
Recognize IPv4-mapped IPv6 loopback addresses

### DIFF
--- a/spec/connection_info_spec.cr
+++ b/spec/connection_info_spec.cr
@@ -1,0 +1,40 @@
+require "./spec_helper"
+
+describe LavinMQ::ConnectionInfo::IPAddress do
+  describe "#loopback?" do
+    it "returns true for IPv4 loopback" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("127.0.0.1", 0))
+      addr.loopback?.should be_true
+    end
+
+    it "returns true for IPv4 loopback subnet" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("127.0.0.2", 0))
+      addr.loopback?.should be_true
+    end
+
+    it "returns true for IPv6 loopback" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::1", 0))
+      addr.loopback?.should be_true
+    end
+
+    it "returns true for IPv4-mapped IPv6 loopback" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::ffff:127.0.0.1", 0))
+      addr.loopback?.should be_true
+    end
+
+    it "returns false for non-loopback IPv4" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("192.168.1.1", 0))
+      addr.loopback?.should be_false
+    end
+
+    it "returns false for non-loopback IPv6" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::2", 0))
+      addr.loopback?.should be_false
+    end
+
+    it "returns false for non-loopback IPv4-mapped IPv6" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::ffff:192.168.1.1", 0))
+      addr.loopback?.should be_false
+    end
+  end
+end

--- a/spec/connection_info_spec.cr
+++ b/spec/connection_info_spec.cr
@@ -2,39 +2,9 @@ require "./spec_helper"
 
 describe LavinMQ::ConnectionInfo::IPAddress do
   describe "#loopback?" do
-    it "returns true for IPv4 loopback" do
-      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("127.0.0.1", 0))
-      addr.loopback?.should be_true
-    end
-
-    it "returns true for IPv4 loopback subnet" do
-      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("127.0.0.2", 0))
-      addr.loopback?.should be_true
-    end
-
-    it "returns true for IPv6 loopback" do
-      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::1", 0))
-      addr.loopback?.should be_true
-    end
-
-    it "returns true for IPv4-mapped IPv6 loopback" do
+    it "recognizes IPv4-mapped IPv6 loopback as loopback" do
       addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::ffff:127.0.0.1", 0))
       addr.loopback?.should be_true
-    end
-
-    it "returns false for non-loopback IPv4" do
-      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("192.168.1.1", 0))
-      addr.loopback?.should be_false
-    end
-
-    it "returns false for non-loopback IPv6" do
-      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::2", 0))
-      addr.loopback?.should be_false
-    end
-
-    it "returns false for non-loopback IPv4-mapped IPv6" do
-      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::ffff:192.168.1.1", 0))
-      addr.loopback?.should be_false
     end
   end
 end

--- a/src/lavinmq/connection_info.cr
+++ b/src/lavinmq/connection_info.cr
@@ -28,18 +28,16 @@ module LavinMQ
     struct IPAddress
       getter address : String
       getter port : UInt16
+      getter? loopback : Bool
 
       def initialize(ip_address : Socket::IPAddress)
         @address = ip_address.address
         @port = ip_address.port.to_u16!
+        @loopback = ip_address.loopback?
       end
 
       def to_s(io)
         io << @address << ':' << @port
-      end
-
-      def loopback?
-        @address == "::1" || @address.starts_with?("127.") || @address.starts_with?("::ffff:127.")
       end
     end
   end

--- a/src/lavinmq/connection_info.cr
+++ b/src/lavinmq/connection_info.cr
@@ -39,7 +39,7 @@ module LavinMQ
       end
 
       def loopback?
-        @address == "::1" || @address.starts_with? "127."
+        @address == "::1" || @address.starts_with?("127.") || @address.starts_with?("::ffff:127.")
       end
     end
   end


### PR DESCRIPTION
### WHAT is this pull request doing?

When the server binds to `::` on a dual-stack machine, IPv4 clients get peer addresses like `::ffff:127.0.0.1`. This was not recognized as loopback, causing `default_user_only_loopback` to reject the default user connecting from localhost over IPv4.

### HOW can this pull request be tested?

Specs