### PR TITLE
perf: optimize shutdown with many autodelete queues

### DIFF
--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -305,6 +305,10 @@ module LavinMQ
         q.name != x_death["queue"]?
       end
 
+      def close
+        @delayed_queue.try &.close
+      end
+
       def to_json(json : JSON::Builder)
         json.object do
           details_tuple.merge(message_stats: stats_details).each do |k, v|

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -437,15 +437,9 @@ module LavinMQ
       @connections.dup.each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
       queues_to_close = @definitions_lock.synchronize { @queues.values }
+      queues_to_close.each &.close
       exchanges_to_close = @definitions_lock.synchronize { @exchanges.values }
-      WaitGroup.wait do |wg|
-        queues_to_close.each do |q|
-          wg.spawn(name: "Queue#close") { q.close }
-        end
-        exchanges_to_close.each do |e|
-          wg.spawn(name: "Exchange#close") { e.close }
-        end
-      end
+      exchanges_to_close.each &.close
       Fiber.yield
       @definitions_file.close
       FileUtils.rm_rf File.join(@data_dir, "transient")

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -434,12 +434,10 @@ module LavinMQ
       end
       close_done.close
       # then force close the remaining (close tcp socket)
-      @connections.dup.each &.force_close
+      @connections.each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
-      queues_to_close = @definitions_lock.synchronize { @queues.values }
-      queues_to_close.each &.close
-      exchanges_to_close = @definitions_lock.synchronize { @exchanges.values }
-      exchanges_to_close.each &.close
+      @queues.each_value &.close
+      @exchanges.each_value &.close
       Fiber.yield
       @definitions_file.close
       FileUtils.rm_rf File.join(@data_dir, "transient")

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -242,10 +242,12 @@ module LavinMQ
           store_definition(f) if !loading && f.durable
         when AMQP::Frame::Exchange::Delete
           if x = @exchanges.delete f.exchange_name
-            @exchanges.each_value do |ex|
-              ex.bindings_details.each do |binding|
-                next unless binding.destination == x
-                ex.unbind(x, binding.routing_key, binding.arguments)
+            unless closed?
+              @exchanges.each_value do |ex|
+                ex.bindings_details.each do |binding|
+                  next unless binding.destination == x
+                  ex.unbind(x, binding.routing_key, binding.arguments)
+                end
               end
             end
             x.delete
@@ -271,10 +273,12 @@ module LavinMQ
           event_tick(EventType::QueueDeclared) unless loading
         when AMQP::Frame::Queue::Delete
           if q = @queues.delete(f.queue_name)
-            @exchanges.each_value do |ex|
-              ex.bindings_details.each do |binding|
-                next unless binding.destination == q
-                ex.unbind(q, binding.routing_key, binding.arguments)
+            unless closed?
+              @exchanges.each_value do |ex|
+                ex.bindings_details.each do |binding|
+                  next unless binding.destination == q
+                  ex.unbind(q, binding.routing_key, binding.arguments)
+                end
               end
             end
             store_definition(f, dirty: true) if !loading && q.durable? && !q.exclusive?
@@ -430,9 +434,18 @@ module LavinMQ
       end
       close_done.close
       # then force close the remaining (close tcp socket)
-      @connections.each &.force_close
+      @connections.dup.each &.force_close
       Fiber.yield # yield so that Client read_loops can shutdown
-      @queues.each_value &.close
+      queues_to_close = @definitions_lock.synchronize { @queues.values }
+      exchanges_to_close = @definitions_lock.synchronize { @exchanges.values }
+      WaitGroup.wait do |wg|
+        queues_to_close.each do |q|
+          wg.spawn(name: "Queue#close") { q.close }
+        end
+        exchanges_to_close.each do |e|
+          wg.spawn(name: "Exchange#close") { e.close }
+        end
+      end
       Fiber.yield
       @definitions_file.close
       FileUtils.rm_rf File.join(@data_dir, "transient")


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR significantly improves the shutdown performance of LavinMQ when there are a large number of autodelete queues.

During shutdown, deleting autodelete queues triggers an unbinding loop in VHost#apply which scales poorly. Since the vhost is shutting down and all queues/exchanges are being destroyed anyway, this loop is redundant. We now skip it if the vhost is already closed.

### HOW can this pull request be tested?

1. Start LavinMQ.
2. Create 5,000 autodelete queues, each bound to 10 topic exchanges.
3. Shutdown LavinMQ (or just the vhost via HTTP API).
4. Observe the shutdown time in the logs.

Before this PR, shutting down a vhost with 5,000 autodelete queues and 50,000 bindings took ~36 seconds. With these optimizations, it takes ~0.11 seconds.