### PR TITLE
Append short commit hash to shard version in build info

### DIFF
--- a/src/lavinmq/version.cr
+++ b/src/lavinmq/version.cr
@@ -1,5 +1,5 @@
 module LavinMQ
-  VERSION = {{ `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") }}
+  VERSION = {{ `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || echo "$(shards version)+$(git rev-parse --short HEAD 2>/dev/null)"`.chomp.stringify.gsub(/^v/, "") }}
 
   macro build_flags
     String.build do |flags|


### PR DESCRIPTION
### WHAT is this pull request doing?
In CI the checkout action is doing a shallow clone so no tags are available and the version string will be made from the fallback `shards version`. Since no hash is available one can't be sure what version that's actually has been built e.g. when the Compile step prints the build info.

This PR appends the short git commit hash to the version string when no tag is available (e.g. 0.x.y+abc1234), making it easier to identify the exact build from shards version fallback.

### HOW can this pull request be tested?
Manually (if testing is needed)