### PR TITLE
Cherry-pick spec reliability fixes into 2.6.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ lint-openapi:
 
 .PHONY: test
 test: lib
-	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(SPEC)
+	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(if $(TAGS),--tag '$(TAGS)') $(SPEC)
 
 .PHONY: format
 format:

--- a/spec/clustering/client_restart_spec.cr
+++ b/spec/clustering/client_restart_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-describe LavinMQ::Clustering::Client do
+describe LavinMQ::Clustering::Client, tags: "etcd" do
   add_etcd_around_each
 
   # Fixes #1366 - metrics_server is not closed when a follower client is closed

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 require "../../src/lavinmq/clustering/server"
 
-describe LavinMQ::Clustering::Server do
+describe LavinMQ::Clustering::Server, tags: "etcd" do
   add_etcd_around_each
 
   describe "#files_with_hash" do

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -118,22 +118,23 @@ describe LavinMQ::Server do
         # AMQP handshake
         io.write AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
         io.flush
-        AMQ::Protocol::Frame.from_io(io) { |f| f.as(AMQ::Protocol::Frame::Connection::Start) }
+        stream = AMQ::Protocol::Stream.new(io)
+        stream.next_frame.as(AMQ::Protocol::Frame::Connection::Start)
         response = "\u0000guest\u0000guest"
         io.write_bytes(AMQ::Protocol::Frame::Connection::StartOk.new(
           AMQ::Protocol::Table.new, "PLAIN", response, ""),
           IO::ByteFormat::NetworkEndian)
         io.flush
-        tune = AMQ::Protocol::Frame.from_io(io) { |f| f.as(AMQ::Protocol::Frame::Connection::Tune) }
+        tune = stream.next_frame.as(AMQ::Protocol::Frame::Connection::Tune)
         io.write_bytes AMQ::Protocol::Frame::Connection::TuneOk.new(
           channel_max: tune.channel_max, frame_max: tune.frame_max, heartbeat: 0_u16),
           IO::ByteFormat::NetworkEndian
         io.write_bytes AMQ::Protocol::Frame::Connection::Open.new("/"), IO::ByteFormat::NetworkEndian
         io.flush
-        AMQ::Protocol::Frame.from_io(io) { |f| f.as(AMQ::Protocol::Frame::Connection::OpenOk) }
+        stream.next_frame.as(AMQ::Protocol::Frame::Connection::OpenOk)
         io.write_bytes AMQ::Protocol::Frame::Channel::Open.new(1_u16), IO::ByteFormat::NetworkEndian
         io.flush
-        AMQ::Protocol::Frame.from_io(io) { |f| f.as(AMQ::Protocol::Frame::Channel::OpenOk) }
+        stream.next_frame.as(AMQ::Protocol::Frame::Channel::OpenOk)
 
         # Simulate a broken client sending a 10,000-byte routing key
         # with a truncated ShortString length byte (10000 & 0xFF = 16)
@@ -157,8 +158,7 @@ describe LavinMQ::Server do
         io.write_byte(206_u8) # frame end
         io.flush
 
-        resp = AMQ::Protocol::Frame.from_io(io) { |f| f }
-        close = resp.as(AMQ::Protocol::Frame::Connection::Close)
+        close = stream.next_frame.as(AMQ::Protocol::Frame::Connection::Close)
         close.reply_code.should eq 501
       ensure
         io.try &.close

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -217,7 +217,7 @@ describe "Delayed Message Exchange" do
         x.publish "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
         queue = s.vhosts["/"].queues[q_name]
         queue.message_count.should eq 0
-        wait_for(200.milliseconds) { queue.message_count == 1 }
+        wait_for { queue.message_count == 1 }
         queue.message_count.should eq 1
       end
     end

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -4,7 +4,7 @@ require "file_utils"
 require "http/client"
 require "./spec_helper"
 
-describe LavinMQ::Etcd do
+describe LavinMQ::Etcd, tags: "etcd" do
   it "can put and get" do
     cluster = EtcdCluster.new(1)
     cluster.run do

--- a/spec/follower_proxy_during_sync_spec.cr
+++ b/spec/follower_proxy_during_sync_spec.cr
@@ -45,7 +45,7 @@ class SlowClusteringServer < LavinMQ::Clustering::Server
   end
 end
 
-describe "extract_conn_info during full_sync with syncing_followers" do
+describe "extract_conn_info during full_sync with syncing_followers", tags: "etcd" do
   add_etcd_around_each
 
   it "should handle PROXY protocol from syncing followers during full_sync" do

--- a/spec/frontend/menu.spec.js
+++ b/spec/frontend/menu.spec.js
@@ -1,94 +1,116 @@
 import * as helpers from './helpers.js'
-import { test, expect } from './fixtures.js';
+import { test, expect } from './fixtures.js'
 
-test.describe("menu", _ => {
+test.describe('menu', _ => {
   test('overview menu item has active class on overview page', async ({ page }) => {
     await page.goto('/')
-    const overviewMenuItem = page.locator('#menu-content li:has(a[href="."])')
-    await expect(overviewMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Overview')
   })
 
   test('nodes menu item has active class on nodes page', async ({ page }) => {
     await page.goto('/nodes')
-    const nodesMenuItem = page.locator('#menu-content li:has(a[href="nodes"])')
-    await expect(nodesMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Nodes')
   })
 
   test('logs menu item has active class on logs page', async ({ page }) => {
     await page.goto('/logs')
-    const logsMenuItem = page.locator('#menu-content li:has(a[href="logs"])')
-    await expect(logsMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Logs')
   })
 
   test('connections menu item has active class on connections page', async ({ page }) => {
     await page.goto('/connections')
-    const connectionsMenuItem = page.locator('#menu-content li:has(a[href="connections"])')
-    await expect(connectionsMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Connections')
   })
 
   test('channels menu item has active class on channels page', async ({ page }) => {
     await page.goto('/channels')
-    const channelsMenuItem = page.locator('#menu-content li:has(a[href="channels"])')
-    await expect(channelsMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Channels')
   })
 
   test('consumers menu item has active class on consumers page', async ({ page }) => {
     await page.goto('/consumers')
-    const consumersMenuItem = page.locator('#menu-content li:has(a[href="consumers"])')
-    await expect(consumersMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Consumers')
   })
 
   test('exchanges menu item has active class on exchanges page', async ({ page }) => {
     await page.goto('/exchanges')
-    const exchangesMenuItem = page.locator('#menu-content li:has(a[href="exchanges"])')
-    await expect(exchangesMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Exchanges')
   })
 
   test('queues menu item has active class on queues page', async ({ page }) => {
     await page.goto('/queues')
-    const queuesMenuItem = page.locator('#menu-content li:has(a[href="queues"])')
-    await expect(queuesMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Queues')
   })
 
   test('shovels menu item has active class on shovels page', async ({ page }) => {
     await page.goto('/shovels')
-    const shovelsMenuItem = page.locator('#menu-content li:has(a[href="shovels"])')
-    await expect(shovelsMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Shovels')
   })
 
   test('federation menu item has active class on federation page', async ({ page }) => {
     await page.goto('/federation')
-    const federationMenuItem = page.locator('#menu-content li:has(a[href="federation"])')
-    await expect(federationMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Federation')
   })
 
   test('vhosts menu item has active class on vhosts page', async ({ page }) => {
     await page.goto('/vhosts')
-    const vhostsMenuItem = page.locator('#menu-content li:has(a[href="vhosts"])')
-    await expect(vhostsMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Virtual hosts')
   })
 
   test('policies menu item has active class on policies page', async ({ page }) => {
     await page.goto('/policies')
-    const policiesMenuItem = page.locator('#menu-content li:has(a[href="policies"])')
-    await expect(policiesMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Policies')
   })
 
   test('operator-policies menu item has active class on operator-policies page', async ({ page }) => {
     await page.goto('/operator-policies')
-    const opPoliciesMenuItem = page.locator('#menu-content li:has(a[href="operator-policies"])')
-    await expect(opPoliciesMenuItem).toHaveClass('active')
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Operator policies')
   })
 
   test('users menu item has active class on users page', async ({ page }) => {
     await page.goto('/users')
-    const usersMenuItem = page.locator('#menu-content li:has(a[href="users"])')
-    await expect(usersMenuItem).toHaveClass('active')
-  })
-
-  test('only one menu item has active class at a time', async ({ page }) => {
-    await page.goto('/queues')
-    const activeMenuItems = page.locator('#menu-content li.active')
-    await expect(activeMenuItems).toHaveCount(1)
+    const activeItems = await page.locator('#menu-content .active')
+    const activeItem = await activeItems.first()
+    await expect(activeItems).toHaveCount(1)
+    await expect(activeItem).toHaveText('Users')
   })
 })

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -20,7 +20,7 @@ end
 
 describe LavinMQ::AMQP::PriorityQueue do
   describe "PriorityMessageStore" do
-    describe "clustering" do
+    describe "clustering", tags: "etcd" do
       add_etcd_around_each
       it "is replicated correctly" do
         with_clustering do |cluster|

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -212,8 +212,8 @@ def create_ttl_and_dl_queues(channel, queue_ttl = 1)
   {q, dlq}
 end
 
-def exit(code = 0)
-  raise SpecExit.new(code)
+def exit(status : Int32 | Process::Status = 0) : NoReturn
+  raise SpecExit.new(status.is_a?(Int32) ? status : status.exit_code)
 end
 
 class SpecExit < Exception


### PR DESCRIPTION
Cherry-pick three spec-only fixes from main that address CI flakiness on macOS:

  - 87163d33 Use default wait_for timeout in delayed_message_exchange_spec
  - 80009dce Refactor frontend menu specs to be less flaky (#1610)
  - 0123288b Replace deprecated Frame.from_io in connection_spec (#1819)