### PR TITLE
ui: Show only `I` as feature for internal queue

### DIFF
--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -87,32 +87,39 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
     }
     const features = document.createElement('span')
     features.className = 'features'
-    if (item.durable) {
+    if (item.internal) {
       const durable = document.createElement('span')
-      durable.textContent = 'D '
-      durable.title = 'Durable'
+      durable.textContent = 'I'
+      durable.title = 'Internal'
       features.appendChild(durable)
-    }
-    if (item.auto_delete) {
-      const autoDelete = document.createElement('span')
-      autoDelete.textContent = 'AD '
-      autoDelete.title = 'Auto Delete'
-      features.appendChild(autoDelete)
-    }
-    if (item.exclusive) {
-      const exclusive = document.createElement('span')
-      exclusive.textContent = 'E '
-      exclusive.title = 'Exclusive'
-      features.appendChild(exclusive)
-    }
-    if (Object.keys(item.arguments).length > 0) {
-      const argsTooltip = Object.entries(item.arguments)
-        .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-        .join('\n')
-      const argsSpan = document.createElement('span')
-      argsSpan.textContent = 'Args '
-      argsSpan.title = argsTooltip
-      features.appendChild(argsSpan)
+    } else {
+      if (item.durable) {
+        const durable = document.createElement('span')
+        durable.textContent = 'D '
+        durable.title = 'Durable'
+        features.appendChild(durable)
+      }
+      if (item.auto_delete) {
+        const autoDelete = document.createElement('span')
+        autoDelete.textContent = 'AD '
+        autoDelete.title = 'Auto Delete'
+        features.appendChild(autoDelete)
+      }
+      if (item.exclusive) {
+        const exclusive = document.createElement('span')
+        exclusive.textContent = 'E '
+        exclusive.title = 'Exclusive'
+        features.appendChild(exclusive)
+      }
+      if (Object.keys(item.arguments).length > 0) {
+        const argsTooltip = Object.entries(item.arguments)
+          .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+          .join('\n')
+        const argsSpan = document.createElement('span')
+        argsSpan.textContent = 'Args '
+        argsSpan.title = argsTooltip
+        features.appendChild(argsSpan)
+      }
     }
     const queueLink = document.createElement('a')
     const qType = item.arguments['x-queue-type']

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -91,7 +91,7 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
       const internal = document.createElement('span')
       internal.textContent = 'I'
       internal.title = 'Internal'
-      internal.appendChild(internal)
+      features.appendChild(internal)
     } else {
       if (item.durable) {
         const durable = document.createElement('span')

--- a/static/js/queues.js
+++ b/static/js/queues.js
@@ -88,10 +88,10 @@ const queuesTable = Table.renderTable('table', tableOptions, function (tr, item,
     const features = document.createElement('span')
     features.className = 'features'
     if (item.internal) {
-      const durable = document.createElement('span')
-      durable.textContent = 'I'
-      durable.title = 'Internal'
-      features.appendChild(durable)
+      const internal = document.createElement('span')
+      internal.textContent = 'I'
+      internal.title = 'Internal'
+      internal.appendChild(internal)
     } else {
       if (item.durable) {
         const durable = document.createElement('span')


### PR DESCRIPTION
### WHAT is this pull request doing?
In #1848 an internal queue will rendered differently in the table to highlight that it's internal. 

I think we also should display only `I` in the feature column for an internal queue, no `D` or `Args`. Since the user haven't configured this queue, the arguments and properties of the queue isn't really of interest.

### HOW can this pull request be tested?
Create a delayed exchange and check the queue listing
