### PR TITLE
Add missing requires so that each file can be compiled independently

### DIFF
--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -9,6 +9,9 @@ require "./channel_reply_code"
 require "./connection_reply_code"
 require "../rough_time"
 require "../connection_info"
+require "../observable"
+require "./queue/event"
+require "../auth/permission_cache"
 
 module LavinMQ
   module AMQP

--- a/src/lavinmq/amqp/exchange/consistent_hash.cr
+++ b/src/lavinmq/amqp/exchange/consistent_hash.cr
@@ -1,15 +1,11 @@
-require "../destination"
 require "./exchange"
+require "./consistent_hash_algorithm"
+require "../destination"
 require "../../hasher.cr"
 require "../../consistent_hasher.cr"
 require "../../jump_consistent_hasher.cr"
 
 module LavinMQ
-  enum ConsistentHashAlgorithm
-    Ring
-    Jump
-  end
-
   module AMQP
     class ConsistentHashExchange < Exchange
       @hasher : Hasher(AMQP::Destination)

--- a/src/lavinmq/amqp/exchange/consistent_hash_algorithm.cr
+++ b/src/lavinmq/amqp/exchange/consistent_hash_algorithm.cr
@@ -1,0 +1,6 @@
+module LavinMQ
+  enum ConsistentHashAlgorithm
+    Ring
+    Jump
+  end
+end

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue/delayed_requeued_store.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue/delayed_requeued_store.cr
@@ -1,4 +1,6 @@
+require "../../../message_store"
 require "../../../message_store/requeued_store"
+require "../queue"
 
 module LavinMQ::AMQP
   class DelayedExchangeQueue < Queue

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -16,6 +16,7 @@ require "../../deduplication"
 require "../../bool_channel"
 require "../argument_target"
 require "../argument"
+require "../argument/dead_lettering"
 require "../../queue_stats"
 
 module LavinMQ::AMQP

--- a/src/lavinmq/auth/base_user.cr
+++ b/src/lavinmq/auth/base_user.cr
@@ -1,4 +1,5 @@
 require "json"
+require "../tag"
 require "./permission_cache"
 
 module LavinMQ

--- a/src/lavinmq/auth/context.cr
+++ b/src/lavinmq/auth/context.cr
@@ -1,4 +1,4 @@
-require "socket/address"
+require "socket"
 
 module LavinMQ
   module Auth

--- a/src/lavinmq/auth/jwt/jwks_fetcher.cr
+++ b/src/lavinmq/auth/jwt/jwks_fetcher.cr
@@ -3,6 +3,7 @@ require "json"
 require "./lib_crypto_ext"
 require "./public_keys"
 require "../../rough_time"
+require "../../bool_channel"
 
 module LavinMQ
   module Auth

--- a/src/lavinmq/auth/jwt/lib_crypto_ext.cr
+++ b/src/lavinmq/auth/jwt/lib_crypto_ext.cr
@@ -1,3 +1,5 @@
+require "openssl"
+
 # src/lavinmq/auth/lib_crypto_ext.cr
 lib LibCrypto
   # Types

--- a/src/lavinmq/auth/jwt/token_claim.cr
+++ b/src/lavinmq/auth/jwt/token_claim.cr
@@ -1,3 +1,6 @@
+require "../user"
+require "../../tag"
+
 module LavinMQ
   module Auth
     module JWT

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -1,3 +1,7 @@
+require "log"
+require "../auth/password"
+require "../amqp/exchange/consistent_hash_algorithm"
+
 module LavinMQ
   class Config
     annotation CliOpt; end

--- a/src/lavinmq/http/controller/shovels.cr
+++ b/src/lavinmq/http/controller/shovels.cr
@@ -1,4 +1,5 @@
 require "../controller.cr"
+require "../stats_helper"
 
 module LavinMQ
   module HTTP

--- a/src/lavinmq/http/handler/require_user_handler.cr
+++ b/src/lavinmq/http/handler/require_user_handler.cr
@@ -1,3 +1,5 @@
+require "http/server/handler"
+
 module LavinMQ
   module HTTP
     class RequireUserHandler

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -1,5 +1,7 @@
 require "../amqp/queue/queue"
 require "../error"
+require "../sortable_json"
+require "./client"
 require "./consts"
 
 module LavinMQ

--- a/src/lavinmq/shovel/amqp_destination.cr
+++ b/src/lavinmq/shovel/amqp_destination.cr
@@ -1,3 +1,4 @@
+require "amqp-client"
 require "./destination"
 
 module LavinMQ

--- a/src/lavinmq/shovel/amqp_source.cr
+++ b/src/lavinmq/shovel/amqp_source.cr
@@ -1,3 +1,5 @@
+require "amqp-client"
+require "wait_group"
 require "./source"
 
 module LavinMQ

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -1,3 +1,4 @@
+require "http/client"
 require "./destination"
 
 module LavinMQ

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -1,3 +1,4 @@
+require "../sortable_json"
 require "./constants"
 require "./destination"
 require "./source"

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -1,5 +1,3 @@
-require "./config"
-
 module LavinMQ
   module Stats
     macro rate_stats(stats_keys, log_keys = %w[])


### PR DESCRIPTION
All files can now be build independently:

```
find ./src/lavinmq/ -name '*.cr' -exec crystal build --no-codegen {} \;
```

In vim (and maybe other editors) you get compile time warnings inline if the file you have open can't be compiled independently. 