### PR TITLE
Clean up empty directories on follower after full sync

### DIFF
--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -1,0 +1,164 @@
+require "../spec_helper"
+require "lz4"
+
+module ClientSyncSpec
+  class TestClient < LavinMQ::Clustering::Client
+    def sync_files_public(socket, lz4)
+      sync_files(socket, lz4)
+    end
+  end
+
+  def self.make_client(data_dir : String) : TestClient
+    config = LavinMQ::Config.instance.dup
+    config.data_dir = data_dir
+    config.metrics_http_port = -1
+    TestClient.new(config, 1, "password", proxy: false)
+  end
+
+  def self.simulate_leader(io : IO, leader_files : Hash(String, String))
+    lz4 = Compress::LZ4::Writer.new(io, Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+    leader_files.each do |filename, content|
+      hash = Digest::SHA1.digest(content)
+      lz4.write_bytes filename.bytesize, IO::ByteFormat::LittleEndian
+      lz4.write filename.to_slice
+      lz4.write hash
+    end
+    lz4.write_bytes 0i32, IO::ByteFormat::LittleEndian
+    lz4.flush
+
+    requested = Array(String).new
+    loop do
+      len = io.read_bytes Int32, IO::ByteFormat::LittleEndian
+      break if len == 0
+      filename = io.read_string(len)
+      requested << filename
+    end
+
+    requested.each do |filename|
+      content = leader_files[filename]? || ""
+      lz4.write_bytes content.bytesize.to_i64, IO::ByteFormat::LittleEndian
+      lz4.write content.to_slice
+      lz4.flush
+    end
+  end
+
+  describe LavinMQ::Clustering::Client do
+    describe "sync_files directory cleanup" do
+      it "deletes directory not on leader" do
+        with_datadir do |data_dir|
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          File.write File.join(data_dir, "queue1", "messages.dat"), "data"
+
+          client = make_client(data_dir)
+          server_io, client_io = UNIXSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_io)
+
+          done = Channel(Nil).new
+          spawn do
+            simulate_leader(server_io, {} of String => String)
+            done.send nil
+          end
+
+          client.sync_files_public(client_io, lz4_reader)
+
+          select
+          when done.receive
+          when timeout(1.second)
+            fail "leader fiber timed out"
+          end
+
+          Dir.exists?(File.join(data_dir, "queue1")).should be_false
+        end
+      end
+
+      it "deletes nested directory tree absent from leader" do
+        with_datadir do |data_dir|
+          Dir.mkdir_p File.join(data_dir, "a", "b", "c")
+          File.write File.join(data_dir, "a", "b", "c", "file.dat"), "data"
+
+          client = make_client(data_dir)
+          server_io, client_io = UNIXSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_io)
+
+          done = Channel(Nil).new
+          spawn do
+            simulate_leader(server_io, {} of String => String)
+            done.send nil
+          end
+
+          client.sync_files_public(client_io, lz4_reader)
+
+          select
+          when done.receive
+          when timeout(1.second)
+            fail "leader fiber timed out"
+          end
+
+          Dir.exists?(File.join(data_dir, "a", "b", "c")).should be_false
+          Dir.exists?(File.join(data_dir, "a", "b")).should be_false
+          Dir.exists?(File.join(data_dir, "a")).should be_false
+        end
+      end
+
+      it "keeps directories containing files present on the leader" do
+        with_datadir do |data_dir|
+          content = "hello"
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          File.write File.join(data_dir, "queue1", "messages.dat"), content
+
+          client = make_client(data_dir)
+          server_io, client_io = UNIXSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_io)
+
+          done = Channel(Nil).new
+          spawn do
+            simulate_leader(server_io, {"queue1/messages.dat" => content})
+            done.send nil
+          end
+
+          client.sync_files_public(client_io, lz4_reader)
+
+          select
+          when done.receive
+          when timeout(1.second)
+            fail "leader fiber timed out"
+          end
+
+          Dir.exists?(File.join(data_dir, "queue1")).should be_true
+          File.exists?(File.join(data_dir, "queue1", "messages.dat")).should be_true
+        end
+      end
+
+      it "deletes only directories absent from leader" do
+        with_datadir do |data_dir|
+          content = "hello"
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          Dir.mkdir_p File.join(data_dir, "queue2")
+          File.write File.join(data_dir, "queue1", "messages.dat"), content
+          File.write File.join(data_dir, "queue2", "messages.dat"), content
+
+          client = make_client(data_dir)
+          server_io, client_io = UNIXSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_io)
+
+          done = Channel(Nil).new
+          spawn do
+            simulate_leader(server_io, {"queue1/messages.dat" => content})
+            done.send nil
+          end
+
+          client.sync_files_public(client_io, lz4_reader)
+
+          select
+          when done.receive
+          when timeout(1.second)
+            fail "leader fiber timed out"
+          end
+
+          Dir.exists?(File.join(data_dir, "queue1")).should be_true
+          Dir.exists?(File.join(data_dir, "queue2")).should be_false
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -149,7 +149,7 @@ module LavinMQ
         Log.info { "Waiting for list of files" }
         sha1 = Digest::SHA1.new
         remote_hash = Bytes.new(sha1.digest_size)
-        files_to_delete = ls_r(@data_dir)
+        files_to_delete, dirs_to_delete = ls_r(@data_dir)
         requested_files = Array(String).new
         loop do
           filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
@@ -159,6 +159,11 @@ module LavinMQ
           lz4.read_fully(remote_hash)
           path = File.join(@data_dir, filename)
           files_to_delete.delete(path)
+          # Walk up the path to remove all ancestors from dirs_to_delete
+          dir = File.dirname(path)
+          while dirs_to_delete.delete(dir)
+            dir = File.dirname(dir)
+          end
           if File.exists? path
             unless local_hash = @checksums[filename]?
               Log.info { "Calculating checksum for #{filename}" }
@@ -186,24 +191,44 @@ module LavinMQ
         files_to_delete.each do |path|
           Log.info { "File not on leader: #{path}" }
           File.delete path
+        rescue ex : File::Error
+          Log.warn(exception: ex) { "Failed to delete #{path}" }
+        end
+        # Clean up any local empty directory
+        # Sort and reverse to cleanup longer paths first
+        dirs_to_delete.sort!.reverse_each do |path|
+          if Dir.empty? path
+            Log.info { "Dir empty or missing on leader: #{path}" }
+            Dir.delete? path
+          else
+            Log.warn { "Dir #{path} in delete set, but not empty?" }
+          end
+        rescue ex : File::Error
+          Log.warn(exception: ex) { "Failed to delete #{path}" }
         end
         requested_files.each do |filename|
           file_from_socket(filename, lz4)
         end
       end
 
-      private def ls_r(dir) : Array(String)
+      private def ls_r(dir) : {Array(String), Array(String)}
         files = Array(String).new
+        dirs = Array(String).new
         ls_r(dir) do |filename|
-          files << filename
+          if File.file?(filename)
+            files << filename
+          elsif File.directory?(filename)
+            dirs << filename
+          end
         end
-        files
+        {files, dirs}
       end
 
       private def ls_r(dir, &blk : String -> Nil)
         Dir.each_child(dir) do |child|
           path = File.join(dir, child)
           if File.directory? path
+            yield path
             ls_r(path, &blk)
           else
             next if child.in?(".lock", ".clustering_id")

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -232,6 +232,7 @@ module LavinMQ
         deprecated: "--default-password is deprecated, use --default-password-hash", section: "options")]
       @[IniOpt(section: "main", deprecated: "default_password_hash")]
       @default_password : Auth::Password::SHA256Password = DEFAULT_PASSWORD_HASH # Hashed password for default user
+
       def default_password=(value)
         # Forward value to the new property
         @default_password_hash = value


### PR DESCRIPTION
### WHAT is this pull request doing?

During a full sync, the follower now removes local directories that are absent from the leader, in addition to the existing removal of stale files.
                                                                                                                                                                                                                                                                                        
Previously, when a queue or other directory was deleted on the leader, a full sync would delete the files inside it but leave behind an empty directory on the follower. Over time this could accumulate orphaned empty directories.                                                  
                                                                                                                                                                                                                                                                                        
Changes:                                                                                                                                                                                                                                                                              
  - `#ls_r` now returns both files and directories separately
  - After syncing, directories whose ancestors are all absent from the leader's file list are deleted (deepest paths first to avoid non-empty errors)
  - File and directory deletion errors are caught and logged as warnings rather than aborting the sync                                               
  - Adds specs covering: single dir removal, nested dir tree removal, preserving dirs with leader files, and partial removal when only some dirs are absent 

Ref #1854

### HOW can this pull request be tested?
Specs



