### PR TITLE
fix: update CSP hash for login page inline theme script

### DIFF
--- a/spec/frontend/auth.spec.js
+++ b/spec/frontend/auth.spec.js
@@ -1,11 +1,17 @@
 // @ts-check
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test'
+import { trackCspViolations } from './helpers.js'
 
-test.describe('when unauthenticated', _ =>  {
+test.describe('when unauthenticated', _ => {
   test.use({ storageState: {} })
   test('redirects to login', async ({ page }) => {
-    await page.goto('/');
-    await expect(page).toHaveURL(/\/login$/);
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/login$/)
+  })
+
+  test('login page loads without CSP violations', async ({ page }) => {
+    const getViolations = await trackCspViolations(page)
+    await page.goto('/login')
+    expect(await getViolations()).toEqual([])
   })
 })
-

--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -1,4 +1,4 @@
-async function waitForPathRequest(page, path, {response = {}, method = 'GET', body = undefined} = {}) {
+async function waitForPathRequest (page, path, { response = {}, method = 'GET', body = undefined } = {}) {
   const matchUrl = new URL(path, 'http://example.com')
   const pathCondition = (url) => {
     const requestedUrl = new URL(url)
@@ -23,7 +23,7 @@ async function waitForPathRequest(page, path, {response = {}, method = 'GET', bo
   })
 }
 
-function deepEqual(obj1, obj2) {
+function deepEqual (obj1, obj2) {
   if (obj1 === obj2) return true
   if (obj1 == null || obj2 == null) return false
   if (typeof obj1 !== 'object' || typeof obj2 !== 'object') return false
@@ -37,4 +37,20 @@ function deepEqual(obj1, obj2) {
   return true
 }
 
-export { waitForPathRequest }
+async function trackCspViolations (page) {
+  await page.addInitScript(() => {
+    window.__cspViolations = []
+    document.addEventListener('securitypolicyviolation', (e) => {
+      window.__cspViolations.push({
+        directive: e.violatedDirective,
+        blockedURI: e.blockedURI,
+        sourceFile: e.sourceFile,
+        lineNumber: e.lineNumber,
+        sample: e.sample
+      })
+    })
+  })
+  return () => page.evaluate(() => window.__cspViolations || [])
+}
+
+export { waitForPathRequest, trackCspViolations }

--- a/spec/frontend/layout.spec.js
+++ b/spec/frontend/layout.spec.js
@@ -1,4 +1,13 @@
 import { test, expect } from './fixtures.js'
+import { trackCspViolations } from './helpers.js'
+
+test.describe('Content Security Policy', _ => {
+  test('authenticated page loads without CSP violations', async ({ page }) => {
+    const getViolations = await trackCspViolations(page)
+    await page.goto('/')
+    expect(await getViolations()).toEqual([])
+  })
+})
 
 test.describe('theme switcher', _ => {
   test('system theme button is active by default', async ({ page }) => {

--- a/spec/http_views_spec.cr
+++ b/spec/http_views_spec.cr
@@ -1,6 +1,17 @@
 require "./spec_helper"
+require "digest/sha256"
+require "base64"
 
 HEADERS = {"Cookie": "m=|:Z3Vlc3Q6Z3Vlc3Q%3D"}
+
+private def inline_script_hashes(body : String) : Array(String)
+  hashes = [] of String
+  body.scan(/<script>(.*?)<\/script>/m) do |m|
+    digest = Digest::SHA256.digest(m[1])
+    hashes << "sha256-#{Base64.strict_encode(digest)}"
+  end
+  hashes
+end
 
 describe LavinMQ::HTTP::MainController do
   it "GET /" do
@@ -36,6 +47,26 @@ describe LavinMQ::HTTP::MainController do
       response.status_code.should eq 200
       response.headers["Content-Type"].should contain("text/html")
       response.body.should contain("<footer>")
+    end
+  end
+
+  it "GET / CSP header allows every inline script in the response body" do
+    with_http_server do |http, _|
+      response = http.get "/", HEADERS
+      csp = response.headers["Content-Security-Policy"]
+      hashes = inline_script_hashes(response.body)
+      hashes.should_not be_empty
+      hashes.each { |h| csp.should contain(h) }
+    end
+  end
+
+  it "GET /login CSP header allows every inline script in the response body" do
+    with_http_server do |http, _|
+      response = http.get "/login"
+      csp = response.headers["Content-Security-Policy"]
+      hashes = inline_script_hashes(response.body)
+      hashes.should_not be_empty
+      hashes.each { |h| csp.should contain(h) }
     end
   end
 end

--- a/src/lavinmq/http/controller/views.cr
+++ b/src/lavinmq/http/controller/views.cr
@@ -64,7 +64,7 @@ module LavinMQ
             context.response.headers.add("X-Frame-Options", "SAMEORIGIN")
             context.response.headers.add("Referrer-Policy", "same-origin")
             layout_inline_js_sha = "sha256-xCBzVV2TewAz4Dk/CrTquSJ4NTH48Y5fckwTF8Lg5bE="
-            login_inline_js_sha = "sha256-geVq8VDXlrdYEnBJnJpZGimivpOlbPNu95QQRXwEZY8="
+            login_inline_js_sha = "sha256-3bUZcnRc7hbNc+igS1dxqJNEEypKXCvZ9ozHwAxXIvc="
             context.response.headers.add("Content-Security-Policy", "default-src 'none'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; script-src 'self' '#{layout_inline_js_sha}' '#{login_inline_js_sha}'")
             {{ block.body if block }}
             render {{ view }}


### PR DESCRIPTION
The `login_inline_js_sha` in `views.cr` drifted from the actual inline theme-init script in `views/login.ecr`, so the browser's CSP blocked it and both light/dark logos rendered at once.
<img width="662" height="568" alt="image" src="https://github.com/user-attachments/assets/d7d98e91-f0ec-4d53-96c1-fef2bb253716" />


Updated the hash and added regression coverage at both layers so this class of bug fails CI instead of reaching users:

- Backend: `spec/http_views_spec.cr` extracts every inline `<script>` body from the rendered HTML and asserts its sha256 is listed in the `Content-Security-Policy` header.
- Frontend: `trackCspViolations(page)` helper in `spec/frontend/helpers.js` listens for `securitypolicyviolation` events via `addInitScript`; new tests assert `/login` (unauthed) and `/` (authed) load with zero violations.