### PR TITLE
refactor: centralize mgmt authentication logic and add whoami caching

### DIFF
--- a/spec/frontend/auth.spec.js
+++ b/spec/frontend/auth.spec.js
@@ -41,6 +41,46 @@ test.describe('login', _ => {
   })
 })
 
+test.describe('whoAmI', _ => {
+  test('logs out and redirects to /login on API failure', async ({ page, context }) => {
+    await page.route(url => url.pathname === '/api/whoami', route => route.fulfill({ status: 401 }))
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/login$/)
+    const cookies = await context.cookies()
+    expect(cookies.some(c => c.name === 'm')).toBe(false)
+  })
+
+  test('caches whoami response and only fetches once', async ({ page }) => {
+    let callCount = 0
+    await page.route(url => url.pathname === '/api/whoami', async route => {
+      callCount++
+      await route.fallback()
+    })
+    await page.goto('/')
+    await page.goto('/')
+    expect(callCount).toBe(1)
+  })
+
+  test('fetches whoami again if missing from localStorage', async ({ page }) => {
+    let callCount = 0
+    await page.route(url => url.pathname === '/api/whoami', async route => {
+      callCount++
+      await route.fallback()
+    })
+    await page.goto('/')
+    await page.evaluate(() => localStorage.removeItem('lmq.whoami'))
+    await page.goto('/')
+    expect(callCount).toBe(2)
+  })
+
+  test('does not store sensitive fields in localStorage', async ({ page }) => {
+    await page.goto('/')
+    const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('lmq.whoami')))
+    expect(stored.password_hash).toBeUndefined()
+    expect(stored.hashing_algorithm).toBeUndefined()
+  })
+})
+
 test.describe('logout', _ => {
   test('clicking sign-out redirects to /login and deletes cookie', async ({ page, context }) => {
     await page.goto('/')

--- a/spec/frontend/auth.spec.js
+++ b/spec/frontend/auth.spec.js
@@ -15,3 +15,40 @@ test.describe('when unauthenticated', _ => {
     expect(await getViolations()).toEqual([])
   })
 })
+
+test.describe('login', _ => {
+  test.use({ storageState: {} })
+
+  test('successful login redirects to / and sets cookie', async ({ page, context }) => {
+    await page.goto('/login')
+    await page.getByLabel('Username').fill('guest')
+    await page.getByLabel('Password').fill('guest')
+    await page.getByRole('button').click()
+    await expect(page).toHaveURL('/')
+    const cookies = await context.cookies()
+    expect(cookies.some(c => c.name === 'm')).toBe(true)
+  })
+
+  test('failed login shows "Authentication failure" alert', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('Username').fill('guest')
+    await page.getByLabel('Password').fill('wrongpassword')
+    const dialog = page.waitForEvent('dialog')
+    await page.getByRole('button').click()
+    const d = await dialog
+    expect(d.message()).toBe('Authentication failure')
+    await d.dismiss()
+  })
+})
+
+test.describe('logout', _ => {
+  test('clicking sign-out redirects to /login and deletes cookie', async ({ page, context }) => {
+    await page.goto('/')
+    await Promise.all([
+      page.waitForURL(/\/login$/),
+      page.locator('#signoutLink').click()
+    ])
+    const cookies = await context.cookies()
+    expect(cookies.some(c => c.name === 'm')).toBe(false)
+  })
+})

--- a/spec/frontend/auth.spec.js
+++ b/spec/frontend/auth.spec.js
@@ -33,9 +33,10 @@ test.describe('login', _ => {
     await page.goto('/login')
     await page.getByLabel('Username').fill('guest')
     await page.getByLabel('Password').fill('wrongpassword')
-    const dialog = page.waitForEvent('dialog')
-    await page.getByRole('button').click()
-    const d = await dialog
+    const [d] = await Promise.all([
+      page.waitForEvent('dialog'),
+      page.getByRole('button').click()
+    ])
     expect(d.message()).toBe('Authentication failure')
     await d.dismiss()
   })
@@ -43,6 +44,7 @@ test.describe('login', _ => {
 
 test.describe('whoAmI', _ => {
   test('logs out and redirects to /login on API failure', async ({ page, context }) => {
+    await page.addInitScript(() => localStorage.removeItem('lmq.whoami'))
     await page.route(url => url.pathname === '/api/whoami', route => route.fulfill({ status: 401 }))
     await page.goto('/')
     await expect(page).toHaveURL(/\/login$/)
@@ -51,6 +53,8 @@ test.describe('whoAmI', _ => {
   })
 
   test('caches whoami response and only fetches once', async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.removeItem('lmq.whoami'))
     let callCount = 0
     await page.route(url => url.pathname === '/api/whoami', async route => {
       callCount++
@@ -62,6 +66,8 @@ test.describe('whoAmI', _ => {
   })
 
   test('fetches whoami again if missing from localStorage', async ({ page }) => {
+    await page.goto('/')
+    await page.evaluate(() => localStorage.removeItem('lmq.whoami'))
     let callCount = 0
     await page.route(url => url.pathname === '/api/whoami', async route => {
       callCount++

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -34,19 +34,8 @@ function logout () {
   window.location.assign('login')
 }
 
-async function whoAmI (forceReload = false) {
-  if (!forceReload) {
-    const data = window.localStorage.getItem('lmq.whoami')
-    let whoAmI = null
-    if (data) {
-      whoAmI = JSON.parse(data)
-    }
-    // Do we have cached and valid info?
-    if (whoAmI && whoAmI.name == getUsername() && (whoAmI._ts + 3600 * 1000) > Date.now()) {
-      return whoAmI
-    }
-  }
-  return await window.fetch('api/whoami')
+async function fetchAndCacheWhoAmI () {
+  return window.fetch('api/whoami')
     .then(async resp => {
       if (resp.ok) {
         return await resp.json().then(data => {
@@ -61,6 +50,23 @@ async function whoAmI (forceReload = false) {
         return null
       }
     })
+}
+
+async function whoAmI (forceReload = false) {
+  if (!forceReload) {
+    const data = window.localStorage.getItem('lmq.whoami')
+    if (data) {
+      const cached = JSON.parse(data)
+      if (cached && cached.name == getUsername()) {
+        const expired = (cached._ts + 3600 * 1000) <= Date.now()
+        if (expired) {
+          fetchAndCacheWhoAmI()
+        }
+        return cached
+      }
+    }
+  }
+  return fetchAndCacheWhoAmI()
 }
 
 export {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -67,7 +67,7 @@ async function whoAmI (forceReload = false) {
       } catch {
         window.localStorage.removeItem('lmq.whoami')
       }
-      if (cached && cached.name == getUsername()) {
+      if (cached && cached.name === getUsername()) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {
           fetchAndCacheWhoAmI()

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -23,9 +23,10 @@ function getCookie (key) {
 async function login (username, password) {
   const auth = window.btoa(`${username}:${password}`)
   document.cookie = `m=|:${encodeURIComponent(auth)}; samesite=strict; max-age=${60 * 60 * 8}`
-  const result = await whoAmI(true)
-  if (!result) document.cookie = 'm=; max-age=0'
-  return result
+  return whoAmI(true).catch(e => {
+    document.cookie = 'm=; max-age=0'
+    throw e
+  })
 }
 
 function logout () {
@@ -43,7 +44,7 @@ async function fetchAndCacheWhoAmI () {
           data = await resp.json()
         } catch {
           window.localStorage.removeItem('lmq.whoami')
-          return null
+          throw new Error('Invalid JSON response from whoami')
         }
         data._ts = Date.now()
         delete data.password_hash
@@ -52,7 +53,7 @@ async function fetchAndCacheWhoAmI () {
         return data
       } else {
         window.localStorage.removeItem('lmq.whoami')
-        return null
+        throw new Error(`whoami failed with status ${resp.status}`)
       }
     })
 }
@@ -70,7 +71,7 @@ async function whoAmI (forceReload = false) {
       if (cached && cached.name === getUsername()) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {
-          fetchAndCacheWhoAmI()
+          fetchAndCacheWhoAmI().catch(e => console.warn(`Failed to load whoAmI: ${e.message}`))
         }
         return cached
       }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -38,13 +38,18 @@ async function fetchAndCacheWhoAmI () {
   return window.fetch('api/whoami')
     .then(async resp => {
       if (resp.ok) {
-        return await resp.json().then(data => {
-          data._ts = Date.now()
-          delete data.password_hash
-          delete data.hashing_algorithm
-          window.localStorage.setItem('lmq.whoami', JSON.stringify(data))
-          return data
-        })
+        let data
+        try {
+          data = await resp.json()
+        } catch {
+          window.localStorage.removeItem('lmq.whoami')
+          return null
+        }
+        data._ts = Date.now()
+        delete data.password_hash
+        delete data.hashing_algorithm
+        window.localStorage.setItem('lmq.whoami', JSON.stringify(data))
+        return data
       } else {
         window.localStorage.removeItem('lmq.whoami')
         return null
@@ -56,7 +61,12 @@ async function whoAmI (forceReload = false) {
   if (!forceReload) {
     const data = window.localStorage.getItem('lmq.whoami')
     if (data) {
-      const cached = JSON.parse(data)
+      let cached
+      try {
+        cached = JSON.parse(data)
+      } catch {
+        window.localStorage.removeItem('lmq.whoami')
+      }
       if (cached && cached.name == getUsername()) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -29,8 +29,10 @@ async function login (username, password) {
   })
 }
 
+const whoAmICacheKey = 'lmq.whoami'
+
 function logout () {
-  window.localStorage.removeItem('lmq.whoami')
+  window.localStorage.removeItem(whoAmICacheKey)
   document.cookie = 'm=; max-age=0'
   window.location.assign('login')
 }
@@ -43,16 +45,16 @@ async function fetchAndCacheWhoAmI () {
         try {
           data = await resp.json()
         } catch {
-          window.localStorage.removeItem('lmq.whoami')
+          window.localStorage.removeItem(whoAmICacheKey)
           throw new Error('Invalid JSON response from whoami')
         }
         data._ts = Date.now()
         delete data.password_hash
         delete data.hashing_algorithm
-        window.localStorage.setItem('lmq.whoami', JSON.stringify(data))
+        window.localStorage.setItem(whoAmICacheKey, JSON.stringify(data))
         return data
       } else {
-        window.localStorage.removeItem('lmq.whoami')
+        window.localStorage.removeItem(whoAmICacheKey)
         throw new Error(`whoami failed with status ${resp.status}`)
       }
     })
@@ -60,17 +62,18 @@ async function fetchAndCacheWhoAmI () {
 
 async function whoAmI (forceReload = false) {
   if (!forceReload) {
-    const data = window.localStorage.getItem('lmq.whoami')
+    const data = window.localStorage.getItem(whoAmICacheKey)
     if (data) {
       let cached
       try {
         cached = JSON.parse(data)
       } catch {
-        window.localStorage.removeItem('lmq.whoami')
+        window.localStorage.removeItem(whoAmICacheKey)
       }
       if (cached && cached.name === getUsername()) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {
+          // fetch in background, we still return the cached
           fetchAndCacheWhoAmI().catch(e => console.warn(`Failed to load whoAmI: ${e.message}`))
         }
         return cached

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -50,6 +50,8 @@ async function whoAmI(forceReload = false) {
       if (resp.ok) {
         return await resp.json().then(data => {
           data['_ts'] = Date.now()
+          delete data['password_hash']
+          delete data['hashing_algorithm']
           window.localStorage.setItem('whoami', JSON.stringify(data))
           return data
         })

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,4 +1,4 @@
-import { stateClasses } from "./helpers.js"
+import { stateClasses } from './helpers.js'
 
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]
@@ -22,26 +22,26 @@ function getCookie (key) {
     ?.split('=')[1]
 }
 
-async function login(username, password) {
+async function login (username, password) {
   const auth = window.btoa(`${username}:${password}`)
   document.cookie = `m=|:${encodeURIComponent(auth)}; samesite=strict; max-age=${60 * 60 * 8}`
   return whoAmI(true)
 }
 
-function logout() {
-  window.localStorage.removeItem('whoami')
+function logout () {
+  window.localStorage.removeItem('lmq.whoami')
   document.cookie = 'm=; max-age=0'
 }
 
-async function whoAmI(forceReload = false) {
+async function whoAmI (forceReload = false) {
   if (!forceReload) {
-    const data = window.localStorage.getItem('whoami')
+    const data = window.localStorage.getItem('lmq.whoami')
     let whoAmI = null
     if (data) {
       whoAmI = JSON.parse(data)
     }
     // Do we have cached and valid info?
-    if (whoAmI && whoAmI['name'] == getUsername() && (whoAmI['_ts']+3600*1000) > Date.now()) {
+    if (whoAmI && whoAmI.name == getUsername() && (whoAmI._ts + 3600 * 1000) > Date.now()) {
       return whoAmI
     }
   }
@@ -49,10 +49,10 @@ async function whoAmI(forceReload = false) {
     .then(async resp => {
       if (resp.ok) {
         return await resp.json().then(data => {
-          data['_ts'] = Date.now()
-          delete data['password_hash']
-          delete data['hashing_algorithm']
-          window.localStorage.setItem('whoami', JSON.stringify(data))
+          data._ts = Date.now()
+          delete data.password_hash
+          delete data.hashing_algorithm
+          window.localStorage.setItem('lmq.whoami', JSON.stringify(data))
           return data
         })
       } else {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -37,7 +37,7 @@ function logout () {
   window.location.assign('login')
 }
 
-async function fetchAndCacheWhoAmI () {
+async function fetchWhoAmI () {
   return window.fetch('api/whoami')
     .then(async resp => {
       if (resp.ok) {
@@ -74,13 +74,13 @@ async function whoAmI (forceReload = false) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {
           // fetch in background, we still return the cached
-          fetchAndCacheWhoAmI().catch(e => console.warn(`Failed to load whoAmI: ${e.message}`))
+          fetchWhoAmI().catch(e => console.warn(`Failed to load whoAmI: ${e.message}`))
         }
         return cached
       }
     }
   }
-  return fetchAndCacheWhoAmI()
+  return fetchWhoAmI()
 }
 
 export {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,3 +1,5 @@
+import { stateClasses } from "./helpers.js"
+
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]
 }
@@ -20,7 +22,48 @@ function getCookie (key) {
     ?.split('=')[1]
 }
 
+async function login(username, password) {
+  const auth = window.btoa(`${username}:${password}`)
+  document.cookie = `m=|:${encodeURIComponent(auth)}; samesite=strict; max-age=${60 * 60 * 8}`
+  return whoAmI(true)
+}
+
+function logout() {
+  window.localStorage.removeItem('whoami')
+  document.cookie = 'm=; max-age=0'
+}
+
+async function whoAmI(forceReload = false) {
+  if (!forceReload) {
+    const data = window.localStorage.getItem('whoami')
+    let whoAmI = null
+    if (data) {
+      whoAmI = JSON.parse(data)
+    }
+    // Do we have cached and valid info?
+    if (whoAmI && whoAmI['name'] == getUsername() && (whoAmI['_ts']+3600*1000) > Date.now()) {
+      return whoAmI
+    }
+  }
+  return await window.fetch('api/whoami')
+    .then(async resp => {
+      if (resp.ok) {
+        return await resp.json().then(data => {
+          data['_ts'] = Date.now()
+          window.localStorage.setItem('whoami', JSON.stringify(data))
+          return data
+        })
+      } else {
+        logout()
+        return null
+      }
+    })
+}
+
 export {
+  whoAmI,
+  login,
+  logout,
   getUsername,
   getPassword
 }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,5 +1,3 @@
-import { stateClasses } from './helpers.js'
-
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]
 }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -23,12 +23,15 @@ function getCookie (key) {
 async function login (username, password) {
   const auth = window.btoa(`${username}:${password}`)
   document.cookie = `m=|:${encodeURIComponent(auth)}; samesite=strict; max-age=${60 * 60 * 8}`
-  return whoAmI(true)
+  const result = await whoAmI(true)
+  if (!result) document.cookie = 'm=; max-age=0'
+  return result
 }
 
 function logout () {
   window.localStorage.removeItem('lmq.whoami')
   document.cookie = 'm=; max-age=0'
+  window.location.assign('login')
 }
 
 async function whoAmI (forceReload = false) {
@@ -54,7 +57,7 @@ async function whoAmI (forceReload = false) {
           return data
         })
       } else {
-        logout()
+        window.localStorage.removeItem('lmq.whoami')
         return null
       }
     })

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -1,7 +1,7 @@
 import * as Auth from './auth.js'
 import * as Helpers from './helpers.js'
 
-Auth.whoAmI().then(data => { if (!data) Auth.logout() })
+Auth.whoAmI().catch(() => Auth.logout())
 
 document.getElementById('username').textContent = Auth.getUsername()
 

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -1,6 +1,8 @@
 import * as Auth from './auth.js'
 import * as Helpers from './helpers.js'
 
+Auth.whoAmI() // Ensure we have whoami data.
+
 document.getElementById('username').textContent = Auth.getUsername()
 
 const menuButton = document.getElementById('menu-button')
@@ -30,7 +32,7 @@ document.getElementById('userMenuVhost').addEventListener('change', (e) => {
 })
 
 document.getElementById('signoutLink').addEventListener('click', () => {
-  document.cookie = 'm=; max-age=0'
+  Auth.logout()
   window.location.assign('login')
 })
 

--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -1,7 +1,7 @@
 import * as Auth from './auth.js'
 import * as Helpers from './helpers.js'
 
-Auth.whoAmI() // Ensure we have whoami data.
+Auth.whoAmI().then(data => { if (!data) Auth.logout() })
 
 document.getElementById('username').textContent = Auth.getUsername()
 
@@ -33,7 +33,6 @@ document.getElementById('userMenuVhost').addEventListener('change', (e) => {
 
 document.getElementById('signoutLink').addEventListener('click', () => {
   Auth.logout()
-  window.location.assign('login')
 })
 
 const usermenuButton = document.getElementById('usermenu-button')

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,3 +1,4 @@
+import * as Auth from './auth.js'
 if (window.location.hash) {
   const params = new URLSearchParams(window.location.hash.substring(1))
   const user = params.get('username')
@@ -13,16 +14,11 @@ document.getElementById('login').addEventListener('submit', (e) => {
   tryLogin(user, pass)
 })
 
-function tryLogin (user, pass) {
-  const auth = window.btoa(`${user}:${pass}`)
-  document.cookie = `m=|:${encodeURIComponent(auth)}; samesite=strict; max-age=${60 * 60 * 8}`
-  window.fetch('api/whoami')
-    .then(resp => {
-      if (resp.ok) {
-        window.location.assign('.')
-      } else {
-        document.cookie = 'm=; max-age=0'
-        window.alert('Authentication failure')
-      }
-    })
+async function tryLogin (user, pass) {
+  const res = await Auth.login(user, pass)
+  if (res) {
+    window.location.assign('.')
+  } else {
+    window.alert('Authentication failure')
+  }
 }

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -14,11 +14,8 @@ document.getElementById('login').addEventListener('submit', (e) => {
   tryLogin(user, pass)
 })
 
-async function tryLogin (user, pass) {
-  const res = await Auth.login(user, pass)
-  if (res) {
-    window.location.assign('.')
-  } else {
-    window.alert('Authentication failure')
-  }
+function tryLogin (user, pass) {
+  Auth.login(user, pass)
+    .then(() => window.location.assign('.'))
+    .catch(() => window.alert('Authentication failure'))
 }


### PR DESCRIPTION
### WHAT is this pull request doing?
Consolidates login, logout, and session validation into auth.js. Introduces a whoAmI() function that caches the API response in localStorage (under lmq.whoami) with a 1-hour TTL, stripping sensitive fields (password_hash, hashing_algorithm) before storage. On API failure, whoAmI automatically calls logout() and redirects to /login.

Adds Playwright specs covering login, logout, and whoAmI behavior (caching, cache miss re-fetch, sensitive field exclusion, and failure redirect).

This PR is parts of #1698 and prepares for the "user tags classes".

### HOW can this pull request be tested?
Specs, but probably good to do some manual too.
