### PR TITLE
Fix SNI config parsing wildcard host corruption

### DIFF
--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -233,7 +233,7 @@ describe LavinMQ::Config do
       wildcard.tls_cert.should eq("spec/resources/wildcard_example_certificate.pem")
 
       # Exact-match host is registered separately
-      exact = config.sni_manager.get_exact_host("test.example.com").not_nil!
+      exact = config.sni_manager.get_exact_host("test.example.com").should_not be_nil
       exact.tls_cert.should eq("spec/resources/foobar_localhost_certificate.pem")
 
       # Runtime lookup: exact match takes precedence over wildcard

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -125,6 +125,22 @@ describe LavinMQ::SNIManager do
     manager.get_host("example.com").should be_nil
     manager.get_host("other.com").should be_nil
   end
+
+  it "get_exact_host does not resolve wildcards" do
+    manager = LavinMQ::SNIManager.new
+
+    wildcard_host = LavinMQ::SNIHost.new("*.example.com")
+    wildcard_host.tls_cert = "spec/resources/server_certificate.pem"
+    wildcard_host.tls_key = "spec/resources/server_key.pem"
+    manager.add_host(wildcard_host)
+
+    # get_host resolves wildcards
+    manager.get_host("foo.example.com").should eq(wildcard_host)
+    # get_exact_host does not
+    manager.get_exact_host("foo.example.com").should be_nil
+    # get_exact_host finds the wildcard by its literal name
+    manager.get_exact_host("*.example.com").should eq(wildcard_host)
+  end
 end
 
 describe LavinMQ::Config do
@@ -184,6 +200,45 @@ describe LavinMQ::Config do
       mtls_host = config.sni_manager.get_host("mtls.example.com").not_nil!
       mtls_host.tls_verify_peer?.should be_true
       mtls_host.http_tls_verify_peer.should eq(false)
+    ensure
+      File.delete(config_file)
+    end
+  end
+
+  it "exact-match section after wildcard does not corrupt wildcard host" do
+    config = LavinMQ::Config.new
+    config.data_dir = "/tmp/lavinmq-sni-spec"
+
+    config_content = <<-INI
+    [main]
+    data_dir = /tmp/lavinmq-sni-spec
+
+    [sni:*.example.com]
+    tls_cert = spec/resources/wildcard_example_certificate.pem
+    tls_key = spec/resources/wildcard_example_key.pem
+
+    [sni:test.example.com]
+    tls_cert = spec/resources/foobar_localhost_certificate.pem
+    tls_key = spec/resources/foobar_localhost_key.pem
+    INI
+
+    config_file = File.tempname("lavinmq", ".ini")
+    File.write(config_file, config_content)
+
+    begin
+      config.parse(["-c", config_file])
+
+      # Wildcard host keeps its own cert
+      wildcard = config.sni_manager.get_exact_host("*.example.com").not_nil!
+      wildcard.tls_cert.should eq("spec/resources/wildcard_example_certificate.pem")
+
+      # Exact-match host is registered separately
+      exact = config.sni_manager.get_exact_host("test.example.com").not_nil!
+      exact.tls_cert.should eq("spec/resources/foobar_localhost_certificate.pem")
+
+      # Runtime lookup: exact match takes precedence over wildcard
+      config.sni_manager.get_host("test.example.com").should eq(exact)
+      config.sni_manager.get_host("foo.example.com").should eq(wildcard)
     ensure
       File.delete(config_file)
     end

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -229,7 +229,7 @@ describe LavinMQ::Config do
       config.parse(["-c", config_file])
 
       # Wildcard host keeps its own cert
-      wildcard = config.sni_manager.get_exact_host("*.example.com").not_nil!
+      wildcard = config.sni_manager.get_exact_host("*.example.com").should_not be_nil
       wildcard.tls_cert.should eq("spec/resources/wildcard_example_certificate.pem")
 
       # Exact-match host is registered separately

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -134,7 +134,7 @@ module LavinMQ
 
     # ameba:disable Metrics/CyclomaticComplexity
     private def parse_sni(hostname : String, settings)
-      host = @sni_manager.get_host(hostname) || SNIHost.new(hostname)
+      host = @sni_manager.get_exact_host(hostname) || SNIHost.new(hostname)
       settings.each do |config, v|
         case config
         # Default TLS settings

--- a/src/lavinmq/sni_config.cr
+++ b/src/lavinmq/sni_config.cr
@@ -174,6 +174,16 @@ module LavinMQ
       @hosts[hostname]? || get_wildcard_host(hostname)
     end
 
+    # Lookup by exact section name only, no wildcard resolution.
+    # Used during config parsing to find a previously registered host.
+    def get_exact_host(hostname : String) : SNIHost?
+      if hostname.starts_with?("*.")
+        @wildcard_hosts[hostname[1..]]?
+      else
+        @hosts[hostname]?
+      end
+    end
+
     private def get_wildcard_host(hostname : String) : SNIHost?
       # Find the first dot and look up the suffix (e.g. "foo.example.com" -> ".example.com")
       if dot_idx = hostname.index('.')


### PR DESCRIPTION
### WHAT is this pull request doing?
Fix SNI config parsing overwriting wildcard host when exact-match host is parsed after it. 

`parse_sni` used `get_host` which includes wildcard resolution, so a section like `test.example.com` parsed after `*.example.com` would match the wildcard instead of creating a new host. The wildcard's cert got overwritten and the exact-match host was never registered. Adds `get_exact_host` to `SNIManager` that only does direct key lookup, and uses it in `parse_sni`.

### HOW can this pull request be tested?
Added spec
