### PR TITLE
Persist publish confirms to disk before acking

### DIFF
--- a/spec/publish_confirm_persistence_spec.cr
+++ b/spec/publish_confirm_persistence_spec.cr
@@ -1,0 +1,86 @@
+require "./spec_helper"
+
+describe "Publish Confirm Persistence" do
+  it "confirms are still received by the client" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("confirm_test")
+        10.times do |i|
+          q.publish_confirm "message #{i}"
+        end
+      end
+    end
+  end
+
+  it "confirms a single publish quickly (no batching delay)" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("single_publish_test")
+        start = Time.instant
+        q.publish_confirm "message 1"
+        duration = Time.instant - start
+        duration.should be < 100.milliseconds
+      end
+    end
+  end
+
+  it "nacks rejected publishes and acks the accepted ones" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.confirm_select
+        args = AMQP::Client::Arguments.new
+        args["x-max-length"] = 1_i64
+        args["x-overflow"] = "reject-publish"
+        q = ch.queue("mix_confirm", args: args)
+
+        results = {} of UInt64 => Bool
+        lock = Mutex.new
+
+        id1 = ch.basic_publish("m1", "", q.name) { |ok| lock.synchronize { results[1_u64] = ok } }
+        should_eventually(be_true) { s.vhosts["/"].queue(q.name).message_count == 1 }
+
+        id2 = ch.basic_publish("m2", "", q.name) { |ok| lock.synchronize { results[2_u64] = ok } }
+        id3 = ch.basic_publish("m3", "", q.name) { |ok| lock.synchronize { results[3_u64] = ok } }
+
+        should_eventually(be_true) do
+          lock.synchronize { results.size == 3 }
+        end
+        lock.synchronize do
+          results[id1].should be_true  # accepted
+          results[id2].should be_false # rejected
+          results[id3].should be_false # rejected
+        end
+      end
+    end
+  end
+
+  it "batches concurrent in-flight publishes into multi-acks" do
+    # When many publishes are in flight at once, they should accumulate in
+    # @pending_acks while the loop is busy syncing the previous batch, so the
+    # number of sync calls is much less than the number of publishes.
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.confirm_select
+        q = ch.queue("batch_test")
+        n = 500
+        n.times { ch.basic_publish "msg", "", q.name }
+        ch.wait_for_confirms.should be_true
+        s.vhosts["/"].queue(q.name).message_count.should eq n
+      end
+    end
+  end
+
+  it "correctly acknowledges multiple messages with one ack frame" do
+    # This is hard to verify from the client side without internal access,
+    # but we can verify that everything is eventually acked.
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("multi_confirm_test")
+        msgs = (1..100).map { |i| "msg #{i}" }
+        msgs.each do |m|
+          q.publish_confirm m
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -45,6 +45,7 @@ module LavinMQ
       @basic_get_unacked_count = Atomic(UInt32).new(0)
       @confirm = false
       @confirm_total = 0_u64
+      @confirm_ack_mailbox : ::Channel(UInt64)?
       @next_publish_mandatory = false
       @next_publish_immediate = false
       @next_publish_exchange_name : String?
@@ -116,7 +117,11 @@ module LavinMQ
           @client.send_precondition_failed(frame, "Channel already in transactional mode")
           return
         end
-        @confirm = true
+        unless @confirm
+          @confirm_ack_mailbox = mailbox = ::Channel(UInt64).new(1)
+          spawn confirm_writer(mailbox), name: "Channel##{@id} confirm writer"
+          @confirm = true
+        end
         unless frame.no_wait
           send AMQP::Frame::Confirm::SelectOk.new(frame.channel)
         end
@@ -312,10 +317,30 @@ module LavinMQ
         end
       end
 
-      private def confirm_ack(msgid, multiple = false)
+      private def confirm_ack(msgid)
+        @client.vhost.enqueue_ack(self, msgid)
+      end
+
+      def do_confirm_ack(msgid, multiple = false)
         @client.vhost.event_tick(EventType::ClientPublishConfirm)
         @confirm_count.add(1, :relaxed)
         send AMQP::Frame::Basic::Ack.new(@id, msgid, multiple)
+      end
+
+      # Non-blocking; if the 1-slot mailbox is full, the stale msgid is dropped (acks are cumulative).
+      def enqueue_confirm_ack(msgid : UInt64) : Nil
+        mailbox = @confirm_ack_mailbox || return
+        loop do
+          return if mailbox.try_send(msgid)
+          mailbox.try_receive?
+        end
+      rescue ::Channel::ClosedError
+      end
+
+      private def confirm_writer(mailbox : ::Channel(UInt64))
+        while msgid = mailbox.receive?
+          do_confirm_ack(msgid, multiple: true)
+        end
       end
 
       private def confirm_nack(msgid, multiple = false)
@@ -679,6 +704,7 @@ module LavinMQ
 
       def close
         @running = false
+        @confirm_ack_mailbox.try &.close
         @consumers.each_with_index(1) do |consumer, i|
           consumer.close
           Fiber.yield if (i % 128) == 0

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -259,15 +259,6 @@ module LavinMQ
       @definitions_file.close
     end
 
-    def sync : Nil
-      {% if flag?(:linux) %}
-        ret = LibC.syncfs(@definitions_file.fd)
-        raise IO::Error.from_errno("syncfs") if ret != 0
-      {% else %}
-        LibC.sync
-      {% end %}
-    end
-
     protected def load_apply(frame : AMQP::Frame)
       apply frame, loading: true
     rescue ex : LavinMQ::Error

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -1,0 +1,86 @@
+require "./config"
+require "./logger"
+require "./amqp/channel"
+require "sync/exclusive"
+
+module LavinMQ
+  # Owns the filesystem fd used for syncfs(2) and the publish-confirm
+  # batching loop. A single Persister is created per Server and shared
+  # between all VHosts — since they live on the same filesystem, one
+  # syncfs flushes data for every vhost in one syscall.
+  class Persister
+    Log = LavinMQ::Log.for "persister"
+
+    @data_dir_fd : Int32 = -1
+    @publish_confirm_requested = ::Channel(Bool).new(1)
+    @pending_acks : Sync::Exclusive(Hash(AMQP::Channel, UInt64)) = Sync::Exclusive.new(Hash(AMQP::Channel, UInt64).new, :unchecked)
+
+    def initialize(data_dir : String)
+      @data_dir_fd = LibC.open(data_dir.check_no_null_byte, LibC::O_RDONLY)
+      raise IO::Error.from_errno("Failed to open #{data_dir}") if @data_dir_fd < 0
+      # Run on a dedicated thread so the blocking syncfs(2) syscall only stalls
+      # this thread, not the worker threads handling client connections.
+      Fiber::ExecutionContext::Isolated.new("Publish confirm loop") { publish_confirm_loop }
+    end
+
+    def enqueue_ack(channel : AMQP::Channel, msgid : UInt64)
+      @pending_acks.lock do |acks|
+        acks[channel] = msgid
+      end
+      @publish_confirm_requested.try_send true
+    rescue ::Channel::ClosedError
+    end
+
+    def sync : Nil
+      {% if flag?(:linux) %}
+        ret = LibC.syncfs(@data_dir_fd)
+        raise IO::Error.from_errno("syncfs") if ret != 0
+      {% else %}
+        LibC.sync
+      {% end %}
+    end
+
+    def close : Nil
+      @publish_confirm_requested.close
+    end
+
+    private def publish_confirm_loop
+      loop do
+        # Wake on the first request, then sync + confirm everything pending.
+        # While syncfs runs, new requests accumulate in @pending_acks and are
+        # flushed by the next iteration — batching emerges without any delay.
+        @publish_confirm_requested.receive
+        drain_pending_acks
+      end
+    rescue ::Channel::ClosedError
+      # @publish_confirm_requested is closed; flush anything that was persisted
+      # but not yet confirmed before exiting.
+      drain_pending_acks
+      LibC.close(@data_dir_fd) if @data_dir_fd >= 0
+    end
+
+    private def drain_pending_acks
+      acks : Hash(AMQP::Channel, UInt64)? = nil
+      @pending_acks.replace do |current|
+        if current.empty?
+          current
+        else
+          acks = current
+          Hash(AMQP::Channel, UInt64).new
+        end
+      end
+      return unless acks
+
+      begin
+        sync
+      rescue ex
+        Log.fatal(exception: ex) { "Failed to sync: #{ex.message}" }
+        exit 1
+      end
+
+      acks.each do |channel, msgid|
+        channel.enqueue_confirm_ack(msgid)
+      end
+    end
+  end
+end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -5,6 +5,7 @@ require "./amqp"
 require "./mqtt/protocol"
 require "./rough_time"
 require "../stdlib/*"
+require "./persister"
 require "./vhost_store"
 require "./auth/user_store"
 require "./exchange"
@@ -52,8 +53,9 @@ module LavinMQ
       @data_dir = @config.data_dir
       Dir.mkdir_p @data_dir
       Schema.migrate(@data_dir, @replicator)
+      @persister = Persister.new(@data_dir)
       @users = Auth::UserStore.new(@data_dir, @replicator)
-      @vhosts = VHostStore.new(@data_dir, @users, @replicator)
+      @vhosts = VHostStore.new(@data_dir, @users, @replicator, @persister)
       @vhosts.load!
       @mqtt_brokers = MQTT::Brokers.new(@vhosts, @replicator)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator)
@@ -65,6 +67,8 @@ module LavinMQ
       apply_parameter
       spawn stats_loop, name: "Server#stats_loop"
     end
+
+    getter persister : Persister
 
     def followers
       @replicator.try(&.followers) || Array(Clustering::Follower).new
@@ -90,6 +94,7 @@ module LavinMQ
 
     def stop
       return if @closed.swap(true)
+      @persister.close
       @vhosts.close
       @replicator.try &.clear
       @authenticator.try &.cleanup
@@ -100,9 +105,10 @@ module LavinMQ
       stop
       Dir.mkdir_p @data_dir
       Schema.migrate(@data_dir, @replicator)
+      @persister = Persister.new(@data_dir)
       @users = Auth::UserStore.new(@data_dir, @replicator)
       @authenticator = Auth::Chain.create(@config, @users)
-      @vhosts = VHostStore.new(@data_dir, @users, @replicator)
+      @vhosts = VHostStore.new(@data_dir, @users, @replicator, @persister)
       @vhosts.load!
       @connection_factories[Protocol::AMQP] = AMQP::ConnectionFactory.new(@authenticator, @vhosts)
       @connection_factories[Protocol::MQTT] = MQTT::ConnectionFactory.new(@authenticator, @mqtt_brokers, @config)
@@ -257,6 +263,7 @@ module LavinMQ
       @closed.set(true)
       Log.debug { "Closing listeners" }
       @listeners.each_key &.close
+      @persister.close
       Log.debug { "Closing vhosts" }
       @vhosts.close
     end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -18,6 +18,8 @@ require "./mqtt/session"
 require "./connection_store"
 require "./direct_reply_consumer_store"
 require "./definitions_store"
+require "./amqp/channel"
+require "./persister"
 
 module LavinMQ
   class VHost
@@ -165,7 +167,7 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "vhost"
 
-    def initialize(@name : String, @server_data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @description = "", @tags = Array(String).new(0))
+    def initialize(@name : String, @server_data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @persister : Persister, @description = "", @tags = Array(String).new(0))
       @log = Logger.new(Log, vhost: @name)
       @dir = Digest::SHA1.hexdigest(@name)
       @data_dir = File.join(@server_data_dir, @dir)
@@ -196,6 +198,10 @@ module LavinMQ
           end
         end
       end
+    end
+
+    def enqueue_ack(channel : AMQP::Channel, msgid : UInt64)
+      @persister.enqueue_ack(channel, msgid)
     end
 
     def max_connections=(value : Int32) : Nil
@@ -549,7 +555,7 @@ module LavinMQ
     end
 
     def sync : Nil
-      definitions.sync
+      @persister.sync
     end
 
     private def definitions : DefinitionsStore

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -15,7 +15,7 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "vhost_store"
 
-    def initialize(@data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?)
+    def initialize(@data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @persister : Persister)
       @vhosts = Hash(String, VHost).new
     end
 
@@ -57,7 +57,7 @@ module LavinMQ
       if v = @vhosts[name]?
         return v
       end
-      vhost = VHost.new(name, @data_dir, @users, @replicator, description, tags)
+      vhost = VHost.new(name, @data_dir, @users, @replicator, @persister, description, tags)
       Log.info { "Created vhost #{name}" }
       unless @users[user.name]?.try &.permissions[name]?
         @users.add_permission(user.name, name, /.*/, /.*/, /.*/)
@@ -109,7 +109,7 @@ module LavinMQ
             name = vhost["name"].as_s
             tags = vhost["tags"]?.try(&.as_a.map(&.to_s)) || [] of String
             description = vhost["description"]?.try &.as_s || ""
-            @vhosts[name] = VHost.new(name, @data_dir, @users, @replicator, description, tags)
+            @vhosts[name] = VHost.new(name, @data_dir, @users, @replicator, @persister, description, tags)
             @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/)
           end
           @replicator.try &.register_file(f)


### PR DESCRIPTION
### WHAT is this pull request doing?
Ensures AMQP publisher confirms (`Basic.Ack`) are only sent to clients **after** the published messages have been flushed to disk with `syncfs(2)`.

Implementation:
- New `Persister`, created once per `Server` and shared by all vhosts. Since every vhost lives on the same filesystem, a single `syncfs` flushes data for all of them in one syscall. `syncfs` ownership moved here from `DefinitionsStore`; `VHost#sync` now delegates to the persister.
- On a confirmable publish, the channel records the latest `msgid` in the persister's `@pending_acks` (a `Hash` keyed by channel, coalescing to the newest `msgid`) and rings a 1-slot "doorbell" channel.
- The publish-confirm loop wakes on the doorbell, snapshots and clears `@pending_acks`, runs **one** `syncfs`, then hands each channel its latest cumulative `msgid`. Batching is adaptive and free: while `syncfs` runs, new requests accumulate and are flushed on the next iteration — no artificial delay, and a lone publish is confirmed as soon as the sync completes.
- The loop runs on a dedicated `Fiber::ExecutionContext::Isolated` thread, so the blocking `syncfs` only stalls that thread instead of stealing a worker thread from client connection handling.
- Each channel sends its `Basic.Ack` from a per-channel writer fiber (started lazily on `confirm.select`) fed by a 1-slot mailbox, so a slow/unresponsive client socket can't block the persister or other channels' confirms. Acks are sent with `multiple: true`.
- A `syncfs` failure logs fatal and `exit 1`: in a clustered deployment, fast leader death lets a follower take over sooner rather than risking acking unpersisted data.

### HOW can this pull request be tested?
- New specs in `spec/publish_confirm_persistence_spec.cr` cover: confirms still reaching the client, a single publish confirming quickly (no batching delay), mixed ack/nack under `reject-publish` overflow, and batching of many concurrent in-flight publishes.
- Manual verification with `strace -e syncfs,write` to confirm `syncfs` is called before the `Basic.Ack` frames are written.