### PR TITLE
Fix: exclusive queue references leak on auto-delete

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -897,7 +897,7 @@ describe LavinMQ::AMQP::Queue do
     end
   end
 
-  describe "Exclusive auto-delete queue cleanup" do
+  describe "Exclusive queue cleanup" do
     it "drops the queue from Client#exclusive_queues when auto-deleted server-side" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
@@ -928,6 +928,20 @@ describe LavinMQ::AMQP::Queue do
         # Connection closed by `with_channel`. All 5 queues should be gone,
         # not just every other one.
         should_eventually(eq 0) { s.vhosts["/"].queues.size }
+      end
+    end
+
+    it "drops the queue from Client#exclusive_queues when expired via x-expires" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.queue("", exclusive: true,
+            args: AMQP::Client::Arguments.new({"x-expires" => 100}))
+
+          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
+          conn.@exclusive_queues.size.should eq 1
+
+          should_eventually(eq 0) { conn.@exclusive_queues.size }
+        end
       end
     end
   end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -896,4 +896,39 @@ describe LavinMQ::AMQP::Queue do
       end
     end
   end
+
+  describe "Exclusive auto-delete queue cleanup" do
+    it "drops the queue from Client#exclusive_queues when auto-deleted server-side" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("", exclusive: true, auto_delete: true)
+          tag = q.subscribe(no_ack: true) { }
+
+          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
+          conn.@exclusive_queues.size.should eq 1
+
+          ch.basic_cancel(tag) # last consumer leaves -> auto-delete fires
+
+          should_eventually(eq 0) { conn.@exclusive_queues.size }
+        end
+      end
+    end
+
+    it "still cleans up exclusive queues on connection close when many are open" do
+      # Regression for the iteration-mutation hazard: cleanup iterates
+      # @exclusive_queues while Queue#close fires the observer that mutates it.
+      with_amqp_server do |s|
+        ch = nil
+        with_channel(s) do |c|
+          ch = c
+          5.times { c.queue("", exclusive: true, auto_delete: true) }
+          conn = s.vhosts["/"].connections.first.as(LavinMQ::AMQP::Client)
+          conn.@exclusive_queues.size.should eq 5
+        end
+        # Connection closed by `with_channel`. All 5 queues should be gone,
+        # not just every other one.
+        should_eventually(eq 0) { s.vhosts["/"].queues.size }
+      end
+    end
+  end
 end

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -15,6 +15,11 @@ module LavinMQ
     class Client < LavinMQ::Client
       include Stats
       include SortableJSON
+      include Observer(QueueEvent)
+
+      def on(event : QueueEvent, data : Object?)
+        @exclusive_queues.delete(data) if event.deleted? && data.is_a?(Queue)
+      end
 
       getter vhost, channels, log, name
       getter user
@@ -754,7 +759,9 @@ module LavinMQ
         @vhost.apply(frame)
         @last_queue_name = frame.queue_name
         if frame.exclusive
-          @exclusive_queues << @vhost.queues[frame.queue_name]
+          q = @vhost.queues[frame.queue_name]
+          @exclusive_queues << q
+          q.register_observer(self)
         end
         unless frame.no_wait
           send AMQP::Frame::Queue::DeclareOk.new(frame.channel, frame.queue_name, 0_u32, 0_u32)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -483,7 +483,9 @@ module LavinMQ
           Fiber.yield if (i &+= 1) % 512 == 0
         end
         @channels.clear
-        @exclusive_queues.each(&.close)
+        # Iterate a snapshot because Queue#close fires QueueEvent::Deleted,
+        # whose observer mutates @exclusive_queues.
+        @exclusive_queues.dup.each(&.close)
         @exclusive_queues.clear
         @vhost.rm_connection(self)
         case user = @user

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -466,7 +466,7 @@ module LavinMQ::AMQP
       end
       @vhost.delete_queue(@name)
       @log.info { "(messages=#{message_count}) Deleted" }
-      notify_observers(QueueEvent::Deleted)
+      notify_observers(QueueEvent::Deleted, self)
       true
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
`Client#@exclusive_queues` kept strong references to exclusive queues, intended to be cleaned up on connection close. Entries were only removed on the explicit `Queue.Delete` frame path, so when a queue with `auto_delete: true` was deleted server-side after the last consumer cancelled, its reference stayed in the array. 

Long-lived connections that churn exclusive `auto-delete` queues (RPC pattern) accumulated dead Queue references and kept the heap growing until the connection finally dropped. 

Fix is to make `Client` an `Observer` of `QueueEvent` and drop the entry on Deleted. The Queue already fires that event, we just pass `self` so the observer can identify it. The pattern matches `federation/link.cr`
  
  
### HOW can this pull request be tested?

Ran a Node `amqplib` loop that declares an exclusive `auto-delete` queue, subscribes a `no-ack` consumer, cancels and repeats on one connection. 

Without the fix: 122k cycles, RSS grew past 290 MB and only dropped once the connection closed. 
With the fix: 150k+ cycles with RSS holding flat around 13 MB throughout. Reproduces identically on 2.6.0 and 2.6.9.