### PR TITLE
avoid double message read in reject(requeue=true)

### DIFF
--- a/spec/queue_dead_lettering_spec.cr
+++ b/spec/queue_dead_lettering_spec.cr
@@ -216,6 +216,39 @@ module DeadLetteringSpec
         end
       end
 
+      it "should dead letter when ttl expires while unacked and reject(requeue=true)" do
+        with_dead_lettering_setup do |q, dlq, ch, _|
+          props = AMQP::Client::Properties.new(expiration: "200")
+          ch.default_exchange.publish_confirm("ttl-msg", q.name, props: props)
+
+          msg = q.get(no_ack: false).not_nil!
+          sleep 300.milliseconds
+          msg.reject(requeue: true)
+
+          dlq_msg = wait_for { dlq.get }.should_not be_nil
+          dlq_msg.body_io.to_s.should eq "ttl-msg"
+          q.message_count.should eq 0
+        end
+      end
+
+      it "should dead letter when delivery-limit exceeded on reject(requeue=true)" do
+        qargs = {
+          "x-dead-letter-exchange"    => "",
+          "x-dead-letter-routing-key" => DLQ_NAME,
+          "x-delivery-limit"          => 1,
+        }
+        with_dead_lettering_setup(qargs: qargs) do |q, dlq, _, _|
+          channel.default_exchange.publish_confirm("dl-msg", q.name)
+
+          get1(q, &.reject(requeue: true))
+          get1(q, &.reject(requeue: true))
+
+          dlq_msg = wait_for { dlq.get }.should_not be_nil
+          dlq_msg.body_io.to_s.should eq "dl-msg"
+          q.message_count.should eq 0
+        end
+      end
+
       it "should dead letter on ttl" do
         qargs = {
           "x-message-ttl"             => 1,

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -629,11 +629,6 @@ module LavinMQ::AMQP
       end
     end
 
-    private def has_expired?(sp : SegmentPosition, requeue = false) : Bool
-      msg = @msg_store_lock.synchronize { @msg_store[sp] }
-      has_expired?(msg, requeue)
-    end
-
     private def has_expired?(msg : BytesMessage, requeue = false) : Bool
       return false if zero_ttl?(msg) && !requeue && !@consumers.empty?
       if expire_at = expire_at(msg)
@@ -817,12 +812,15 @@ module LavinMQ::AMQP
       @unacked_count.sub(1, :relaxed)
       @unacked_bytesize.sub(sp.bytesize, :relaxed)
       if requeue
-        if has_expired?(sp, requeue: true) # guarantee to not deliver expired messages
-          expire_msg(sp, :expired)
+        msg = @msg_store_lock.synchronize { @msg_store[sp] }
+        if has_expired?(msg, requeue: true) # guarantee to not deliver expired messages
+          env = Envelope.new(sp, msg, false)
+          expire_msg(env, :expired)
         else
           if delivery_limit = @delivery_limit
             if @deliveries.fetch(sp, 0) > delivery_limit
-              return expire_msg(sp, :delivery_limit)
+              env = Envelope.new(sp, msg, false)
+              return expire_msg(env, :delivery_limit)
             end
           end
           @msg_store_lock.synchronize do


### PR DESCRIPTION
## Summary

The expire path in `Queue#reject(sp, requeue: true)` read the message twice - once in `has_expired?(sp)` and again in `expire_msg(sp)` when a DLX was configured. Read once, reuse the envelope across the expiry check and dead-lettering call. Removes the now-unused `has_expired?(sp)` overload.

Behavior is preserved: `expire_msg(env)` calls `@dead_letter.route`, which falls through to `routed.call` (i.e. `delete_message sp`) when no DLX is configured — same end state as the old `expire_msg(sp)` no-DLX branch.

## Test plan

- [x] New regression spec: `reject(requeue=true)` when TTL has elapsed while the message was unacked → asserts DLQ receives the message
- [x] New regression spec: `reject(requeue=true)` when `x-delivery-limit` is exceeded → asserts DLQ receives the message (the existing `policies_spec` only counted the drop, didn't verify DLX routing)
- [x] `make test SPEC=spec/queue_dead_lettering_spec.cr` — 41 examples, 0 failures
- [x] `make lint` — clean