### PR TITLE
Fix flaky etcd spec caused by duplicate ports

### DIFF
--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -184,7 +184,7 @@ class EtcdCluster
   @ports : Array(Int32)
 
   def initialize(nodes = 3)
-    @ports = (100..998).to_a.sample(nodes)
+    @ports = (100..999).sample(nodes)
   end
 
   def endpoints

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -184,7 +184,7 @@ class EtcdCluster
   @ports : Array(Int32)
 
   def initialize(nodes = 3)
-    @ports = nodes.times.map { rand(899) + 100 }.to_a
+    @ports = (100..998).to_a.sample(nodes)
   end
 
   def endpoints


### PR DESCRIPTION
Use `Array#sample` instead of repeated `rand` calls to guarantee unique port numbers in `EtcdCluster#initialize`, preventing random collisions that caused bind failures.