### PR TITLE
Add user tag classes to control element visibility

### DIFF
--- a/spec/frontend/auth.spec.js
+++ b/spec/frontend/auth.spec.js
@@ -98,3 +98,54 @@ test.describe('logout', _ => {
     expect(cookies.some(c => c.name === 'm')).toBe(false)
   })
 })
+
+test.describe('user tag state classes', _ => {
+  test('adds user-is-<tag> class for each tag after whoAmI', async ({ page }) => {
+    await page.addInitScript(() => localStorage.removeItem('lmq.whoami'))
+    await page.route(url => url.pathname === '/api/whoami', route => route.fulfill({
+      json: { name: 'guest', tags: 'administrator, monitoring' }
+    }))
+    await page.goto('/')
+    const classes = await page.evaluate(() => [...document.documentElement.classList])
+    expect(classes).toContain('user-is-administrator')
+    expect(classes).toContain('user-is-monitoring')
+  })
+
+  test('removes existing user-is-* classes before adding new ones', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('lmq.whoami')
+      localStorage.setItem('lmq.stateclasses', 'user-is-old-tag')
+    })
+    await page.route(url => url.pathname === '/api/whoami', route => route.fulfill({
+      json: { name: 'guest', tags: 'administrator' }
+    }))
+    await page.goto('/')
+    const classes = await page.evaluate(() => [...document.documentElement.classList])
+    expect(classes).not.toContain('user-is-old-tag')
+    expect(classes).toContain('user-is-administrator')
+  })
+
+  test('adds no user-is-* classes when tags is empty', async ({ page }) => {
+    await page.addInitScript(() => localStorage.removeItem('lmq.whoami'))
+    await page.route(url => url.pathname === '/api/whoami', route => route.fulfill({
+      json: { name: 'guest', tags: '' }
+    }))
+    await page.goto('/')
+    const classes = await page.evaluate(() => [...document.documentElement.classList])
+    expect(classes.filter(c => c.startsWith('user-is-'))).toHaveLength(0)
+  })
+
+  test('removes user-is-* classes on logout', async ({ page }) => {
+    await page.addInitScript(() => localStorage.removeItem('lmq.whoami'))
+    await page.route(url => url.pathname === '/api/whoami', route => route.fulfill({
+      json: { name: 'guest', tags: 'administrator' }
+    }))
+    await page.goto('/')
+    await Promise.all([
+      page.waitForURL(/\/login$/),
+      page.locator('#signoutLink').click()
+    ])
+    const classes = await page.evaluate(() => [...document.documentElement.classList])
+    expect(classes.filter(c => c.startsWith('user-is-'))).toHaveLength(0)
+  })
+})

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,3 +1,5 @@
+import { stateClasses } from './helpers.js'
+
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]
 }
@@ -34,6 +36,7 @@ const whoAmICacheKey = 'lmq.whoami'
 function logout () {
   window.localStorage.removeItem(whoAmICacheKey)
   document.cookie = 'm=; max-age=0'
+  stateClasses.remove(/^user-is-/)
   window.location.assign('login')
 }
 
@@ -52,6 +55,10 @@ async function fetchWhoAmI () {
         delete data.password_hash
         delete data.hashing_algorithm
         window.localStorage.setItem(whoAmICacheKey, JSON.stringify(data))
+        stateClasses.remove(/^user-is-/);
+        (data.tags?.split(/,\s*/).filter(Boolean) || []).forEach(tag => {
+          stateClasses.add(`user-is-${tag}`)
+        })
         return data
       } else {
         window.localStorage.removeItem(whoAmICacheKey)
@@ -69,12 +76,13 @@ async function whoAmI (forceReload = false) {
         cached = JSON.parse(data)
       } catch {
         window.localStorage.removeItem(whoAmICacheKey)
+        cached = null
       }
       if (cached && cached.name === getUsername()) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {
-          // fetch in background, we still return the cached
-          fetchWhoAmI().catch(e => console.warn(`Failed to load whoAmI: ${e.message}`))
+          // fetch in background, we still return the cache
+          fetchWhoAmI().catch(e => console.warn(`Failed to fetch whoAmI: ${e.message}`))
         }
         return cached
       }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,4 +1,4 @@
-import { stateClasses } from "./helpers.js"
+import { stateClasses } from './helpers.js'
 
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -76,12 +76,11 @@ async function whoAmI (forceReload = false) {
         cached = JSON.parse(data)
       } catch {
         window.localStorage.removeItem(whoAmICacheKey)
-        cached = null
       }
       if (cached && cached.name === getUsername()) {
         const expired = (cached._ts + 3600 * 1000) <= Date.now()
         if (expired) {
-          // fetch in background, we still return the cache
+          // fetch in background, we still return the cached
           fetchWhoAmI().catch(e => console.warn(`Failed to fetch whoAmI: ${e.message}`))
         }
         return cached

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,3 +1,5 @@
+import { stateClasses } from "./helpers.js"
+
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]
 }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,5 +1,3 @@
-import { stateClasses } from './helpers.js'
-
 function getUsername () {
   return window.atob(getAuth()).split(':')[0]
 }

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -14,11 +14,8 @@ document.getElementById('login').addEventListener('submit', (e) => {
   tryLogin(user, pass)
 })
 
-async function tryLogin (user, pass) {
-  const res = await Auth.login(user, pass)
-  if (res) {
-    window.location.assign('.')
-  } else {
-    window.alert('Authentication failure')
-  }
+function tryLogin (user, pass) {
+  Auth.login(user, pass)
+    .then(() => window.location.assign('.'))
+    .catch(() => window.alert('Authentication failure'))
 }

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -14,8 +14,11 @@ document.getElementById('login').addEventListener('submit', (e) => {
   tryLogin(user, pass)
 })
 
-function tryLogin (user, pass) {
-  Auth.login(user, pass)
-    .then(() => window.location.assign('.'))
-    .catch(() => window.alert('Authentication failure'))
+async function tryLogin (user, pass) {
+  const res = await Auth.login(user, pass)
+  if (res) {
+    window.location.assign('.')
+  } else {
+    window.alert('Authentication failure')
+  }
 }

--- a/static/main.css
+++ b/static/main.css
@@ -2311,6 +2311,22 @@ pre.arguments .inactive-argument:before {
   gap: 0.5rem;
 }
 
+.require-administrator,
+.require-monitoring,
+.require-management,
+.require-policymaker,
+.require-impersonator {
+  display: none;
+}
+
+.user-is-administrator .require-administrator,
+.user-is-monitoring .require-monitoring,
+.user-is-management .require-management,
+.user-is-policymaker .require-policymaker,
+.user-is-impersonator .require-impersonator {
+  display: revert;
+}
+
 /* === RESPONSIVE === */
 @media (max-width: 1850px) {
   .cols-6-md {

--- a/static/main.css
+++ b/static/main.css
@@ -2317,9 +2317,11 @@ pre.arguments .inactive-argument:before {
 .require-policymaker,
 .require-impersonator {
   display: none;
+  .user-is-administrator & {
+    display: revert;* 
+  }
 }
 
-.user-is-administrator .require-administrator,
 .user-is-monitoring .require-monitoring,
 .user-is-management .require-management,
 .user-is-policymaker .require-policymaker,

--- a/static/main.css
+++ b/static/main.css
@@ -2318,7 +2318,7 @@ pre.arguments .inactive-argument:before {
 .require-impersonator {
   display: none;
   .user-is-administrator & {
-    display: revert;* 
+    display: revert;
   }
 }
 

--- a/views/overview.shtml
+++ b/views/overview.shtml
@@ -54,7 +54,7 @@
         <h3>Message rates</h3>
         <div class="chart-container relative" id="rateChart"></div>
       </section>
-      <form id="importDefinitions" method="post" enctype="multipart/form-data" class="form card align-start tb-card cols-6">
+      <form id="importDefinitions" method="post" enctype="multipart/form-data" class="form card align-start tb-card cols-6 require-administrator">
         <h3 class="form-card-title">Upload definitions</h3>
         <div class="form-card-inner">
           <label>
@@ -72,7 +72,7 @@
 </svg></button>
         </div>
       </form>
-      <form id="exportDefinitions" method="post" class="form card tb-card cols-6">
+      <form id="exportDefinitions" method="post" class="form card tb-card cols-6 require-administrator">
         <h3 class="form-card-title">Export definitions</h3>
         <div class="form-card-inner">
           <label>


### PR DESCRIPTION
### WHAT is this pull request doing?
This PR is based in #1883 and should be merged after that.

This PR makes it easy to require tags ("permissions") for elements to visible. It's done by introducing classes for each user tag (`user-is-<tag>`) which is applied to the html element. To require a certain tag for an element to be visible one just has to apply the class `require-<tag>` to the element.

This PR does this for the definitions forms in the overview view.

### HOW can this pull request be tested?
Some specs, some manual
