### PR TITLE
Render lavinmqctl list command output as Unicode box-drawing tables

### DIFF
--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -432,29 +432,50 @@ class LavinMQCtl
   end
 
   private def output_array(data : Array, columns : Array(String)?)
-    if columns
-      @io.puts columns.join("\t")
-    else
-      case first = data.first?
-      when NamedTuple
-        @io.puts first.keys.join("\t")
-      when JSON::Any
-        @io.puts first.as_h.each_key.join("\t")
+    first = data.first? || return
+
+    headers = if columns
+                columns
+              else
+                case first
+                when NamedTuple then first.keys.to_a.map(&.to_s)
+                when JSON::Any  then first.as_h.keys
+                else                 [] of String
+                end
+              end
+
+    if @options["silent"]?
+      @io.puts headers.join("\t")
+      data.each do |item|
+        case item
+        when Hash       then item.each_value.join(@io, "\t")
+        when JSON::Any  then item.as_h.each_value.join(@io, "\t")
+        when NamedTuple then item.values.join(@io, "\t")
+        else                 item.to_s(@io)
+        end
+        @io.puts
       end
+      return
     end
-    data.each do |item|
+
+    rows = data.compact_map do |item|
       case item
-      when Hash
-        item.each_value.join(@io, "\t")
-      when JSON::Any
-        item.as_h.each_value.join(@io, "\t")
       when NamedTuple
-        item.values.join(@io, "\t")
+        values = [] of String
+        item.each_value { |v| values << v.to_s }
+        values
+      when JSON::Any
+        if h = item.as_h?
+          columns ? columns.map { |c| item[c]?.try(&.to_s) || "" } : h.values.map(&.to_s)
+        end
+      when Hash
+        item.values.map(&.to_s)
       else
-        item.to_s(@io)
+        [item.to_s]
       end
-      @io.puts
     end
+
+    render_table rows, headers
   end
 
   private def url_encoded_vhost
@@ -594,21 +615,7 @@ class LavinMQCtl
       end
       output cc
     else
-      @io.puts columns.join("\t")
-      conns.each do |u|
-        if conn = u.as_h?
-          columns.each_with_index do |c, i|
-            case c
-            when "client_properties"
-              print_erlang_terms(conn[c].as_h)
-            else
-              @io.print conn[c]?
-            end
-            @io.print "\t" unless i == columns.size - 1
-          end
-          @io.puts
-        end
-      end
+      output_array(conns, columns)
     end
   end
 
@@ -925,5 +932,41 @@ class LavinMQCtl
     url = "/api/parameters/federation-upstream/#{URI.encode_www_form(vhost)}/#{URI.encode_www_form(name)}"
     resp = http.delete url
     handle_response(resp, 204)
+  end
+
+  private def render_table(rows : Array(Array(String)), headers : Array(String))
+    widths = headers.map(&.size)
+    rows.each do |row|
+      row.each_with_index do |cell, i|
+        widths[i] = {widths[i], cell.size}.max if i < widths.size
+      end
+    end
+    table_line("┌", "─", "┬", "┐", widths)
+    table_row(headers, widths)
+    table_line("├", "─", "┼", "┤", widths)
+    rows.each_with_index do |row, i|
+      table_row(row, widths)
+      if i < rows.size - 1
+        table_line("├", "─", "┼", "┤", widths)
+      end
+    end
+    table_line("└", "─", "┴", "┘", widths)
+  end
+
+  private def table_line(left : String, fill : String, sep : String, right : String, widths : Array(Int32))
+    @io << left
+    widths.each_with_index do |w, i|
+      @io << fill * (w + 2)
+      @io << (i < widths.size - 1 ? sep : right)
+    end
+    @io.puts
+  end
+
+  private def table_row(cells : Array(String), widths : Array(Int32))
+    @io << "│"
+    cells.each_with_index do |cell, i|
+      @io << " " << cell.ljust(widths[i]) << " │"
+    end
+    @io.puts
   end
 end


### PR DESCRIPTION
## Summary

- Refactors `output_array` to render results as Unicode box-drawing tables instead of raw tab-separated output
- Adds a `--silent` flag path that falls back to machine-readable TSV for scripting
- Applies to all existing `lavinmqctl list_*` commands

## Test plan

- [ ] Run `lavinmqctl list_queues` and verify table formatting
- [ ] Run `lavinmqctl list_queues --silent` and verify tab-separated output
- [ ] Run `make test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)