### PR TITLE
Remove duplicate `UserStore#direct_user` method

### DIFF
--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -8,10 +8,6 @@ module LavinMQ
       private DIRECT_USER = "__direct"
       Log         = LavinMQ::Log.for "user_store"
 
-      def direct_user
-        @users[DIRECT_USER]
-      end
-
       def self.hidden?(name)
         DIRECT_USER == name
       end


### PR DESCRIPTION
### WHAT is this pull request doing?

Duplicate introduced in #1579. Kept the oldest one.

### HOW can this pull request be tested?

Specs, as I understand it - the last definition wins during build so this should be a no-op change.
