### PR TITLE
Log security-relevant auth and user management events

### DIFF
--- a/spec/users_spec.cr
+++ b/spec/users_spec.cr
@@ -119,6 +119,44 @@ describe LavinMQ::Auth::User do
 end
 
 describe LavinMQ::Auth::UserStore do
+  describe "#update_password" do
+    it "changes the password and persists it" do
+      Dir.mkdir_p "/tmp/lavinmq-spec"
+      user_store = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store.create("testuser", "old")
+      user_store.update_password("testuser", "new")
+      user_store2 = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store2["testuser"].password.try(&.verify("new")).should be_true
+    ensure
+      FileUtils.rm_rf "/tmp/lavinmq-spec"
+    end
+
+    it "does nothing when password is unchanged" do
+      Dir.mkdir_p "/tmp/lavinmq-spec"
+      user_store = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store.create("testuser", "password")
+      hash_before = user_store["testuser"].password
+      user_store.update_password("testuser", "password")
+      user_store["testuser"].password.should eq hash_before
+    ensure
+      FileUtils.rm_rf "/tmp/lavinmq-spec"
+    end
+  end
+
+  describe "#update_password_hash" do
+    it "changes the password hash and persists it" do
+      Dir.mkdir_p "/tmp/lavinmq-spec"
+      user_store = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store.create("testuser", "old")
+      new_hash = LavinMQ::Auth::User.hash_password("new", "SHA256").to_s
+      user_store.update_password_hash("testuser", new_hash, "SHA256")
+      user_store2 = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store2["testuser"].password.try(&.verify("new")).should be_true
+    ensure
+      FileUtils.rm_rf "/tmp/lavinmq-spec"
+    end
+  end
+
   describe "#delete" do
     it "should clear permissions cache when deleting a user" do
       Dir.mkdir_p "/tmp/lavinmq-spec"

--- a/spec/users_spec.cr
+++ b/spec/users_spec.cr
@@ -157,6 +157,19 @@ describe LavinMQ::Auth::UserStore do
     end
   end
 
+  describe "#update_tags" do
+    it "changes the tags and persists them" do
+      Dir.mkdir_p "/tmp/lavinmq-spec"
+      user_store = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store.create("testuser", "password")
+      user_store.update_tags("testuser", [LavinMQ::Tag::Monitoring])
+      user_store2 = LavinMQ::Auth::UserStore.new("/tmp/lavinmq-spec", nil)
+      user_store2["testuser"].tags.should eq [LavinMQ::Tag::Monitoring]
+    ensure
+      FileUtils.rm_rf "/tmp/lavinmq-spec"
+    end
+  end
+
   describe "#delete" do
     it "should clear permissions cache when deleting a user" do
       Dir.mkdir_p "/tmp/lavinmq-spec"

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -176,6 +176,7 @@ module LavinMQ
             end
             socket.write_bytes AMQP::Frame::Connection::OpenOk.new, IO::ByteFormat::NetworkEndian
             socket.flush
+            log.info { "Authenticated user=\"#{user.name}\" vhost=\"#{vhost_name}\"" }
             return vhost
           else
             log.warn { "Access denied for user \"#{user.name}\" to vhost \"#{vhost_name}\"" }

--- a/src/lavinmq/auth/user.cr
+++ b/src/lavinmq/auth/user.cr
@@ -99,9 +99,10 @@ module LavinMQ
         @password = parse_password(password_hash, hash_algorithm)
       end
 
-      def update_password(password, hash_algorithm = "sha256")
-        return if @password.try &.verify(password)
+      def update_password(password, hash_algorithm = "sha256") : Bool
+        return false if @password.try &.verify(password)
         @password = self.class.hash_password(password, hash_algorithm)
+        true
       end
 
       def user_details

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -61,13 +61,16 @@ module LavinMQ
       end
 
       def update_password(name, password, hash_algorithm = "sha256")
-        @users[name].update_password(password, hash_algorithm)
-        Log.info { "Updated password for user=#{name} length=#{password.bytesize}" }
+        if @users[name].update_password(password, hash_algorithm)
+          Log.info { "Updated password for user=#{name} length=#{password.bytesize}" }
+          save!
+        end
       end
 
       def update_password_hash(name, password_hash, hash_algorithm)
         @users[name].update_password_hash(password_hash, hash_algorithm)
         Log.info { "Updated password for user=#{name}" }
+        save!
       end
 
       def rm_permission(user, vhost)

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -73,6 +73,12 @@ module LavinMQ
         save!
       end
 
+      def update_tags(name, tags : Array(Tag))
+        @users[name].tags = tags
+        Log.info { "Updated tags for user=#{name} tags=#{tags.join(",")}" }
+        save!
+      end
+
       def rm_permission(user, vhost)
         if perm = @users[user].permissions.delete vhost
           @users[user].clear_permissions_cache

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -55,8 +55,19 @@ module LavinMQ
         end
         @users[user].permissions[vhost] = perm
         @users[user].clear_permissions_cache
+        Log.info { "Set permissions for user=#{user} on vhost=#{vhost}" }
         save!
         perm
+      end
+
+      def update_password(name, password, hash_algorithm = "sha256")
+        @users[name].update_password(password, hash_algorithm)
+        Log.info { "Updated password for user=#{name} length=#{password.bytesize}" }
+      end
+
+      def update_password_hash(name, password_hash, hash_algorithm)
+        @users[name].update_password_hash(password_hash, hash_algorithm)
+        Log.info { "Updated password for user=#{name}" }
       end
 
       def rm_permission(user, vhost)

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -62,7 +62,7 @@ module LavinMQ
 
       def update_password(name, password, hash_algorithm = "sha256")
         if @users[name].update_password(password, hash_algorithm)
-          Log.info { "Updated password for user=#{name} length=#{password.bytesize}" }
+          Log.info { "Updated password for user=#{name}" }
           save!
         end
       end

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -89,10 +89,7 @@ module LavinMQ
             elsif password
               @amqp_server.users.update_password(name, password)
             end
-            if body["tags"]?
-              u.tags = tags
-              @amqp_server.users.save!
-            end
+            @amqp_server.users.update_tags(name, tags) if body["tags"]?
             context.response.status_code = 204
           else
             if password_hash

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -85,9 +85,9 @@ module LavinMQ
           end
           if u = @amqp_server.users[name]?
             if password_hash
-              u.update_password_hash(password_hash, hashing_algorithm)
+              @amqp_server.users.update_password_hash(name, password_hash, hashing_algorithm)
             elsif password
-              u.update_password(password)
+              @amqp_server.users.update_password(name, password)
             end
             u.tags = tags if body["tags"]?
             @amqp_server.users.save!

--- a/src/lavinmq/http/controller/users.cr
+++ b/src/lavinmq/http/controller/users.cr
@@ -89,8 +89,10 @@ module LavinMQ
             elsif password
               @amqp_server.users.update_password(name, password)
             end
-            u.tags = tags if body["tags"]?
-            @amqp_server.users.save!
+            if body["tags"]?
+              u.tags = tags
+              @amqp_server.users.save!
+            end
             context.response.status_code = 204
           else
             if password_hash

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -23,7 +23,7 @@ module LavinMQ
           io = MQTT::IO.new(socket, @config.mqtt_max_packet_size)
           if packet = io.read_packet.as?(Connect)
             logger.trace { "recv #{packet.inspect}" }
-            if user_and_broker = authenticate(io, packet)
+            if user_and_broker = authenticate(io, packet, logger)
               user, broker = user_and_broker
               packet = assign_client_id(packet) if packet.client_id.empty?
               session_present = broker.session_present?(packet.client_id, packet.clean_session?)
@@ -53,7 +53,7 @@ module LavinMQ
         io.flush
       end
 
-      def authenticate(io : MQTT::IO, packet)
+      def authenticate(io : MQTT::IO, packet, logger : Logger)
         return unless (username = packet.username) && (password = packet.password)
 
         vhost = @config.default_mqtt_vhost
@@ -70,6 +70,7 @@ module LavinMQ
         broker = @brokers[vhost]?
         return unless broker
 
+        logger.info { "Authenticated user=\"#{user.name}\" vhost=\"#{vhost}\"" }
         {user, broker}
       end
 


### PR DESCRIPTION
- Log successful authentication with vhost on connection open
- Log permission grants (already logged removals)
- Log password updates via new UserStore wrappers, including byte length when a plain-text password is provided

### WHAT is this pull request doing?
Introduce more logging. These can be helpful when a user no longer can login, the operator can find the time of when password was changed.