### PR TITLE
Fix: advance @rfile in delete_unused_segments to prevent Closed mfile crash

### DIFF
--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -151,6 +151,34 @@ describe LavinMQ::MessageStore do
     end
   end
 
+  it "advances @rfile when delete_unused_segments removes the rfile's segment" do
+    mktmpdir do |dir|
+      msg_size = LavinMQ::Config.instance.segment_size.to_u64 // 2 + 1
+      msg = LavinMQ::Message.new(RoughTime.unix_ms, "e", "k",
+        AMQ::Protocol::Properties.new, msg_size, IO::Memory.new("a" * msg_size))
+
+      # Leave one segment on disk with all messages acked.
+      store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+      store.push(msg)
+      env = store.shift?.should_not be_nil
+      store.delete(env.segment_position)
+      store.close
+
+      # Reopen. The leftover segment is kept at startup because it is
+      # current_seg, so @rfile = @wfile points at it.
+      store = LavinMQ::MessageStore.new(dir, nil, durable: true)
+
+      # Pushing a message that needs to roll the segment runs
+      # delete_unused_segments. The fix must advance @rfile before
+      # delete_file closes the orphaned mfile, otherwise the next shift?
+      # would raise IO::Error("Closed mfile").
+      store.push(msg)
+      env = store.shift?.should_not be_nil
+      store.delete(env.segment_position)
+      store.close
+    end
+  end
+
   #
   # Run all specs for both durable and non-durable stores
   #

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -35,16 +35,15 @@ module LavinMQ
       @acks = Hash(UInt32, MFile).new { |acks, seg| acks[seg] = open_ack_file(seg) }
       load_segments_from_disk
       load_acks_from_disk
+      @wfile_id = @segments.last_key
+      @wfile = @segments.last_value
+      @rfile_id = @segments.first_key
+      @rfile = @segments.first_value
       unless @closed
         load_stats_from_segments
         prune_orphaned_acks
         delete_unused_segments
       end
-
-      @wfile_id = @segments.last_key
-      @wfile = @segments.last_value
-      @rfile_id = @segments.first_key
-      @rfile = @segments.first_value
       @empty.set empty? unless @closed
     end
 
@@ -637,6 +636,7 @@ module LavinMQ
 
         if (acks = @acks[seg]?) && @segment_msg_count[seg] <= (acks.size // sizeof(UInt32))
           @log.debug { "Deleting unused segment #{seg}" }
+          select_next_read_segment if seg == @rfile_id
           @segment_msg_count.delete seg
           @deleted.delete seg
           if ack = @acks.delete(seg)


### PR DESCRIPTION
Fixes #1909

### WHAT is this pull request doing?
Adds `select_next_read_segment if seg == @rfile_id` inside `MessageStore#delete_unused_segments` so the read pointer advances before the segment's mfile is closed by `delete_file`. Mirrors the existing logic in `delete(sp)` at line 178.

Without this, when a queue starts up with one segment whose messages are all acked, `@rfile = @wfile` points at it (kept as `current_seg`). The first publish that rolls the segment runs `delete_unused_segments` again, which removes the now non-current segment from `@segments` and queues its mfile for close. `@rfile` / `@rfile_id` are not updated, so the next `shift?` reads from the closed mfile and raises `IO::Error("Closed mfile")`, wrapped as `MessageStore::Error`, surfacing as `Queue closed due to error`.

### HOW can this pull request be tested?
Regression spec in `spec/message_store_spec.cr`: open a `MessageStore`, push and ack a message, close, reopen on the same dir, push another message large enough to roll the segment, then `shift?`. Fails on `main` with `MessageStore::Error` caused by `IO::Error("Closed mfile")`, passes with the fix.