### PR TITLE
lavinmqctl reset — offline command to wipe node data and cluster identity

### DIFF
--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -370,4 +370,82 @@ describe "LavinMQCtl" do
       end
     end
   end
+
+  describe "reset" do
+    it "should delete all messages and metadata" do
+      with_datadir do |data_dir|
+        File.write(File.join(data_dir, "users.json"), "[{\"name\":\"guest\"}]")
+        File.write(File.join(data_dir, "vhosts.json"), "[{\"name\":\"/\"}]")
+        File.write(File.join(data_dir, ".clustering_id"), "abc123")
+        vhost_dir = File.join(data_dir, "a" * 40)
+        queue_dir = File.join(vhost_dir, "b" * 40)
+        Dir.mkdir_p(queue_dir)
+
+        original_argv = ARGV.dup
+        stdout = IO::Memory.new
+        begin
+          ARGV.clear
+          ARGV << "reset"
+          ENV["LAVINMQ_DATADIR"] = data_dir
+          LavinMQCtl.new(stdout).run_cmd
+        ensure
+          ENV.delete("LAVINMQ_DATADIR")
+          ARGV.clear
+          ARGV.concat(original_argv)
+        end
+
+        File.exists?(File.join(data_dir, "users.json")).should be_false
+        File.exists?(File.join(data_dir, "vhosts.json")).should be_false
+        File.exists?(File.join(data_dir, ".clustering_id")).should be_false
+        Dir.exists?(vhost_dir).should be_false
+      end
+    end
+
+    it "should read data-dir from config file" do
+      with_datadir do |data_dir|
+        config_dir = File.join(data_dir, "config")
+        Dir.mkdir_p(config_dir)
+        File.write(File.join(config_dir, "lavinmq.ini"), "[main]\ndata_dir = #{data_dir}\n")
+        File.write(File.join(data_dir, "users.json"), "[{\"name\":\"guest\"}]")
+
+        original_argv = ARGV.dup
+        begin
+          ARGV.clear
+          ARGV << "reset"
+          ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = config_dir
+          LavinMQCtl.new(IO::Memory.new).run_cmd
+        ensure
+          ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
+          ARGV.clear
+          ARGV.concat(original_argv)
+        end
+
+        File.exists?(File.join(data_dir, "users.json")).should be_false
+      end
+    end
+
+    it "should fail if LavinMQ is running" do
+      with_datadir do |data_dir|
+        lock_path = File.join(data_dir, ".lock")
+        File.open(lock_path, "w") do |lock|
+          lock.flock_exclusive
+          original_argv = ARGV.dup
+          exit_code = 0
+          begin
+            ARGV.clear
+            ARGV << "reset"
+            ENV["LAVINMQ_DATADIR"] = data_dir
+            LavinMQCtl.new(IO::Memory.new).run_cmd
+          rescue ex
+            exit_code = 1
+          ensure
+            ENV.delete("LAVINMQ_DATADIR")
+            ARGV.clear
+            ARGV.concat(original_argv)
+          end
+          exit_code.should eq(1)
+        end
+      end
+    end
+  end
 end

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -385,7 +385,7 @@ describe "LavinMQCtl" do
         stdout = IO::Memory.new
         begin
           ARGV.clear
-          ARGV << "reset"
+          ARGV.concat(["reset", "--force"])
           ENV["LAVINMQ_DATADIR"] = data_dir
           LavinMQCtl.new(stdout).run_cmd
         ensure
@@ -411,7 +411,7 @@ describe "LavinMQCtl" do
         original_argv = ARGV.dup
         begin
           ARGV.clear
-          ARGV << "reset"
+          ARGV.concat(["reset", "--force"])
           ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = config_dir
           LavinMQCtl.new(IO::Memory.new).run_cmd
         ensure
@@ -430,20 +430,18 @@ describe "LavinMQCtl" do
         File.open(lock_path, "w") do |lock|
           lock.flock_exclusive
           original_argv = ARGV.dup
-          exit_code = 0
           begin
             ARGV.clear
-            ARGV << "reset"
+            ARGV.concat(["reset", "--force"])
             ENV["LAVINMQ_DATADIR"] = data_dir
-            LavinMQCtl.new(IO::Memory.new).run_cmd
-          rescue ex
-            exit_code = 1
+            expect_raises(Exception, /running/) do
+              LavinMQCtl.new(IO::Memory.new).run_cmd
+            end
           ensure
             ENV.delete("LAVINMQ_DATADIR")
             ARGV.clear
             ARGV.concat(original_argv)
           end
-          exit_code.should eq(1)
         end
       end
     end

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -864,14 +864,12 @@ class LavinMQCtl
     end
 
     lock_path = File.join(data_dir, ".lock")
-    lock = File.exists?(lock_path) ? File.open(lock_path, "r") : nil
-    if lock
-      begin
-        lock.flock_exclusive(blocking: false)
-      rescue IO::Error
-        lock.close
-        raise Exception.new("LavinMQ is running. Please stop it first with 'lavinmqctl stop_app'.")
-      end
+    lock = File.open(lock_path, "a+")
+    begin
+      lock.flock_exclusive(blocking: false)
+    rescue IO::Error
+      lock.close
+      raise Exception.new("LavinMQ is running. Please stop it first with 'lavinmqctl stop_app'.")
     end
 
     @io.puts "Resetting node ..." unless quiet?

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -7,6 +7,8 @@ require "../lavinmq/shovel/constants"
 require "../lavinmq/federation/constants"
 require "../lavinmq/definitions_generator"
 require "../lavinmq/auth/user"
+require "file_utils"
+require "ini"
 
 class LavinMQCtl
   @options = {} of String => String
@@ -150,6 +152,10 @@ class LavinMQCtl
     @parser.on("definitions", "Generate definitions json from a data directory") do
       @cmd = "definitions"
     end
+    @parser.on("reset", "Removes the node from any cluster and deletes all messages and metadata") do
+      @cmd = "reset"
+      self.banner = "Usage: #{PROGRAM_NAME} reset"
+    end
     @parser.on("add_shovel", "Create a shovel") do
       @cmd = "add_shovel"
       self.banner = "Usage: #{PROGRAM_NAME} add_shovel <name> --src-uri=<uri> --dest-uri=<uri>"
@@ -273,6 +279,7 @@ class LavinMQCtl
     when "set_vhost_limits"      then set_vhost_limits
     when "set_permissions"       then set_permissions
     when "definitions"           then definitions
+    when "reset"                 then reset
     when "hash_password"         then hash_password
     when "list_shovels"          then list_shovels
     when "add_shovel"            then add_shovel
@@ -841,6 +848,49 @@ class LavinMQCtl
   private def definitions
     data_dir = ARGV.shift? || abort "definitions <datadir>"
     DefinitionsGenerator.new(data_dir).generate(@io)
+  end
+
+  private def reset
+    data_dir = resolve_data_dir
+    abort "Not a directory: #{data_dir}" unless Dir.exists?(data_dir)
+    lock_path = File.join(data_dir, ".lock")
+    if File.exists?(lock_path)
+      lock = File.open(lock_path, "r")
+      begin
+        lock.flock_exclusive(blocking: false)
+        lock.flock_unlock
+      rescue
+        abort "LavinMQ is running. Please stop it first with 'lavinmqctl stop_app'."
+      ensure
+        lock.close
+      end
+    end
+    @io.puts "Resetting node ..." unless quiet?
+    Dir.each_child(data_dir) do |entry|
+      vhost_path = File.join(data_dir, entry)
+      FileUtils.rm_rf(vhost_path) if File.directory?(vhost_path)
+    end
+    File.delete?(File.join(data_dir, "users.json"))
+    File.delete?(File.join(data_dir, "vhosts.json"))
+    File.delete?(File.join(data_dir, "parameters.json"))
+    File.delete?(File.join(data_dir, ".clustering_id"))
+  end
+
+  private def resolve_data_dir : String
+    if data_dir = ENV["LAVINMQ_DATADIR"]?
+      return data_dir
+    end
+    config_dir = ENV.fetch("LAVINMQ_CONFIGURATION_DIRECTORY", "/etc/lavinmq")
+    config_file = File.join(config_dir, "lavinmq.ini")
+    if File.file?(config_file)
+      ini = INI.parse(File.read(config_file))
+      if main = ini["main"]?
+        if data_dir = main["data_dir"]?
+          return data_dir
+        end
+      end
+    end
+    "/var/lib/lavinmq"
   end
 
   private def hash_password

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -155,6 +155,9 @@ class LavinMQCtl
     @parser.on("reset", "Removes the node from any cluster and deletes all messages and metadata") do
       @cmd = "reset"
       self.banner = "Usage: #{PROGRAM_NAME} reset"
+      @parser.on("-f", "--force", "Skip confirmation prompt") do
+        @options["force"] = "yes"
+      end
     end
     @parser.on("add_shovel", "Create a shovel") do
       @cmd = "add_shovel"
@@ -853,18 +856,24 @@ class LavinMQCtl
   private def reset
     data_dir = resolve_data_dir
     abort "Not a directory: #{data_dir}" unless Dir.exists?(data_dir)
+
+    unless @options["force"]?
+      STDERR.print "Reset node at #{data_dir}? All messages and metadata will be permanently deleted. [y/N] "
+      answer = STDIN.gets.to_s.strip.downcase
+      abort "Reset cancelled." unless answer == "y" || answer == "yes"
+    end
+
     lock_path = File.join(data_dir, ".lock")
-    if File.exists?(lock_path)
-      lock = File.open(lock_path, "r")
+    lock = File.exists?(lock_path) ? File.open(lock_path, "r") : nil
+    if lock
       begin
         lock.flock_exclusive(blocking: false)
-        lock.flock_unlock
-      rescue
-        abort "LavinMQ is running. Please stop it first with 'lavinmqctl stop_app'."
-      ensure
+      rescue IO::Error
         lock.close
+        raise Exception.new("LavinMQ is running. Please stop it first with 'lavinmqctl stop_app'.")
       end
     end
+
     @io.puts "Resetting node ..." unless quiet?
     Dir.each_child(data_dir) do |entry|
       vhost_path = File.join(data_dir, entry)
@@ -874,6 +883,8 @@ class LavinMQCtl
     File.delete?(File.join(data_dir, "vhosts.json"))
     File.delete?(File.join(data_dir, "parameters.json"))
     File.delete?(File.join(data_dir, ".clustering_id"))
+  ensure
+    lock.try(&.close)
   end
 
   private def resolve_data_dir : String


### PR DESCRIPTION
Closes #1797.

Adds a `lavinmqctl reset` command that places a node back in a virgin state.

## What it does

- Removes all configured users and vhosts (`users.json`, `vhosts.json`, `parameters.json`)
- Deletes all persistent messages by removing the vhost data directories
- Removes the node's cluster identity (`.clustering_id`) so it rejoins any cluster as a fresh node on next startup

## How it works

The command operates directly on the data directory — no running server required. The data directory is resolved in priority order:

1. `LAVINMQ_DATADIR` environment variable
2. `data_dir` from the `[main]` section of the config file (`/etc/lavinmq/lavinmq.ini` by default, or the directory set by `LAVINMQ_CONFIGURATION_DIRECTORY`)
3. Default: `/var/lib/lavinmq`

Before wiping anything, the command:

1. Asks for confirmation — prompts `Reset node at <data-dir>? All messages and metadata will be permanently deleted. [y/N]`. Use `--force` to skip.
2. Checks that LavinMQ is not running by attempting a non-blocking exclusive flock on the `.lock` file. If the lock is held, the command raises with a clear message:

```
LavinMQ is running. Please stop it first with 'lavinmqctl stop_app'.
```

The flock is held for the entire duration of the reset so LavinMQ cannot start mid-wipe.

## Usage

```
lavinmqctl reset
lavinmqctl reset --force
```

## Cluster behaviour

Deleting `.clustering_id` is sufficient to remove a node from a cluster. On restart the node is assigned a new cluster ID; the leader automatically updates the ISR set when the node goes offline (etcd lease expires on stop), so no manual cluster reconfiguration is needed.

## Testing

Three new specs cover:
- data directory is fully wiped (users, vhosts, clustering ID, message directories), resolving data dir via `LAVINMQ_DATADIR`
- data dir is correctly read from a config file via `LAVINMQ_CONFIGURATION_DIRECTORY`
- command raises if LavinMQ is already running (lock held)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
