### PR TITLE
fix: flaky stream timestamp-across-segment-boundary spec

### DIFF
--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -225,16 +225,17 @@ describe LavinMQ::AMQP::Stream do
     with_amqp_server do |s|
       with_channel(s) do |ch|
         q = ch.queue("stream-ts-across-segments", args: stream_queue_args)
-        # Use half-segment messages so exactly 1 fits per segment
+        # Half-segment payload so each publish lands in its own segment.
         data = Bytes.new(LavinMQ::Config.instance.segment_size // 2)
-        # Fill segment 1 — two half-segment messages won't fit, so second triggers new segment
         q.publish_confirm data
-        # Sleep to create a timestamp gap
-        sleep 1.seconds
-        target_time = Time.utc
-        # This publish can't fit in current segment, creates a new one with first_ts > target
+        # Sleep > 1s so the two messages land in distinct whole seconds
+        sleep 1.2.seconds
         q.publish_confirm data
-        # Consume from timestamp in the gap — find_offset_in_segments must cross segment boundary
+        # Derive target from msg1's stored timestamp; Time.utc here would race RoughTime's
+        # 100ms coarsening and could land inside segment 2's bucket, hanging the consumer.
+        store = s.vhosts["/"].queues["stream-ts-across-segments"].as(LavinMQ::AMQP::Stream).stream_msg_store
+        msg1_ts = store.@segment_last_ts.values.first
+        target_time = Time.unix(msg1_ts // 1000 + 1)
         ch.prefetch 1
         msgs = Channel(AMQP::Client::DeliverMessage).new
         q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": target_time})) do |msg|


### PR DESCRIPTION
The spec "consume from timestamp offset across segment boundary" (`spec/stream_queue_spec.cr`) was flaky because it didn't guarantee the two published messages landed at distinguishable timestamps — the precisions of the time sources involved are much coarser than the wall-clock `Time.utc` the spec used as `target_time`:

- **Message timestamps** are set from `RoughTime.unix_ms`, which ticks every 100ms and is truncated to 100ms. Two publishes less than 100ms apart can share the exact same timestamp.
- **AMQP's `timestamp` wire type has 1-second resolution**, so `x-stream-offset: Time` is truncated to whole seconds on the way in — the server sees only the second, not the ms.

With a 1s sleep between publishes, `target_time = Time.utc` could still land inside segment 2's coarsened bucket; `find_offset_in_segments` then walked past `@last_offset` and returned `last_offset + 1`, hanging the consumer.

Fix: sleep `1.2s` between publishes to guarantee the two messages fall in distinct whole seconds, then derive the consumer's offset from the actual stored timestamp — `Time.unix((@segment_last_ts.values.first // 1000) + 1)` — the whole-second boundary immediately after msg1's second, which is ≤ msg2's second. Both `offset_index_lookup` branches then route deterministically to offset 2.

Measured over 100-iteration loops of the built spec binary:
- Old spec: **4/100** failures (2 assertion failures + 2 timeouts)
- New spec: **0/100** failures