### PR TITLE
fix(deb): install libssl-dev for ubuntu 26.04 builds

### DIFF
--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,7 +1,7 @@
 ARG build_image=84codes/crystal:latest-ubuntu-22.04
 
 FROM $build_image AS builder
-RUN apt-get update && apt-get install -y devscripts help2man lintian debhelper liblz4-dev
+RUN apt-get update && apt-get install -y devscripts help2man lintian debhelper liblz4-dev libssl-dev
 ARG version
 WORKDIR /usr/src/lavinmq_${version}
 COPY Makefile README.md LICENSE NOTICE CHANGELOG.md shard.yml shard.lock ./


### PR DESCRIPTION
## Summary

The `ubuntu-26.04` deb build added in #1934 fails to link because the `84codes/crystal:latest-ubuntu-26.04` image no longer ships `libssl-dev`:

```
/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lssl
/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lcrypto
```

Install `libssl-dev` explicitly in `packaging/debian/Dockerfile` so the deb build links cleanly on 26.04 (and stays correct on the older Ubuntu/Debian images). On Debian/Ubuntu, `libssl-dev` provides both `libssl.so` and `libcrypto.so`.

## Scope

Only the deb Dockerfile is touched. CI containers and the rpm build are intentionally left alone:

- CI containers and `runs-on:` are not bumped to `ubuntu-26.04` in this PR. GitHub Actions does not expose an `ubuntu-26.04` runner label yet (see [actions/runner-images#13964](https://github.com/actions/runner-images/issues/13964)), so the host runners are stuck on 24.04 anyway. We'll bump CI once 26.04 runners ship so host + container stay symmetric and the compiled `bin/` artifact remains runnable on the downstream host jobs.
- The rpm build already lists `openssl-devel` in `lavinmq.spec` BuildRequires, so the fedora-44 build is unaffected.