### PR TITLE
bugfix: MQTT max inflight message flow control

### DIFF
--- a/spec/mqtt/integrations/message_qos_spec.cr
+++ b/spec/mqtt/integrations/message_qos_spec.cr
@@ -268,6 +268,58 @@ module MqttSpecs
       end
     end
 
+    describe "max inflight messages" do
+      it "delivery halts at the inflight limit" do
+        LavinMQ::Config.instance.max_inflight_messages = 3u16
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, client_id: "subscriber")
+            subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+            with_client_io(server) do |pub_io|
+              connect(pub_io, client_id: "publisher")
+              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8) }
+              disconnect(pub_io)
+            end
+
+            3.times { read_packet(io).should be_a(MQTT::Protocol::Publish) }
+            read_packet(io).should be_nil
+
+            disconnect(io)
+          end
+        end
+      ensure
+        LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
+      end
+
+      it "delivery resumes after acking" do
+        LavinMQ::Config.instance.max_inflight_messages = 3u16
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, client_id: "subscriber")
+            subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+            with_client_io(server) do |pub_io|
+              connect(pub_io, client_id: "publisher")
+              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8) }
+              disconnect(pub_io)
+            end
+
+            first = read_packet(io).as(MQTT::Protocol::Publish)
+            2.times { read_packet(io).should be_a(MQTT::Protocol::Publish) }
+            read_packet(io).should be_nil
+
+            puback(io, first.packet_id)
+            read_packet(io).should be_a(MQTT::Protocol::Publish)
+
+            disconnect(io)
+          end
+        end
+      ensure
+        LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
+      end
+    end
+
     it "should not enqueue messages with QoS 0 if no client is connected to the session" do
       with_server do |server|
         with_client_io(server) do |io|

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -205,10 +205,11 @@ module LavinMQ
 
       def ack(packet : MQTT::PubAck) : Nil
         id = packet.packet_id
-        sp = @unacked[id]
-        @unacked.delete id
-        @has_capacity.set(true)
-        super sp
+        # TODO: disconncet client if sp is nil?
+        if sp = @unacked.delete(id)
+          super sp
+          @has_capacity.set(true)
+        end
       rescue
         raise ::IO::Error.new("Could not acknowledge package with id: #{id}")
       end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -70,6 +70,7 @@ module LavinMQ
         end
         @unacked.clear
         @unacked_count.set(0, :release)
+        @unacked_bytesize.set(0, :release)
         @has_capacity.set(true)
 
         @consumers.each do |c|

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -133,7 +133,10 @@ module LavinMQ
           else
             begin
               id = next_id
-              return false unless id
+              unless id
+                @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+                return false
+              end
               packet = build_packet(env, id)
               @unacked_count.add(1, :relaxed)
               @unacked_bytesize.add(sp.bytesize, :relaxed)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -18,6 +18,7 @@ module LavinMQ
                                arguments : ::AMQ::Protocol::Table = AMQP::Table.new)
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
+        @has_capacity = BoolChannel.new(true)
 
         super(@vhost, @name, false, @auto_delete, arguments)
 
@@ -35,6 +36,7 @@ module LavinMQ
           break if @closed
           next @msg_store.empty.when_false.receive? if @msg_store.empty?
           next @consumers_empty.when_false.receive? if @consumers.empty?
+          next @has_capacity.when_true.receive? unless @has_capacity.value
           consumer = @consumers.first.as(MQTT::Consumer)
           get_packet do |pub_packet, bytesize|
             consumer.deliver(pub_packet)
@@ -137,6 +139,7 @@ module LavinMQ
               @unacked_bytesize.add(sp.bytesize, :relaxed)
               yield packet, sp.bytesize
               @unacked[id] = sp
+              @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
               @unacked_count.sub(1, :relaxed)
@@ -199,6 +202,7 @@ module LavinMQ
         id = packet.packet_id
         sp = @unacked[id]
         @unacked.delete id
+        @has_capacity.set(true)
         super sp
       rescue
         raise ::IO::Error.new("Could not acknowledge package with id: #{id}")

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -205,13 +205,16 @@ module LavinMQ
 
       def ack(packet : MQTT::PubAck) : Nil
         id = packet.packet_id
-        # TODO: disconncet client if sp is nil?
         if sp = @unacked.delete(id)
-          super sp
+          begin
+            super sp
+          rescue ex
+            raise ::IO::Error.new("Could not acknowledge packet with id '#{id}'", ex)
+          end
           @has_capacity.set(true)
+        else
+          raise ::IO::Error.new("No message inflight for id '#{id}'")
         end
-      rescue
-        raise ::IO::Error.new("Could not acknowledge package with id: #{id}")
       end
 
       private def message_expire_loop; end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -69,6 +69,8 @@ module LavinMQ
           end
         end
         @unacked.clear
+        @unacked_count.set(0, :release)
+        @has_capacity.set(true)
 
         @consumers.each do |c|
           rm_consumer c

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -68,14 +68,16 @@ module LavinMQ
             end
           end
         end
+
+        @consumers.each do |c|
+          rm_consumer c
+        end
+
         @unacked.clear
         @unacked_count.set(0, :release)
         @unacked_bytesize.set(0, :release)
         @has_capacity.set(true)
 
-        @consumers.each do |c|
-          rm_consumer c
-        end
         @client = client
         if c = client
           add_consumer MQTT::Consumer.new(c, self)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -211,8 +211,9 @@ module LavinMQ
             super sp
           rescue ex
             raise ::IO::Error.new("Could not acknowledge packet with id '#{id}'", ex)
+          ensure
+            @has_capacity.set(true)
           end
-          @has_capacity.set(true)
         else
           raise ::IO::Error.new("No message inflight for id '#{id}'")
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
I discovered some issues when working with #1920.

Two bugs in MQTT::Session around the max_inflight_messages limit:

#### Bug 1 — busy-loop when inflight limit is reached
When `@unacked` hit `max_inflight_messages`, `next_id` returned `nil` and `get_packet` returned false, but `deliver_loop` ignored the return value and looped immediately — spinning at 100% CPU until acks arrived. Fixed by adding a `BoolChannel` `@has_capacity` (initialized true) that the deliver loop waits on when at capacity. It is set to false when the last inflight slot is taken and back to true on each ack.

#### Bug 2 — message loss when next_id returns nil
`get_packet` shifts a message from the store before calling `next_id`. If `next_id` returned `nil`, the method returned early without requeuing — the message was silently dropped. Fixed by requeuing sp before returning false in that path. Since the message won't be acked it's not really lost and will come back on restart.

### HOW can this pull request be tested?
Specs
