### PR TITLE
Fix data_dir and config_file not reading systemd env vars

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -418,6 +418,23 @@ describe LavinMQ::Config do
     end
   end
 
+  it "STATE_DIRECTORY takes precedence over INI data_dir" do
+    config_file = File.tempfile do |file|
+      file.print <<-CONFIG
+        [main]
+        data_dir = /tmp/lavinmq-ini
+      CONFIG
+    end
+    begin
+      ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
+      config = LavinMQ::Config.new
+      config.parse(["-c", config_file.path])
+      config.data_dir.should eq "/var/lib/custom-state"
+    ensure
+      ENV.delete("STATE_DIRECTORY")
+    end
+  end
+
   it "LAVINMQ_DATADIR takes precedence over STATE_DIRECTORY" do
     begin
       ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -407,6 +407,67 @@ describe LavinMQ::Config do
     end
   end
 
+  it "uses systemd STATE_DIRECTORY as default for data_dir" do
+    begin
+      ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
+      config = LavinMQ::Config.new
+      config.parse([] of String)
+      config.data_dir.should eq "/var/lib/custom-state"
+    ensure
+      ENV.delete("STATE_DIRECTORY")
+    end
+  end
+
+  it "LAVINMQ_DATADIR takes precedence over STATE_DIRECTORY" do
+    begin
+      ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
+      ENV["LAVINMQ_DATADIR"] = "/var/lib/lavinmq-explicit"
+      config = LavinMQ::Config.new
+      config.parse([] of String)
+      config.data_dir.should eq "/var/lib/lavinmq-explicit"
+    ensure
+      ENV.delete("STATE_DIRECTORY")
+      ENV.delete("LAVINMQ_DATADIR")
+    end
+  end
+
+  it "uses systemd CONFIGURATION_DIRECTORY for config file lookup" do
+    config_dir = File.tempname("lavinmq-conf")
+    Dir.mkdir_p(config_dir)
+    File.write(File.join(config_dir, "lavinmq.ini"), "[main]\nlog_level = fatal\n")
+    begin
+      ENV["CONFIGURATION_DIRECTORY"] = config_dir
+      config = LavinMQ::Config.new
+      config.parse([] of String)
+      config.config_file.should eq File.join(config_dir, "lavinmq.ini")
+    ensure
+      ENV.delete("CONFIGURATION_DIRECTORY")
+      FileUtils.rm_rf(config_dir)
+    end
+  end
+
+  it "LAVINMQ_CONFIGURATION_DIRECTORY takes precedence over CONFIGURATION_DIRECTORY" do
+    config_dir = File.tempname("lavinmq-conf")
+    Dir.mkdir_p(config_dir)
+    File.write(File.join(config_dir, "lavinmq.ini"), "[main]\nlog_level = fatal\n")
+    systemd_dir = File.tempname("lavinmq-systemd")
+    Dir.mkdir_p(systemd_dir)
+    File.write(File.join(systemd_dir, "lavinmq.ini"), "[main]\nlog_level = fatal\n")
+    begin
+      ENV["CONFIGURATION_DIRECTORY"] = systemd_dir
+      ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = config_dir
+      config = LavinMQ::Config.new
+      config.parse([] of String)
+      # config_file should NOT point to the systemd_dir
+      config.config_file.should_not contain systemd_dir
+    ensure
+      ENV.delete("CONFIGURATION_DIRECTORY")
+      ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
+      FileUtils.rm_rf(config_dir)
+      FileUtils.rm_rf(systemd_dir)
+    end
+  end
+
   it "accepts deprecated [http] section as alias for [mgmt]" do
     config_file = File.tempfile do |file|
       file.print <<-CONFIG

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -51,10 +51,12 @@ module LavinMQ
 
     private def parse_env
       {% for ivar in @type.instance_vars.select(&.annotation(EnvOpt)) %}
-        {% env_name, transform = ivar.annotation(EnvOpt).args %}
-        if v = ENV.fetch({{env_name}}, nil)
-          @{{ivar}} = parse_value(v, {{transform || ivar.type}})
-        end
+        {% for ann in ivar.annotations(EnvOpt) %}
+          {% env_name, transform = ann.args %}
+          if v = ENV.fetch({{env_name}}, nil)
+            @{{ivar}} = parse_value(v, {{transform || ivar.type}})
+          end
+        {% end %}
       {% end %}
     end
 

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -27,8 +27,9 @@ module LavinMQ
     # Command line arguments take precedence over environment variables,
     # which take precedence over the configuration file.
     def parse(argv = ARGV)
+      config_dir = ENV.fetch("LAVINMQ_CONFIGURATION_DIRECTORY") { ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq") }
       @config_file = File.exists?(
-        File.join(ENV.fetch("LAVINMQ_CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini")) ? File.join(ENV.fetch("LAVINMQ_CONFIGURATION_DIRECTORY", "/etc/lavinmq"), "lavinmq.ini") : ""
+        File.join(config_dir, "lavinmq.ini")) ? File.join(config_dir, "lavinmq.ini") : ""
       parse_config_from_cli(argv)
       parse_ini(@config_file)
       parse_env()

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -13,13 +13,13 @@ module LavinMQ
       DEFAULT_PASSWORD_HASH = Auth::Password::SHA256Password.new("+pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+") # Hash of 'guest'
 
       @[CliOpt("-c CONFIG", "--config=CONFIG", "Path to config file", section: "options")]
-      @[EnvOpt("LAVINMQ_CONFIGURATION_DIRECTORY")]
       property config_file = ""
 
       @[CliOpt("-D DIRECTORY", "--data-dir=DIRECTORY", "Data directory", section: "options")]
       @[IniOpt(section: "main")]
+      @[EnvOpt("STATE_DIRECTORY")]
       @[EnvOpt("LAVINMQ_DATADIR")]
-      property data_dir : String = ENV.fetch("STATE_DIRECTORY", "/var/lib/lavinmq")
+      property data_dir : String = "/var/lib/lavinmq"
 
       @[CliOpt("-l LEVEL", "--log-level=LEVEL", "Log level (Default: info)", ->::Log::Severity.parse(String), section: "options")]
       @[IniOpt(section: "main", transform: ->::Log::Severity.parse(String))]

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -19,7 +19,7 @@ module LavinMQ
       @[CliOpt("-D DIRECTORY", "--data-dir=DIRECTORY", "Data directory", section: "options")]
       @[IniOpt(section: "main")]
       @[EnvOpt("LAVINMQ_DATADIR")]
-      property data_dir : String = "/var/lib/lavinmq"
+      property data_dir : String = ENV.fetch("STATE_DIRECTORY", "/var/lib/lavinmq")
 
       @[CliOpt("-l LEVEL", "--log-level=LEVEL", "Log level (Default: info)", ->::Log::Severity.parse(String), section: "options")]
       @[IniOpt(section: "main", transform: ->::Log::Severity.parse(String))]


### PR DESCRIPTION
### WHAT is this pull request doing?
The config rewrite (#917) replaced the systemd-standard `STATE_DIRECTORY` and `CONFIGURATION_DIRECTORY` env vars with `LAVINMQ_`-prefixed variants. Since the systemd unit file (`extras/lavinmq.service`) declares `StateDirectory=lavinmq` and `ConfigurationDirectory=lavinmq`, systemd sets these vars automatically, and they are no longer read. 

This means anyone using a non-default `StateDirectory= path` in a systemd override will have it silently ignored, falling back to the hardcoded `/var/lib/lavinmq`. Similarly, a custom `ConfigurationDirectory= `in a systemd override would be ignored when resolving the default config file path.

This PR restores both systemd env vars as fallbacks. `LAVINMQ_DATADIR` and `LAVINMQ_CONFIGURATION_DIRECTORY` still take precedence when set.

### HOW can this pull request be tested?
run added spec
