### PR TITLE
fix: prune orphaned ack positions on startup

### DIFF
--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "file_utils"
+require "log/spec"
 require "time"
 require "../src/lavinmq/message_store"
 
@@ -84,10 +85,10 @@ def with_store(*, replicator = nil, durable = true, &)
   end
 end
 
-# Sets up a fully-acked segment 1 and appends 2 phantom ack positions past the
+# Sets up a fully-acked segment 1 and appends 2 orphaned ack positions past the
 # real data end — simulates an unclean shutdown where ack writes survived but
 # the matching msg writes didn't.
-def setup_phantom_ack_scenario(dir)
+def setup_orphaned_ack_scenario(dir)
   body = "a" * 1000
   store = LavinMQ::MessageStore.new(dir, nil, durable: true)
   5.times { store.push(LavinMQ::Message.new("ex", "rk", body)) }
@@ -102,16 +103,6 @@ def setup_phantom_ack_scenario(dir)
   File.open(File.join(dir, "acks.0000000001"), "a") do |f|
     f.write_bytes(real_data_end, IO::ByteFormat::SystemEndian)
     f.write_bytes(real_data_end + 1024u32, IO::ByteFormat::SystemEndian)
-  end
-end
-
-def with_log_capture(source = "lmq.*", level : ::Log::Severity = :info, &)
-  memory = ::Log::MemoryBackend.new
-  ::Log.builder.bind(source, level, memory)
-  begin
-    yield memory
-  ensure
-    ::Log.builder.unbind(source, level, memory)
   end
 end
 
@@ -540,9 +531,9 @@ describe LavinMQ::MessageStore do
       end
     end
 
-    it "replicates the rewritten ack file after pruning phantoms" do
+    it "replicates the rewritten ack file after pruning orphans" do
       mktmpdir do |dir|
-        setup_phantom_ack_scenario(dir)
+        setup_orphaned_ack_scenario(dir)
 
         replicator = SpyReplicator.new
         store = LavinMQ::MessageStore.new(dir, replicator, durable: true)
@@ -555,14 +546,14 @@ describe LavinMQ::MessageStore do
   end
 
   # #1862 — on unclean shutdown, acks.* can end up with positions past the
-  # corresponding msgs.* data end (phantom acks), causing shift? to skip
+  # corresponding msgs.* data end (orphaned acks), causing shift? to skip
   # newly-pushed messages and raise "EOF but @size=1".
   describe "after crash with fully acked segment" do
     # Simulates unclean shutdown where mmap msg writes were lost but ack writes survived:
     # the ack file references positions that don't exist in the msg file anymore.
-    it "prunes phantom acks across multiple segments when all positions are phantoms" do
+    it "prunes orphaned acks across multiple segments when all positions are orphaned" do
       mktmpdir do |dir|
-        # Two segments with only a schema header and an all-phantom ack file
+        # Two segments with only a schema header and an all-orphaned ack file
         # each — exercises the @deleted.delete(seg) branch for multiple segments.
         [1u32, 2u32].each do |seg|
           File.write(File.join(dir, "msgs.#{seg.to_s.rjust(10, '0')}"), "\x04\x00\x00\x00")
@@ -578,11 +569,11 @@ describe LavinMQ::MessageStore do
       end
     end
 
-    it "does not raise EOF when ack file has phantom positions past data" do
+    it "does not raise EOF when ack file has orphaned positions past data" do
       mktmpdir do |dir|
-        setup_phantom_ack_scenario(dir)
+        setup_orphaned_ack_scenario(dir)
 
-        # Reopen — prune_phantom_acks should drop the 2 phantom positions.
+        # Reopen — prune_orphaned_acks should drop the 2 orphaned positions.
         store = LavinMQ::MessageStore.new(dir, nil, durable: true)
         store.@size.should eq 0
         store.@deleted[1]?.try(&.size).should eq 5
@@ -600,37 +591,20 @@ describe LavinMQ::MessageStore do
       end
     end
 
-    it "logs when pruning phantom ack positions" do
+    it "logs when pruning orphaned ack positions" do
       mktmpdir do |dir|
-        setup_phantom_ack_scenario(dir)
-        with_log_capture do |log|
+        setup_orphaned_ack_scenario(dir)
+        Log.capture("lmq.*", :warn) do |log|
           store = LavinMQ::MessageStore.new(dir, nil, durable: true)
           store.close
-          log.entries.any?(&.message.matches?(/Pruned 2 phantom ack position\(s\) from segment 1/)).should be_true
+          log.check(:warn, /Msgs\/acks files for segment 1 are out of sync.*Removing 2 orphaned ack position\(s\)/)
         end
       end
     end
 
-    it "does not re-prune on a second clean restart after phantom cleanup" do
+    it "handles orphaned ack positions without crashing when opened as non-durable" do
       mktmpdir do |dir|
-        setup_phantom_ack_scenario(dir)
-
-        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
-        store.close
-        wait_for { store.closed }
-
-        with_log_capture do |log|
-          store = LavinMQ::MessageStore.new(dir, nil, durable: true)
-          store.@acks[1].size.should eq 5 * sizeof(UInt32)
-          store.close
-          log.entries.any?(&.message.matches?(/Pruned/)).should be_false
-        end
-      end
-    end
-
-    it "handles phantom ack positions without crashing when opened as non-durable" do
-      mktmpdir do |dir|
-        setup_phantom_ack_scenario(dir)
+        setup_orphaned_ack_scenario(dir)
 
         # Non-durable reopens unlink the msg/ack files as they load, so the
         # ack file is detected as orphaned and @deleted never gets populated.
@@ -641,11 +615,11 @@ describe LavinMQ::MessageStore do
       end
     end
 
-    it "deletes leftover acks.*.tmp files in the data dir" do
+    it "deletes leftover tmp.acks.* files in the data dir" do
       mktmpdir do |dir|
         File.write(File.join(dir, "msgs.0000000001"), "\x04\x00\x00\x00")
         File.write(File.join(dir, "acks.0000000001"), "")
-        orphan_tmp = File.join(dir, "acks.0000000001.tmp")
+        orphan_tmp = File.join(dir, "tmp.acks.0000000001")
         File.write(orphan_tmp, "garbage-bytes")
 
         store = LavinMQ::MessageStore.new(dir, nil, durable: true)

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -560,6 +560,24 @@ describe LavinMQ::MessageStore do
   describe "after crash with fully acked segment" do
     # Simulates unclean shutdown where mmap msg writes were lost but ack writes survived:
     # the ack file references positions that don't exist in the msg file anymore.
+    it "prunes phantom acks across multiple segments when all positions are phantoms" do
+      mktmpdir do |dir|
+        # Two segments with only a schema header and an all-phantom ack file
+        # each — exercises the @deleted.delete(seg) branch for multiple segments.
+        [1u32, 2u32].each do |seg|
+          File.write(File.join(dir, "msgs.#{seg.to_s.rjust(10, '0')}"), "\x04\x00\x00\x00")
+          File.open(File.join(dir, "acks.#{seg.to_s.rjust(10, '0')}"), "w") do |f|
+            f.write_bytes(100u32, IO::ByteFormat::SystemEndian)
+            f.write_bytes(200u32, IO::ByteFormat::SystemEndian)
+          end
+        end
+
+        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+        store.@deleted.empty?.should be_true
+        store.close
+      end
+    end
+
     it "does not raise EOF when ack file has phantom positions past data" do
       mktmpdir do |dir|
         setup_phantom_ack_scenario(dir)

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -8,6 +8,7 @@ class SpyReplicator
 
   getter registered_files = Hash(String, Symbol).new
   getter deleted_files = Set(String).new
+  getter replaced_files = Array(String).new
 
   def register_file(path : String)
     @registered_files[path] = :path
@@ -22,6 +23,7 @@ class SpyReplicator
   end
 
   def replace_file(path : String)
+    @replaced_files << path
   end
 
   def append(path : String, obj)
@@ -79,6 +81,37 @@ def with_store(*, replicator = nil, durable = true, &)
     ensure
       store.close
     end
+  end
+end
+
+# Sets up a fully-acked segment 1 and appends 2 phantom ack positions past the
+# real data end — simulates an unclean shutdown where ack writes survived but
+# the matching msg writes didn't.
+def setup_phantom_ack_scenario(dir)
+  body = "a" * 1000
+  store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+  5.times { store.push(LavinMQ::Message.new("ex", "rk", body)) }
+  while env = store.shift?
+    store.delete(env.segment_position)
+  end
+  store.close
+  wait_for { store.closed }
+
+  msg_path = File.join(dir, "msgs.0000000001")
+  real_data_end = File.size(msg_path).to_u32
+  File.open(File.join(dir, "acks.0000000001"), "a") do |f|
+    f.write_bytes(real_data_end, IO::ByteFormat::SystemEndian)
+    f.write_bytes(real_data_end + 1024u32, IO::ByteFormat::SystemEndian)
+  end
+end
+
+def with_log_capture(source = "lmq.*", level : ::Log::Severity = :info, &)
+  memory = ::Log::MemoryBackend.new
+  ::Log.builder.bind(source, level, memory)
+  begin
+    yield memory
+  ensure
+    ::Log.builder.unbind(source, level, memory)
   end
 end
 
@@ -504,6 +537,140 @@ describe LavinMQ::MessageStore do
           registered = replicator.registered_files.keys.map { |p| File.basename(p) }
           (seg_files + ack_files).each { |f| registered.should contain(f) }
         end
+      end
+    end
+
+    it "replicates the rewritten ack file after pruning phantoms" do
+      mktmpdir do |dir|
+        setup_phantom_ack_scenario(dir)
+
+        replicator = SpyReplicator.new
+        store = LavinMQ::MessageStore.new(dir, replicator, durable: true)
+        store.close
+
+        replicator.replaced_files.map { |p| File.basename(p) }.should contain("acks.0000000001")
+        replicator.registered_files.keys.map { |p| File.basename(p) }.should contain("acks.0000000001")
+      end
+    end
+  end
+
+  # #1862 — on unclean shutdown, acks.* can end up with positions past the
+  # corresponding msgs.* data end (phantom acks), causing shift? to skip
+  # newly-pushed messages and raise "EOF but @size=1".
+  describe "after crash with fully acked segment" do
+    # Simulates unclean shutdown where mmap msg writes were lost but ack writes survived:
+    # the ack file references positions that don't exist in the msg file anymore.
+    it "does not raise EOF when ack file has phantom positions past data" do
+      mktmpdir do |dir|
+        setup_phantom_ack_scenario(dir)
+
+        # Reopen — prune_phantom_acks should drop the 2 phantom positions.
+        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+        store.@size.should eq 0
+        store.@deleted[1]?.try(&.size).should eq 5
+        store.@acks[1].size.should eq 5 * sizeof(UInt32)
+
+        body = "a" * 1000
+        store.push(LavinMQ::Message.new("ex", "rk", body))
+        store.@size.should eq 1
+
+        env = store.shift?
+        env.should_not be_nil
+        String.new(env.not_nil!.message.body).should eq body
+        store.@size.should eq 0
+        store.close
+      end
+    end
+
+    it "logs when pruning phantom ack positions" do
+      mktmpdir do |dir|
+        setup_phantom_ack_scenario(dir)
+        with_log_capture do |log|
+          store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+          store.close
+          log.entries.any?(&.message.matches?(/Pruned 2 phantom ack position\(s\) from segment 1/)).should be_true
+        end
+      end
+    end
+
+    it "does not re-prune on a second clean restart after phantom cleanup" do
+      mktmpdir do |dir|
+        setup_phantom_ack_scenario(dir)
+
+        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+        store.close
+        wait_for { store.closed }
+
+        with_log_capture do |log|
+          store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+          store.@acks[1].size.should eq 5 * sizeof(UInt32)
+          store.close
+          log.entries.any?(&.message.matches?(/Pruned/)).should be_false
+        end
+      end
+    end
+
+    it "handles phantom ack positions without crashing when opened as non-durable" do
+      mktmpdir do |dir|
+        setup_phantom_ack_scenario(dir)
+
+        # Non-durable reopens unlink the msg/ack files as they load, so the
+        # ack file is detected as orphaned and @deleted never gets populated.
+        # The important thing is that opening doesn't crash.
+        store = LavinMQ::MessageStore.new(dir, nil, durable: false)
+        (store.@deleted[1]?.nil? || store.@deleted[1].empty?).should be_true
+        store.close
+      end
+    end
+
+    it "deletes leftover acks.*.tmp files in the data dir" do
+      mktmpdir do |dir|
+        File.write(File.join(dir, "msgs.0000000001"), "\x04\x00\x00\x00")
+        File.write(File.join(dir, "acks.0000000001"), "")
+        orphan_tmp = File.join(dir, "acks.0000000001.tmp")
+        File.write(orphan_tmp, "garbage-bytes")
+
+        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+        store.@acks.has_key?(1u32).should be_true
+        File.exists?(orphan_tmp).should be_false
+        store.close
+      end
+    end
+
+    it "does not raise EOF when rfile.pos is at end when open_new_segment fires" do
+      mktmpdir do |dir|
+        body = "a" * 1000
+        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+        5.times { store.push(LavinMQ::Message.new("ex", "rk", body)) }
+        while env = store.shift?
+          store.delete(env.segment_position)
+        end
+        store.close
+        wait_for { store.closed }
+
+        store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+        store.@size.should eq 0
+
+        # Push-shift-ack one small msg; rfile.pos is now at end of segment 1.
+        store.push(LavinMQ::Message.new("ex", "rk", body))
+        env = store.shift?.not_nil!
+        store.delete(env.segment_position)
+        store.empty?.should be_true
+
+        # Invariant: rfile == wfile and rfile.pos == rfile.size (fully consumed).
+        store.@rfile.pos.should eq store.@rfile.size
+
+        # Now push a large message that forces open_new_segment.
+        # open_new_segment adds segment 2 and delete_unused_segments deletes segment 1.
+        # @rfile still points to orphan segment 1 with pos == size.
+        half_seg = LavinMQ::Config.instance.segment_size.to_u64 // 2 + 1
+        store.push(LavinMQ::Message.new(RoughTime.unix_ms, "e", "k",
+          AMQ::Protocol::Properties.new, half_seg, IO::Memory.new("b" * half_seg)))
+        store.@size.should eq 1
+
+        env = store.shift?
+        env.should_not be_nil
+        store.close
       end
     end
   end

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -551,9 +551,10 @@ module LavinMQ
     # flushes the acks file but not the corresponding msgs file, and would
     # otherwise cause shift? to skip over brand-new messages as if acked.
     private def prune_phantom_acks : Nil
-      @deleted.each do |seg, positions|
-        mfile = @segments[seg]?
-        next unless mfile
+      # Snapshot keys — prune_phantom_acks_for_segment mutates @deleted.
+      @deleted.keys.each do |seg|
+        next unless positions = @deleted[seg]?
+        next unless mfile = @segments[seg]?
         prune_phantom_acks_for_segment(seg, mfile, positions)
       end
     end

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -37,7 +37,7 @@ module LavinMQ
       load_acks_from_disk
       unless @closed
         load_stats_from_segments
-        prune_phantom_acks
+        prune_orphaned_acks
         delete_unused_segments
       end
 
@@ -369,14 +369,13 @@ module LavinMQ
     private def load_acks_from_disk : Nil
       count = 0u32
       Dir.each_child(@msg_dir) do |f|
-        next unless f.starts_with?("acks.")
-        if f.ends_with?(".tmp")
+        if f.starts_with?("tmp.acks.")
           stale = File.join(@msg_dir, f)
           @log.debug { "Deleting stale ack rewrite tempfile: #{stale}" }
           File.delete?(stale)
           next
         end
-        next unless f.size == 15
+        next unless f.starts_with?("acks.")
         seg = f[5, 10].to_u32
         path = File.join(@msg_dir, f)
 
@@ -547,25 +546,28 @@ module LavinMQ
     end
 
     # Removes ack positions referencing data past the reconstructed segment size.
-    # Such "phantom" acks can survive an unclean shutdown when kernel page-cache
+    # Such orphaned acks can survive an unclean shutdown when kernel page-cache
     # flushes the acks file but not the corresponding msgs file, and would
     # otherwise cause shift? to skip over brand-new messages as if acked.
-    private def prune_phantom_acks : Nil
-      # Snapshot keys — prune_phantom_acks_for_segment mutates @deleted.
+    private def prune_orphaned_acks : Nil
+      # Snapshot keys — prune_orphaned_acks_for_segment mutates @deleted.
       @deleted.keys.each do |seg|
         next unless positions = @deleted[seg]?
         next unless mfile = @segments[seg]?
-        prune_phantom_acks_for_segment(seg, mfile, positions)
+        prune_orphaned_acks_for_segment(seg, mfile, positions)
       end
     end
 
-    private def prune_phantom_acks_for_segment(seg : UInt32, mfile : MFile, positions : Array(UInt32)) : Nil
+    private def prune_orphaned_acks_for_segment(seg : UInt32, mfile : MFile, positions : Array(UInt32)) : Nil
       data_end = mfile.size.to_u32
       valid = positions.select { |p| p < data_end }
-      phantom_count = positions.size - valid.size
-      return if phantom_count.zero?
+      orphan_count = positions.size - valid.size
+      return if orphan_count.zero?
 
-      @log.info { "Pruned #{phantom_count} phantom ack position(s) from segment #{seg}" }
+      @log.warn {
+        "Msgs/acks files for segment #{seg} are out of sync (possibly because of " \
+        "an unclean shutdown). Removing #{orphan_count} orphaned ack position(s)."
+      }
 
       if valid.empty?
         @deleted.delete(seg)
@@ -579,8 +581,9 @@ module LavinMQ
     private def rewrite_ack_file(seg : UInt32, positions : Array(UInt32)) : Nil
       return unless @durable
 
-      final_path = File.join(@msg_dir, "acks.#{seg.to_s.rjust(10, '0')}")
-      tmp_path = "#{final_path}.tmp"
+      basename = "acks.#{seg.to_s.rjust(10, '0')}"
+      final_path = File.join(@msg_dir, basename)
+      tmp_path = File.join(@msg_dir, "tmp.#{basename}")
 
       File.open(tmp_path, "w") do |f|
         positions.each { |p| f.write_bytes(p, IO::ByteFormat::SystemEndian) }

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -37,6 +37,7 @@ module LavinMQ
       load_acks_from_disk
       unless @closed
         load_stats_from_segments
+        prune_phantom_acks
         delete_unused_segments
       end
 
@@ -368,7 +369,14 @@ module LavinMQ
     private def load_acks_from_disk : Nil
       count = 0u32
       Dir.each_child(@msg_dir) do |f|
-        next unless f.starts_with? "acks."
+        next unless f.starts_with?("acks.")
+        if f.ends_with?(".tmp")
+          stale = File.join(@msg_dir, f)
+          @log.debug { "Deleting stale ack rewrite tempfile: #{stale}" }
+          File.delete?(stale)
+          next
+        end
+        next unless f.size == 15
         seg = f[5, 10].to_u32
         path = File.join(@msg_dir, f)
 
@@ -536,6 +544,60 @@ module LavinMQ
 
     private def read_extra_metadata_fields(file : File, seg : UInt32)
       # Used in subclasses of MessageStore to read additional metadata fields
+    end
+
+    # Removes ack positions referencing data past the reconstructed segment size.
+    # Such "phantom" acks can survive an unclean shutdown when kernel page-cache
+    # flushes the acks file but not the corresponding msgs file, and would
+    # otherwise cause shift? to skip over brand-new messages as if acked.
+    private def prune_phantom_acks : Nil
+      @deleted.each do |seg, positions|
+        mfile = @segments[seg]?
+        next unless mfile
+        prune_phantom_acks_for_segment(seg, mfile, positions)
+      end
+    end
+
+    private def prune_phantom_acks_for_segment(seg : UInt32, mfile : MFile, positions : Array(UInt32)) : Nil
+      data_end = mfile.size.to_u32
+      valid = positions.select { |p| p < data_end }
+      phantom_count = positions.size - valid.size
+      return if phantom_count.zero?
+
+      @log.info { "Pruned #{phantom_count} phantom ack position(s) from segment #{seg}" }
+
+      if valid.empty?
+        @deleted.delete(seg)
+      else
+        @deleted[seg] = valid
+      end
+
+      rewrite_ack_file(seg, valid)
+    end
+
+    private def rewrite_ack_file(seg : UInt32, positions : Array(UInt32)) : Nil
+      return unless @durable
+
+      final_path = File.join(@msg_dir, "acks.#{seg.to_s.rjust(10, '0')}")
+      tmp_path = "#{final_path}.tmp"
+
+      File.open(tmp_path, "w") do |f|
+        positions.each { |p| f.write_bytes(p, IO::ByteFormat::SystemEndian) }
+        f.fsync
+      end
+
+      # Unmap the old file before renaming so mmap stops pinning the old inode.
+      if old = @acks.delete(seg)
+        old.close(truncate_to_size: false)
+      end
+
+      File.rename(tmp_path, final_path)
+
+      # Ship the rewritten (short) file to followers before reopening, so
+      # ReplaceAction captures the post-rename file size rather than the
+      # capacity-sized file produced by open_ack_file's ftruncate.
+      @replicator.try &.replace_file(final_path)
+      @acks[seg] = open_ack_file(seg)
     end
 
     private def produce_metadata(seg, mfile)


### PR DESCRIPTION
Fixes #1862.

After an unclean shutdown the kernel page cache may flush `acks.*` without flushing the matching `msgs.*`, leaving ack positions that reference data past the reconstructed segment end. The next push into that segment is skipped by `shift?` as already-acked, raising `EOF but @size=1` and closing the queue until process restart.

On load, drop any ack position `>= mfile.size`, rewrite the ack file (temp + rename, replicated), and clean up stale `acks.*.tmp` files.