### PR TITLE
Use annotations for lavinmqctl command registration

### DIFF
--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -36,35 +36,38 @@ class LavinMQCtl
   def parse_cmd
     {% begin %}
       {% for section in SECTIONS %}
+        {%
+          methods = @type.methods.select(&.annotation(Cmd))
+            .select { |m| m.annotation(Cmd)[:section] == section }
+            .sort_by(&.name)
+        %}
         @parser.separator({{"\n" + section}})
-        {% for method in @type.methods.select(&.annotation(Cmd)).sort_by(&.name) %}
+        {% for method in methods %}
           {% cmd = method.annotation(Cmd) %}
-          {% if cmd[:section] == section %}
-            {% name = method.name.stringify %}
-            {% description = cmd[0] %}
-            {% usage = cmd[1] %}
-            @parser.on({{name}}, {{description}}) do
-              @cmd = ->{ {{method.name.id}}; nil }
-              self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{usage.id}}"
-              {% for opt in method.annotations(Opt) %}
-                {%
-                  flag = opt[0]
-                  desc = opt[1]
-                  options_key = opt[:options]
-                  args_key = opt[:args]
-                  literal = opt[:value]
-                  value = literal || (opt[:coerce] == :i64 ? "v.to_i64".id : "v".id)
-                %}
-                @parser.on({{flag}}, {{desc}}) do {% unless literal %}|v|{% end %}
-                  {% if options_key %}
-                    @options[{{options_key}}] = {{value}}
-                  {% else %}
-                    @args[{{args_key}}] = JSON::Any.new({{value}})
-                  {% end %}
-                end
-              {% end %}
-            end
-          {% end %}
+          {% name = method.name.stringify %}
+          {% description = cmd[0] %}
+          {% usage = cmd[1] %}
+          @parser.on({{name}}, {{description}}) do
+            @cmd = ->{ {{method.name.id}}; nil }
+            self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{usage.id}}"
+            {% for opt in method.annotations(Opt) %}
+              {%
+                flag = opt[0]
+                desc = opt[1]
+                options_key = opt[:options]
+                args_key = opt[:args]
+                literal = opt[:value]
+                value = literal || (opt[:coerce] == :i64 ? "v.to_i64".id : "v".id)
+              %}
+              @parser.on({{flag}}, {{desc}}) do {% unless literal %}|v|{% end %}
+                {% if options_key %}
+                  @options[{{options_key}}] = {{value}}
+                {% else %}
+                  @args[{{args_key}}] = JSON::Any.new({{value}})
+                {% end %}
+              end
+            {% end %}
+          end
         {% end %}
       {% end %}
     {% end %}

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -36,7 +36,7 @@ class LavinMQCtl
     {% begin %}
       {% for section in SECTIONS %}
         @parser.separator({{"\n" + section}})
-        {% for method in @type.methods.select(&.annotation(Cmd)) %}
+        {% for method in @type.methods.select(&.annotation(Cmd)).sort_by(&.name) %}
           {% ann = method.annotation(Cmd) %}
           {% if ann[:section] == section %}
             @parser.on({{method.name.stringify}}, {{ann[0]}}) do

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -18,6 +18,7 @@ class LavinMQCtl
   @io : IO
 
   annotation Cmd; end
+  annotation Opt; end
 
   SECTIONS = {"User Management", "Virtual Hosts", "Queues", "Exchanges",
               "Policies", "Connections", "Definitions", "Shovels",
@@ -37,156 +38,35 @@ class LavinMQCtl
       {% for section in SECTIONS %}
         @parser.separator({{"\n" + section}})
         {% for method in @type.methods.select(&.annotation(Cmd)).sort_by(&.name) %}
-          {% ann = method.annotation(Cmd) %}
-          {% if ann[:section] == section %}
-            @parser.on({{method.name.stringify}}, {{ann[0]}}) do
+          {% cmd = method.annotation(Cmd) %}
+          {% if cmd[:section] == section %}
+            {% name = method.name.stringify %}
+            {% description = cmd[0] %}
+            {% usage = cmd[1] %}
+            @parser.on({{name}}, {{description}}) do
               @cmd = ->{ {{method.name.id}}; nil }
-              self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{ann[1].id}}"
-              {{ ann[:options] }}
+              self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{usage.id}}"
+              {% for opt in method.annotations(Opt) %}
+                {% flag = opt[0] %}
+                {% desc = opt[1] %}
+                {% options_key = opt[:options] %}
+                {% args_key = opt[:args] %}
+                {% literal = opt[:value] %}
+                {% value = literal || (opt[:coerce] == :i64 ? "v.to_i64".id : "v".id) %}
+                @parser.on({{flag}}, {{desc}}) do {% unless literal %}|v|{% end %}
+                  {% if options_key %}
+                    @options[{{options_key}}] = {{value}}
+                  {% else %}
+                    @args[{{args_key}}] = JSON::Any.new({{value}})
+                  {% end %}
+                end
+              {% end %}
             end
           {% end %}
         {% end %}
       {% end %}
     {% end %}
     @parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
-  end
-
-  private def parse_create_queue_options
-    @parser.on("--auto-delete", "Auto delete queue when last consumer is removed") do
-      @options["auto_delete"] = "true"
-    end
-    @parser.on("--durable", "Make the queue durable") do
-      @options["durable"] = "true"
-    end
-    @parser.on("--expires", "") do |v|
-      @args["x-expires"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--max-length", "Set a max length for the queue") do |v|
-      @args["x-max-length"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--message-ttl", "Message time to live") do |v|
-      @args["x-message-ttl"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--delivery-limit", "How many time a message will be delivered before dead lettered") do |v|
-      @args["x-delivery-limit"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped") do
-      @args["x-overflow"] = JSON::Any.new("reject-publish")
-    end
-    @parser.on("--dead-letter-exchange", "To which exchange to dead letter messages") do |v|
-      @args["x-dead-letter-exchange"] = JSON::Any.new(v)
-    end
-    @parser.on("--dead-letter-routing-key", "Which routing key to use when dead lettering") do |v|
-      @args["x-dead-letter-routing-key"] = JSON::Any.new(v)
-    end
-    @parser.on("--stream-queue", "Create a Stream Queue") do
-      @args["x-queue-type"] = JSON::Any.new("stream")
-    end
-  end
-
-  private def parse_create_exchange_options
-    @parser.on("--auto-delete", "Auto delete exchange") do
-      @options["auto_delete"] = "true"
-    end
-    @parser.on("--durable", "Make the exchange durable") do
-      @options["durable"] = "true"
-    end
-    @parser.on("--internal", "Make the exchange internal") do
-      @options["internal"] = "true"
-    end
-    @parser.on("--delayed", "Make the exchange delayed") do
-      @options["delayed"] = "true"
-    end
-    @parser.on("--alternate-exchange", "Exchange to route all unroutable messages to") do |v|
-      @args["x-alternate-exchange"] = JSON::Any.new(v)
-    end
-    @parser.on("--persist-messages", "Number of messages to persist in the exchange") do |v|
-      @args["x-persist-messages"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--persist-ms", "Persist messages in the exchange for this amount of time") do |v|
-      @args["x-persist-ms"] = JSON::Any.new(v.to_i64)
-    end
-  end
-
-  private def parse_set_policy_options
-    @parser.on("--priority=priority", "Specify priority") do |v|
-      @options["priority"] = v
-    end
-    @parser.on("--apply-to=apply-to", "Apply-to") do |v|
-      @options["apply-to"] = v
-    end
-  end
-
-  private def parse_add_shovel_options
-    @parser.on("--src-uri=URI", "Source URI (required)") do |v|
-      @args["src-uri"] = JSON::Any.new(v)
-    end
-    @parser.on("--dest-uri=URI", "Destination URI (required)") do |v|
-      @args["dest-uri"] = JSON::Any.new(v)
-    end
-    @parser.on("--src-queue=QUEUE", "Source queue name") do |v|
-      @args["src-queue"] = JSON::Any.new(v)
-    end
-    @parser.on("--dest-queue=QUEUE", "Destination queue name") do |v|
-      @args["dest-queue"] = JSON::Any.new(v)
-    end
-    @parser.on("--src-exchange=EXCHANGE", "Source exchange name") do |v|
-      @args["src-exchange"] = JSON::Any.new(v)
-    end
-    @parser.on("--dest-exchange=EXCHANGE", "Destination exchange name") do |v|
-      @args["dest-exchange"] = JSON::Any.new(v)
-    end
-    @parser.on("--src-exchange-key=KEY", "Source routing key") do |v|
-      @args["src-exchange-key"] = JSON::Any.new(v)
-    end
-    @parser.on("--dest-exchange-key=KEY", "Destination routing key") do |v|
-      @args["dest-exchange-key"] = JSON::Any.new(v)
-    end
-    @parser.on("--src-prefetch-count=COUNT", "Source prefetch count") do |v|
-      @args["src-prefetch-count"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)") do |v|
-      @args["src-delete-after"] = JSON::Any.new(v)
-    end
-    @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
-      @args["ack-mode"] = JSON::Any.new(v)
-    end
-    @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
-      @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
-    end
-  end
-
-  private def parse_add_federation_options
-    @parser.on("--uri=URI", "Upstream URI (required)") do |v|
-      @args["uri"] = JSON::Any.new(v)
-    end
-    @parser.on("--expires=SECONDS", "Expiry time for federation link") do |v|
-      @args["expires"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--message-ttl=MILLISECONDS", "Message TTL for federation") do |v|
-      @args["message-ttl"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--max-hops=COUNT", "Maximum hops for federation") do |v|
-      @args["max-hops"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--prefetch-count=COUNT", "Prefetch count for federation") do |v|
-      @args["prefetch-count"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
-      @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
-    end
-    @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
-      @args["ack-mode"] = JSON::Any.new(v)
-    end
-    @parser.on("--consumer-tag=TAG", "Consumer tag for federation link") do |v|
-      @args["consumer-tag"] = JSON::Any.new(v)
-    end
-    @parser.on("--exchange=EXCHANGE", "Exchange name to federate") do |v|
-      @args["exchange"] = JSON::Any.new(v)
-    end
-    @parser.on("--queue=QUEUE", "Queue name to federate") do |v|
-      @args["queue"] = JSON::Any.new(v)
-    end
   end
 
   def banner=(@banner : String)
@@ -629,7 +509,9 @@ class LavinMQCtl
     output get("/api/policies/#{URI.encode_www_form(vhost)}")
   end
 
-  @[Cmd("Sets or updates a policy", "<name> <pattern> <definition>", section: "Policies", options: parse_set_policy_options)]
+  @[Opt("--priority=priority", "Specify priority", options: "priority")]
+  @[Opt("--apply-to=apply-to", "Apply-to", options: "apply-to")]
+  @[Cmd("Sets or updates a policy", "<name> <pattern> <definition>", section: "Policies")]
   private def set_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?
@@ -646,7 +528,17 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
-  @[Cmd("Create queue", "<name>", section: "Queues", options: parse_create_queue_options)]
+  @[Opt("--auto-delete", "Auto delete queue when last consumer is removed", options: "auto_delete", value: "true")]
+  @[Opt("--durable", "Make the queue durable", options: "durable", value: "true")]
+  @[Opt("--expires", "", args: "x-expires", coerce: :i64)]
+  @[Opt("--max-length", "Set a max length for the queue", args: "x-max-length", coerce: :i64)]
+  @[Opt("--message-ttl", "Message time to live", args: "x-message-ttl", coerce: :i64)]
+  @[Opt("--delivery-limit", "How many time a message will be delivered before dead lettered", args: "x-delivery-limit", coerce: :i64)]
+  @[Opt("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped", args: "x-overflow", value: "reject-publish")]
+  @[Opt("--dead-letter-exchange", "To which exchange to dead letter messages", args: "x-dead-letter-exchange")]
+  @[Opt("--dead-letter-routing-key", "Which routing key to use when dead lettering", args: "x-dead-letter-routing-key")]
+  @[Opt("--stream-queue", "Create a Stream Queue", args: "x-queue-type", value: "stream")]
+  @[Cmd("Create queue", "<name>", section: "Queues")]
   private def create_queue
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -686,7 +578,14 @@ class LavinMQCtl
     output ee
   end
 
-  @[Cmd("Create exchange", "<type> <name>", section: "Exchanges", options: parse_create_exchange_options)]
+  @[Opt("--auto-delete", "Auto delete exchange", options: "auto_delete", value: "true")]
+  @[Opt("--durable", "Make the exchange durable", options: "durable", value: "true")]
+  @[Opt("--internal", "Make the exchange internal", options: "internal", value: "true")]
+  @[Opt("--delayed", "Make the exchange delayed", options: "delayed", value: "true")]
+  @[Opt("--alternate-exchange", "Exchange to route all unroutable messages to", args: "x-alternate-exchange")]
+  @[Opt("--persist-messages", "Number of messages to persist in the exchange", args: "x-persist-messages", coerce: :i64)]
+  @[Opt("--persist-ms", "Persist messages in the exchange for this amount of time", args: "x-persist-ms", coerce: :i64)]
+  @[Cmd("Create exchange", "<type> <name>", section: "Exchanges")]
   private def create_exchange
     etype = ARGV.shift?
     name = ARGV.shift?
@@ -823,7 +722,19 @@ class LavinMQCtl
     output ss
   end
 
-  @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels", options: parse_add_shovel_options)]
+  @[Opt("--src-uri=URI", "Source URI (required)", args: "src-uri")]
+  @[Opt("--dest-uri=URI", "Destination URI (required)", args: "dest-uri")]
+  @[Opt("--src-queue=QUEUE", "Source queue name", args: "src-queue")]
+  @[Opt("--dest-queue=QUEUE", "Destination queue name", args: "dest-queue")]
+  @[Opt("--src-exchange=EXCHANGE", "Source exchange name", args: "src-exchange")]
+  @[Opt("--dest-exchange=EXCHANGE", "Destination exchange name", args: "dest-exchange")]
+  @[Opt("--src-exchange-key=KEY", "Source routing key", args: "src-exchange-key")]
+  @[Opt("--dest-exchange-key=KEY", "Destination routing key", args: "dest-exchange-key")]
+  @[Opt("--src-prefetch-count=COUNT", "Source prefetch count", args: "src-prefetch-count", coerce: :i64)]
+  @[Opt("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)", args: "src-delete-after")]
+  @[Opt("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)", args: "ack-mode")]
+  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", coerce: :i64)]
+  @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels")]
   private def add_shovel
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -863,7 +774,17 @@ class LavinMQCtl
     output ff
   end
 
-  @[Cmd("Create a federation upstream", "<name> --uri=<uri>", section: "Federation", options: parse_add_federation_options)]
+  @[Opt("--uri=URI", "Upstream URI (required)", args: "uri")]
+  @[Opt("--expires=SECONDS", "Expiry time for federation link", args: "expires", coerce: :i64)]
+  @[Opt("--message-ttl=MILLISECONDS", "Message TTL for federation", args: "message-ttl", coerce: :i64)]
+  @[Opt("--max-hops=COUNT", "Maximum hops for federation", args: "max-hops", coerce: :i64)]
+  @[Opt("--prefetch-count=COUNT", "Prefetch count for federation", args: "prefetch-count", coerce: :i64)]
+  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", coerce: :i64)]
+  @[Opt("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)", args: "ack-mode")]
+  @[Opt("--consumer-tag=TAG", "Consumer tag for federation link", args: "consumer-tag")]
+  @[Opt("--exchange=EXCHANGE", "Exchange name to federate", args: "exchange")]
+  @[Opt("--queue=QUEUE", "Queue name to federate", args: "queue")]
+  @[Cmd("Create a federation upstream", "<name> --uri=<uri>", section: "Federation")]
   private def add_federation
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -48,7 +48,7 @@ class LavinMQCtl
           {% description = cmd[0] %}
           {% usage = cmd[1] %}
           @parser.on({{name}}, {{description}}) do
-            @cmd = ->{ {{method.name.id}}; nil }
+            @cmd = ->{{method.name.id}}
             self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{usage.id}}"
             {% for opt in method.annotations(Opt).sort_by(&.[0]) %}
               {%

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -11,7 +11,7 @@ require "../lavinmq/auth/user"
 class LavinMQCtl
   @options = {} of String => String
   @args = {} of String => JSON::Any
-  @cmd : String?
+  @cmd : Proc(Nil)?
   @headers = HTTP::Headers{"Content-Type" => "application/json"}
   @parser = OptionParser.new
   @http : HTTP::Client?
@@ -40,11 +40,9 @@ class LavinMQCtl
           {% ann = method.annotation(Cmd) %}
           {% if ann[:section] == section %}
             @parser.on({{method.name.stringify}}, {{ann[0]}}) do
-              @cmd = {{method.name.stringify}}
+              @cmd = ->{ {{method.name.id}}; nil }
               self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{ann[1].id}}"
-              {% if ann[:has_options] %}
-                parse_{{method.name.id}}_options
-              {% end %}
+              {{ ann[:options] }}
             end
           {% end %}
         {% end %}
@@ -197,16 +195,12 @@ class LavinMQCtl
 
   def run_cmd
     @parser.parse
-    {% begin %}
-    case @cmd
-    {% for method in @type.methods.select(&.annotation(Cmd)) %}
-    when {{method.name.stringify}} then {{method.name.id}}
-    {% end %}
+    if cmd = @cmd
+      cmd.call
     else
       @io.puts @parser
       abort
     end
-    {% end %}
   rescue ex : OptionParser::MissingOption
     abort ex
   rescue ex : IO::Error
@@ -635,7 +629,7 @@ class LavinMQCtl
     output get("/api/policies/#{URI.encode_www_form(vhost)}")
   end
 
-  @[Cmd("Sets or updates a policy", "<name> <pattern> <definition>", section: "Policies", has_options: true)]
+  @[Cmd("Sets or updates a policy", "<name> <pattern> <definition>", section: "Policies", options: parse_set_policy_options)]
   private def set_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?
@@ -652,7 +646,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
-  @[Cmd("Create queue", "<name>", section: "Queues", has_options: true)]
+  @[Cmd("Create queue", "<name>", section: "Queues", options: parse_create_queue_options)]
   private def create_queue
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -692,7 +686,7 @@ class LavinMQCtl
     output ee
   end
 
-  @[Cmd("Create exchange", "<type> <name>", section: "Exchanges", has_options: true)]
+  @[Cmd("Create exchange", "<type> <name>", section: "Exchanges", options: parse_create_exchange_options)]
   private def create_exchange
     etype = ARGV.shift?
     name = ARGV.shift?
@@ -829,7 +823,7 @@ class LavinMQCtl
     output ss
   end
 
-  @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels", has_options: true)]
+  @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels", options: parse_add_shovel_options)]
   private def add_shovel
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -869,7 +863,7 @@ class LavinMQCtl
     output ff
   end
 
-  @[Cmd("Create a federation upstream", "<name> --uri=<uri>", section: "Federation", has_options: true)]
+  @[Cmd("Create a federation upstream", "<name> --uri=<uri>", section: "Federation", options: parse_add_federation_options)]
   private def add_federation
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -50,7 +50,7 @@ class LavinMQCtl
           @parser.on({{name}}, {{description}}) do
             @cmd = ->{ {{method.name.id}}; nil }
             self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{usage.id}}"
-            {% for opt in method.annotations(Opt) %}
+            {% for opt in method.annotations(Opt).sort_by(&.[0]) %}
               {%
                 flag = opt[0]
                 desc = opt[1]

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -56,10 +56,9 @@ class LavinMQCtl
                 desc = opt[1]
                 options_key = opt[:options]
                 args_key = opt[:args]
-                literal = opt[:value]
-                value = literal || (opt[:coerce] == :i64 ? "v.to_i64".id : "v".id)
+                value = opt[:value] || "v".id
               %}
-              @parser.on({{flag}}, {{desc}}) do {% unless literal %}|v|{% end %}
+              @parser.on({{flag}}, {{desc}}) do |v|
                 {% if options_key %}
                   @options[{{options_key}}] = {{value}}
                 {% else %}
@@ -535,10 +534,10 @@ class LavinMQCtl
 
   @[Opt("--auto-delete", "Auto delete queue when last consumer is removed", options: "auto_delete", value: "true")]
   @[Opt("--durable", "Make the queue durable", options: "durable", value: "true")]
-  @[Opt("--expires", "", args: "x-expires", coerce: :i64)]
-  @[Opt("--max-length", "Set a max length for the queue", args: "x-max-length", coerce: :i64)]
-  @[Opt("--message-ttl", "Message time to live", args: "x-message-ttl", coerce: :i64)]
-  @[Opt("--delivery-limit", "How many time a message will be delivered before dead lettered", args: "x-delivery-limit", coerce: :i64)]
+  @[Opt("--expires", "", args: "x-expires", value: v.to_i64)]
+  @[Opt("--max-length", "Set a max length for the queue", args: "x-max-length", value: v.to_i64)]
+  @[Opt("--message-ttl", "Message time to live", args: "x-message-ttl", value: v.to_i64)]
+  @[Opt("--delivery-limit", "How many time a message will be delivered before dead lettered", args: "x-delivery-limit", value: v.to_i64)]
   @[Opt("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped", args: "x-overflow", value: "reject-publish")]
   @[Opt("--dead-letter-exchange", "To which exchange to dead letter messages", args: "x-dead-letter-exchange")]
   @[Opt("--dead-letter-routing-key", "Which routing key to use when dead lettering", args: "x-dead-letter-routing-key")]
@@ -588,8 +587,8 @@ class LavinMQCtl
   @[Opt("--internal", "Make the exchange internal", options: "internal", value: "true")]
   @[Opt("--delayed", "Make the exchange delayed", options: "delayed", value: "true")]
   @[Opt("--alternate-exchange", "Exchange to route all unroutable messages to", args: "x-alternate-exchange")]
-  @[Opt("--persist-messages", "Number of messages to persist in the exchange", args: "x-persist-messages", coerce: :i64)]
-  @[Opt("--persist-ms", "Persist messages in the exchange for this amount of time", args: "x-persist-ms", coerce: :i64)]
+  @[Opt("--persist-messages", "Number of messages to persist in the exchange", args: "x-persist-messages", value: v.to_i64)]
+  @[Opt("--persist-ms", "Persist messages in the exchange for this amount of time", args: "x-persist-ms", value: v.to_i64)]
   @[Cmd("Create exchange", "<type> <name>", section: "Exchanges")]
   private def create_exchange
     etype = ARGV.shift?
@@ -735,10 +734,10 @@ class LavinMQCtl
   @[Opt("--dest-exchange=EXCHANGE", "Destination exchange name", args: "dest-exchange")]
   @[Opt("--src-exchange-key=KEY", "Source routing key", args: "src-exchange-key")]
   @[Opt("--dest-exchange-key=KEY", "Destination routing key", args: "dest-exchange-key")]
-  @[Opt("--src-prefetch-count=COUNT", "Source prefetch count", args: "src-prefetch-count", coerce: :i64)]
+  @[Opt("--src-prefetch-count=COUNT", "Source prefetch count", args: "src-prefetch-count", value: v.to_i64)]
   @[Opt("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)", args: "src-delete-after")]
   @[Opt("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)", args: "ack-mode")]
-  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", coerce: :i64)]
+  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", value: v.to_i64)]
   @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels")]
   private def add_shovel
     name = ARGV.shift?
@@ -780,11 +779,11 @@ class LavinMQCtl
   end
 
   @[Opt("--uri=URI", "Upstream URI (required)", args: "uri")]
-  @[Opt("--expires=SECONDS", "Expiry time for federation link", args: "expires", coerce: :i64)]
-  @[Opt("--message-ttl=MILLISECONDS", "Message TTL for federation", args: "message-ttl", coerce: :i64)]
-  @[Opt("--max-hops=COUNT", "Maximum hops for federation", args: "max-hops", coerce: :i64)]
-  @[Opt("--prefetch-count=COUNT", "Prefetch count for federation", args: "prefetch-count", coerce: :i64)]
-  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", coerce: :i64)]
+  @[Opt("--expires=SECONDS", "Expiry time for federation link", args: "expires", value: v.to_i64)]
+  @[Opt("--message-ttl=MILLISECONDS", "Message TTL for federation", args: "message-ttl", value: v.to_i64)]
+  @[Opt("--max-hops=COUNT", "Maximum hops for federation", args: "max-hops", value: v.to_i64)]
+  @[Opt("--prefetch-count=COUNT", "Prefetch count for federation", args: "prefetch-count", value: v.to_i64)]
+  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", value: v.to_i64)]
   @[Opt("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)", args: "ack-mode")]
   @[Opt("--consumer-tag=TAG", "Consumer tag for federation link", args: "consumer-tag")]
   @[Opt("--exchange=EXCHANGE", "Exchange name to federate", args: "exchange")]

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -17,67 +17,11 @@ class LavinMQCtl
   @http : HTTP::Client?
   @io : IO
 
-  USER_CMDS = {
-    {"add_user", "Creates a new user", "<username> <password>"},
-    {"delete_user", "Delete a user", "<username>"},
-    {"list_users", "List user names and tags", ""},
-    {"change_password", "Change the user password", "<username> <new_password>"},
-    {"set_user_tags", "Sets user tags", "<username> <tags>"},
-    {"set_permissions", "Set permissions for a user", "<username> <configure> <write> <read>"},
-    {"hash_password", "Hash a password", "<password>"},
-  }
+  annotation Cmd; end
 
-  VHOST_CMDS = {
-    {"add_vhost", "Creates a virtual host", "<vhost>"},
-    {"delete_vhost", "Deletes a virtual host", "<vhost>"},
-    {"list_vhosts", "Lists virtual hosts", ""},
-    {"set_vhost_limits", "Set VHost limits (max-connections, max-queues)", "<json>"},
-  }
-
-  QUEUE_CMDS = {
-    {"list_queues", "Lists queues and their properties", ""},
-    {"purge_queue", "Purges a queue (removes all messages in it)", "<queue>"},
-    {"pause_queue", "Pause all consumers on a queue", "<queue>"},
-    {"resume_queue", "Resume all consumers on a queue", "<queue>"},
-    {"restart_queue", "Restarts a closed queue", "<queue>"},
-    {"delete_queue", "Delete queue", "<queue>"},
-  }
-
-  EXCHANGE_CMDS = {
-    {"list_exchanges", "Lists exchanges", ""},
-    {"delete_exchange", "Delete exchange", "<name>"},
-  }
-
-  POLICY_CMDS = {
-    {"list_policies", "Lists all policies in a virtual host", ""},
-    {"clear_policy", "Clears (removes) a policy", "<name>"},
-  }
-
-  CONNECTION_CMDS = {
-    {"list_connections", "Lists AMQP 0.9.1 connections for the node", ""},
-    {"close_connection", "Instructs the broker to close a connection by pid", "<pid> <reason>"},
-    {"close_all_connections", "Instructs the broker to close all connections for the specified vhost or entire node", "<reason>"},
-  }
-
-  DEFINITION_CMDS = {
-    {"export_definitions", "Exports definitions in JSON", ""},
-    {"import_definitions", "Import definitions in JSON", "<file>"},
-  }
-
-  SHOVEL_CMDS = {
-    {"list_shovels", "Lists shovels", ""},
-    {"delete_shovel", "Delete a shovel", "<name>"},
-  }
-
-  FEDERATION_CMDS = {
-    {"list_federations", "Lists federation upstreams", ""},
-    {"delete_federation", "Delete a federation upstream", "<name>"},
-  }
-
-  SERVER_CMDS = {
-    {"stop_app", "Stop the AMQP broker", ""},
-    {"start_app", "Starts the AMQP broker", ""},
-  }
+  SECTIONS = {"User Management", "Virtual Hosts", "Queues", "Exchanges",
+              "Policies", "Connections", "Definitions", "Shovels",
+              "Federation", "Server"}
 
   def initialize(@io : IO = STDOUT)
     self.banner = "Usage: #{PROGRAM_NAME} [arguments] entity"
@@ -88,250 +32,181 @@ class LavinMQCtl
     parse_cmd
   end
 
-  private def register_cmds(group)
-    group.each do |cmd|
-      @parser.on(cmd[0], cmd[1]) do
-        @cmd = cmd[0]
-        self.banner = "Usage: #{PROGRAM_NAME} #{cmd[0]} #{cmd[2]}"
-      end
+  def parse_cmd
+    {% begin %}
+      {% for section in SECTIONS %}
+        @parser.separator({{"\n" + section}})
+        {% for method in @type.methods.select(&.annotation(Cmd)) %}
+          {% ann = method.annotation(Cmd) %}
+          {% if ann[:section] == section %}
+            @parser.on({{method.name.stringify}}, {{ann[0]}}) do
+              @cmd = {{method.name.stringify}}
+              self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{ann[1].id}}"
+              {% if ann[:has_options] %}
+                parse_{{method.name.id}}_options
+              {% end %}
+            end
+          {% end %}
+        {% end %}
+      {% end %}
+    {% end %}
+    @parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
+  end
+
+  private def parse_create_queue_options
+    @parser.on("--auto-delete", "Auto delete queue when last consumer is removed") do
+      @options["auto_delete"] = "true"
+    end
+    @parser.on("--durable", "Make the queue durable") do
+      @options["durable"] = "true"
+    end
+    @parser.on("--expires", "") do |v|
+      @args["x-expires"] = JSON::Any.new(v.to_i64)
+    end
+    @parser.on("--max-length", "Set a max length for the queue") do |v|
+      @args["x-max-length"] = JSON::Any.new(v.to_i64)
+    end
+    @parser.on("--message-ttl", "Message time to live") do |v|
+      @args["x-message-ttl"] = JSON::Any.new(v.to_i64)
+    end
+    @parser.on("--delivery-limit", "How many time a message will be delivered before dead lettered") do |v|
+      @args["x-delivery-limit"] = JSON::Any.new(v.to_i64)
+    end
+    @parser.on("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped") do
+      @args["x-overflow"] = JSON::Any.new("reject-publish")
+    end
+    @parser.on("--dead-letter-exchange", "To which exchange to dead letter messages") do |v|
+      @args["x-dead-letter-exchange"] = JSON::Any.new(v)
+    end
+    @parser.on("--dead-letter-routing-key", "Which routing key to use when dead lettering") do |v|
+      @args["x-dead-letter-routing-key"] = JSON::Any.new(v)
+    end
+    @parser.on("--stream-queue", "Create a Stream Queue") do
+      @args["x-queue-type"] = JSON::Any.new("stream")
     end
   end
 
-  def parse_cmd
-    @parser.separator("\nUser Management")
-    register_cmds(USER_CMDS)
+  private def parse_create_exchange_options
+    @parser.on("--auto-delete", "Auto delete exchange") do
+      @options["auto_delete"] = "true"
+    end
+    @parser.on("--durable", "Make the exchange durable") do
+      @options["durable"] = "true"
+    end
+    @parser.on("--internal", "Make the exchange internal") do
+      @options["internal"] = "true"
+    end
+    @parser.on("--delayed", "Make the exchange delayed") do
+      @options["delayed"] = "true"
+    end
+    @parser.on("--alternate-exchange", "Exchange to route all unroutable messages to") do |v|
+      @args["x-alternate-exchange"] = JSON::Any.new(v)
+    end
+    @parser.on("--persist-messages", "Number of messages to persist in the exchange") do |v|
+      @args["x-persist-messages"] = JSON::Any.new(v.to_i64)
+    end
+    @parser.on("--persist-ms", "Persist messages in the exchange for this amount of time") do |v|
+      @args["x-persist-ms"] = JSON::Any.new(v.to_i64)
+    end
+  end
 
-    @parser.separator("\nVirtual Hosts")
-    register_cmds(VHOST_CMDS)
+  private def parse_set_policy_options
+    @parser.on("--priority=priority", "Specify priority") do |v|
+      @options["priority"] = v
+    end
+    @parser.on("--apply-to=apply-to", "Apply-to") do |v|
+      @options["apply-to"] = v
+    end
+  end
 
-    @parser.separator("\nQueues")
-    register_cmds(QUEUE_CMDS)
-    @parser.on("create_queue", "Create queue") do
-      @cmd = "create_queue"
-      self.banner = "Usage: #{PROGRAM_NAME} create_queue <name>"
-      @parser.on("--auto-delete", "Auto delete queue when last consumer is removed") do
-        @options["auto_delete"] = "true"
-      end
-      @parser.on("--durable", "Make the queue durable") do
-        @options["durable"] = "true"
-      end
-      @parser.on("--expires", "") do |v|
-        @args["x-expires"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--max-length", "Set a max length for the queue") do |v|
-        @args["x-max-length"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--message-ttl", "Message time to live") do |v|
-        @args["x-message-ttl"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--delivery-limit", "How many time a message will be delivered before dead lettered") do |v|
-        @args["x-delivery-limit"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped") do
-        @args["x-overflow"] = JSON::Any.new("reject-publish")
-      end
-      @parser.on("--dead-letter-exchange", "To which exchange to dead letter messages") do |v|
-        @args["x-dead-letter-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--dead-letter-routing-key", "Which routing key to use when dead lettering") do |v|
-        @args["x-dead-letter-routing-key"] = JSON::Any.new(v)
-      end
-      @parser.on("--stream-queue", "Create a Stream Queue") do
-        @args["x-queue-type"] = JSON::Any.new("stream")
-      end
+  private def parse_add_shovel_options
+    @parser.on("--src-uri=URI", "Source URI (required)") do |v|
+      @args["src-uri"] = JSON::Any.new(v)
     end
+    @parser.on("--dest-uri=URI", "Destination URI (required)") do |v|
+      @args["dest-uri"] = JSON::Any.new(v)
+    end
+    @parser.on("--src-queue=QUEUE", "Source queue name") do |v|
+      @args["src-queue"] = JSON::Any.new(v)
+    end
+    @parser.on("--dest-queue=QUEUE", "Destination queue name") do |v|
+      @args["dest-queue"] = JSON::Any.new(v)
+    end
+    @parser.on("--src-exchange=EXCHANGE", "Source exchange name") do |v|
+      @args["src-exchange"] = JSON::Any.new(v)
+    end
+    @parser.on("--dest-exchange=EXCHANGE", "Destination exchange name") do |v|
+      @args["dest-exchange"] = JSON::Any.new(v)
+    end
+    @parser.on("--src-exchange-key=KEY", "Source routing key") do |v|
+      @args["src-exchange-key"] = JSON::Any.new(v)
+    end
+    @parser.on("--dest-exchange-key=KEY", "Destination routing key") do |v|
+      @args["dest-exchange-key"] = JSON::Any.new(v)
+    end
+    @parser.on("--src-prefetch-count=COUNT", "Source prefetch count") do |v|
+      @args["src-prefetch-count"] = JSON::Any.new(v.to_i64)
+    end
+    @parser.on("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)") do |v|
+      @args["src-delete-after"] = JSON::Any.new(v)
+    end
+    @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
+      @args["ack-mode"] = JSON::Any.new(v)
+    end
+    @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
+      @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
+    end
+  end
 
-    @parser.separator("\nExchanges")
-    register_cmds(EXCHANGE_CMDS)
-    @parser.on("create_exchange", "Create exchange") do
-      @cmd = "create_exchange"
-      self.banner = "Usage: #{PROGRAM_NAME} create_exchange <type> <name>"
-      @parser.on("--auto-delete", "Auto delete exchange") do
-        @options["auto_delete"] = "true"
-      end
-      @parser.on("--durable", "Make the exchange durable") do
-        @options["durable"] = "true"
-      end
-      @parser.on("--internal", "Make the exchange internal") do
-        @options["internal"] = "true"
-      end
-      @parser.on("--delayed", "Make the exchange delayed") do
-        @options["delayed"] = "true"
-      end
-      @parser.on("--alternate-exchange", "Exchange to route all unroutable messages to") do |v|
-        @args["x-alternate-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--persist-messages", "Number of messages to persist in the exchange") do |v|
-        @args["x-persist-messages"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--persist-ms", "Persist messages in the exchange for this amount of time") do |v|
-        @args["x-persist-ms"] = JSON::Any.new(v.to_i64)
-      end
+  private def parse_add_federation_options
+    @parser.on("--uri=URI", "Upstream URI (required)") do |v|
+      @args["uri"] = JSON::Any.new(v)
     end
-
-    @parser.separator("\nPolicies")
-    register_cmds(POLICY_CMDS)
-    @parser.on("set_policy", "Sets or updates a policy") do
-      @cmd = "set_policy"
-      self.banner = "Usage: #{PROGRAM_NAME} set_policy <name> <pattern> <definition>"
-      @parser.on("--priority=priority", "Specify priority") do |v|
-        @options["priority"] = v
-      end
-      @parser.on("--apply-to=apply-to", "Apply-to") do |v|
-        @options["apply-to"] = v
-      end
+    @parser.on("--expires=SECONDS", "Expiry time for federation link") do |v|
+      @args["expires"] = JSON::Any.new(v.to_i64)
     end
-    @parser.separator("\nConnections")
-    register_cmds(CONNECTION_CMDS)
-
-    @parser.separator("\nDefinitions")
-    register_cmds(DEFINITION_CMDS)
-    @parser.on("definitions", "Generate definitions json from a data directory") do
-      @cmd = "definitions"
+    @parser.on("--message-ttl=MILLISECONDS", "Message TTL for federation") do |v|
+      @args["message-ttl"] = JSON::Any.new(v.to_i64)
     end
-
-    @parser.separator("\nShovels")
-    register_cmds(SHOVEL_CMDS)
-    @parser.on("add_shovel", "Create a shovel") do
-      @cmd = "add_shovel"
-      self.banner = "Usage: #{PROGRAM_NAME} add_shovel <name> --src-uri=<uri> --dest-uri=<uri>"
-      @parser.on("--src-uri=URI", "Source URI (required)") do |v|
-        @args["src-uri"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-uri=URI", "Destination URI (required)") do |v|
-        @args["dest-uri"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-queue=QUEUE", "Source queue name") do |v|
-        @args["src-queue"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-queue=QUEUE", "Destination queue name") do |v|
-        @args["dest-queue"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-exchange=EXCHANGE", "Source exchange name") do |v|
-        @args["src-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-exchange=EXCHANGE", "Destination exchange name") do |v|
-        @args["dest-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-exchange-key=KEY", "Source routing key") do |v|
-        @args["src-exchange-key"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-exchange-key=KEY", "Destination routing key") do |v|
-        @args["dest-exchange-key"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-prefetch-count=COUNT", "Source prefetch count") do |v|
-        @args["src-prefetch-count"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)") do |v|
-        @args["src-delete-after"] = JSON::Any.new(v)
-      end
-      @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
-        @args["ack-mode"] = JSON::Any.new(v)
-      end
-      @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
-        @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
-      end
+    @parser.on("--max-hops=COUNT", "Maximum hops for federation") do |v|
+      @args["max-hops"] = JSON::Any.new(v.to_i64)
     end
-    @parser.separator("\nFederation")
-    register_cmds(FEDERATION_CMDS)
-    @parser.on("add_federation", "Create a federation upstream") do
-      @cmd = "add_federation"
-      self.banner = "Usage: #{PROGRAM_NAME} add_federation <name> --uri=<uri>"
-      @parser.on("--uri=URI", "Upstream URI (required)") do |v|
-        @args["uri"] = JSON::Any.new(v)
-      end
-      @parser.on("--expires=SECONDS", "Expiry time for federation link") do |v|
-        @args["expires"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--message-ttl=MILLISECONDS", "Message TTL for federation") do |v|
-        @args["message-ttl"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--max-hops=COUNT", "Maximum hops for federation") do |v|
-        @args["max-hops"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--prefetch-count=COUNT", "Prefetch count for federation") do |v|
-        @args["prefetch-count"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
-        @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
-        @args["ack-mode"] = JSON::Any.new(v)
-      end
-      @parser.on("--consumer-tag=TAG", "Consumer tag for federation link") do |v|
-        @args["consumer-tag"] = JSON::Any.new(v)
-      end
-      @parser.on("--exchange=EXCHANGE", "Exchange name to federate") do |v|
-        @args["exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--queue=QUEUE", "Queue name to federate") do |v|
-        @args["queue"] = JSON::Any.new(v)
-      end
+    @parser.on("--prefetch-count=COUNT", "Prefetch count for federation") do |v|
+      @args["prefetch-count"] = JSON::Any.new(v.to_i64)
     end
-    @parser.separator("\nServer")
-    register_cmds(SERVER_CMDS)
-    @parser.on("status", "Display server status") do
-      @cmd = "status"
+    @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
+      @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
     end
-    @parser.on("cluster_status", "Display cluster status") do
-      @cmd = "cluster_status"
+    @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
+      @args["ack-mode"] = JSON::Any.new(v)
     end
-
-    @parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
+    @parser.on("--consumer-tag=TAG", "Consumer tag for federation link") do |v|
+      @args["consumer-tag"] = JSON::Any.new(v)
+    end
+    @parser.on("--exchange=EXCHANGE", "Exchange name to federate") do |v|
+      @args["exchange"] = JSON::Any.new(v)
+    end
+    @parser.on("--queue=QUEUE", "Queue name to federate") do |v|
+      @args["queue"] = JSON::Any.new(v)
+    end
   end
 
   def banner=(@banner : String)
     @parser.banner = @banner
   end
 
-  # ameba:disable Metrics/CyclomaticComplexity
   def run_cmd
     @parser.parse
+    {% begin %}
     case @cmd
-    when "create_queue"          then create_queue
-    when "delete_queue"          then delete_queue
-    when "import_definitions"    then import_definitions
-    when "export_definitions"    then export_definitions
-    when "set_user_tags"         then set_user_tags
-    when "add_user"              then add_user
-    when "list_users"            then list_users
-    when "delete_user"           then delete_user
-    when "change_password"       then change_password
-    when "list_queues"           then list_queues
-    when "purge_queue"           then purge_queue
-    when "pause_queue"           then pause_queue
-    when "resume_queue"          then resume_queue
-    when "restart_queue"         then restart_queue
-    when "list_vhosts"           then list_vhosts
-    when "add_vhost"             then add_vhost
-    when "delete_vhost"          then delete_vhost
-    when "clear_policy"          then clear_policy
-    when "list_policies"         then list_policies
-    when "set_policy"            then set_policy
-    when "list_connections"      then list_connections
-    when "close_connection"      then close_connection
-    when "close_all_connections" then close_all_connections
-    when "list_exchanges"        then list_exchanges
-    when "create_exchange"       then create_exchange
-    when "delete_exchange"       then delete_exchange
-    when "status"                then status
-    when "cluster_status"        then cluster_status
-    when "set_vhost_limits"      then set_vhost_limits
-    when "set_permissions"       then set_permissions
-    when "definitions"           then definitions
-    when "hash_password"         then hash_password
-    when "list_shovels"          then list_shovels
-    when "add_shovel"            then add_shovel
-    when "delete_shovel"         then delete_shovel
-    when "list_federations"      then list_federations
-    when "add_federation"        then add_federation
-    when "delete_federation"     then delete_federation
-    when "stop_app"
-    when "start_app"
+    {% for method in @type.methods.select(&.annotation(Cmd)) %}
+    when {{method.name.stringify}} then {{method.name.id}}
+    {% end %}
     else
       @io.puts @parser
       abort
     end
+    {% end %}
   rescue ex : OptionParser::MissingOption
     abort ex
   rescue ex : IO::Error
@@ -528,6 +403,7 @@ class LavinMQCtl
     items
   end
 
+  @[Cmd("Import definitions in JSON", "<file>", section: "Definitions")]
   private def import_definitions
     file = ARGV.shift? || ""
     resp = if file == "-"
@@ -543,6 +419,7 @@ class LavinMQCtl
     handle_response(resp, 200)
   end
 
+  @[Cmd("Exports definitions in JSON", "", section: "Definitions")]
   private def export_definitions
     url = "/api/definitions"
     url += "/#{URI.encode_www_form(@options["vhost"])}" if @options.has_key?("vhost")
@@ -551,6 +428,7 @@ class LavinMQCtl
     output resp.body
   end
 
+  @[Cmd("List user names and tags", "", section: "User Management")]
   private def list_users
     @io.puts "Listing users ..." unless quiet?
     uu = get("/api/users").map do |u|
@@ -560,6 +438,7 @@ class LavinMQCtl
     output uu
   end
 
+  @[Cmd("Creates a new user", "<username> <password>", section: "User Management")]
   private def add_user
     username = ARGV.shift?
     password = ARGV.shift?
@@ -568,6 +447,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete a user", "<username>", section: "User Management")]
   private def delete_user
     username = ARGV.shift?
     abort @banner unless username
@@ -575,6 +455,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Sets user tags", "<username> <tags>", section: "User Management")]
   private def set_user_tags
     username = ARGV.shift?
     tags = ARGV.join(",")
@@ -583,6 +464,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Change the user password", "<username> <new_password>", section: "User Management")]
   private def change_password
     username = ARGV.shift?
     pwd = ARGV.shift?
@@ -591,6 +473,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists queues and their properties", "", section: "Queues")]
   private def list_queues
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing queues for vhost #{vhost} ..." unless quiet?
@@ -601,6 +484,7 @@ class LavinMQCtl
     output qq
   end
 
+  @[Cmd("Purges a queue (removes all messages in it)", "<queue>", section: "Queues")]
   private def purge_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -609,6 +493,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Pause all consumers on a queue", "<queue>", section: "Queues")]
   private def pause_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -617,6 +502,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Resume all consumers on a queue", "<queue>", section: "Queues")]
   private def resume_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -625,6 +511,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Restarts a closed queue", "<queue>", section: "Queues")]
   private def restart_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -633,6 +520,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists AMQP 0.9.1 connections for the node", "", section: "Connections")]
   private def list_connections
     columns = ARGV
     columns = ["user", "peer_host", "peer_port", "state"] if columns.empty?
@@ -680,6 +568,7 @@ class LavinMQCtl
     @io.print ']'
   end
 
+  @[Cmd("Instructs the broker to close a connection by pid", "<pid> <reason>", section: "Connections")]
   private def close_connection
     name = ARGV.shift?
     abort @banner unless name
@@ -689,6 +578,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Instructs the broker to close all connections for the specified vhost or entire node", "<reason>", section: "Connections")]
   private def close_all_connections
     conns = get("/api/connections")
     closed_conns = [] of NamedTuple(name: String)
@@ -703,6 +593,7 @@ class LavinMQCtl
     output closed_conns, ["closed_connections"]
   end
 
+  @[Cmd("Lists virtual hosts", "", section: "Virtual Hosts")]
   private def list_vhosts
     @io.puts "Listing vhosts ..." unless quiet?
     vv = get("/api/vhosts").map do |u|
@@ -712,6 +603,7 @@ class LavinMQCtl
     output vv
   end
 
+  @[Cmd("Creates a virtual host", "<vhost>", section: "Virtual Hosts")]
   private def add_vhost
     name = ARGV.shift?
     abort @banner unless name
@@ -719,6 +611,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Deletes a virtual host", "<vhost>", section: "Virtual Hosts")]
   private def delete_vhost
     name = ARGV.shift?
     abort @banner unless name
@@ -726,6 +619,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Clears (removes) a policy", "<name>", section: "Policies")]
   private def clear_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?
@@ -734,12 +628,14 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists all policies in a virtual host", "", section: "Policies")]
   private def list_policies
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing policies for vhost #{vhost} ..." unless quiet?
     output get("/api/policies/#{URI.encode_www_form(vhost)}")
   end
 
+  @[Cmd("Sets or updates a policy", "<name> <pattern> <definition>", section: "Policies", has_options: true)]
   private def set_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?
@@ -756,6 +652,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Create queue", "<name>", section: "Queues", has_options: true)]
   private def create_queue
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -770,6 +667,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete queue", "<queue>", section: "Queues")]
   private def delete_queue
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -779,6 +677,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists exchanges", "", section: "Exchanges")]
   private def list_exchanges
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing exchanges for vhost #{vhost} ..." unless quiet?
@@ -793,6 +692,7 @@ class LavinMQCtl
     output ee
   end
 
+  @[Cmd("Create exchange", "<type> <name>", section: "Exchanges", has_options: true)]
   private def create_exchange
     etype = ARGV.shift?
     name = ARGV.shift?
@@ -811,6 +711,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete exchange", "<name>", section: "Exchanges")]
   private def delete_exchange
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -820,6 +721,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Display server status", "", section: "Server")]
   private def status
     resp = http.get "/api/overview"
     handle_response(resp, 200)
@@ -840,6 +742,7 @@ class LavinMQCtl
     output(status_obj)
   end
 
+  @[Cmd("Display cluster status", "", section: "Server")]
   private def cluster_status
     resp = http.get "/api/nodes"
     handle_response(resp, 200)
@@ -854,6 +757,13 @@ class LavinMQCtl
     end
   end
 
+  @[Cmd("Stop the AMQP broker", "", section: "Server")]
+  private def stop_app; end
+
+  @[Cmd("Starts the AMQP broker", "", section: "Server")]
+  private def start_app; end
+
+  @[Cmd("Set VHost limits (max-connections, max-queues)", "<json>", section: "Virtual Hosts")]
   private def set_vhost_limits
     vhost = @options["vhost"]? || "/"
     data = ARGV.shift?
@@ -873,6 +783,7 @@ class LavinMQCtl
     ok || abort "max-queues or max-connections required"
   end
 
+  @[Cmd("Set permissions for a user", "<username> <configure> <write> <read>", section: "User Management")]
   private def set_permissions
     user = ARGV.shift?
     configure = ARGV.shift?
@@ -890,17 +801,20 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Generate definitions json from a data directory", "", section: "Definitions")]
   private def definitions
     data_dir = ARGV.shift? || abort "definitions <datadir>"
     DefinitionsGenerator.new(data_dir).generate(@io)
   end
 
+  @[Cmd("Hash a password", "<password>", section: "User Management")]
   private def hash_password
     password = ARGV.shift?
     abort @banner unless password
     output LavinMQ::Auth::User.hash_password(password, "SHA256")
   end
 
+  @[Cmd("Lists shovels", "", section: "Shovels")]
   private def list_shovels
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing shovels for vhost #{vhost} ..." unless quiet?
@@ -915,6 +829,7 @@ class LavinMQCtl
     output ss
   end
 
+  @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels", has_options: true)]
   private def add_shovel
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -933,6 +848,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete a shovel", "<name>", section: "Shovels")]
   private def delete_shovel
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -942,6 +858,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists federation upstreams", "", section: "Federation")]
   private def list_federations
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing federation upstreams for vhost #{vhost} ..." unless quiet?
@@ -952,6 +869,7 @@ class LavinMQCtl
     output ff
   end
 
+  @[Cmd("Create a federation upstream", "<name> --uri=<uri>", section: "Federation", has_options: true)]
   private def add_federation
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -970,6 +888,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete a federation upstream", "<name>", section: "Federation")]
   private def delete_federation
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -47,12 +47,14 @@ class LavinMQCtl
               @cmd = ->{ {{method.name.id}}; nil }
               self.banner = "Usage: #{PROGRAM_NAME} {{method.name.id}} {{usage.id}}"
               {% for opt in method.annotations(Opt) %}
-                {% flag = opt[0] %}
-                {% desc = opt[1] %}
-                {% options_key = opt[:options] %}
-                {% args_key = opt[:args] %}
-                {% literal = opt[:value] %}
-                {% value = literal || (opt[:coerce] == :i64 ? "v.to_i64".id : "v".id) %}
+                {%
+                  flag = opt[0]
+                  desc = opt[1]
+                  options_key = opt[:options]
+                  args_key = opt[:args]
+                  literal = opt[:value]
+                  value = literal || (opt[:coerce] == :i64 ? "v.to_i64".id : "v".id)
+                %}
                 @parser.on({{flag}}, {{desc}}) do {% unless literal %}|v|{% end %}
                   {% if options_key %}
                     @options[{{options_key}}] = {{value}}

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -11,75 +11,19 @@ require "../lavinmq/auth/user"
 class LavinMQCtl
   @options = {} of String => String
   @args = {} of String => JSON::Any
-  @cmd : String?
+  @cmd : Proc(Nil)?
   @headers = HTTP::Headers{"Content-Type" => "application/json"}
   @parser = OptionParser.new
   @http : HTTP::Client?
   @io : IO
   @err_io : IO
 
-  USER_CMDS = {
-    {"add_user", "Creates a new user", "<username> <password>"},
-    {"delete_user", "Delete a user", "<username>"},
-    {"list_users", "List user names and tags", ""},
-    {"change_password", "Change the user password", "<username> <new_password>"},
-    {"set_user_tags", "Sets user tags", "<username> <tags>"},
-    {"set_permissions", "Set permissions for a user", "<username> <configure> <write> <read>"},
-    {"hash_password", "Hash a password", "<password>"},
-  }
+  annotation Cmd; end
+  annotation Opt; end
 
-  VHOST_CMDS = {
-    {"add_vhost", "Creates a virtual host", "<vhost>"},
-    {"delete_vhost", "Deletes a virtual host", "<vhost>"},
-    {"list_vhosts", "Lists virtual hosts", ""},
-    {"set_vhost_limits", "Set VHost limits (max-connections, max-queues)", "<json>"},
-  }
-
-  QUEUE_CMDS = {
-    {"list_queues", "Lists queues and their properties", ""},
-    {"purge_queue", "Purges a queue (removes all messages in it)", "<queue>"},
-    {"pause_queue", "Pause all consumers on a queue", "<queue>"},
-    {"resume_queue", "Resume all consumers on a queue", "<queue>"},
-    {"restart_queue", "Restarts a closed queue", "<queue>"},
-    {"delete_queue", "Delete queue", "<queue>"},
-  }
-
-  EXCHANGE_CMDS = {
-    {"list_exchanges", "Lists exchanges", ""},
-    {"delete_exchange", "Delete exchange", "<name>"},
-  }
-
-  POLICY_CMDS = {
-    {"list_policies", "Lists all policies in a virtual host", ""},
-    {"clear_policy", "Clears (removes) a policy", "<name>"},
-  }
-
-  CONNECTION_CMDS = {
-    {"list_connections", "Lists AMQP 0.9.1 connections for the node", ""},
-    {"close_connection", "Instructs the broker to close a connection by pid", "<pid> <reason>"},
-    {"close_all_connections", "Instructs the broker to close all connections for the specified vhost or entire node", "<reason>"},
-  }
-
-  DEFINITION_CMDS = {
-    {"export_definitions", "Exports definitions in JSON", ""},
-    {"import_definitions", "Import definitions in JSON", "<file>"},
-  }
-
-  SHOVEL_CMDS = {
-    {"list_shovels", "Lists shovels", ""},
-    {"delete_shovel", "Delete a shovel", "<name>"},
-  }
-
-  FEDERATION_CMDS = {
-    {"list_federations", "Lists federation upstreams", ""},
-    {"delete_federation", "Delete a federation upstream", "<name>"},
-  }
-
-  SERVER_CMDS = {
-    {"stop_app", "Stop the AMQP broker", ""},
-    {"start_app", "Starts the AMQP broker", ""},
-    {"gc_collect", "Trigger a garbage collection cycle and print GC stats", ""},
-  }
+  SECTIONS = {"User Management", "Virtual Hosts", "Queues", "Exchanges",
+              "Policies", "Connections", "Definitions", "Shovels",
+              "Federation", "Server"}
 
   def initialize(@io : IO = STDOUT, @err_io : IO = STDERR)
     self.banner = "Usage: #{PROGRAM_NAME} [arguments] entity"
@@ -93,195 +37,53 @@ class LavinMQCtl
     parse_cmd
   end
 
-  private def register_cmds(group)
-    group.each do |cmd|
-      @parser.on(cmd[0], cmd[1]) do
-        @cmd = cmd[0]
-        self.banner = "Usage: #{PROGRAM_NAME} #{cmd[0]} #{cmd[2]}"
-      end
-    end
-  end
-
   def parse_cmd
-    @parser.separator("\nUser Management")
-    register_cmds(USER_CMDS)
-
-    @parser.separator("\nVirtual Hosts")
-    register_cmds(VHOST_CMDS)
-
-    @parser.separator("\nQueues")
-    register_cmds(QUEUE_CMDS)
-    @parser.on("create_queue", "Create queue") do
-      @cmd = "create_queue"
-      self.banner = "Usage: #{PROGRAM_NAME} create_queue <name>"
-      @parser.on("--auto-delete", "Auto delete queue when last consumer is removed") do
-        @options["auto_delete"] = "true"
-      end
-      @parser.on("--durable", "Make the queue durable") do
-        @options["durable"] = "true"
-      end
-      @parser.on("--expires", "") do |v|
-        @args["x-expires"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--max-length", "Set a max length for the queue") do |v|
-        @args["x-max-length"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--message-ttl", "Message time to live") do |v|
-        @args["x-message-ttl"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--delivery-limit", "How many time a message will be delivered before dead lettered") do |v|
-        @args["x-delivery-limit"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped") do
-        @args["x-overflow"] = JSON::Any.new("reject-publish")
-      end
-      @parser.on("--dead-letter-exchange", "To which exchange to dead letter messages") do |v|
-        @args["x-dead-letter-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--dead-letter-routing-key", "Which routing key to use when dead lettering") do |v|
-        @args["x-dead-letter-routing-key"] = JSON::Any.new(v)
-      end
-      @parser.on("--stream-queue", "Create a Stream Queue") do
-        @args["x-queue-type"] = JSON::Any.new("stream")
-      end
-    end
-
-    @parser.separator("\nExchanges")
-    register_cmds(EXCHANGE_CMDS)
-    @parser.on("create_exchange", "Create exchange") do
-      @cmd = "create_exchange"
-      self.banner = "Usage: #{PROGRAM_NAME} create_exchange <type> <name>"
-      @parser.on("--auto-delete", "Auto delete exchange") do
-        @options["auto_delete"] = "true"
-      end
-      @parser.on("--durable", "Make the exchange durable") do
-        @options["durable"] = "true"
-      end
-      @parser.on("--internal", "Make the exchange internal") do
-        @options["internal"] = "true"
-      end
-      @parser.on("--delayed", "Make the exchange delayed") do
-        @options["delayed"] = "true"
-      end
-      @parser.on("--alternate-exchange", "Exchange to route all unroutable messages to") do |v|
-        @args["x-alternate-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--persist-messages", "Number of messages to persist in the exchange") do |v|
-        @args["x-persist-messages"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--persist-ms", "Persist messages in the exchange for this amount of time") do |v|
-        @args["x-persist-ms"] = JSON::Any.new(v.to_i64)
-      end
-    end
-
-    @parser.separator("\nPolicies")
-    register_cmds(POLICY_CMDS)
-    @parser.on("set_policy", "Sets or updates a policy") do
-      @cmd = "set_policy"
-      self.banner = "Usage: #{PROGRAM_NAME} set_policy <name> <pattern> <definition>"
-      @parser.on("--priority=priority", "Specify priority") do |v|
-        @options["priority"] = v
-      end
-      @parser.on("--apply-to=apply-to", "Apply-to") do |v|
-        @options["apply-to"] = v
-      end
-    end
-    @parser.separator("\nConnections")
-    register_cmds(CONNECTION_CMDS)
-
-    @parser.separator("\nDefinitions")
-    register_cmds(DEFINITION_CMDS)
-    @parser.on("definitions", "Generate definitions json from a data directory") do
-      @cmd = "definitions"
-    end
-
-    @parser.separator("\nShovels")
-    register_cmds(SHOVEL_CMDS)
-    @parser.on("add_shovel", "Create a shovel") do
-      @cmd = "add_shovel"
-      self.banner = "Usage: #{PROGRAM_NAME} add_shovel <name> --src-uri=<uri> --dest-uri=<uri>"
-      @parser.on("--src-uri=URI", "Source URI (required)") do |v|
-        @args["src-uri"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-uri=URI", "Destination URI (required)") do |v|
-        @args["dest-uri"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-queue=QUEUE", "Source queue name") do |v|
-        @args["src-queue"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-queue=QUEUE", "Destination queue name") do |v|
-        @args["dest-queue"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-exchange=EXCHANGE", "Source exchange name") do |v|
-        @args["src-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-exchange=EXCHANGE", "Destination exchange name") do |v|
-        @args["dest-exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-exchange-key=KEY", "Source routing key") do |v|
-        @args["src-exchange-key"] = JSON::Any.new(v)
-      end
-      @parser.on("--dest-exchange-key=KEY", "Destination routing key") do |v|
-        @args["dest-exchange-key"] = JSON::Any.new(v)
-      end
-      @parser.on("--src-prefetch-count=COUNT", "Source prefetch count") do |v|
-        @args["src-prefetch-count"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)") do |v|
-        @args["src-delete-after"] = JSON::Any.new(v)
-      end
-      @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
-        @args["ack-mode"] = JSON::Any.new(v)
-      end
-      @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
-        @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
-      end
-    end
-    @parser.separator("\nFederation")
-    register_cmds(FEDERATION_CMDS)
-    @parser.on("add_federation", "Create a federation upstream") do
-      @cmd = "add_federation"
-      self.banner = "Usage: #{PROGRAM_NAME} add_federation <name> --uri=<uri>"
-      @parser.on("--uri=URI", "Upstream URI (required)") do |v|
-        @args["uri"] = JSON::Any.new(v)
-      end
-      @parser.on("--expires=SECONDS", "Expiry time for federation link") do |v|
-        @args["expires"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--message-ttl=MILLISECONDS", "Message TTL for federation") do |v|
-        @args["message-ttl"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--max-hops=COUNT", "Maximum hops for federation") do |v|
-        @args["max-hops"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--prefetch-count=COUNT", "Prefetch count for federation") do |v|
-        @args["prefetch-count"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--reconnect-delay=SECONDS", "Reconnect delay in seconds") do |v|
-        @args["reconnect-delay"] = JSON::Any.new(v.to_i64)
-      end
-      @parser.on("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)") do |v|
-        @args["ack-mode"] = JSON::Any.new(v)
-      end
-      @parser.on("--consumer-tag=TAG", "Consumer tag for federation link") do |v|
-        @args["consumer-tag"] = JSON::Any.new(v)
-      end
-      @parser.on("--exchange=EXCHANGE", "Exchange name to federate") do |v|
-        @args["exchange"] = JSON::Any.new(v)
-      end
-      @parser.on("--queue=QUEUE", "Queue name to federate") do |v|
-        @args["queue"] = JSON::Any.new(v)
-      end
-    end
-    @parser.separator("\nServer")
-    register_cmds(SERVER_CMDS)
-    @parser.on("status", "Display server status") do
-      @cmd = "status"
-    end
-    @parser.on("cluster_status", "Display cluster status") do
-      @cmd = "cluster_status"
-    end
-
+    {% begin %}
+      {%
+        methods_by_section = {} of String => Object
+        SECTIONS.each { |s| methods_by_section[s] = [] of Object }
+        @type.methods.select(&.annotation(Cmd)).each do |m|
+          cmd = m.annotation(Cmd)
+          unless methods_by_section.has_key?(cmd[:section])
+            cmd[:section].raise "Invalid section #{cmd[:section]}, must be one of #{SECTIONS}"
+          end
+          methods_by_section[cmd[:section]] << m
+        end
+      %}
+      {% for section in SECTIONS %}
+        {% section.raise "Section #{section} has no commands" if methods_by_section[section].empty? %}
+        {% methods = methods_by_section[section].sort_by(&.name) %}
+        @parser.separator({{ "\n" + section }})
+        {% for method in methods %}
+          {%
+            cmd = method.annotation(Cmd)
+            name = method.name.stringify
+            description = cmd[0]
+            usage = cmd[1]
+          %}
+          @parser.on({{ name }}, {{ description }}) do
+            @cmd = ->{{ method.name.id }}
+            self.banner = "Usage: #{PROGRAM_NAME} {{ method.name.id }} {{ usage.id }}"
+            {% for opt in method.annotations(Opt).sort_by(&.[0]) %}
+              {%
+                flag = opt[0]
+                desc = opt[1]
+                options_key = opt[:options]
+                args_key = opt[:args]
+                value = opt[:value] || "v".id
+              %}
+              @parser.on({{ flag }}, {{ desc }}) do |v|
+                {% if options_key %}
+                  @options[{{ options_key }}] = {{ value }}
+                {% else %}
+                  @args[{{ args_key }}] = JSON::Any.new({{ value }})
+                {% end %}
+              end
+            {% end %}
+          end
+        {% end %}
+      {% end %}
+    {% end %}
     @parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
   end
 
@@ -296,51 +98,10 @@ class LavinMQCtl
     exit status
   end
 
-  # ameba:disable Metrics/CyclomaticComplexity
   def run_cmd
     @parser.parse
-    case @cmd
-    when "create_queue"          then create_queue
-    when "delete_queue"          then delete_queue
-    when "import_definitions"    then import_definitions
-    when "export_definitions"    then export_definitions
-    when "set_user_tags"         then set_user_tags
-    when "add_user"              then add_user
-    when "list_users"            then list_users
-    when "delete_user"           then delete_user
-    when "change_password"       then change_password
-    when "list_queues"           then list_queues
-    when "purge_queue"           then purge_queue
-    when "pause_queue"           then pause_queue
-    when "resume_queue"          then resume_queue
-    when "restart_queue"         then restart_queue
-    when "list_vhosts"           then list_vhosts
-    when "add_vhost"             then add_vhost
-    when "delete_vhost"          then delete_vhost
-    when "clear_policy"          then clear_policy
-    when "list_policies"         then list_policies
-    when "set_policy"            then set_policy
-    when "list_connections"      then list_connections
-    when "close_connection"      then close_connection
-    when "close_all_connections" then close_all_connections
-    when "list_exchanges"        then list_exchanges
-    when "create_exchange"       then create_exchange
-    when "delete_exchange"       then delete_exchange
-    when "status"                then status
-    when "cluster_status"        then cluster_status
-    when "gc_collect"            then gc_collect
-    when "set_vhost_limits"      then set_vhost_limits
-    when "set_permissions"       then set_permissions
-    when "definitions"           then definitions
-    when "hash_password"         then hash_password
-    when "list_shovels"          then list_shovels
-    when "add_shovel"            then add_shovel
-    when "delete_shovel"         then delete_shovel
-    when "list_federations"      then list_federations
-    when "add_federation"        then add_federation
-    when "delete_federation"     then delete_federation
-    when "stop_app"
-    when "start_app"
+    if cmd = @cmd
+      cmd.call
     else
       @io.puts @parser
       abort
@@ -545,6 +306,7 @@ class LavinMQCtl
     items
   end
 
+  @[Cmd("Import definitions in JSON", "<file>", section: "Definitions")]
   private def import_definitions
     file = ARGV.shift? || ""
     resp = if file == "-"
@@ -560,6 +322,7 @@ class LavinMQCtl
     handle_response(resp, 200)
   end
 
+  @[Cmd("Exports definitions in JSON", "", section: "Definitions")]
   private def export_definitions
     url = "/api/definitions"
     url += "/#{URI.encode_www_form(@options["vhost"])}" if @options.has_key?("vhost")
@@ -568,6 +331,7 @@ class LavinMQCtl
     output resp.body
   end
 
+  @[Cmd("List user names and tags", "", section: "User Management")]
   private def list_users
     @io.puts "Listing users ..." unless quiet?
     uu = get("/api/users").map do |u|
@@ -577,6 +341,7 @@ class LavinMQCtl
     output uu
   end
 
+  @[Cmd("Creates a new user", "<username> <password>", section: "User Management")]
   private def add_user
     username = ARGV.shift?
     password = ARGV.shift?
@@ -585,6 +350,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete a user", "<username>", section: "User Management")]
   private def delete_user
     username = ARGV.shift?
     abort @banner unless username
@@ -592,6 +358,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Sets user tags", "<username> <tags>", section: "User Management")]
   private def set_user_tags
     username = ARGV.shift?
     tags = ARGV.join(",")
@@ -600,6 +367,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Change the user password", "<username> <new_password>", section: "User Management")]
   private def change_password
     username = ARGV.shift?
     pwd = ARGV.shift?
@@ -608,6 +376,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists queues and their properties", "", section: "Queues")]
   private def list_queues
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing queues for vhost #{vhost} ..." unless quiet?
@@ -618,6 +387,7 @@ class LavinMQCtl
     output qq
   end
 
+  @[Cmd("Purges a queue (removes all messages in it)", "<queue>", section: "Queues")]
   private def purge_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -626,6 +396,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Pause all consumers on a queue", "<queue>", section: "Queues")]
   private def pause_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -634,6 +405,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Resume all consumers on a queue", "<queue>", section: "Queues")]
   private def resume_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -642,6 +414,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Restarts a closed queue", "<queue>", section: "Queues")]
   private def restart_queue
     vhost = @options["vhost"]? || "/"
     queue = ARGV.shift?
@@ -650,6 +423,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists AMQP 0.9.1 connections for the node", "", section: "Connections")]
   private def list_connections
     columns = ARGV
     columns = ["user", "peer_host", "peer_port", "state"] if columns.empty?
@@ -697,6 +471,7 @@ class LavinMQCtl
     @io.print ']'
   end
 
+  @[Cmd("Instructs the broker to close a connection by pid", "<pid> <reason>", section: "Connections")]
   private def close_connection
     name = ARGV.shift?
     abort @banner unless name
@@ -706,6 +481,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Instructs the broker to close all connections for the specified vhost or entire node", "<reason>", section: "Connections")]
   private def close_all_connections
     conns = get("/api/connections")
     closed_conns = [] of NamedTuple(name: String)
@@ -720,6 +496,7 @@ class LavinMQCtl
     output closed_conns, ["closed_connections"]
   end
 
+  @[Cmd("Lists virtual hosts", "", section: "Virtual Hosts")]
   private def list_vhosts
     @io.puts "Listing vhosts ..." unless quiet?
     vv = get("/api/vhosts").map do |u|
@@ -729,6 +506,7 @@ class LavinMQCtl
     output vv
   end
 
+  @[Cmd("Creates a virtual host", "<vhost>", section: "Virtual Hosts")]
   private def add_vhost
     name = ARGV.shift?
     abort @banner unless name
@@ -736,6 +514,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Deletes a virtual host", "<vhost>", section: "Virtual Hosts")]
   private def delete_vhost
     name = ARGV.shift?
     abort @banner unless name
@@ -743,6 +522,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Clears (removes) a policy", "<name>", section: "Policies")]
   private def clear_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?
@@ -751,12 +531,16 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists all policies in a virtual host", "", section: "Policies")]
   private def list_policies
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing policies for vhost #{vhost} ..." unless quiet?
     output get("/api/policies/#{URI.encode_www_form(vhost)}")
   end
 
+  @[Cmd("Sets or updates a policy", "<name> <pattern> <definition>", section: "Policies")]
+  @[Opt("--priority=priority", "Specify priority", options: "priority")]
+  @[Opt("--apply-to=apply-to", "Apply-to", options: "apply-to")]
   private def set_policy
     vhost = @options["vhost"]? || "/"
     name = ARGV.shift?
@@ -773,6 +557,17 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Create queue", "<name>", section: "Queues")]
+  @[Opt("--auto-delete", "Auto delete queue when last consumer is removed", options: "auto_delete", value: "true")]
+  @[Opt("--durable", "Make the queue durable", options: "durable", value: "true")]
+  @[Opt("--expires", "", args: "x-expires", value: v.to_i64)]
+  @[Opt("--max-length", "Set a max length for the queue", args: "x-max-length", value: v.to_i64)]
+  @[Opt("--message-ttl", "Message time to live", args: "x-message-ttl", value: v.to_i64)]
+  @[Opt("--delivery-limit", "How many time a message will be delivered before dead lettered", args: "x-delivery-limit", value: v.to_i64)]
+  @[Opt("--reject-on-overflow", "Reject publish if max-length is met, otherwise messages in the queue is dropped", args: "x-overflow", value: "reject-publish")]
+  @[Opt("--dead-letter-exchange", "To which exchange to dead letter messages", args: "x-dead-letter-exchange")]
+  @[Opt("--dead-letter-routing-key", "Which routing key to use when dead lettering", args: "x-dead-letter-routing-key")]
+  @[Opt("--stream-queue", "Create a Stream Queue", args: "x-queue-type", value: "stream")]
   private def create_queue
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -787,6 +582,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete queue", "<queue>", section: "Queues")]
   private def delete_queue
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -796,6 +592,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists exchanges", "", section: "Exchanges")]
   private def list_exchanges
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing exchanges for vhost #{vhost} ..." unless quiet?
@@ -810,6 +607,14 @@ class LavinMQCtl
     output ee
   end
 
+  @[Cmd("Create exchange", "<type> <name>", section: "Exchanges")]
+  @[Opt("--auto-delete", "Auto delete exchange", options: "auto_delete", value: "true")]
+  @[Opt("--durable", "Make the exchange durable", options: "durable", value: "true")]
+  @[Opt("--internal", "Make the exchange internal", options: "internal", value: "true")]
+  @[Opt("--delayed", "Make the exchange delayed", options: "delayed", value: "true")]
+  @[Opt("--alternate-exchange", "Exchange to route all unroutable messages to", args: "x-alternate-exchange")]
+  @[Opt("--persist-messages", "Number of messages to persist in the exchange", args: "x-persist-messages", value: v.to_i64)]
+  @[Opt("--persist-ms", "Persist messages in the exchange for this amount of time", args: "x-persist-ms", value: v.to_i64)]
   private def create_exchange
     etype = ARGV.shift?
     name = ARGV.shift?
@@ -828,6 +633,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete exchange", "<name>", section: "Exchanges")]
   private def delete_exchange
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -837,6 +643,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Display server status", "", section: "Server")]
   private def status
     resp = http.get "/api/overview"
     handle_response(resp, 200)
@@ -858,6 +665,7 @@ class LavinMQCtl
     output(status_obj)
   end
 
+  @[Cmd("Display cluster status", "", section: "Server")]
   private def cluster_status
     resp = http.get "/api/nodes"
     handle_response(resp, 200)
@@ -872,6 +680,7 @@ class LavinMQCtl
     end
   end
 
+  @[Cmd("Trigger a garbage collection cycle and print GC stats", "", section: "Server")]
   private def gc_collect
     resp = http.post "/api/nodes/gc_collect", @headers
     handle_response(resp, 204)
@@ -880,6 +689,13 @@ class LavinMQCtl
     output JSON.parse(resp.body).as_h
   end
 
+  @[Cmd("Stop the AMQP broker", "", section: "Server")]
+  private def stop_app; end
+
+  @[Cmd("Starts the AMQP broker", "", section: "Server")]
+  private def start_app; end
+
+  @[Cmd("Set VHost limits (max-connections, max-queues)", "<json>", section: "Virtual Hosts")]
   private def set_vhost_limits
     vhost = @options["vhost"]? || "/"
     data = ARGV.shift?
@@ -899,6 +715,7 @@ class LavinMQCtl
     ok || abort "max-queues or max-connections required"
   end
 
+  @[Cmd("Set permissions for a user", "<username> <configure> <write> <read>", section: "User Management")]
   private def set_permissions
     user = ARGV.shift?
     configure = ARGV.shift?
@@ -916,17 +733,20 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Generate definitions json from a data directory", "", section: "Definitions")]
   private def definitions
     data_dir = ARGV.shift? || abort "definitions <datadir>"
     DefinitionsGenerator.new(data_dir).generate(@io)
   end
 
+  @[Cmd("Hash a password", "<password>", section: "User Management")]
   private def hash_password
     password = ARGV.shift?
     abort @banner unless password
     output LavinMQ::Auth::User.hash_password(password, "SHA256")
   end
 
+  @[Cmd("Lists shovels", "", section: "Shovels")]
   private def list_shovels
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing shovels for vhost #{vhost} ..." unless quiet?
@@ -941,6 +761,19 @@ class LavinMQCtl
     output ss
   end
 
+  @[Cmd("Create a shovel", "<name> --src-uri=<uri> --dest-uri=<uri>", section: "Shovels")]
+  @[Opt("--src-uri=URI", "Source URI (required)", args: "src-uri")]
+  @[Opt("--dest-uri=URI", "Destination URI (required)", args: "dest-uri")]
+  @[Opt("--src-queue=QUEUE", "Source queue name", args: "src-queue")]
+  @[Opt("--dest-queue=QUEUE", "Destination queue name", args: "dest-queue")]
+  @[Opt("--src-exchange=EXCHANGE", "Source exchange name", args: "src-exchange")]
+  @[Opt("--dest-exchange=EXCHANGE", "Destination exchange name", args: "dest-exchange")]
+  @[Opt("--src-exchange-key=KEY", "Source routing key", args: "src-exchange-key")]
+  @[Opt("--dest-exchange-key=KEY", "Destination routing key", args: "dest-exchange-key")]
+  @[Opt("--src-prefetch-count=COUNT", "Source prefetch count", args: "src-prefetch-count", value: v.to_i64)]
+  @[Opt("--src-delete-after=AFTER", "Delete after mode (never, queue-length, count)", args: "src-delete-after")]
+  @[Opt("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)", args: "ack-mode")]
+  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", value: v.to_i64)]
   private def add_shovel
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -959,6 +792,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete a shovel", "<name>", section: "Shovels")]
   private def delete_shovel
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -968,6 +802,7 @@ class LavinMQCtl
     handle_response(resp, 204)
   end
 
+  @[Cmd("Lists federation upstreams", "", section: "Federation")]
   private def list_federations
     vhost = @options["vhost"]? || "/"
     @io.puts "Listing federation upstreams for vhost #{vhost} ..." unless quiet?
@@ -978,6 +813,17 @@ class LavinMQCtl
     output ff
   end
 
+  @[Cmd("Create a federation upstream", "<name> --uri=<uri>", section: "Federation")]
+  @[Opt("--uri=URI", "Upstream URI (required)", args: "uri")]
+  @[Opt("--expires=SECONDS", "Expiry time for federation link", args: "expires", value: v.to_i64)]
+  @[Opt("--message-ttl=MILLISECONDS", "Message TTL for federation", args: "message-ttl", value: v.to_i64)]
+  @[Opt("--max-hops=COUNT", "Maximum hops for federation", args: "max-hops", value: v.to_i64)]
+  @[Opt("--prefetch-count=COUNT", "Prefetch count for federation", args: "prefetch-count", value: v.to_i64)]
+  @[Opt("--reconnect-delay=SECONDS", "Reconnect delay in seconds", args: "reconnect-delay", value: v.to_i64)]
+  @[Opt("--ack-mode=MODE", "Acknowledgment mode (on-confirm, on-publish, no-ack)", args: "ack-mode")]
+  @[Opt("--consumer-tag=TAG", "Consumer tag for federation link", args: "consumer-tag")]
+  @[Opt("--exchange=EXCHANGE", "Exchange name to federate", args: "exchange")]
+  @[Opt("--queue=QUEUE", "Queue name to federate", args: "queue")]
   private def add_federation
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"
@@ -996,6 +842,7 @@ class LavinMQCtl
     handle_response(resp, 201, 204)
   end
 
+  @[Cmd("Delete a federation upstream", "<name>", section: "Federation")]
   private def delete_federation
     name = ARGV.shift?
     vhost = @options["vhost"]? || "/"


### PR DESCRIPTION
### WHAT is this pull request doing?
Replace command-group constants with `@[Cmd]` annotations on handler methods. A macro generates the `OptionParser` registrations grouped by section and the case dispatch in `run_cmd`. Follows the same pattern used in `config/options.cr` with `@[CliOpt]`/`@[IniOpt]`/`@[EnvOpt]`.

### HOW can this pull request be tested?
TBA if we like this approach