### PR TITLE
Checkout deep when compiling in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Build lavinmq
         run: make -j bin/lavinmq bin/lavinmqctl DOCS= CRYSTAL_FLAGS="--error-on-warnings -Dbake_static"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Build lavinmq
         run: make -j bin/lavinmq bin/lavinmqctl DOCS= CRYSTAL_FLAGS="--error-on-warnings -Dbake_static"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Build lavinmq
         run: make -j bin/lavinmq bin/lavinmqctl DOCS= CRYSTAL_FLAGS="--error-on-warnings -Dbake_static"


### PR DESCRIPTION
### WHAT is this pull request doing?
In CI the checkout action is doing a shallow clone so no tags are available and the version string will be made from the fallback `shards version`. Since no hash is available one can't be sure what version that's actually has been built e.g. when the Compile step prints the build info.

This PR changes so the compile step will do a deep clone.

### HOW can this pull request be tested?
Manually (if testing is needed)