### PR TITLE
Fix 404 on /metrics/detailed for follower nodes

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -217,19 +217,6 @@ describe LavinMQ::HTTP::PrometheusController do
   end
 end
 
-def with_follower_metrics_server(&)
-  # Passing nil for amqp_server wires up FollowerPrometheusController — the same path a real follower takes.
-  h = LavinMQ::HTTP::MetricsServer.new(nil)
-  begin
-    addr = h.bind_tcp("::1", 0)
-    spawn(name: "follower metrics listen") { h.listen }
-    Fiber.yield
-    yield HTTPSpecHelper.new(addr)
-  ensure
-    h.close
-  end
-end
-
 describe LavinMQ::HTTP::FollowerPrometheusController do
   it "returns gc metrics on /metrics" do
     with_follower_metrics_server do |http|

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -217,6 +217,40 @@ describe LavinMQ::HTTP::PrometheusController do
   end
 end
 
+def with_follower_metrics_server(&)
+  # Passing nil for amqp_server wires up FollowerPrometheusController — the same path a real follower takes.
+  h = LavinMQ::HTTP::MetricsServer.new(nil)
+  begin
+    addr = h.bind_tcp("::1", 0)
+    spawn(name: "follower metrics listen") { h.listen }
+    Fiber.yield
+    yield HTTPSpecHelper.new(addr)
+  ensure
+    h.close
+  end
+end
+
+describe LavinMQ::HTTP::FollowerPrometheusController do
+  it "returns gc metrics on /metrics" do
+    with_follower_metrics_server do |http|
+      response = http.get("/metrics")
+      response.status_code.should eq 200
+      response.body.lines.any?(&.starts_with? "telemetry_scrape_duration_seconds").should be_true
+      response.body.lines.any?(&.starts_with? "lavinmq_gc_heap_size_bytes").should be_true
+    end
+  end
+
+  it "returns 200 on /metrics/detailed with only scrape telemetry" do
+    with_follower_metrics_server do |http|
+      response = http.get("/metrics/detailed?family=queue_coarse_metrics")
+      response.status_code.should eq 200
+      response.body.lines.any?(&.starts_with? "telemetry_scrape_duration_seconds").should be_true
+      response.body.lines.any?(&.starts_with? "lavinmq_gc_heap_size_bytes").should be_false
+      response.body.lines.any?(&.starts_with? "lavinmq_detailed_queue_messages_ready").should be_false
+    end
+  end
+end
+
 class PrometheusSpecHelper
   class Invalid < Exception
     def initialize

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -153,17 +153,30 @@ def with_http_server(file = __FILE__, line = __LINE__, &)
   end
 end
 
+def serve_metrics(amqp_server, &)
+  h = LavinMQ::HTTP::MetricsServer.new(amqp_server)
+  begin
+    addr = h.bind_tcp("::1", ENV.has_key?("NATIVE_PORTS") ? 15692 : 0)
+    spawn(name: "metrics listen") { h.listen }
+    Fiber.yield
+    yield HTTPSpecHelper.new(addr)
+  ensure
+    h.close
+  end
+end
+
 def with_metrics_server(file = __FILE__, line = __LINE__, &)
   with_amqp_server(file: file, line: line) do |s|
-    h = LavinMQ::HTTP::MetricsServer.new(s)
-    begin
-      addr = h.bind_tcp("::1", ENV.has_key?("NATIVE_PORTS") ? 15692 : 0)
-      spawn(name: "http listen") { h.listen }
-      Fiber.yield
-      yield({HTTPSpecHelper.new(addr), s})
-    ensure
-      h.close
+    serve_metrics(s) do |http|
+      yield({http, s})
     end
+  end
+end
+
+def with_follower_metrics_server(&)
+  # Passing nil for amqp_server wires up FollowerPrometheusController — the same path a real follower takes.
+  serve_metrics(nil) do |http|
+    yield http
   end
 end
 

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -188,6 +188,14 @@ module LavinMQ
           end
           context
         end
+
+        # Followers have no AMQP state for per-family samples. Respond 200 with only the
+        # scrape telemetry so Prometheus doesn't mark `/metrics/detailed` targets as failed.
+        get "/metrics/detailed" do |context, _|
+          context.response.content_type = "text/plain"
+          report(context.response) { }
+          context
+        end
       end
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Follower nodes returned 404 for `/metrics/detailed`. Respond 200 with only scrape telemetry instead.

### HOW can this pull request be tested?

Specs
