### PR TITLE
Fix: handle valueless boolean CLI flags at compile time

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -281,6 +281,8 @@ describe LavinMQ::Config do
       "--default-user=cliuser",
       "--default-user-only-loopback=false",
       "--no-data-dir-lock",
+      "--clustering",
+      "--raise-gc-warn",
       "--clustering-advertised-uri=lavinmq://test:5679",
       "--clustering-bind=0.0.0.0",
       "--clustering-etcd-endpoints=etcd1:2379,etcd2:2379",
@@ -317,6 +319,8 @@ describe LavinMQ::Config do
     config.default_user.should eq "cliuser"
     config.default_user_only_loopback?.should be_false
     config.data_dir_lock?.should be_false
+    config.clustering?.should be_true
+    config.raise_gc_warn?.should be_true
     config.clustering_advertised_uri.should eq "lavinmq://test:5679"
     config.clustering_bind.should eq "0.0.0.0"
     config.clustering_etcd_endpoints.should eq "etcd1:2379,etcd2:2379"

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -87,7 +87,11 @@ module LavinMQ
             {% if cli_opt[:deprecated] %}
               @io.puts "WARNING: {{cli_opt[:deprecated].id}}"
             {% end %}
-            self.{{ivar.name.id}} = parse_value(value, {{value_parser}})
+            {% if ivar.type.resolve == Bool && !cli_opt.args[1].includes?("=") %}
+              self.{{ivar.name.id}} = {{!cli_opt.args[1].starts_with?("--no-")}}
+            {% else %}
+              self.{{ivar.name.id}} = parse_value(value, {{value_parser}})
+            {% end %}
           end
         {% end %}
         sections.each do |_section_id, section|

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -87,11 +87,7 @@ module LavinMQ
             {% if cli_opt[:deprecated] %}
               @io.puts "WARNING: {{cli_opt[:deprecated].id}}"
             {% end %}
-            {% if ivar.type.resolve == Bool && !cli_opt.args[1].includes?("=") %}
-              self.{{ivar.name.id}} = {{!cli_opt.args[1].starts_with?("--no-")}}
-            {% else %}
-              self.{{ivar.name.id}} = parse_value(value, {{value_parser}})
-            {% end %}
+            self.{{ivar.name.id}} = parse_value(value, {{value_parser}})
           end
         {% end %}
         sections.each do |_section_id, section|

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -255,14 +255,14 @@ module LavinMQ
       @[IniOpt(section: "main", deprecated: "default_user_only_loopback")]
       property? guest_only_loopback : Bool = true
 
-      @[CliOpt("", "--no-data-dir-lock", "Don't put a file lock in the data directory (default true)", section: "options")]
+      @[CliOpt("", "--no-data-dir-lock", "Don't put a file lock in the data directory (default true)", ->(_v : String) { false }, section: "options")]
       @[IniOpt(section: "main")]
       property? data_dir_lock : Bool = true
 
-      @[CliOpt("", "--raise-gc-warn", "Raise on GC warnings", section: "options")]
+      @[CliOpt("", "--raise-gc-warn", "Raise on GC warnings", ->(_v : String) { true }, section: "options")]
       property? raise_gc_warn : Bool = false
 
-      @[CliOpt("", "--clustering", "Enable clustering", section: "clustering")]
+      @[CliOpt("", "--clustering", "Enable clustering", ->(_v : String) { true }, section: "clustering")]
       @[IniOpt(ini_name: enabled, section: "clustering")]
       @[EnvOpt("LAVINMQ_CLUSTERING")]
       property? clustering = false


### PR DESCRIPTION
### WHAT is this pull request doing?
Valueless boolean CLI flags like `--clustering` and `--raise-gc-warn` are broken. `OptionParser` passes an empty string for flags without `=VALUE`, and `parse_value("", Bool)` evaluates to `false` instead of `true`.

Fixed by detecting valueless boolean flags at compile time in the `parse_cli` macro and assigning the correct literal (`true`, or `false` for --no- prefixed flags) instead of always going through `parse_value`.

maybe this code is a bit clunky? I'd love to discuss if there are more elegant solutions

### HOW can this pull request be tested?
run updated specs