### PR TITLE
fix: add missing vhost-limits OpenAPI schema

### DIFF
--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -141,6 +141,8 @@ components:
       "$ref": "./schemas/auth.yaml#/PutHashPasswordRequestBody"
     auth-PasswordHash:
       "$ref": "./schemas/auth.yaml#/PasswordHash"
+    vhost-limits:
+      "$ref": "./schemas/vhost-limits.yaml#/vhost-limits"
 paths:
   "/bindings":
     "$ref": "./paths/bindings.yaml#/~1bindings"

--- a/static/docs/schemas/vhost-limits.yaml
+++ b/static/docs/schemas/vhost-limits.yaml
@@ -1,0 +1,17 @@
+---
+vhost-limits:
+  type: object
+  properties:
+    vhost:
+      type: string
+      description: Name of the vhost.
+    value:
+      type: object
+      description: Limits set on the vhost. Only limits with a value are present.
+      properties:
+        max-connections:
+          type: integer
+          description: Maximum number of concurrent connections allowed to the vhost.
+        max-queues:
+          type: integer
+          description: Maximum number of queues allowed in the vhost.


### PR DESCRIPTION
The `/vhost-limits` endpoints referenced `#/components/schemas/vhost-limits`, but no such schema existed. Stoplight Elements silently ignored the dangling pointer; stricter renderers (Redoc, Scalar) fail to load.

Schema mirrors `VHostLimitsView#details_tuple` in `src/lavinmq/http/controller/vhost-limits.cr`.

<details><summary>Fixes this this problem that can be seen at <a href="https://docs.lavinmq.com/docs/#/operations/GetVhostLimits">https://docs.lavinmq.com/docs/#/operations/GetVhostLimits</a></summary>
<p>


<img width="2560" height="2646" alt="docs_lavinmq_com-20260508-100550" src="https://github.com/user-attachments/assets/88daf941-0efc-4f2b-a609-3ee5d63e3442" />

</p>
</details> 

<details><summary>How it looks with this PR</summary>
<p>

<img width="2560" height="2646" alt="127_0_0_1-20260508-100557" src="https://github.com/user-attachments/assets/4abd9661-4517-456d-9563-bb29503dcf62" />

</p>
</details> 



