### PR TITLE
Add lavinmqctl stop_app and start_app commands

### DIFF
--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -352,6 +352,33 @@ describe "LavinMQCtl" do
       end
     end
 
+    it "stop_app closes connections and rejects new ones" do
+      with_http_server do |(http, s)|
+        s.closed?.should be_false
+        result = run_lavinmqctl(http.addr.to_s, ["stop_app"])
+        result[:exit].should eq(0)
+        s.closed?.should be_true
+      end
+    end
+
+    it "start_app reopens the server after stop_app" do
+      with_http_server do |(http, s)|
+        run_lavinmqctl(http.addr.to_s, ["stop_app"])
+        s.closed?.should be_true
+        result = run_lavinmqctl(http.addr.to_s, ["start_app"])
+        result[:exit].should eq(0)
+        s.closed?.should be_false
+      end
+    end
+
+    it "HTTP management stays up after stop_app" do
+      with_http_server do |(http, s)|
+        run_lavinmqctl(http.addr.to_s, ["stop_app"])
+        resp = http.get("/api/overview")
+        resp.status_code.should eq(200)
+      end
+    end
+
     it "should list exchanges in JSON format" do
       with_http_server do |(http, s)|
         result = run_lavinmqctl(http.addr.to_s, ["list_exchanges", "--format=json"])

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -162,6 +162,20 @@ module LavinMQ
           Tuple.new.to_json(context.response)
           context
         end
+
+        put "/api/broker/stop" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          @amqp_server.stop
+          context.response.status_code = 204
+          context
+        end
+
+        put "/api/broker/start" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          @amqp_server.restart
+          context.response.status_code = 204
+          context
+        end
       end
     end
   end

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -280,8 +280,8 @@ class LavinMQCtl
     when "list_federations"      then list_federations
     when "add_federation"        then add_federation
     when "delete_federation"     then delete_federation
-    when "stop_app"
-    when "start_app"
+    when "stop_app"              then stop_app
+    when "start_app"             then start_app
     else
       @io.puts @parser
       abort
@@ -800,6 +800,18 @@ class LavinMQCtl
       }
       output cluster_status_obj
     end
+  end
+
+  private def stop_app
+    @io.puts "Stopping app ..." unless quiet?
+    resp = http.put "/api/broker/stop", @headers
+    handle_response(resp, 204)
+  end
+
+  private def start_app
+    @io.puts "Starting app ..." unless quiet?
+    resp = http.put "/api/broker/start", @headers
+    handle_response(resp, 204)
   end
 
   private def set_vhost_limits


### PR DESCRIPTION
## Summary

- Adds `PUT /api/broker/stop` and `PUT /api/broker/start` HTTP management endpoints
- Wires `stop_app` and `start_app` commands in `lavinmqctl`
- `stop_app` stops the AMQP/MQTT broker layer (closes connections, rejects new ones) while keeping the HTTP management API and etcd lease alive
- `start_app` restarts the broker layer, reloading vhosts and user store from disk
- Both commands require administrator privileges

## Test plan

- [ ] `lavinmqctl stop_app` exits 0 and sets server to closed state
- [ ] `lavinmqctl start_app` exits 0 and reopens the broker after a stop
- [ ] HTTP management API (`/api/overview`) remains reachable after `stop_app`
- [ ] `make test SPEC=spec/lavinmqctl_spec.cr` — 40 examples, 0 failures

Closes #1927

🤖 Generated with [Claude Code](https://claude.com/claude-code)