### PR TITLE
ci: skip paid macOS runner on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
   spec_osx:
     name: Spec macOS
     runs-on: macos-15-xlarge
+    if: github.repository == 'cloudamqp/lavinmq'
     timeout-minutes: 10
     steps:
       - name: Install dependencies


### PR DESCRIPTION
The macos-15-xlarge runner is not free, which means contributors who fork the repo and enable Actions could be billed for CI runs. Restrict the spec_osx job to the upstream repository.