### PR TITLE
Fix shovel vhost permission check for named vhosts

### DIFF
--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -800,4 +800,36 @@ describe LavinMQ::Shovel do
       end
     end
   end
+
+  describe "Store.validate_config!" do
+    it "looks up vhost permissions by bare name (strips leading slash from URI path)" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user", "pass")
+        s.users.add_permission("shovel_user", "test", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":    "amqp:///test",
+          "dest-uri":   "amqp:///test",
+          "src-queue":  "q1",
+          "dest-queue": "q2",
+        }.to_json)
+        LavinMQ::Shovel::Store.validate_config!(config, user)
+      end
+    end
+
+    it "raises when user lacks permission on the named vhost" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user2", "pass")
+        s.users.add_permission("shovel_user2", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":    "amqp:///test",
+          "dest-uri":   "amqp:///test",
+          "src-queue":  "q1",
+          "dest-queue": "q2",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError) do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
+  end
 end

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -46,8 +46,7 @@ module LavinMQ
         src_uris.select!(&.user.nil?)
 
         dest_uris.each do |uri|
-          vhost = uri.path
-          vhost = "/" if vhost.empty?
+          vhost = vhost_from_uri(uri)
           if d = dst
             if !(user.can_write?(vhost, d) && user.can_config?(vhost, d))
               raise ConfigError.new("#{user.name} can't access exchange '#{d}' in #{vhost}")
@@ -61,8 +60,7 @@ module LavinMQ
         end
 
         src_uris.each do |uri|
-          vhost = uri.path
-          vhost = "/" if vhost.empty?
+          vhost = vhost_from_uri(uri)
           if q = src_q
             if !(user.can_read?(vhost, q) && user.can_config?(vhost, q))
               raise ConfigError.new("#{user.name} can't access queue '#{q}' in #{vhost}")
@@ -74,6 +72,11 @@ module LavinMQ
             end
           end
         end
+      end
+
+      private def self.vhost_from_uri(uri : URI) : String
+        path = uri.path.lchop("/")
+        path.empty? ? "/" : path
       end
 
       def self.parse_uris(src_uri : JSON::Any?) : Array(URI)


### PR DESCRIPTION
### Description
While looking at some JavaScript in the moveMessage context I was unable to move messages between queues, 
getting `guest can't access exchange '' in /test` as an alert. The reason behind this behavior is that the validator is using uri.path (e.g. "/test") as the vhost key when calling user.can_read?/can_write?/can_config?, but the user’s permission map is keyed by the bare vhost name (e.g. "test"). As a result, a user with full permissions on vhost test would incorrectly be rejected with `can't access queue/exchange ... in /test` etc.

### WHAT is this pull request doing?
Fixes a permission-check bug in Shovel::Store.validate_config! for shovels targeting a named vhost.

### Changes:
- Add a private vhost_from_uri helper in src/lavinmq/shovel/store.cr that strips the leading / from the URI path, returning "/" for the default vhost.
- Use the helper in both the dest_uris and src_uris loops in place of the inline uri.path / "/" if empty logic.

### HOW can this pull request be tested?
Specs and manually tried moving messages between queues.