### PR TITLE
allow x-stream-offset to be negative, so you can get N last messages …

### DIFF
--- a/docs/streams.md
+++ b/docs/streams.md
@@ -23,6 +23,7 @@ Each consumer can specify where to start reading from using the `x-stream-offset
 | `next` | Start from new messages only |
 | (timestamp) | Start from the first message after the given timestamp |
 | (integer) | Start from a specific offset number |
+| (negative integer) | Start `N` messages before the head (e.g. `-100` reads the last 100 messages). Clamped to the oldest available message when fewer than `N` are stored. `0` retains its meaning of "start from the beginning". |
 
 Delivered messages include an `x-stream-offset` header with the current offset position.
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -23,7 +23,7 @@ Each consumer can specify where to start reading from using the `x-stream-offset
 | `next` | Start from new messages only |
 | (timestamp) | Start from the first message after the given timestamp |
 | (integer) | Start from a specific offset number |
-| (negative integer) | Start `N` messages before the head (e.g. `-100` reads the last 100 messages). Clamped to the oldest available message when fewer than `N` are stored. `0` retains its meaning of "start from the beginning". |
+| (negative integer) | Start `N` messages before the end of the stream (e.g. `-100` reads the last 100 messages). Clamped to the oldest available message when fewer than `N` are stored. `0` retains its meaning of "start from the beginning". |
 
 Delivered messages include an `x-stream-offset` header with the current offset position.
 

--- a/spec/stream_queue_filters_spec.cr
+++ b/spec/stream_queue_filters_spec.cr
@@ -102,6 +102,28 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
+    it "applies negative offset before filtering" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = PublishHelper.create_queue_and_messages(s, ch)
+
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          args = AMQP::Client::Arguments.new({"x-stream-filter": "foo", "x-stream-offset": -2})
+          q.subscribe(no_ack: false, args: args) do |msg|
+            msgs.send msg
+            msg.ack
+          end
+          msg = msgs.receive
+          msg.body_io.to_s.should eq "msg with filter: foo,bar,xyz"
+          if headers = msg.properties.headers
+            headers["x-stream-offset"].should eq 5
+          else
+            fail "No headers in message"
+          end
+        end
+      end
+    end
+
     describe "Filter on any header" do
       it "should support filtering on any header" do
         with_amqp_server do |s|

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -248,6 +248,99 @@ describe LavinMQ::AMQP::Stream do
     end
   end
 
+  describe "x-stream-offset negative integer" do
+    it "delivers the last N messages" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-last-n", args: stream_queue_args)
+          200.times { |i| q.publish "m#{i}" }
+          ch.prefetch 100
+          msgs = Channel(AMQP::Client::DeliverMessage).new(100)
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          received = Array(AMQP::Client::DeliverMessage).new
+          100.times { received << msgs.receive }
+          StreamSpecHelpers.offset_from_headers(received.first.properties.headers).should eq 101
+          StreamSpecHelpers.offset_from_headers(received.last.properties.headers).should eq 200
+        end
+      end
+    end
+
+    it "clamps to oldest available when stream has fewer messages than requested" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-underflow", args: stream_queue_args)
+          30.times { |i| q.publish "m#{i}" }
+          ch.prefetch 30
+          msgs = Channel(AMQP::Client::DeliverMessage).new(30)
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          received = Array(AMQP::Client::DeliverMessage).new
+          30.times { received << msgs.receive }
+          StreamSpecHelpers.offset_from_headers(received.first.properties.headers).should eq 1
+          StreamSpecHelpers.offset_from_headers(received.last.properties.headers).should eq 30
+        end
+      end
+    end
+
+    it "x-stream-offset=-1 delivers only the latest message" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-one", args: stream_queue_args)
+          5.times { |i| q.publish "m#{i}" }
+          ch.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -1})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          msg = msgs.receive
+          StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 5
+          msg.body_io.to_s.should eq "m4"
+        end
+      end
+    end
+
+    it "delivers remaining messages when older segments have been dropped" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-length": 1}
+          q = ch.queue("neg-offset-after-drop", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          3.times { q.publish_confirm data }
+          q.message_count.should eq 1
+          ch.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          msg = msgs.receive
+          StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 3
+        end
+      end
+    end
+
+    it "rejects Int64::MIN" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-min", args: stream_queue_args)
+          q.publish_confirm "m"
+          ch.prefetch 1
+          expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+            q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": Int64::MIN})) do |msg|
+              msg.ack
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "Expiration" do
     it "segments should be removed if max-length set" do
       with_amqp_server do |s|
@@ -611,6 +704,38 @@ describe LavinMQ::AMQP::Stream do
         # should consume the same message again, no tracked offset
         msg = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
         StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 1
+      end
+    end
+
+    it "negative x-stream-offset does not override tracked offset on reconnect" do
+      queue_name = Random::Secure.hex
+      consumer_tag = Random::Secure.hex
+      c_args = AMQP::Client::Arguments.new({"x-stream-offset": -5, "x-stream-automatic-offset-tracking": "true"})
+
+      with_amqp_server do |s|
+        StreamSpecHelpers.publish(s, queue_name, 10)
+        msg = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
+        StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 6
+        sleep 0.1.seconds
+
+        StreamSpecHelpers.publish(s, queue_name, 5)
+
+        # tracked offset (7) wins over the -5 that would otherwise re-anchor to 11
+        msg2 = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
+        StreamSpecHelpers.offset_from_headers(msg2.properties.headers).should eq 7
+      end
+    end
+
+    it "drop_overflow does not raise after the store has been deleted" do
+      queue_name = Random::Secure.hex
+      with_amqp_server do |s|
+        StreamSpecHelpers.publish(s, queue_name, 1)
+
+        data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest queue_name)
+        msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
+        msg_store.store_consumer_offset("ctag", 1_i64)
+        msg_store.delete
+        msg_store.drop_overflow
       end
     end
 

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -248,6 +248,99 @@ describe LavinMQ::AMQP::Stream do
     end
   end
 
+  describe "x-stream-offset negative integer" do
+    it "delivers the last N messages" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-last-n", args: stream_queue_args)
+          200.times { |i| q.publish "m#{i}" }
+          ch.prefetch 100
+          msgs = Channel(AMQP::Client::DeliverMessage).new(100)
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          received = Array(AMQP::Client::DeliverMessage).new
+          100.times { received << msgs.receive }
+          StreamSpecHelpers.offset_from_headers(received.first.properties.headers).should eq 101
+          StreamSpecHelpers.offset_from_headers(received.last.properties.headers).should eq 200
+        end
+      end
+    end
+
+    it "clamps to oldest available when stream has fewer messages than requested" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-underflow", args: stream_queue_args)
+          30.times { |i| q.publish "m#{i}" }
+          ch.prefetch 30
+          msgs = Channel(AMQP::Client::DeliverMessage).new(30)
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          received = Array(AMQP::Client::DeliverMessage).new
+          30.times { received << msgs.receive }
+          StreamSpecHelpers.offset_from_headers(received.first.properties.headers).should eq 1
+          StreamSpecHelpers.offset_from_headers(received.last.properties.headers).should eq 30
+        end
+      end
+    end
+
+    it "x-stream-offset=-1 delivers only the latest message" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-one", args: stream_queue_args)
+          5.times { |i| q.publish "m#{i}" }
+          ch.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -1})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          msg = msgs.receive
+          StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 5
+          msg.body_io.to_s.should eq "m4"
+        end
+      end
+    end
+
+    it "delivers remaining messages when older segments have been dropped" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream", "x-max-length": 1}
+          q = ch.queue("neg-offset-after-drop", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          3.times { q.publish_confirm data }
+          q.message_count.should eq 1
+          ch.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          msg = msgs.receive
+          StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 3
+        end
+      end
+    end
+
+    it "rejects Int64::MIN" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-min", args: stream_queue_args)
+          q.publish_confirm "m"
+          ch.prefetch 1
+          expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
+            q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": Int64::MIN})) do |msg|
+              msg.ack
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "Expiration" do
     it "segments should be removed if max-length set" do
       with_amqp_server do |s|
@@ -753,6 +846,38 @@ describe LavinMQ::AMQP::Stream do
           # still round-trips. Without the rescue this raises (connection gone).
           ch.queue(Random::Secure.hex, args: stream_queue_args).should_not be_nil
         end
+      end
+    end
+
+    it "negative x-stream-offset does not override tracked offset on reconnect" do
+      queue_name = Random::Secure.hex
+      consumer_tag = Random::Secure.hex
+      c_args = AMQP::Client::Arguments.new({"x-stream-offset": -5, "x-stream-automatic-offset-tracking": "true"})
+
+      with_amqp_server do |s|
+        StreamSpecHelpers.publish(s, queue_name, 10)
+        msg = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
+        StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 6
+        sleep 0.1.seconds
+
+        StreamSpecHelpers.publish(s, queue_name, 5)
+
+        # tracked offset (7) wins over the -5 that would otherwise re-anchor to 11
+        msg2 = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
+        StreamSpecHelpers.offset_from_headers(msg2.properties.headers).should eq 7
+      end
+    end
+
+    it "drop_overflow does not raise after the store has been deleted" do
+      queue_name = Random::Secure.hex
+      with_amqp_server do |s|
+        StreamSpecHelpers.publish(s, queue_name, 1)
+
+        data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest queue_name)
+        msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
+        msg_store.store_consumer_offset("ctag", 1_i64)
+        msg_store.delete
+        msg_store.drop_overflow
       end
     end
 

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -287,6 +287,24 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
+    it "waits for new messages from the next offset when the stream is empty" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-empty", args: stream_queue_args)
+          ch.prefetch 1
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -100})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+          q.publish "m"
+          msg = msgs.receive
+          StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 1
+          msg.body_io.to_s.should eq "m"
+        end
+      end
+    end
+
     it "x-stream-offset=-1 delivers only the latest message" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
@@ -325,17 +343,20 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
-    it "rejects Int64::MIN" do
+    it "clamps Int64::MIN to the oldest available message" do
       with_amqp_server do |s|
         with_channel(s) do |ch|
           q = ch.queue("neg-offset-min", args: stream_queue_args)
           q.publish_confirm "m"
           ch.prefetch 1
-          expect_raises(AMQP::Client::Channel::ClosedException, "PRECONDITION_FAILED") do
-            q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": Int64::MIN})) do |msg|
-              msg.ack
-            end
+          msgs = Channel(AMQP::Client::DeliverMessage).new
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": Int64::MIN})) do |msg|
+            msgs.send(msg)
+            msg.ack
           end
+          msg = msgs.receive
+          StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 1
+          msg.body_io.to_s.should eq "m"
         end
       end
     end
@@ -865,19 +886,6 @@ describe LavinMQ::AMQP::Stream do
         # tracked offset (7) wins over the -5 that would otherwise re-anchor to 11
         msg2 = StreamSpecHelpers.consume_one(s, queue_name, consumer_tag, c_args)
         StreamSpecHelpers.offset_from_headers(msg2.properties.headers).should eq 7
-      end
-    end
-
-    it "drop_overflow does not raise after the store has been deleted" do
-      queue_name = Random::Secure.hex
-      with_amqp_server do |s|
-        StreamSpecHelpers.publish(s, queue_name, 1)
-
-        data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest queue_name)
-        msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
-        msg_store.store_consumer_offset("ctag", 1_i64)
-        msg_store.delete
-        msg_store.drop_overflow
       end
     end
 

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -268,6 +268,35 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
+    it "continues with new messages after delivering the last N messages" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          q = ch.queue("neg-offset-continues", args: stream_queue_args)
+          5.times { |i| q.publish "m#{i}" }
+          ch.prefetch 10
+          msgs = Channel(AMQP::Client::DeliverMessage).new(4)
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": -3})) do |msg|
+            msgs.send(msg)
+            msg.ack
+          end
+
+          received = Array(AMQP::Client::DeliverMessage).new
+          3.times { received << msgs.receive }
+          received.map { |msg| StreamSpecHelpers.offset_from_headers(msg.properties.headers) }.should eq [3_i64, 4_i64, 5_i64]
+          received.map(&.body_io.to_s).should eq ["m2", "m3", "m4"]
+
+          q.publish "m5"
+          select
+          when msg = msgs.receive
+            StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 6
+            msg.body_io.to_s.should eq "m5"
+          when timeout(1.second)
+            fail("Consumer did not continue with the next stream message")
+          end
+        end
+      end
+    end
+
     it "clamps to oldest available when stream has fewer messages than requested" do
       with_amqp_server do |s|
         with_channel(s) do |ch|

--- a/src/lavinmq/amqp/stream/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream/stream_consumer.cr
@@ -55,10 +55,13 @@ module LavinMQ
       end
 
       private def validate_stream_offset(frame)
-        case frame.arguments["x-stream-offset"]?
+        case offset = frame.arguments["x-stream-offset"]?
         when Nil
           @track_offset = true unless @tag.starts_with?("amq.ctag-")
         when Int, Time, "first", "next", "last"
+          if offset.is_a?(Int) && offset == Int64::MIN
+            raise LavinMQ::Error::PreconditionFailed.new("x-stream-offset cannot be Int64::MIN")
+          end
           case frame.arguments["x-stream-automatic-offset-tracking"]?
           when Bool
             @track_offset = frame.arguments["x-stream-automatic-offset-tracking"]?.as(Bool)

--- a/src/lavinmq/amqp/stream/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream/stream_consumer.cr
@@ -55,13 +55,10 @@ module LavinMQ
       end
 
       private def validate_stream_offset(frame)
-        case offset = frame.arguments["x-stream-offset"]?
+        case frame.arguments["x-stream-offset"]?
         when Nil
           @track_offset = true unless @tag.starts_with?("amq.ctag-")
         when Int, Time, "first", "next", "last"
-          if offset.is_a?(Int) && offset == Int64::MIN
-            raise LavinMQ::Error::PreconditionFailed.new("x-stream-offset cannot be Int64::MIN")
-          end
           case frame.arguments["x-stream-automatic-offset-tracking"]?
           when Bool
             @track_offset = frame.arguments["x-stream-automatic-offset-tracking"]?.as(Bool)

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -60,7 +60,13 @@ module LavinMQ::AMQP
         consumer_last_offset = last_offset_by_consumer_tag(tag) || 0
         find_offset_in_segments(consumer_last_offset)
       when Int
-        if offset > @last_offset
+        if offset.negative?
+          if -offset.to_i64 >= @last_offset
+            offset_at(@segments.first_key, 4u32)
+          else
+            find_offset_in_segments(@last_offset + offset.to_i64 + 1)
+          end
+        elsif offset > @last_offset
           last_offset_seg_pos
         else
           find_offset_in_segments(offset)

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -65,11 +65,7 @@ module LavinMQ::AMQP
         find_offset_in_segments(consumer_last_offset)
       when Int
         if offset.negative?
-          if -offset.to_i64 >= @last_offset
-            offset_at(@segments.first_key, 4u32)
-          else
-            find_offset_in_segments(@last_offset + offset.to_i64 + 1)
-          end
+          find_negative_offset(offset)
         elsif offset > @last_offset
           last_offset_seg_pos
         else
@@ -104,6 +100,15 @@ module LavinMQ::AMQP
 
     private def last_offset_seg_pos
       {@last_offset + 1, @segments.last_key, @segments.last_value.size.to_u32}
+    end
+
+    private def find_negative_offset(offset : Int) : Tuple(Int64, UInt32, UInt32)
+      return last_offset_seg_pos if @size.zero?
+
+      first_offset, _seg, _pos = offset_at(@segments.first_key, 4u32)
+      target_offset = @last_offset + offset.to_i64 + 1
+      target_offset = first_offset if target_offset < first_offset
+      find_offset_in_segments(target_offset)
     end
 
     private def find_offset_in_segments(offset : Int | Time) : Tuple(Int64, UInt32, UInt32)

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -64,7 +64,13 @@ module LavinMQ::AMQP
         consumer_last_offset = last_offset_by_consumer_tag(tag) || 0
         find_offset_in_segments(consumer_last_offset)
       when Int
-        if offset > @last_offset
+        if offset.negative?
+          if -offset.to_i64 >= @last_offset
+            offset_at(@segments.first_key, 4u32)
+          else
+            find_offset_in_segments(@last_offset + offset.to_i64 + 1)
+          end
+        elsif offset > @last_offset
           last_offset_seg_pos
         else
           find_offset_in_segments(offset)


### PR DESCRIPTION
### WHAT is this pull request doing?

Allows the consumer to set x-stream-offset to a negative number that will result in getting the last N message from the stream. 

Fixes #1940 

### HOW can this pull request be tested?

Specs