### PR TITLE
Render HTTP API docs with Scalar themed to match management UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ package-lock.json
 /playwright/
 /playwright-report/
 /static/*.html
+/static/docs/openapi.bundle.yaml
 .DS_Store
 .claude/settings.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN shards install --production
 COPY ./static ./static
 COPY ./views ./views
 COPY ./src ./src
+COPY ./openapi ./openapi
 
 # Run specs on build platform
 FROM base AS spec

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ static/js/lib/scalar-api-reference-1.52.6.js: | static/js/lib
 	curl --fail --retry 5 -sLo $@ https://unpkg.com/@scalar/api-reference@1.52.6/dist/browser/standalone.js
 	[ "e5cab69c3b20583a60fff3fd97eb3ae6b66fa8c0aa218ed36fb94163f2fbd66a *$@" = "$$(openssl dgst -sha256 -r $@)" ]
 
-static/docs/openapi.bundle.yaml: $(OPENAPI_SOURCES)
-	npx --yes --package=@redocly/cli@1.28.0 redocly bundle $< --output $@ --force
+static/docs/openapi.bundle.yaml: $(OPENAPI_SOURCES) openapi/bundle.cr
+	crystal run openapi/bundle.cr -- $< $@
 
 man1/lavinmq.1: bin/lavinmq | man1
 	help2man -Nn "fast and advanced message queue server" $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ CTL_SOURCES := $(shell find src/lavinmqctl -name '*.cr' 2> /dev/null)
 VIEW_SOURCES := $(wildcard views/*.ecr)
 VIEW_TARGETS := $(patsubst views/%.ecr,static/%.html,$(VIEW_SOURCES))
 VIEW_PARTIALS := $(wildcard views/partials/*.ecr)
-JS := static/js/lib/chunks/helpers.segment.js static/js/lib/chart.js static/js/lib/luxon.js static/js/lib/chartjs-adapter-luxon.esm.js static/js/lib/elements-8.2.0.js static/js/lib/elements-8.2.0.css $(wildcard static/js/*.js)
+JS := static/js/lib/chunks/helpers.segment.js static/js/lib/chart.js static/js/lib/luxon.js static/js/lib/chartjs-adapter-luxon.esm.js static/js/lib/scalar-api-reference-1.52.6.js $(wildcard static/js/*.js)
+DOCS := static/docs/openapi.bundle.yaml
+OPENAPI_SOURCES := static/docs/openapi.yaml $(wildcard static/docs/paths/*.yaml) $(wildcard static/docs/schemas/*.yaml)
 CRYSTAL_FLAGS := --release
 override CRYSTAL_FLAGS += --stats -Dpreview_mt -Dexecution_context --link-flags="$(LDFLAGS)"
 .DELETE_ON_ERROR:
@@ -58,13 +60,12 @@ static/js/lib/chartjs-adapter-luxon.esm.js: | static/js/lib
 	sed -i'' -e "s|\(import { _adapters } from\).*|\1 './chart.js'|; s|\(import { DateTime } from\).*|\1 './luxon.js'|" $@
 	[ "17d7b6567d656a004f86b6b5cbdbe64cb308e9a2ebfa7675caa79ba0bc72ef91 *$@" = "$$(openssl dgst -sha256 -r $@)" ]
 
-static/js/lib/elements-8.2.0.js: | static/js/lib
-	curl --fail --retry 5 -sLo $@ https://unpkg.com/@stoplight/elements@8.2.0/web-components.min.js
-	[ "598862da6d551769ebad9d61d4e3037535de573a13d3e0bd1ded4c5fc65c5885 *$@" = "$$(openssl dgst -sha256 -r $@)" ]
+static/js/lib/scalar-api-reference-1.52.6.js: | static/js/lib
+	curl --fail --retry 5 -sLo $@ https://unpkg.com/@scalar/api-reference@1.52.6/dist/browser/standalone.js
+	[ "e5cab69c3b20583a60fff3fd97eb3ae6b66fa8c0aa218ed36fb94163f2fbd66a *$@" = "$$(openssl dgst -sha256 -r $@)" ]
 
-static/js/lib/elements-8.2.0.css: | static/js/lib
-	curl --fail --retry 5 -sLo $@ https://unpkg.com/@stoplight/elements@8.2.0/styles.min.css
-	[ "119784e23ffc39b6fa3fdb3df93f391f8250e8af141b78dfc3b6bed86079f93b *$@" = "$$(openssl dgst -sha256 -r $@)" ]
+static/docs/openapi.bundle.yaml: $(OPENAPI_SOURCES)
+	npx --yes --package=@redocly/cli@1.28.0 redocly bundle $< --output $@ --force
 
 man1/lavinmq.1: bin/lavinmq | man1
 	help2man -Nn "fast and advanced message queue server" $< -o $@
@@ -83,8 +84,11 @@ man: $(MANPAGES)
 .PHONY: js
 js: $(JS)
 
+.PHONY: docs
+docs: $(DOCS)
+
 .PHONY: deps
-deps: js lib
+deps: js lib docs
 
 
 .PHONY: lint

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,6 +1,6 @@
 # LavinMQ HTTP API OpenAPI spec
 
-OpenAPI docs rendered in browser using https://github.com/stoplightio/elements
+OpenAPI docs rendered in browser using https://github.com/scalar/scalar
 
 (Note the gotcha: the browser caches the YAML files even if they have changed, open dev console in the browser to mitigate.)
 

--- a/openapi/bundle.cr
+++ b/openapi/bundle.cr
@@ -1,0 +1,75 @@
+# Bundles a modular OpenAPI spec into a single YAML file by inlining
+# external $refs (./paths/*.yaml, ./schemas/*.yaml) and rewriting
+# inward refs (../openapi.yaml#/...) to local anchors (#/...).
+#
+# Usage: crystal run openapi/bundle.cr -- <source.yaml> <bundled.yaml>
+
+require "yaml"
+require "json"
+
+class Bundler
+  @cache = {} of String => JSON::Any
+
+  def initialize(@root_dir : String)
+  end
+
+  def bundle(source : String) : JSON::Any
+    doc = load(source)
+    rewrite(doc, File.dirname(source))
+  end
+
+  private def load(path : String) : JSON::Any
+    absolute = File.expand_path(path)
+    @cache[absolute] ||= JSON.parse(YAML.parse(File.read(absolute)).to_json)
+  end
+
+  private def resolve(doc : JSON::Any, pointer : String) : JSON::Any
+    return doc if pointer.empty? || pointer == "/"
+    parts = pointer.lchop('/').split('/').map { |p| p.gsub("~1", "/").gsub("~0", "~") }
+    parts.reduce(doc) do |acc, part|
+      case raw = acc.raw
+      when Hash  then acc[part]
+      when Array then acc[part.to_i]
+      else            raise "cannot descend into #{raw.class} with #{part.inspect}"
+      end
+    end
+  end
+
+  private def rewrite(value : JSON::Any, base_dir : String) : JSON::Any
+    case raw = value.raw
+    when Hash(String, JSON::Any)
+      if raw.size == 1 && (ref = raw["$ref"]?)
+        return inline(ref.as_s, base_dir)
+      end
+      new_hash = {} of String => JSON::Any
+      raw.each { |k, v| new_hash[k] = rewrite(v, base_dir) }
+      JSON::Any.new(new_hash)
+    when Array(JSON::Any)
+      JSON::Any.new(raw.map { |v| rewrite(v, base_dir).as(JSON::Any) })
+    else
+      value
+    end
+  end
+
+  private def inline(ref : String, base_dir : String) : JSON::Any
+    # Already a local anchor — nothing to do.
+    return JSON::Any.new({"$ref" => JSON::Any.new(ref)}) if ref.starts_with?('#')
+
+    file_part, _, pointer = ref.partition('#')
+    target_path = File.expand_path(file_part, base_dir)
+
+    # Refs pointing back at the root spec become local anchors.
+    if target_path == File.expand_path(@root_dir)
+      return JSON::Any.new({"$ref" => JSON::Any.new("#" + pointer)})
+    end
+
+    target = resolve(load(target_path), pointer)
+    rewrite(target, File.dirname(target_path))
+  end
+end
+
+source = ARGV[0]? || abort "usage: bundle.cr <source.yaml> <output.yaml>"
+output = ARGV[1]? || abort "usage: bundle.cr <source.yaml> <output.yaml>"
+
+bundled = Bundler.new(source).bundle(source)
+File.write(output, bundled.to_yaml)

--- a/packaging/alpine/Dockerfile
+++ b/packaging/alpine/Dockerfile
@@ -6,6 +6,7 @@ RUN shards install --production
 COPY ./static ./static
 COPY ./views ./views
 COPY ./src ./src
+COPY ./openapi ./openapi
 COPY Makefile .
 ARG MAKEFLAGS=-j2
 RUN make all

--- a/packaging/arch/Dockerfile
+++ b/packaging/arch/Dockerfile
@@ -6,6 +6,7 @@ COPY extras/lavinmq.service extras/lavinmq.ini extras/lavinmq.sysusers extras/
 COPY static/ static/
 COPY views/ views/
 COPY src/ src/
+COPY openapi/ openapi/
 WORKDIR /usr/src/lavinmq
 COPY packaging/arch/PKGBUILD .
 ARG version

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -9,6 +9,7 @@ COPY extras/lavinmq.service extras/lavinmq.ini extras/lavinmq.sysusers extras/
 COPY static/ static/
 COPY views/ views/
 COPY src/ src/
+COPY openapi/ openapi/
 RUN tar -czf ../lavinmq_${version}.orig.tar.gz -C /usr/src lavinmq_${version}
 COPY packaging/debian/ debian/
 RUN sed -i -E "s/^(lavinmq) \(.*\)/\1 \(${version}-1\)/" debian/changelog

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -18,6 +18,7 @@ COPY extras/lavinmq.service extras/lavinmq.ini extras/lavinmq.sysusers extras/
 COPY static/ static/
 COPY views/ views/
 COPY src/ src/
+COPY openapi/ openapi/
 RUN tar -czf /root/rpmbuild/SOURCES/lavinmq.tar.gz -C /usr/src lavinmq
 ARG MAKEFLAGS=-j2
 RUN rpmbuild -ba /root/rpmbuild/SPECS/lavinmq.spec

--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -4,18 +4,37 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>LavinMQ HTTP API</title>
-    <script src="../js/lib/elements-8.2.0.js"></script>
-    <link rel="stylesheet" href="../js/lib/elements-8.2.0.css">
+    <link rel="icon" href="../img/favicon.png">
+    <link rel="stylesheet" href="lavinmq-docs.css">
   </head>
   <body>
-    <elements-api
-      apiDescriptionUrl="openapi.yaml"
-      router="hash"
-      layout="sidebar"
-      logo="../img/favicon.png"
-      tryItCredentialsPolicy="same-origin"
-      hideSchemas="true"
-      />
+    <header class="lavinmq-docs-header">
+      <img src="../img/favicon.png" alt="LavinMQ">
+      <span>LavinMQ HTTP API</span>
+      <span class="spacer"></span>
+      <a href="../">Back to management UI</a>
+    </header>
+    <script id="api-reference" data-url="openapi.bundle.yaml"></script>
+    <script>
+      (function () {
+        var classes = (window.localStorage.getItem('lmq.stateclasses') || '').split(' ').filter(Boolean)
+        var explicit = classes.indexOf('theme-dark') !== -1 || classes.indexOf('theme-light') !== -1
+        var dark = explicit
+          ? classes.indexOf('theme-dark') !== -1
+          : window.matchMedia('(prefers-color-scheme: dark)').matches
+        document.documentElement.classList.add(dark ? 'theme-dark' : 'theme-light')
+        var script = document.getElementById('api-reference')
+        script.dataset.configuration = JSON.stringify({
+          theme: 'default',
+          layout: 'modern',
+          darkMode: dark,
+          forceDarkModeState: dark ? 'dark' : 'light',
+          hideDarkModeToggle: false,
+          hideModels: true,
+          searchHotKey: 'k'
+        })
+      })()
+    </script>
+    <script src="../js/lib/scalar-api-reference-1.52.6.js"></script>
   </body>
 </html>
-

--- a/static/docs/lavinmq-docs.css
+++ b/static/docs/lavinmq-docs.css
@@ -1,0 +1,142 @@
+@font-face {
+  font-family: Inter;
+  src: url("../fonts/Inter-Regular.woff2") format("woff2");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: Inter;
+  src: url("../fonts/Inter-SemiBold.woff2") format("woff2");
+  font-weight: 600;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: Inter;
+  src: url("../fonts/Inter-Italic.woff2") format("woff2");
+  font-style: italic;
+  font-display: swap;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--scalar-background-1);
+}
+
+.lavinmq-docs-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  background: var(--scalar-background-2);
+  border-bottom: 1px solid var(--scalar-border-color);
+  color: var(--scalar-color-1);
+  font-weight: 600;
+}
+
+.lavinmq-docs-header img {
+  height: 24px;
+  width: 24px;
+}
+
+.lavinmq-docs-header .spacer {
+  flex: 1;
+}
+
+.lavinmq-docs-header a {
+  color: var(--scalar-color-accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.lavinmq-docs-header a:hover {
+  text-decoration: underline;
+}
+
+/* Map Scalar tokens onto LavinMQ palette */
+.light-mode,
+.dark-mode {
+  --scalar-font: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --scalar-font-code: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --scalar-radius: 4px;
+  --scalar-radius-lg: 6px;
+  --scalar-radius-xl: 8px;
+}
+
+.light-mode {
+  --scalar-color-1: #141414;
+  --scalar-color-2: #374151;
+  --scalar-color-3: #6B7280;
+  --scalar-color-accent: #3c9368;
+
+  --scalar-background-1: #FFFFFF;
+  --scalar-background-2: #F4F4F4;
+  --scalar-background-3: #f3f4f6;
+  --scalar-background-accent: rgba(60, 147, 104, 0.12);
+
+  --scalar-border-color: rgba(0, 0, 0, 0.1);
+
+  --scalar-button-1: #3c9368;
+  --scalar-button-1-color: #fafafa;
+  --scalar-button-1-hover: #348056;
+
+  --scalar-color-green: #54BE7E;
+  --scalar-color-red: #ED4337;
+  --scalar-color-yellow: #e2b149;
+  --scalar-color-blue: #3c9368;
+  --scalar-color-orange: #e2b149;
+  --scalar-color-purple: #3c9368;
+
+  --scalar-sidebar-background-1: #F4F4F4;
+  --scalar-sidebar-item-hover-background: #FFFFFF;
+  --scalar-sidebar-item-hover-color: #141414;
+  --scalar-sidebar-item-active-background: rgba(60, 147, 104, 0.12);
+  --scalar-sidebar-color-1: #141414;
+  --scalar-sidebar-color-2: #6B7280;
+  --scalar-sidebar-color-active: #3c9368;
+  --scalar-sidebar-border-color: rgba(0, 0, 0, 0.1);
+  --scalar-sidebar-search-background: #FFFFFF;
+  --scalar-sidebar-search-color: #141414;
+  --scalar-sidebar-search-border-color: rgba(0, 0, 0, 0.1);
+}
+
+.dark-mode {
+  --scalar-color-1: #fafafa;
+  --scalar-color-2: #CDCBC9;
+  --scalar-color-3: #9D9C9A;
+  --scalar-color-accent: #54BE7E;
+
+  --scalar-background-1: #181818;
+  --scalar-background-2: #1D1D1D;
+  --scalar-background-3: #2d2c2c;
+  --scalar-background-accent: rgba(84, 190, 126, 0.14);
+
+  --scalar-border-color: rgba(247, 245, 242, 0.1);
+
+  --scalar-button-1: #54BE7E;
+  --scalar-button-1-color: #181818;
+  --scalar-button-1-hover: #44FC70;
+
+  --scalar-color-green: #54BE7E;
+  --scalar-color-red: #ED4337;
+  --scalar-color-yellow: #e2b149;
+  --scalar-color-blue: #54BE7E;
+  --scalar-color-orange: #e2b149;
+  --scalar-color-purple: #54BE7E;
+
+  --scalar-sidebar-background-1: #1D1D1D;
+  --scalar-sidebar-item-hover-background: #2d2c2c;
+  --scalar-sidebar-item-hover-color: #fafafa;
+  --scalar-sidebar-item-active-background: rgba(84, 190, 126, 0.14);
+  --scalar-sidebar-color-1: #fafafa;
+  --scalar-sidebar-color-2: #9D9C9A;
+  --scalar-sidebar-color-active: #54BE7E;
+  --scalar-sidebar-border-color: rgba(247, 245, 242, 0.1);
+  --scalar-sidebar-search-background: #2D2C2C;
+  --scalar-sidebar-search-color: #fafafa;
+  --scalar-sidebar-search-border-color: rgba(247, 245, 242, 0.1);
+}


### PR DESCRIPTION
Swap Stoplight Elements for Scalar API Reference on /docs/ so the page matches the LavinMQ management UI (Inter font, #3c9368 / #54BE7E accents, light/dark theme synced via lmq.stateclasses). Scalar's runtime resolver can't follow the modular $refs, so bundle the spec with @redocly/cli as a build artifact (static/docs/openapi.bundle.yaml, gitignored).

<img width="2560" height="2652" alt="Screenshot 2026-04-24 at 23-17-07 LavinMQ HTTP API" src="https://github.com/user-attachments/assets/196b68db-a64e-42d5-849b-4a9a2efd0567" />
