### PR TITLE
test: trigger docs-check workflow

### DIFF
--- a/src/lavinmq/version.cr
+++ b/src/lavinmq/version.cr
@@ -1,4 +1,5 @@
 module LavinMQ
+  # test change for docs-check workflow, revert before merge
   VERSION = {{ `[ -n "$version" ] && echo "$version" || git describe --tags 2>/dev/null || shards version`.chomp.stringify.gsub(/^v/, "") }}
 
   macro build_flags


### PR DESCRIPTION
Throwaway PR to verify the docs-check workflow.

Touches a single line in src/ without touching docs/, so the workflow should add the missing-docs label. A follow-up commit that touches docs/ should remove it again.

Do not merge.