### PR TITLE
Build deb packages for Ubuntu 26.04, RPM for Fedora 44, drop support for Fedora 41

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, debian-13, debian-12, debian-11]
+        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04, debian-13, debian-12, debian-11]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['fedora-43', 'fedora-42', 'fedora-41', 'el-9']
+        os: ['fedora-44', 'fedora-43', 'fedora-42', 'el-9']
     runs-on: ubuntu-latest
     # Set permissions if you're using OIDC token authentication
     permissions:


### PR DESCRIPTION
- Ubuntu 26.04: https://documentation.ubuntu.com/release-notes/26.04/
- Fedora 44: https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/
- Fedora 41 EoL: https://docs.fedoraproject.org/en-US/releases/eol/