### PR TITLE
New action bar for tables with row counter and moves the column selec…

### DIFF
--- a/static/img/icons/icon-sliders-dark.svg
+++ b/static/img/icons/icon-sliders-dark.svg
@@ -1,0 +1,11 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 10.5V7" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 5V1.5" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 10.5V6" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 4V1.5" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 10.5V8" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 6V1.5" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.5 7H3.5" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.5 4H7.5" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.5 8H11.5" stroke="#414040" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/img/icons/icon-sliders-light.svg
+++ b/static/img/icons/icon-sliders-light.svg
@@ -1,0 +1,11 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 10.5V7" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 5V1.5" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 10.5V6" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 4V1.5" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 10.5V8" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 6V1.5" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.5 7H3.5" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.5 4H7.5" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.5 8H11.5" stroke="#CFCFCF" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -8,12 +8,13 @@ function renderTable (id, options = {}, renderRow) {
   const table = document.getElementById(id)
   const grandparent = table.parentElement && table.parentElement.parentElement
   const tableHeader = grandparent ? grandparent.querySelector(':scope > .table-header') : null
+  const subheader = grandparent ? grandparent.querySelector(':scope > .table-subheader') : null
   const container = tableHeader || table.parentElement
   const keyColumns = options.keyColumns
   const events = new EventTarget()
 
   if (options.columnSelector) {
-    renderColumnSelector(table)
+    renderColumnSelector(table, subheader)
   }
 
   if (options.search) {
@@ -33,7 +34,7 @@ function renderTable (id, options = {}, renderRow) {
   }
 
   dataSource.on('update', updateTable)
-  dataSource.on('update', updatePageInfo)
+  dataSource.on('update', () => updatePageInfo(subheader))
   dataSource.on('error', error => {
     console.log(error)
     toggleDisplayError(id, 'Error fetching data: ' + error.detail)
@@ -154,11 +155,11 @@ function renderTable (id, options = {}, renderRow) {
     })
   }
 
-  function updatePageInfo () { // <-- new
-    const pageInfoEl = document.querySelector('.table-page-info')
+  function updatePageInfo (subheader) {
+    const pageInfoEl = subheader?.querySelector('.table-page-info')
     if (!pageInfoEl) return
 
-    const total = dataSource.totalCount
+    const total = dataSource.filteredCount
     const pageSize = dataSource.items.length
     const page = dataSource.page ?? 1
 
@@ -235,10 +236,9 @@ function toggleCol (table, colIndex) {
   }
 }
 
-function renderColumnSelector (table) {
-  const subheader = document.querySelector('.table-subheader')
+function renderColumnSelector (table, subheader) {
   const container = subheader ?? table.parentElement
-  container.insertAdjacentHTML('afterbegin', '<a class="col-toggle" id="col-toggle">+/- <span>Columns</span></a>')
+  container.insertAdjacentHTML('afterbegin', '<a class="col-toggle">+/- <span>Columns</span></a>')
   const target = subheader ? container : container.parentElement
 
   const hiddenColumns = getHiddenColumns(table)
@@ -271,24 +271,27 @@ function renderColumnSelector (table) {
     }
     str += '</form>'
     target.insertAdjacentHTML('beforeend', str)
-    target.addEventListener('click', e => {
-      if (e.target.classList.contains('close')) close()
-    })
-    target.addEventListener('change', e => {
-      if (!e.target.classList.contains('col-toggle-checkbox')) return true
-      const i = parseInt(e.target.dataset.index)
-      toggleCol(table, i)
-      const hiddenColumns = getHiddenColumns(table)
-      if (hiddenColumns.has(i)) {
-        hiddenColumns.delete(i)
-      } else {
-        hiddenColumns.add(i)
-      }
-      setHiddenColumns(table, hiddenColumns)
-    })
-    document.addEventListener('keyup', e => {
-      if (e.key === 'Escape') close()
-    })
+  })
+
+  target.addEventListener('click', e => {
+    if (e.target.classList.contains('close')) close()
+  })
+
+  target.addEventListener('change', e => {
+    if (!e.target.classList.contains('col-toggle-checkbox')) return true
+    const i = parseInt(e.target.dataset.index)
+    toggleCol(table, i)
+    const hiddenColumns = getHiddenColumns(table)
+    if (hiddenColumns.has(i)) {
+      hiddenColumns.delete(i)
+    } else {
+      hiddenColumns.add(i)
+    }
+    setHiddenColumns(table, hiddenColumns)
+  })
+
+  document.addEventListener('keyup', e => {
+    if (e.key === 'Escape') close()
   })
 }
 

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -238,7 +238,7 @@ function toggleCol (table, colIndex) {
 
 function renderColumnSelector (table, subheader) {
   const container = subheader ?? table.parentElement
-  container.insertAdjacentHTML('afterbegin', '<a class="col-toggle">+/- <span>Columns</span></a>')
+  container.insertAdjacentHTML('afterbegin', '<a class="col-toggle"><span>Columns</span></a>')
   const target = subheader ? container : container.parentElement
 
   const hiddenColumns = getHiddenColumns(table)

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -237,7 +237,7 @@ function toggleCol (table, colIndex) {
 
 function renderColumnSelector (table) {
   const subheader = document.querySelector('.table-subheader')
-  const container = subheader ?? table.parentElement  
+  const container = subheader ?? table.parentElement
   container.insertAdjacentHTML('afterbegin', '<a class="col-toggle" id="col-toggle">+/- <span>Columns</span></a>')
   const target = subheader ? container : container.parentElement
 

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -33,6 +33,7 @@ function renderTable (id, options = {}, renderRow) {
   }
 
   dataSource.on('update', updateTable)
+  dataSource.on('update', updatePageInfo)
   dataSource.on('error', error => {
     console.log(error)
     toggleDisplayError(id, 'Error fetching data: ' + error.detail)
@@ -153,6 +154,29 @@ function renderTable (id, options = {}, renderRow) {
     })
   }
 
+  function updatePageInfo () { // <-- new
+    const pageInfoEl = document.querySelector('.table-page-info')
+    if (!pageInfoEl) return
+
+    const total = dataSource.totalCount
+    const pageSize = dataSource.items.length
+    const page = dataSource.page ?? 1
+
+    if (total === 0) {
+      pageInfoEl.textContent = '0 results'
+      return
+    }
+
+    // Calculate the row range for the current page.
+    // dataSource.pageSize holds the configured page size;
+    // fall back to the current items length if unavailable.
+    const configuredPageSize = dataSource.pageSize ?? pageSize
+    const firstRow = (page - 1) * configuredPageSize + 1
+    const lastRow = firstRow + pageSize - 1
+
+    pageInfoEl.textContent = `${firstRow}–${lastRow} of ${total}`
+  }
+
   return { updateTable, reload, on }
 }
 
@@ -212,8 +236,10 @@ function toggleCol (table, colIndex) {
 }
 
 function renderColumnSelector (table) {
-  const container = table.parentElement
-  container.insertAdjacentHTML('afterbegin', '<a class="col-toggle" id="col-toggle">+/-</a>')
+  const subheader = document.querySelector('.table-subheader')
+  const container = subheader ?? table.parentElement  
+  container.insertAdjacentHTML('afterbegin', '<a class="col-toggle" id="col-toggle">+/- <span>Columns</span></a>')
+  const target = subheader ? container : container.parentElement
 
   const hiddenColumns = getHiddenColumns(table)
   hiddenColumns.forEach(i => {
@@ -221,14 +247,14 @@ function renderColumnSelector (table) {
   })
 
   function close () {
-    container.parentElement.querySelectorAll('.tooltip').forEach(el => {
-      container.parentElement.removeChild(el)
+    target.querySelectorAll('.tooltip').forEach(el => {
+      target.removeChild(el)
     })
   }
 
   container.addEventListener('click', e => {
-    if (!e.target.classList.contains('col-toggle')) return true
-    const tooltip = container.parentElement.querySelector('.tooltip')
+    if (!e.target.closest('.col-toggle')) return true
+    const tooltip = target.querySelector('.tooltip')
     if (tooltip) return close()
     let str = '<form class="form tooltip"><a class="close">&times;</a>'
     const allCol = table.getElementsByTagName('th')
@@ -244,11 +270,11 @@ function renderColumnSelector (table) {
                 </label>`
     }
     str += '</form>'
-    container.parentElement.insertAdjacentHTML('beforeend', str)
-    container.parentElement.addEventListener('click', e => {
+    target.insertAdjacentHTML('beforeend', str)
+    target.addEventListener('click', e => {
       if (e.target.classList.contains('close')) close()
     })
-    container.parentElement.addEventListener('change', e => {
+    target.addEventListener('change', e => {
       if (!e.target.classList.contains('col-toggle-checkbox')) return true
       const i = parseInt(e.target.dataset.index)
       toggleCol(table, i)

--- a/static/main.css
+++ b/static/main.css
@@ -1267,6 +1267,36 @@ footer .logo {
   }
 }
 
+.table-subheader {
+  position: relative;
+  padding: 0.875rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row-reverse;
+  align-items: center;
+  border-left: 1px solid var(--color-border-primary);
+  border-right: 1px solid var(--color-border-primary);
+
+  &:has(.col-toggle) {
+    padding: .5rem 1.5rem;
+  }
+
+  .col-toggle {
+    position: relative;
+    border: 1px solid var(--color-border-primary);
+    top: auto;
+    right: auto;
+    padding: .4rem;
+    border-radius: .5rem;
+    font-size: 12px;
+
+    span {
+      display: inline-block;
+      font-weight: 600;
+    }
+  }
+}
+
 .table-wrapper {
   overflow: auto;
   scrollbar-color: var(--color-scrollbar);
@@ -1298,6 +1328,10 @@ footer .logo {
   top: 15px;
   right: 1.5rem;
   color: var(--color-text-primary);
+
+  span {
+    display: none;
+  }
 }
 
 .table th {
@@ -2598,5 +2632,13 @@ pre.arguments .inactive-argument:before {
 
   .table-header form {
     width: 100%;
+  }
+
+  .table-subheader {
+    padding: 1rem;
+
+    &:has(.col-toggle) {
+      padding: .5rem 1rem;
+    }
   }
 }

--- a/static/main.css
+++ b/static/main.css
@@ -929,6 +929,7 @@ footer .logo {
   --icon-operator-policies: url(img/icons/icon-opolicies-dark.svg);
   --icon-users: url(img/icons/icon-users-dark.svg);
   --icon-http-api: url(img/icons/icon-external-dark.svg);
+  --icon-sliders: url('img/icons/icon-sliders-dark.svg');
 }
 .theme-dark {
   --icon-overview: url(img/icons/icon-overview-light.svg);
@@ -946,6 +947,7 @@ footer .logo {
   --icon-operator-policies: url(img/icons/icon-opolicies-light.svg);
   --icon-users: url(img/icons/icon-users-light.svg);
   --icon-http-api: url(img/icons/icon-external-light.svg);
+  --icon-sliders: url('img/icons/icon-sliders-light.svg');
 }
 
 #menu>ul {
@@ -1272,13 +1274,13 @@ footer .logo {
   padding: 0.875rem 1.5rem;
   display: flex;
   justify-content: space-between;
-  flex-direction: row-reverse;
   align-items: center;
   border-left: 1px solid var(--color-border-primary);
   border-right: 1px solid var(--color-border-primary);
 
   &:has(.col-toggle) {
     padding: .5rem 1.5rem;
+    flex-direction: row-reverse;
   }
 
   .col-toggle {
@@ -1286,14 +1288,27 @@ footer .logo {
     border: 1px solid var(--color-border-primary);
     top: auto;
     right: auto;
-    padding: .4rem;
+    padding: .4rem .4rem .4rem 1.4rem;
     border-radius: .5rem;
     font-size: 12px;
+    background-position: .4rem center;
 
     span {
       display: inline-block;
       font-weight: 600;
     }
+
+    &:hover {
+      background-color: var(--color-bg-hover);
+      color: var(--color-text-primary);
+    }
+  }
+
+  .tooltip {
+    top: 2.5rem;
+    right: 1.5rem;
+    max-height: 400px;
+    overflow: auto;
   }
 }
 
@@ -1328,6 +1343,10 @@ footer .logo {
   top: 15px;
   right: 1.5rem;
   color: var(--color-text-primary);
+  background-image: var(--icon-sliders);
+  background-repeat: no-repeat;
+  background-position: center center;
+  padding: .4rem;
 
   span {
     display: none;

--- a/views/channels.ecr
+++ b/views/channels.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage channels</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/connections.ecr
+++ b/views/connections.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage connections</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/consumers.ecr
+++ b/views/consumers.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage consumers</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/exchanges.ecr
+++ b/views/exchanges.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage exchanges</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/operator-policies.ecr
+++ b/views/operator-policies.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage operator policies</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/policies.ecr
+++ b/views/policies.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage policies</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/queues.ecr
+++ b/views/queues.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage queues</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div id="multiselect-controls" class="popup-card hide">
           <a class="popup-close" href="#">&#x2715</a>
           <h4 class="popup-header">Queue actions (<em><span id="multi-queue-count">0</span> selected</em>)</h4>

--- a/views/shovels.ecr
+++ b/views/shovels.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage shovels</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/unacked.ecr
+++ b/views/unacked.ecr
@@ -12,10 +12,15 @@
           <h2 class="page-title"><%=pagename%><div id="pagename-label" class="subpage-title"></div></h2>
       </div>
       <section class="card">
-        <h3 class="has-badge">
-          <a href="" id="queue-link"></a>
-          <small class="tiny-badge counter-pill" id="unacked-count"></small>
-        </h3>
+        <div class="table-header">
+          <h2 class="has-badge">
+            <a href="" id="queue-link"></a>
+            <small class="tiny-badge counter-pill" id="unacked-count"></small>
+          </h2>
+        </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div class="table-wrapper">
           <div id="table-error"></div>
           <table id="table" class="table">

--- a/views/users.ecr
+++ b/views/users.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage users</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div id="users-error"></div>
         <div class="table-wrapper">
           <table id="users" class="table">

--- a/views/vhosts.ecr
+++ b/views/vhosts.ecr
@@ -15,6 +15,9 @@
         <div class="table-header">
           <h2>Manage virtual hosts</h2>
         </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
         <div id="table-error"></div>
         <div class="table-wrapper">
           <table id="table" class="table">


### PR DESCRIPTION
### WHAT is this pull request doing?
Adds a new action bar for tables. Adds a table row counter and moves the column selector to the new action bar. This is to make place for the "Add queue..."-button(s) in the top later on. See design for how it is intended to look.

### HOW can this pull request be tested?
For now only implemented on Exchanges to try it out. Look there.


<img width="1512" height="944" alt="queues-design-example" src="https://github.com/user-attachments/assets/8db858f4-275a-4546-bbb1-e27595755ff1" />
