### PR TITLE
Add lavinmqctl move_etcd_leader command

### DIFF
--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -162,16 +162,21 @@ module LavinMQ
       end
     end
 
-    def member_list : Array(NamedTuple(name: String, peer_urls: String, client_urls: String, learner: Bool))
+    def member_list : Array(NamedTuple(id: UInt64, name: String, peer_urls: String, client_urls: String, learner: Bool))
       json = post("/v3/cluster/member/list", "{}")
-      members = json["members"]?.try(&.as_a) || return [] of NamedTuple(name: String, peer_urls: String, client_urls: String, learner: Bool)
+      members = json["members"]?.try(&.as_a) || return [] of NamedTuple(id: UInt64, name: String, peer_urls: String, client_urls: String, learner: Bool)
       members.map do |m|
+        id = m["ID"]?.try(&.as_s.to_u64) || 0_u64
         name = m["name"]?.try(&.as_s) || ""
         peer_urls = m["peerURLs"]?.try(&.as_a.map(&.as_s).join(",")) || ""
         client_urls = m["clientURLs"]?.try(&.as_a.map(&.as_s).join(",")) || ""
         learner = m["isLearner"]?.try(&.as_bool) || false
-        {name: name, peer_urls: peer_urls, client_urls: client_urls, learner: learner}
+        {id: id, name: name, peer_urls: peer_urls, client_urls: client_urls, learner: learner}
       end
+    end
+
+    def move_leader(target_id : UInt64) : Nil
+      post("/v3/maintenance/transfer-leadership", %({"targetID":"#{target_id}"}))
     end
 
     def election_leader(name) : String?

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -239,6 +239,13 @@ class LavinMQCtl
       @cmd = "list_etcd_members"
       self.banner = "Usage: #{PROGRAM_NAME} list_etcd_members"
     end
+    @parser.on("move_etcd_leader", "Transfer etcd leadership to another member") do
+      @cmd = "move_etcd_leader"
+      self.banner = "Usage: #{PROGRAM_NAME} move_etcd_leader --node=NAME"
+      @parser.on("--node=NAME", "Name of the target etcd member") do |v|
+        @options["node"] = v
+      end
+    end
 
     @parser.on("-v", "--version", "Show version") { @io.puts LavinMQ::VERSION; exit 0 }
     @parser.on("--build-info", "Show build information") { @io.puts LavinMQ::BUILD_INFO; exit 0 }
@@ -297,6 +304,7 @@ class LavinMQCtl
     when "delete_federation"     then delete_federation
     when "list_in_sync_replicas" then list_in_sync_replicas
     when "list_etcd_members"     then list_etcd_members
+    when "move_etcd_leader"      then move_etcd_leader
     when "stop_app"
     when "start_app"
     else
@@ -958,6 +966,17 @@ class LavinMQCtl
     members = etcd.member_list
     abort "No members found. Is etcd running?" if members.empty?
     output members, ["name", "peer_urls", "client_urls", "learner"]
+  end
+
+  private def move_etcd_leader
+    name = @options["node"]? || abort "Missing required flag: --node=NAME"
+    endpoints = @options["etcd-endpoints"]? || "localhost:2379"
+    etcd = LavinMQ::Etcd.new(endpoints)
+    members = etcd.member_list
+    target = members.find { |m| m[:name] == name } || abort "Member '#{name}' not found"
+    abort "Member '#{name}' is a learner and cannot be elected leader" if target[:learner]
+    etcd.move_leader(target[:id])
+    @io.puts "Leadership transferred to '#{name}'"
   end
 
   private def list_in_sync_replicas


### PR DESCRIPTION
## Summary

- Adds `move_etcd_leader --node=NAME` command to transfer etcd leadership to a named cluster member
- Validates that the target node exists and is not a learner before attempting the transfer
- Uses the etcd MoveLeader API

**Depends on:** #1918

## Test plan

- [ ] Run `lavinmqctl move_etcd_leader --node=<name>` against a running etcd cluster with multiple members
- [ ] Verify leadership transfers correctly
- [ ] Verify error messages for missing `--node`, unknown node name, and learner nodes
- [ ] Run `make test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)