### PR TITLE
Remove dead default_user_only_loopback? method

### DIFF
--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -189,12 +189,6 @@ module LavinMQ
         nil
       end
 
-      private def default_user_only_loopback?(remote_address, user) : Bool
-        return true unless user.name == Config.instance.default_user
-        return true unless Config.instance.default_user_only_loopback?
-        remote_address.loopback?
-      end
-
       private def close_connection(socket, code : ConnectionReplyCode, text, frame)
         text = "#{code} - #{text}"
         socket.write_bytes(


### PR DESCRIPTION
### WHAT is this pull request doing?

The private method in AMQP::ConnectionFactory was orphaned by #1578
when the loopback check moved into Auth::Context and LocalAuthenticator.

### HOW can this pull request be tested?

Specs + it builds.
