### PR TITLE
Fix -b flag to also set MQTT bind address

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -523,4 +523,13 @@ describe LavinMQ::Config do
     config.parse(argv)
     config.pidfile.should eq "/tmp/lavinmq.pid"
   end
+
+  it "should set amqp, http and mqtt bind with -b flag" do
+    config = LavinMQ::Config.new
+    argv = ["-b", "0.0.0.0"]
+    config.parse(argv)
+    config.amqp_bind.should eq "0.0.0.0"
+    config.http_bind.should eq "0.0.0.0"
+    config.mqtt_bind.should eq "0.0.0.0"
+  end
 end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -264,6 +264,7 @@ module LavinMQ
     private def parse_bind(value)
       @amqp_bind = value
       @http_bind = value
+      @mqtt_bind = value
     end
 
     def reload

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -25,7 +25,7 @@ module LavinMQ
       @[IniOpt(section: "main", transform: ->::Log::Severity.parse(String))]
       property log_level : ::Log::Severity = DEFAULT_LOG_LEVEL
 
-      @[CliOpt("-b BIND", "--bind=BIND", "IP address that both the AMQP and HTTP servers will listen on (default: 127.0.0.1)", ->parse_bind(String), section: "bindings")]
+      @[CliOpt("-b BIND", "--bind=BIND", "IP address that the AMQP, MQTT and HTTP servers will listen on (default: 127.0.0.1)", ->parse_bind(String), section: "bindings")]
       property bind = "127.0.0.1"
 
       @[CliOpt("-p PORT", "--amqp-port=PORT", "AMQP port to listen on (default: 5672)", section: "bindings")]


### PR DESCRIPTION
### WHAT is this pull request doing?
The `-b`/`--bind` flag sets the bind address for all protocols, but `mqtt_bind` was not included. This adds it to `parse_bind` so MQTT is also set when using the flag, and updates the help text to reflect that.

### HOW can this pull request be tested?
Run added specs