### PR TITLE
http: clearer error reason when restart_queue fails

### DIFF
--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -628,6 +628,8 @@ describe LavinMQ::HTTP::QueuesController do
           s.vhosts["/"].queues[queue_name]
           response = http.put("/api/queues/%2f/#{queue_name}/restart")
           response.status_code.should eq 400
+          body = JSON.parse(response.body)
+          body["reason"].as_s.should eq "Queue is running; only closed queues can be restarted"
 
           response = http.get("/api/queues/%2f/#{queue_name}")
           response.status_code.should eq 200

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -116,7 +116,7 @@ module LavinMQ
             if q.restart!
               context.response.status_code = 204
             else
-              bad_request(context, "Queue was not restarted")
+              bad_request(context, "Queue is #{q.state}; only closed queues can be restarted")
             end
           end
         end


### PR DESCRIPTION
## Summary
- The `PUT /api/queues/:vhost/:name/restart` endpoint (used by `lavinmqctl restart_queue`) returned `"Queue was not restarted"` on failure, which didn't tell the user what to do about it.
- Replace the message with the queue's current state and the actual requirement, e.g. `"Queue is running; only closed queues can be restarted"`. Restart only succeeds when the queue is in the `closed` state, so surfacing that makes the failure self-explanatory.

## Test plan
- [x] `make test SPEC=spec/api/queues_spec.cr` passes
- [x] `ameba` clean on changed files
- [x] Existing "should not restart if queue is still running" spec extended to assert the new reason string