### PR TITLE
Add lavinmqctl list_etcd_members command

### DIFF
--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -162,6 +162,18 @@ module LavinMQ
       end
     end
 
+    def member_list : Array(NamedTuple(name: String, peer_urls: String, client_urls: String, learner: Bool))
+      json = post("/v3/cluster/member/list", "{}")
+      members = json["members"]?.try(&.as_a) || return [] of NamedTuple(name: String, peer_urls: String, client_urls: String, learner: Bool)
+      members.map do |m|
+        name = m["name"]?.try(&.as_s) || ""
+        peer_urls = m["peerURLs"]?.try(&.as_a.map(&.as_s).join(",")) || ""
+        client_urls = m["clientURLs"]?.try(&.as_a.map(&.as_s).join(",")) || ""
+        learner = m["isLearner"]?.try(&.as_bool) || false
+        {name: name, peer_urls: peer_urls, client_urls: client_urls, learner: learner}
+      end
+    end
+
     def election_leader(name) : String?
       json = post("/v3/election/leader", %({"name":"#{Base64.strict_encode name}"}))
       if value = json.dig?("kv", "value")

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -235,6 +235,10 @@ class LavinMQCtl
       @cmd = "list_in_sync_replicas"
       self.banner = "Usage: #{PROGRAM_NAME} list_in_sync_replicas"
     end
+    @parser.on("list_etcd_members", "List etcd cluster members") do
+      @cmd = "list_etcd_members"
+      self.banner = "Usage: #{PROGRAM_NAME} list_etcd_members"
+    end
 
     @parser.on("-v", "--version", "Show version") { @io.puts LavinMQ::VERSION; exit 0 }
     @parser.on("--build-info", "Show build information") { @io.puts LavinMQ::BUILD_INFO; exit 0 }
@@ -292,6 +296,7 @@ class LavinMQCtl
     when "add_federation"        then add_federation
     when "delete_federation"     then delete_federation
     when "list_in_sync_replicas" then list_in_sync_replicas
+    when "list_etcd_members"     then list_etcd_members
     when "stop_app"
     when "start_app"
     else
@@ -945,6 +950,14 @@ class LavinMQCtl
     url = "/api/parameters/federation-upstream/#{URI.encode_www_form(vhost)}/#{URI.encode_www_form(name)}"
     resp = http.delete url
     handle_response(resp, 204)
+  end
+
+  private def list_etcd_members
+    endpoints = @options["etcd-endpoints"]? || "localhost:2379"
+    etcd = LavinMQ::Etcd.new(endpoints)
+    members = etcd.member_list
+    abort "No members found. Is etcd running?" if members.empty?
+    output members, ["name", "peer_urls", "client_urls", "learner"]
   end
 
   private def list_in_sync_replicas


### PR DESCRIPTION
## Summary

- Adds `list_etcd_members` command that lists etcd cluster members using the MemberList API, showing name, peer URLs, client URLs, and learner status
- Depends on the `--etcd-endpoints` flag introduced in the `list_in_sync_replicas` PR

**Depends on:** #1917

## Test plan

- [ ] Run `lavinmqctl list_etcd_members` against a running etcd cluster
- [ ] Verify all member fields (name, peer_urls, client_urls, learner) are shown
- [ ] Run `make test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)