### PR TITLE
Fix: clear consumer flags on queue close to unblock restart

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -434,6 +434,28 @@ describe LavinMQ::AMQP::Queue do
         end
       end
     end
+
+    it "should clear exclusive consumer flag after restart" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue(q_name, durable: true)
+          queue = s.vhosts["/"].queues[q_name].as(LavinMQ::AMQP::DurableQueue)
+
+          q.subscribe(no_ack: true, exclusive: true) { }
+          should_eventually(be_true) { queue.has_exclusive_consumer? }
+
+          queue.close
+          queue.restart!.should be_true
+
+          queue.has_exclusive_consumer?.should be_false
+        end
+
+        with_channel(s) do |ch|
+          q = ch.queue(q_name, durable: true)
+          q.subscribe(no_ack: true) { }
+        end
+      end
+    end
   end
 
   describe "Purge" do

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -433,6 +433,8 @@ module LavinMQ::AMQP
       @consumers_lock.synchronize do
         @consumers.each &.cancel
         @consumers.clear
+        @exclusive_consumer = false
+        @has_priority_consumers = false
       end
       Fiber.yield           # Let deliver_loop fibers start and react to closed channels
       @deliver_loop_wg.wait # Wait for all deliver loops to exit before closing mmap:s


### PR DESCRIPTION
Fixes #1903

### WHAT is this pull request doing?
Resets `@exclusive_consumer` and `@has_priority_consumers` to `false` inside the existing `@consumers_lock` block in `Queue#close`, alongside `@consumers.clear`. 

Without this, `rm_consumer` (called from each `consumer.cancel`) returns early on `return if @closed` and never clears the flags, so they survive into `restart!`.

### HOW can this pull request be tested?
Regression spec in `spec/queue_spec.cr`: declare a non-exclusive durable queue, subscribe with `exclusive: true`, close, restart, assert `has_exclusive_consumer?` is `false`. Fails on `main`, passes with the fix.