### PR TITLE
increase timeout of claude code review workflow to 10 minutes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### WHAT is this pull request doing?
increase timeout of claude code review workflow to 10 minutes as some runs are timing out

### HOW can this pull request be tested?
.
