### PR TITLE
Add scheduled jobs

### DIFF
--- a/spec/api/scheduled_jobs_spec.cr
+++ b/spec/api/scheduled_jobs_spec.cr
@@ -1,0 +1,219 @@
+require "../spec_helper"
+require "uri"
+
+private def put_job(http, vhost, name, value)
+  http.put("/api/parameters/scheduled-job/#{URI.encode_path_segment(vhost)}/#{URI.encode_path_segment(name)}",
+    body: {value: value}.to_json)
+end
+
+describe LavinMQ::HTTP::ScheduledJobsController do
+  describe "PUT /api/parameters/scheduled-job/:vhost/:name (validation)" do
+    it "creates a job and returns 201" do
+      with_http_server do |http, s|
+        response = put_job(http, "/", "create-201", {
+          cron:          "*/5 * * * *",
+          exchange:      "",
+          "routing-key": "noop",
+          body:          "{}",
+        })
+        response.status_code.should eq 201
+        s.vhosts["/"].scheduled_jobs.has_key?("create-201").should be_true
+        s.vhosts["/"].delete_parameter("scheduled-job", "create-201")
+      end
+    end
+
+    it "returns 400 for an invalid cron" do
+      with_http_server do |http, _s|
+        response = put_job(http, "/", "bad-cron", {
+          cron:          "not-a-cron",
+          "routing-key": "noop",
+          body:          "{}",
+        })
+        response.status_code.should eq 400
+        response.body.includes?("cron").should be_true
+      end
+    end
+
+    it "returns 400 for a missing routing-key" do
+      with_http_server do |http, _s|
+        response = put_job(http, "/", "no-rk", {
+          cron: "* * * * *",
+          body: "{}",
+        })
+        response.status_code.should eq 400
+      end
+    end
+
+    it "accepts the alternate 'schedule' and 'routing_key' field names" do
+      with_http_server do |http, s|
+        response = put_job(http, "/", "alt-names", {
+          schedule:    "0 9 * * 1-5",
+          exchange:    "amq.default",
+          routing_key: "any",
+          body:        "{}",
+        })
+        response.status_code.should eq 201
+        s.vhosts["/"].scheduled_jobs["alt-names"].exchange.should eq ""
+        s.vhosts["/"].delete_parameter("scheduled-job", "alt-names")
+      end
+    end
+  end
+
+  describe "GET /api/scheduled-jobs" do
+    it "lists scheduled jobs across vhosts" do
+      with_http_server do |http, s|
+        put_job(http, "/", "list-1", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        response = http.get("/api/scheduled-jobs")
+        response.status_code.should eq 200
+        names = JSON.parse(response.body).as_a.map(&.["name"].as_s)
+        names.includes?("list-1").should be_true
+        s.vhosts["/"].delete_parameter("scheduled-job", "list-1")
+      end
+    end
+
+    it "lists scheduled jobs for a single vhost" do
+      with_http_server do |http, s|
+        put_job(http, "/", "list-vh", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        response = http.get("/api/scheduled-jobs/#{URI.encode_path_segment("/")}")
+        response.status_code.should eq 200
+        names = JSON.parse(response.body).as_a.map(&.["name"].as_s)
+        names.should eq ["list-vh"]
+        s.vhosts["/"].delete_parameter("scheduled-job", "list-vh")
+      end
+    end
+  end
+
+  describe "GET /api/scheduled-jobs/:vhost/:name" do
+    it "returns 404 for a missing job" do
+      with_http_server do |http, _s|
+        response = http.get("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/missing")
+        response.status_code.should eq 404
+      end
+    end
+
+    it "returns the job's details_tuple" do
+      with_http_server do |http, s|
+        put_job(http, "/", "details", {
+          cron: "*/30 * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        response = http.get("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/details")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["name"].as_s.should eq "details"
+        body["cron"].as_s.should eq "*/30 * * * *"
+        body["state"].as_s.should eq "Scheduled"
+        body["run_count"].as_i.should eq 0
+        s.vhosts["/"].delete_parameter("scheduled-job", "details")
+      end
+    end
+  end
+
+  describe "PUT /api/scheduled-jobs/:vhost/:name/pause" do
+    it "returns 204 on success" do
+      with_http_server do |http, s|
+        put_job(http, "/", "pause-ok", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        response = http.put("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/pause-ok/pause")
+        response.status_code.should eq 204
+        s.vhosts["/"].scheduled_jobs["pause-ok"].state.should eq LavinMQ::ScheduledJob::Runner::State::Paused
+        s.vhosts["/"].delete_parameter("scheduled-job", "pause-ok")
+      end
+    end
+
+    it "returns 422 if already paused" do
+      with_http_server do |http, s|
+        put_job(http, "/", "pause-422", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        s.vhosts["/"].scheduled_jobs["pause-422"].pause
+        response = http.put("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/pause-422/pause")
+        response.status_code.should eq 422
+        s.vhosts["/"].delete_parameter("scheduled-job", "pause-422")
+      end
+    end
+
+    it "returns 404 for missing" do
+      with_http_server do |http, _s|
+        response = http.put("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/no-such/pause")
+        response.status_code.should eq 404
+      end
+    end
+  end
+
+  describe "PUT /api/scheduled-jobs/:vhost/:name/resume" do
+    it "returns 204 on success" do
+      with_http_server do |http, s|
+        put_job(http, "/", "resume-ok", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        s.vhosts["/"].scheduled_jobs["resume-ok"].pause
+        response = http.put("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/resume-ok/resume")
+        response.status_code.should eq 204
+        s.vhosts["/"].scheduled_jobs["resume-ok"].state.should eq LavinMQ::ScheduledJob::Runner::State::Scheduled
+        s.vhosts["/"].delete_parameter("scheduled-job", "resume-ok")
+      end
+    end
+
+    it "returns 422 if not paused" do
+      with_http_server do |http, s|
+        put_job(http, "/", "resume-422", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        response = http.put("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/resume-422/resume")
+        response.status_code.should eq 422
+        s.vhosts["/"].delete_parameter("scheduled-job", "resume-422")
+      end
+    end
+  end
+
+  describe "POST /api/scheduled-jobs/:vhost/:name/run" do
+    it "fires the job and returns 202" do
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("run-target", durable: false, auto_delete: false)
+        s.vhosts["/"].bind_queue("run-target", "amq.topic", "run.target")
+        put_job(http, "/", "run-now", {
+          cron:          "0 0 1 1 *",
+          exchange:      "amq.topic",
+          "routing-key": "run.target",
+          body:          "hi",
+        }).status_code.should eq 201
+        response = http.post("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/run-now/run")
+        response.status_code.should eq 202
+        wait_for { s.vhosts["/"].scheduled_jobs["run-now"].run_count > 0 }
+        s.vhosts["/"].queue("run-target").message_count.should eq 1
+        s.vhosts["/"].delete_parameter("scheduled-job", "run-now")
+      end
+    end
+
+    it "returns 422 when paused" do
+      with_http_server do |http, s|
+        put_job(http, "/", "run-paused", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        s.vhosts["/"].scheduled_jobs["run-paused"].pause
+        response = http.post("/api/scheduled-jobs/#{URI.encode_path_segment("/")}/run-paused/run")
+        response.status_code.should eq 422
+        s.vhosts["/"].delete_parameter("scheduled-job", "run-paused")
+      end
+    end
+  end
+
+  describe "DELETE via /api/parameters/scheduled-job/:vhost/:name" do
+    it "removes the job and the runner" do
+      with_http_server do |http, s|
+        put_job(http, "/", "del-me", {
+          cron: "* * * * *", "routing-key": "k", body: "b",
+        }).status_code.should eq 201
+        s.vhosts["/"].scheduled_jobs.has_key?("del-me").should be_true
+        response = http.delete("/api/parameters/scheduled-job/#{URI.encode_path_segment("/")}/del-me")
+        response.status_code.should eq 204
+        s.vhosts["/"].scheduled_jobs.has_key?("del-me").should be_false
+      end
+    end
+  end
+end

--- a/spec/scheduled_job/cron_spec.cr
+++ b/spec/scheduled_job/cron_spec.cr
@@ -1,0 +1,160 @@
+require "../spec_helper"
+require "../../src/lavinmq/scheduled_job/cron"
+
+alias Cron = LavinMQ::ScheduledJob::Cron
+
+describe LavinMQ::ScheduledJob::Cron do
+  describe ".parse" do
+    it "accepts a valid 5-field expression" do
+      Cron.parse("* * * * *").should_not be_nil
+    end
+
+    it "rejects an expression without 5 fields" do
+      expect_raises(Cron::ParseError) { Cron.parse("* * * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("") }
+    end
+
+    it "rejects out-of-range values" do
+      expect_raises(Cron::ParseError) { Cron.parse("60 * * * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("* 24 * * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("* * 0 * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("* * * 13 *") }
+      expect_raises(Cron::ParseError) { Cron.parse("* * * * 8") }
+    end
+
+    it "rejects malformed parts" do
+      expect_raises(Cron::ParseError) { Cron.parse("a * * * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("*/0 * * * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("5-2 * * * *") }
+      expect_raises(Cron::ParseError) { Cron.parse("*,, * * * *") }
+    end
+  end
+
+  describe "#next_after" do
+    it "every minute advances by one minute" do
+      cron = Cron.parse("* * * * *")
+      cron.next_after(Time.utc(2026, 5, 15, 12, 0, 30)).should eq Time.utc(2026, 5, 15, 12, 1)
+      cron.next_after(Time.utc(2026, 5, 15, 12, 0, 0)).should eq Time.utc(2026, 5, 15, 12, 1)
+    end
+
+    it "fires on the next matching minute within the same hour" do
+      cron = Cron.parse("*/15 * * * *")
+      cron.next_after(Time.utc(2026, 5, 15, 12, 0)).should eq Time.utc(2026, 5, 15, 12, 15)
+      cron.next_after(Time.utc(2026, 5, 15, 12, 14)).should eq Time.utc(2026, 5, 15, 12, 15)
+      cron.next_after(Time.utc(2026, 5, 15, 12, 45)).should eq Time.utc(2026, 5, 15, 13, 0)
+    end
+
+    it "weekday-only with hour restriction" do
+      # Mon-Fri at 09:00. 2026-05-15 is a Friday, 2026-05-16 a Saturday.
+      cron = Cron.parse("0 9 * * 1-5")
+      cron.next_after(Time.utc(2026, 5, 15, 8, 0)).should eq Time.utc(2026, 5, 15, 9, 0)
+      cron.next_after(Time.utc(2026, 5, 15, 9, 0)).should eq Time.utc(2026, 5, 18, 9, 0)
+      cron.next_after(Time.utc(2026, 5, 16, 12, 0)).should eq Time.utc(2026, 5, 18, 9, 0)
+    end
+
+    it "Sunday=0 and Sunday=7 are equivalent" do
+      a = Cron.parse("0 12 * * 0")
+      b = Cron.parse("0 12 * * 7")
+      ref = Time.utc(2026, 5, 15, 0, 0)
+      a.next_after(ref).should eq b.next_after(ref)
+    end
+
+    it "yearly schedule: midnight on Jan 1" do
+      cron = Cron.parse("0 0 1 1 *")
+      cron.next_after(Time.utc(2026, 5, 15, 12, 0)).should eq Time.utc(2027, 1, 1, 0, 0)
+      cron.next_after(Time.utc(2026, 12, 31, 23, 59)).should eq Time.utc(2027, 1, 1, 0, 0)
+    end
+
+    it "Feb 29 only fires on leap years" do
+      cron = Cron.parse("0 0 29 2 *")
+      # 2027 is not a leap year; next is 2028
+      cron.next_after(Time.utc(2026, 3, 1, 0, 0)).should eq Time.utc(2028, 2, 29, 0, 0)
+    end
+
+    it "DoM and DoW are OR'd when both restricted" do
+      # Fires on the 1st of any month OR on any Monday
+      cron = Cron.parse("0 0 1 * 1")
+      # 2026-05-15 is Friday; next Monday is 2026-05-18
+      cron.next_after(Time.utc(2026, 5, 15, 12, 0)).should eq Time.utc(2026, 5, 18, 0, 0)
+      # From 2026-05-18 midnight (Mon), next match is 2026-05-25 midnight (next Mon)
+      cron.next_after(Time.utc(2026, 5, 18, 0, 0)).should eq Time.utc(2026, 5, 25, 0, 0)
+      # From May 30 evening, next is June 1 (day 1) before next Monday June 8
+      cron.next_after(Time.utc(2026, 5, 30, 20, 0)).should eq Time.utc(2026, 6, 1, 0, 0)
+    end
+
+    it "step over an explicit range" do
+      cron = Cron.parse("0 8-18/2 * * *")
+      cron.next_after(Time.utc(2026, 5, 15, 7, 0)).should eq Time.utc(2026, 5, 15, 8, 0)
+      cron.next_after(Time.utc(2026, 5, 15, 8, 0)).should eq Time.utc(2026, 5, 15, 10, 0)
+      cron.next_after(Time.utc(2026, 5, 15, 18, 0)).should eq Time.utc(2026, 5, 16, 8, 0)
+    end
+
+    it "comma list of values" do
+      cron = Cron.parse("0,30 * * * *")
+      cron.next_after(Time.utc(2026, 5, 15, 12, 0)).should eq Time.utc(2026, 5, 15, 12, 30)
+      cron.next_after(Time.utc(2026, 5, 15, 12, 30)).should eq Time.utc(2026, 5, 15, 13, 0)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the original expression" do
+      Cron.parse("*/5 * * * *").to_s.should eq "*/5 * * * *"
+    end
+  end
+
+  describe "additional edge cases" do
+    it "accepts boundary values" do
+      Cron.parse("0 0 1 1 0").should_not be_nil
+      Cron.parse("59 23 31 12 6").should_not be_nil
+      Cron.parse("59 23 31 12 7").should_not be_nil # Sunday=7
+    end
+
+    it "accepts leading/trailing whitespace" do
+      Cron.parse("   */5 * * * *   ").to_s.should eq "*/5 * * * *"
+    end
+
+    it "rejects negative numbers" do
+      expect_raises(Cron::ParseError) { Cron.parse("-1 * * * *") }
+    end
+
+    it "rejects too many fields" do
+      expect_raises(Cron::ParseError) { Cron.parse("* * * * * *") }
+    end
+
+    it "rejects empty parts in a comma list" do
+      expect_raises(Cron::ParseError) { Cron.parse("1,,2 * * * *") }
+    end
+
+    it "rejects standalone step without range" do
+      expect_raises(Cron::ParseError) { Cron.parse("5/10 * * * *") }
+    end
+
+    it "next_after never returns a time <= input" do
+      cron = Cron.parse("*/7 * * * *")
+      [Time.utc(2026, 5, 15, 12, 0),
+       Time.utc(2026, 5, 15, 12, 7),
+       Time.utc(2026, 5, 15, 12, 13),
+       Time.utc(2026, 5, 15, 23, 59)].each do |t|
+        (cron.next_after(t) > t).should be_true
+      end
+    end
+
+    it "single-value DoW restricts to that day" do
+      cron = Cron.parse("0 12 * * 3") # Wednesday
+      # 2026-05-15 is Friday; next Wednesday is 2026-05-20
+      cron.next_after(Time.utc(2026, 5, 15, 0, 0)).should eq Time.utc(2026, 5, 20, 12, 0)
+    end
+
+    it "hour list works across midnight" do
+      cron = Cron.parse("0 0,12 * * *")
+      cron.next_after(Time.utc(2026, 5, 15, 6, 0)).should eq Time.utc(2026, 5, 15, 12, 0)
+      cron.next_after(Time.utc(2026, 5, 15, 18, 0)).should eq Time.utc(2026, 5, 16, 0, 0)
+    end
+
+    it "DoM range with step skips correctly" do
+      cron = Cron.parse("0 0 1-7/2 * *") # day 1, 3, 5, 7 of each month
+      cron.next_after(Time.utc(2026, 5, 2, 0, 0)).should eq Time.utc(2026, 5, 3, 0, 0)
+      cron.next_after(Time.utc(2026, 5, 7, 0, 0)).should eq Time.utc(2026, 6, 1, 0, 0)
+    end
+  end
+end

--- a/spec/scheduled_job/runner_spec.cr
+++ b/spec/scheduled_job/runner_spec.cr
@@ -1,0 +1,162 @@
+require "../spec_helper"
+
+private def make_runner(vhost, name = "spec-runner", *, cron : String = "0 0 1 1 *",
+                        exchange : String = "", routing_key : String = "rk",
+                        body : String = "x", start_paused : Bool = false,
+                        calls : Array(String)? = nil)
+  c = LavinMQ::ScheduledJob::Cron.parse(cron)
+  callback = ->(_r : LavinMQ::ScheduledJob::Runner) {
+    calls.try &.push("state-change")
+    nil
+  }
+  if start_paused
+    File.write(File.join(LavinMQ::Config.instance.data_dir,
+      "scheduled_jobs.#{Digest::SHA1.hexdigest(name)}.paused"), name)
+  end
+  LavinMQ::ScheduledJob::Runner.new(name, vhost, c, exchange, routing_key, body,
+    AMQ::Protocol::Properties.new, callback)
+end
+
+describe LavinMQ::ScheduledJob::Runner do
+  describe "initial state" do
+    it "starts Scheduled by default" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"])
+        r.state.should eq LavinMQ::ScheduledJob::Runner::State::Scheduled
+        r.terminate
+      end
+    end
+
+    it "starts Paused when a paused-file marker already exists on disk" do
+      with_amqp_server do |s|
+        name = "preexisting-paused"
+        path = File.join(LavinMQ::Config.instance.data_dir,
+          "scheduled_jobs.#{Digest::SHA1.hexdigest(name)}.paused")
+        File.write(path, name)
+        r = make_runner(s.vhosts["/"], name)
+        r.state.should eq LavinMQ::ScheduledJob::Runner::State::Paused
+        r.delete
+      end
+    end
+  end
+
+  describe "#run_now" do
+    it "returns false when paused" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "rn-paused", start_paused: true)
+        r.run_now.should be_false
+        r.delete
+      end
+    end
+
+    it "returns false when terminated" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "rn-terminated")
+        r.terminate
+        r.run_now.should be_false
+      end
+    end
+  end
+
+  describe "#pause / #resume" do
+    it "is idempotent for pause" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "pause-idem")
+        spawn r.run
+        Fiber.yield
+        r.pause.should be_true
+        r.pause.should be_false # already paused
+        r.delete
+      end
+    end
+
+    it "is idempotent for resume" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "resume-idem", start_paused: true)
+        r.resume.should be_true
+        r.resume.should be_false # already scheduled
+        r.terminate
+      end
+    end
+
+    it "pause invokes the state-change callback" do
+      with_amqp_server do |s|
+        calls = [] of String
+        r = make_runner(s.vhosts["/"], "pause-cb", calls: calls)
+        spawn r.run
+        Fiber.yield
+        r.pause
+        calls.includes?("state-change").should be_true
+        r.delete
+      end
+    end
+  end
+
+  describe "#terminate" do
+    it "transitions state to Terminated" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "term")
+        r.terminate
+        r.state.should eq LavinMQ::ScheduledJob::Runner::State::Terminated
+      end
+    end
+
+    it "is idempotent" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "term-idem")
+        r.terminate
+        r.terminate # should not raise
+        r.state.should eq LavinMQ::ScheduledJob::Runner::State::Terminated
+      end
+    end
+  end
+
+  describe "#restore_stats" do
+    it "overrides default counters" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "restore")
+        r.restore_stats(42_u64, Time.utc(2026, 5, 15), "boom", 17_i64)
+        r.run_count.should eq 42
+        r.last_run_at.should eq Time.utc(2026, 5, 15)
+        r.last_error.should eq "boom"
+        r.last_duration_ms.should eq 17
+        r.terminate
+      end
+    end
+  end
+
+  describe "#details_tuple" do
+    it "exposes all relevant fields" do
+      with_amqp_server do |s|
+        r = make_runner(s.vhosts["/"], "detail", cron: "*/15 * * * *",
+          exchange: "amq.topic", routing_key: "x.y")
+        t = r.details_tuple
+        t[:name].should eq "detail"
+        t[:vhost].should eq "/"
+        t[:exchange].should eq "amq.topic"
+        t[:routing_key].should eq "x.y"
+        t[:cron].should eq "*/15 * * * *"
+        t[:run_count].should eq 0
+        t[:state].should eq "Scheduled"
+        r.terminate
+      end
+    end
+  end
+
+  describe "fire failure isolation" do
+    it "records last_error when the exchange does not exist" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        r = make_runner(vhost, "fire-fail",
+          exchange: "does-not-exist-xyz", routing_key: "k")
+        spawn r.run
+        r.run_now.should be_true
+        # The publish itself doesn't raise on unknown exchange (it returns false),
+        # so we just confirm the runner survives and is still scheduled.
+        wait_for { r.run_count > 0 || r.last_error }
+        r.state.should eq LavinMQ::ScheduledJob::Runner::State::Scheduled
+        r.delete
+      end
+    end
+  end
+end

--- a/spec/scheduled_job/store_spec.cr
+++ b/spec/scheduled_job/store_spec.cr
@@ -1,0 +1,335 @@
+require "../spec_helper"
+
+describe LavinMQ::ScheduledJob::Store do
+  describe ".validate_config!" do
+    it "accepts a valid config" do
+      cfg = JSON.parse({
+        cron:          "*/5 * * * *",
+        exchange:      "",
+        "routing-key": "task",
+        body:          "hi",
+      }.to_json)
+      LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+    end
+
+    it "rejects a missing cron" do
+      cfg = JSON.parse({"routing-key": "x", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /cron/i) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects an invalid cron expression" do
+      cfg = JSON.parse({cron: "not-a-cron", "routing-key": "x", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /cron/i) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects a missing routing-key" do
+      cfg = JSON.parse({cron: "* * * * *", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /routing-key/i) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects a missing body" do
+      cfg = JSON.parse({cron: "* * * * *", "routing-key": "x"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /body/i) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "accepts 'schedule' as an alias for 'cron'" do
+      cfg = JSON.parse({
+        schedule:      "*/5 * * * *",
+        "routing-key": "x",
+        body:          "y",
+      }.to_json)
+      LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+    end
+
+    it "accepts 'routing_key' as an alias for 'routing-key'" do
+      cfg = JSON.parse({
+        cron:        "* * * * *",
+        routing_key: "x",
+        body:        "y",
+      }.to_json)
+      LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+    end
+
+    it "rejects a non-object config" do
+      cfg = JSON.parse(%q(["not", "a", "hash"]))
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /JSON object/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects an empty cron string" do
+      cfg = JSON.parse({cron: "", "routing-key": "x", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /must not be empty/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects an empty routing-key" do
+      cfg = JSON.parse({cron: "* * * * *", "routing-key": "", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /must not be empty/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "allows an empty body" do
+      cfg = JSON.parse({cron: "* * * * *", "routing-key": "x", body: ""}.to_json)
+      LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+    end
+
+    it "rejects wrong type for cron" do
+      cfg = JSON.parse({cron: 5, "routing-key": "x", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /'cron' must be a string/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects wrong type for routing-key" do
+      cfg = JSON.parse({cron: "* * * * *", "routing-key": true, body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /'routing-key' must be a string/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects wrong type for body" do
+      cfg = JSON.parse({cron: "* * * * *", "routing-key": "x", body: {a: 1}}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /'body' must be a string/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects wrong type for exchange" do
+      cfg = JSON.parse({cron: "* * * * *", exchange: 1, "routing-key": "x", body: "y"}.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /'exchange' must be a string/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects wrong type for content-type" do
+      cfg = JSON.parse({
+        cron: "* * * * *", "routing-key": "x", body: "y", "content-type": 7,
+      }.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /'content-type' must be a string/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "rejects wrong type for headers" do
+      cfg = JSON.parse({
+        cron: "* * * * *", "routing-key": "x", body: "y", headers: "nope",
+      }.to_json)
+      expect_raises(LavinMQ::ScheduledJob::ConfigError, /'headers' must be a JSON object/) do
+        LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+      end
+    end
+
+    it "accepts the empty string for exchange (default exchange)" do
+      cfg = JSON.parse({cron: "* * * * *", exchange: "", "routing-key": "x", body: "y"}.to_json)
+      LavinMQ::ScheduledJob::Store.validate_config!(cfg, nil)
+    end
+  end
+
+  describe "debounced state persistence" do
+    it "does not write to disk on every fire (only on explicit flush or interval)" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        cfg = JSON.parse({
+          cron: "0 0 1 1 *", "routing-key": "k", body: "b",
+        }.to_json)
+        runner = vhost.scheduled_jobs.create("debounced", cfg)
+        # State file should not exist before any fire
+        File.exists?(File.join(vhost.data_dir, "scheduled_jobs_state.json")).should be_false
+        runner.run_now
+        wait_for { runner.run_count > 0 }
+        # Immediately after fire, no synchronous write happened
+        File.exists?(File.join(vhost.data_dir, "scheduled_jobs_state.json")).should be_false
+        vhost.scheduled_jobs.flush!
+        # After explicit flush, file exists and contains the stats
+        path = File.join(vhost.data_dir, "scheduled_jobs_state.json")
+        File.exists?(path).should be_true
+        File.read(path).includes?(%("run_count":1)).should be_true
+        vhost.scheduled_jobs.delete("debounced")
+      end
+    end
+
+    it "coalesces many fires into a single flush" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        cfg = JSON.parse({
+          cron: "0 0 1 1 *", "routing-key": "k", body: "b",
+        }.to_json)
+        runner = vhost.scheduled_jobs.create("coalesce", cfg)
+        100.times { runner.run_now; Fiber.yield }
+        wait_for { runner.run_count >= 100 }
+        vhost.scheduled_jobs.flush!
+        path = File.join(vhost.data_dir, "scheduled_jobs_state.json")
+        File.read(path).includes?(%("run_count":#{runner.run_count})).should be_true
+        vhost.scheduled_jobs.delete("coalesce")
+      end
+    end
+
+    it "delete is synchronously persisted" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        cfg = JSON.parse({
+          cron: "0 0 1 1 *", "routing-key": "k", body: "b",
+        }.to_json)
+        runner = vhost.scheduled_jobs.create("del-sync", cfg)
+        runner.run_now
+        wait_for { runner.run_count > 0 }
+        vhost.scheduled_jobs.delete("del-sync")
+        path = File.join(vhost.data_dir, "scheduled_jobs_state.json")
+        File.exists?(path).should be_true
+        File.read(path).includes?("del-sync").should be_false
+      end
+    end
+
+    it "close flushes pending stats" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        # Use a private store so we can close it without tearing down the vhost
+        store = LavinMQ::ScheduledJob::Store.new(vhost)
+        cfg = JSON.parse({
+          cron: "0 0 1 1 *", "routing-key": "k", body: "b",
+        }.to_json)
+        runner = store.create("flush-on-close", cfg)
+        runner.run_now
+        wait_for { runner.run_count > 0 }
+        store.close
+        path = File.join(vhost.data_dir, "scheduled_jobs_state.json")
+        File.read(path).includes?(%("run_count":1)).should be_true
+      end
+    end
+  end
+
+  describe "create() also enforces validation" do
+    it "raises ConfigError on missing body when called directly" do
+      with_amqp_server do |s|
+        cfg = JSON.parse({cron: "* * * * *", "routing-key": "x"}.to_json)
+        expect_raises(LavinMQ::ScheduledJob::ConfigError, /body/) do
+          s.vhosts["/"].scheduled_jobs.create("bad", cfg)
+        end
+        s.vhosts["/"].scheduled_jobs.has_key?("bad").should be_false
+      end
+    end
+  end
+
+  describe "run_now / fire" do
+    it "publishes a message into the target exchange" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("scheduled-target-q", durable: false, auto_delete: false)
+        vhost.bind_queue("scheduled-target-q", "amq.topic", "scheduled.test")
+
+        cfg = JSON.parse({
+          cron:          "0 0 1 1 *", # never within the test window
+          exchange:      "amq.topic",
+          "routing-key": "scheduled.test",
+          body:          "payload",
+        }.to_json)
+        runner = vhost.scheduled_jobs.create("test-job", cfg)
+        runner.run_now.should be_true
+
+        wait_for { runner.run_count > 0 }
+        runner.run_count.should eq 1
+        vhost.queue("scheduled-target-q").message_count.should eq 1
+        vhost.scheduled_jobs.delete("test-job")
+      end
+    end
+  end
+
+  describe "create with alternate field names" do
+    it "accepts schedule/routing_key aliases and amq.default" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("alt-target-q", durable: false, auto_delete: false)
+
+        cfg = JSON.parse({
+          schedule:    "0 0 1 1 *",
+          exchange:    "amq.default", # normalized to "" (default exchange)
+          routing_key: "alt-target-q",
+          body:        "{}",
+        }.to_json)
+        runner = vhost.scheduled_jobs.create("alt-job", cfg)
+        runner.exchange.should eq ""
+        runner.routing_key.should eq "alt-target-q"
+        runner.run_now.should be_true
+        wait_for { runner.run_count > 0 }
+        vhost.queue("alt-target-q").message_count.should eq 1
+        vhost.scheduled_jobs.delete("alt-job")
+      end
+    end
+  end
+
+  describe "vhost parameter wiring" do
+    it "creating a 'scheduled-job' parameter creates a runner" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        cfg = JSON.parse({
+          cron: "0 0 1 1 *", "routing-key": "x", body: "y",
+        }.to_json)
+        param = LavinMQ::Parameter.new("scheduled-job", "via-param", cfg)
+        vhost.add_parameter(param)
+        vhost.scheduled_jobs.has_key?("via-param").should be_true
+        vhost.delete_parameter("scheduled-job", "via-param")
+        vhost.scheduled_jobs.has_key?("via-param").should be_false
+      end
+    end
+  end
+
+  describe "delete behavior" do
+    it "delete is a no-op for an unknown name" do
+      with_amqp_server do |s|
+        s.vhosts["/"].scheduled_jobs.delete("never-existed").should be_nil
+      end
+    end
+
+    it "create with an existing name terminates the previous runner" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        cfg = JSON.parse({
+          cron: "0 0 1 1 *", "routing-key": "x", body: "y",
+        }.to_json)
+        first = vhost.scheduled_jobs.create("replace-me", cfg)
+        second = vhost.scheduled_jobs.create("replace-me", cfg)
+        first.state.should eq LavinMQ::ScheduledJob::Runner::State::Terminated
+        second.state.should eq LavinMQ::ScheduledJob::Runner::State::Scheduled
+        vhost.scheduled_jobs.delete("replace-me")
+      end
+    end
+  end
+
+  describe "stats persistence" do
+    it "restores run_count from disk after store reload" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        cfg = JSON.parse({
+          cron:          "0 0 1 1 *",
+          exchange:      "",
+          "routing-key": "noop",
+          body:          "x",
+        }.to_json)
+        runner = vhost.scheduled_jobs.create("persist-job", cfg)
+        runner.run_now
+        wait_for { runner.run_count > 0 }
+        runner.run_count.should eq 1
+        vhost.scheduled_jobs["persist-job"].terminate
+        vhost.scheduled_jobs.flush! # debounced writer needs an explicit sync
+
+        # Build a fresh store on the same data dir; stats file should be loaded.
+        fresh = LavinMQ::ScheduledJob::Store.new(vhost)
+        restored = fresh.create("persist-job", cfg)
+        restored.run_count.should eq 1
+        fresh.close
+        vhost.scheduled_jobs.delete("persist-job")
+      end
+    end
+  end
+end

--- a/src/lavinmq/http/controller/parameters.cr
+++ b/src/lavinmq/http/controller/parameters.cr
@@ -1,6 +1,7 @@
 require "../controller"
 require "../../sortable_json"
 require "../../shovel/store"
+require "../../scheduled_job/store"
 
 module LavinMQ
   module HTTP
@@ -86,6 +87,13 @@ module LavinMQ
               begin
                 Shovel::Store.validate_config!(value, context.user)
               rescue ex : Shovel::ConfigError
+                bad_request(context, ex.message)
+              end
+            end
+            if component == "scheduled-job"
+              begin
+                ScheduledJob::Store.validate_config!(value, context.user, vhost)
+              rescue ex : ScheduledJob::ConfigError
                 bad_request(context, ex.message)
               end
             end

--- a/src/lavinmq/http/controller/scheduled_jobs.cr
+++ b/src/lavinmq/http/controller/scheduled_jobs.cr
@@ -1,0 +1,77 @@
+require "../controller.cr"
+
+module LavinMQ
+  module HTTP
+    class ScheduledJobsController < Controller
+      private def register_routes
+        get "/api/scheduled-jobs" do |context, _params|
+          arr = vhosts(user(context)).flat_map do |v|
+            v.scheduled_jobs.values
+          end
+          page(context, arr)
+        end
+
+        get "/api/scheduled-jobs/:vhost" do |context, params|
+          with_vhost(context, params) do |vhost|
+            page(context, vhost.scheduled_jobs.values)
+          end
+        end
+
+        get "/api/scheduled-jobs/:vhost/:name" do |context, params|
+          with_vhost(context, params) do |vhost|
+            if job = vhost.scheduled_jobs[params["name"]]?
+              job.to_json(context.response)
+            else
+              not_found(context)
+            end
+          end
+        end
+
+        put "/api/scheduled-jobs/:vhost/:name/pause" do |context, params|
+          with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
+            if job = vhost.scheduled_jobs[params["name"]]?
+              if job.pause
+                context.response.status_code = 204
+              else
+                context.response.status_code = 422
+              end
+            else
+              not_found(context)
+            end
+          end
+        end
+
+        put "/api/scheduled-jobs/:vhost/:name/resume" do |context, params|
+          with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
+            if job = vhost.scheduled_jobs[params["name"]]?
+              if job.resume
+                context.response.status_code = 204
+              else
+                context.response.status_code = 422
+              end
+            else
+              not_found(context)
+            end
+          end
+        end
+
+        post "/api/scheduled-jobs/:vhost/:name/run" do |context, params|
+          with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
+            if job = vhost.scheduled_jobs[params["name"]]?
+              if job.run_now
+                context.response.status_code = 202
+              else
+                context.response.status_code = 422
+              end
+            else
+              not_found(context)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/http/controller/views.cr
+++ b/src/lavinmq/http/controller/views.cr
@@ -11,6 +11,7 @@ module LavinMQ
         static_view "/login", auth_required: false
         static_view "/federation"
         static_view "/shovels"
+        static_view "/scheduled-jobs"
         static_view "/connections"
         static_view "/consumers"
         static_view "/connection"

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -42,6 +42,7 @@ module LavinMQ
           PermissionsController.new(@amqp_server),
           ParametersController.new(@amqp_server),
           ShovelsController.new(@amqp_server),
+          ScheduledJobsController.new(@amqp_server),
           NodesController.new(@amqp_server),
           LogsController.new(@amqp_server),
         ] of ::HTTP::Handler

--- a/src/lavinmq/scheduled_job/cron.cr
+++ b/src/lavinmq/scheduled_job/cron.cr
@@ -1,0 +1,146 @@
+module LavinMQ
+  module ScheduledJob
+    # Standard 5-field cron parser: "minute hour day-of-month month day-of-week".
+    # Sunday is accepted as either 0 or 7. All times are interpreted as UTC.
+    # No timezone, no @hourly aliases, no L/W modifiers.
+    struct Cron
+      class ParseError < Exception; end
+
+      MAX_ITERATIONS = 4 * 366 * 24 * 60
+
+      getter expression : String
+      @minute : UInt64
+      @hour : UInt64
+      @dom : UInt64
+      @month : UInt64
+      @dow : UInt64
+      @dom_restricted : Bool
+      @dow_restricted : Bool
+
+      def initialize(@expression, @minute, @hour, @dom, @month, @dow,
+                     @dom_restricted, @dow_restricted)
+      end
+
+      def self.parse(expr : String) : Cron
+        trimmed = expr.strip
+        fields = trimmed.split(/\s+/)
+        unless fields.size == 5
+          raise ParseError.new("Expected 5 fields, got #{fields.size}: #{expr.inspect}")
+        end
+        minute = parse_field(fields[0], 0, 59)
+        hour = parse_field(fields[1], 0, 23)
+        dom = parse_field(fields[2], 1, 31)
+        month = parse_field(fields[3], 1, 12)
+        dow_raw = parse_field(fields[4], 0, 7)
+        # Normalize Sunday: bit 7 -> bit 0
+        dow = (dow_raw | (dow_raw >> 7)) & 0x7F_u64
+        Cron.new(fields.join(' '), minute, hour, dom, month, dow,
+          dom_restricted: fields[2] != "*",
+          dow_restricted: fields[4] != "*")
+      end
+
+      # Returns the smallest Time > `time` that matches the expression.
+      def next_after(time : Time) : Time
+        # Round up to the next minute boundary, dropping seconds/nanoseconds.
+        t = Time.utc(time.year, time.month, time.day, time.hour, time.minute) + 1.minute
+        MAX_ITERATIONS.times do
+          if @month.bit(t.month) == 0
+            t = beginning_of_next_month(t)
+            next
+          end
+          unless day_matches?(t)
+            t = (t + 1.day).at_beginning_of_day
+            next
+          end
+          if @hour.bit(t.hour) == 0
+            t = Time.utc(t.year, t.month, t.day, t.hour, 0) + 1.hour
+            next
+          end
+          if @minute.bit(t.minute) == 0
+            t += 1.minute
+            next
+          end
+          return t
+        end
+        raise ParseError.new("No future match for cron expression #{@expression.inspect}")
+      end
+
+      def to_s(io : IO) : Nil
+        io << @expression
+      end
+
+      private def day_matches?(t : Time) : Bool
+        dom_match = @dom.bit(t.day) == 1
+        # Crystal: Monday=1..Sunday=7; cron: Sunday=0..Saturday=6
+        crystal_dow = t.day_of_week.value
+        cron_dow = crystal_dow == 7 ? 0 : crystal_dow
+        dow_match = @dow.bit(cron_dow) == 1
+        if @dom_restricted && @dow_restricted
+          dom_match || dow_match
+        elsif @dom_restricted
+          dom_match
+        elsif @dow_restricted
+          dow_match
+        else
+          true
+        end
+      end
+
+      private def beginning_of_next_month(t : Time) : Time
+        if t.month == 12
+          Time.utc(t.year + 1, 1, 1, 0, 0)
+        else
+          Time.utc(t.year, t.month + 1, 1, 0, 0)
+        end
+      end
+
+      private def self.parse_field(s : String, lo : Int32, hi : Int32) : UInt64
+        bits = 0_u64
+        s.split(',').each do |part|
+          raise ParseError.new("Empty field part") if part.empty?
+          bits |= parse_part(part, lo, hi)
+        end
+        bits
+      end
+
+      # ameba:disable Metrics/CyclomaticComplexity
+      private def self.parse_part(s : String, lo : Int32, hi : Int32) : UInt64
+        range_str, step = if slash = s.index('/')
+                            step_str = s[slash + 1..]
+                            step_n = step_str.to_i? || raise ParseError.new("Invalid step #{step_str.inspect} in #{s.inspect}")
+                            raise ParseError.new("Step must be > 0 in #{s.inspect}") if step_n < 1
+                            {s[0...slash], step_n}
+                          else
+                            {s, 1}
+                          end
+
+        from, to = case range_str
+                   when "*"
+                     {lo, hi}
+                   else
+                     if dash = range_str.index('-')
+                       a = range_str[0...dash].to_i? || raise ParseError.new("Invalid range bound in #{s.inspect}")
+                       b = range_str[dash + 1..].to_i? || raise ParseError.new("Invalid range bound in #{s.inspect}")
+                       {a, b}
+                     else
+                       raise ParseError.new("Step requires range or wildcard: #{s.inspect}") if step != 1
+                       n = range_str.to_i? || raise ParseError.new("Invalid number in #{s.inspect}")
+                       {n, n}
+                     end
+                   end
+
+        if from < lo || to > hi || from > to
+          raise ParseError.new("Value #{from}-#{to} out of range #{lo}-#{hi} in #{s.inspect}")
+        end
+
+        bits = 0_u64
+        n = from
+        while n <= to
+          bits |= 1_u64 << n
+          n += step
+        end
+        bits
+      end
+    end
+  end
+end

--- a/src/lavinmq/scheduled_job/runner.cr
+++ b/src/lavinmq/scheduled_job/runner.cr
@@ -1,0 +1,189 @@
+require "digest/sha1"
+require "amq-protocol"
+require "../sortable_json"
+require "../message"
+require "../bool_channel"
+require "../config"
+require "./cron"
+
+module LavinMQ
+  module ScheduledJob
+    class Runner
+      include SortableJSON
+
+      enum State
+        Scheduled
+        Paused
+        Terminated
+      end
+
+      Log = LavinMQ::Log.for "scheduled_job"
+
+      getter name : String
+      getter cron : Cron
+      getter exchange : String
+      getter routing_key : String
+
+      @run_count : UInt64 = 0
+      @last_run_at : Time? = nil
+      @last_error : String? = nil
+      @last_duration_ms : Int64? = nil
+      @next_run_at : Time? = nil
+      @paused_file_path : String
+      @paused : BoolChannel
+      @stopped : BoolChannel
+      @manual_trigger : Channel(Nil)
+      @log : ::Log
+
+      def initialize(@name : String, @vhost : VHost, @cron : Cron,
+                     @exchange : String, @routing_key : String,
+                     @body : String, @properties : AMQ::Protocol::Properties,
+                     @on_state_change : Runner -> Nil)
+        @log = Log.for(@name)
+        @manual_trigger = Channel(Nil).new(1)
+        @stopped = BoolChannel.new(false)
+        filename = "scheduled_jobs.#{Digest::SHA1.hexdigest @name}.paused"
+        @paused_file_path = File.join(Config.instance.data_dir, filename)
+        @paused = BoolChannel.new(File.exists?(@paused_file_path))
+      end
+
+      def restore_stats(run_count : UInt64, last_run_at : Time?,
+                        last_error : String?, last_duration_ms : Int64?) : Nil
+        @run_count = run_count
+        @last_run_at = last_run_at
+        @last_error = last_error
+        @last_duration_ms = last_duration_ms
+      end
+
+      def state : State
+        return State::Terminated if @stopped.value
+        return State::Paused if @paused.value
+        State::Scheduled
+      end
+
+      def run : Nil
+        ::Log.context.set(name: @name, vhost: @vhost.name)
+        loop do
+          return if @stopped.value
+          if @paused.value
+            @next_run_at = nil
+            select
+            when @paused.when_false.receive?
+            when @stopped.when_true.receive?
+              return
+            end
+            next
+          end
+          next_at = @cron.next_after(Time.utc)
+          @next_run_at = next_at
+          delay = next_at - Time.utc
+          delay = 1.millisecond if delay < 1.millisecond
+          select
+          when timeout delay
+            fire!
+          when @manual_trigger.receive?
+            fire!
+          when @stopped.when_true.receive?
+            return
+          when @paused.when_true.receive?
+            next
+          end
+        end
+      ensure
+        @next_run_at = nil
+      end
+
+      def run_now : Bool
+        return false unless state.scheduled?
+        select
+        when @manual_trigger.send(nil)
+        else
+          # a trigger is already queued; collapse
+        end
+        true
+      end
+
+      def pause : Bool
+        return false unless state.scheduled?
+        File.write(@paused_file_path, @name)
+        @paused.set(true)
+        @on_state_change.call(self)
+        true
+      end
+
+      def resume : Bool
+        return false unless state.paused?
+        delete_paused_file
+        @paused.set(false)
+        @on_state_change.call(self)
+        true
+      end
+
+      def terminate : Nil
+        return if @stopped.value
+        @stopped.set(true)
+      end
+
+      def delete : Nil
+        terminate
+        delete_paused_file
+      end
+
+      def run_count : UInt64
+        @run_count
+      end
+
+      def last_run_at : Time?
+        @last_run_at
+      end
+
+      def last_error : String?
+        @last_error
+      end
+
+      def last_duration_ms : Int64?
+        @last_duration_ms
+      end
+
+      def next_run_at : Time?
+        @next_run_at
+      end
+
+      def details_tuple
+        {
+          name:             @name,
+          vhost:            @vhost.name,
+          exchange:         @exchange,
+          routing_key:      @routing_key,
+          cron:             @cron.to_s,
+          state:            state.to_s,
+          run_count:        @run_count,
+          last_run_at:      @last_run_at.try(&.to_rfc3339),
+          next_run_at:      @next_run_at.try(&.to_rfc3339),
+          last_error:       @last_error,
+          last_duration_ms: @last_duration_ms,
+        }
+      end
+
+      private def fire! : Nil
+        start = Time.instant
+        msg = LavinMQ::Message.new(@exchange, @routing_key, @body, @properties)
+        @vhost.publish(msg)
+        @run_count &+= 1
+        @last_run_at = Time.utc
+        @last_duration_ms = (Time.instant - start).total_milliseconds.to_i64
+        @last_error = nil
+      rescue ex
+        @last_error = ex.message
+        @last_run_at = Time.utc
+        @log.warn(exception: ex) { "Failed to publish" }
+      ensure
+        @on_state_change.call(self)
+      end
+
+      private def delete_paused_file : Nil
+        FileUtils.rm(@paused_file_path) if File.exists?(@paused_file_path)
+      end
+    end
+  end
+end

--- a/src/lavinmq/scheduled_job/store.cr
+++ b/src/lavinmq/scheduled_job/store.cr
@@ -1,0 +1,277 @@
+require "json"
+require "amq-protocol"
+require "./cron"
+require "./runner"
+require "../auth/user"
+require "../bool_channel"
+
+module LavinMQ
+  module ScheduledJob
+    class ConfigError < Exception; end
+
+    class Store
+      STATE_FILENAME = "scheduled_jobs_state.json"
+      FLUSH_INTERVAL = 1.second
+      Log            = LavinMQ::Log.for "scheduled_job_store"
+
+      def initialize(@vhost : VHost)
+        @jobs = Hash(String, Runner).new
+        @stats = Hash(String, PersistedStats).new
+        @state_path = File.join(@vhost.data_dir, STATE_FILENAME)
+        @dirty = Atomic(Bool).new(false)
+        @closed = Atomic(Bool).new(false)
+        @flusher_stopped = BoolChannel.new(false)
+        load_state!
+        spawn run_flusher, name: "ScheduledJob state flusher vhost=#{@vhost.name}"
+      end
+
+      # Stops the flusher fiber, terminates every runner, and writes any
+      # pending stats to disk. Safe to call more than once.
+      def close : Nil
+        return if @closed.swap(true)
+        @jobs.each_value &.terminate
+        @flusher_stopped.set(true)
+        flush!
+      end
+
+      # Forces an immediate synchronous write of the stats file if any
+      # runner has updated its stats since the last flush. No-op otherwise.
+      def flush! : Nil
+        return unless @dirty.swap(false)
+        save_state!
+      end
+
+      def []?(name : String) : Runner?
+        @jobs[name]?
+      end
+
+      def [](name : String) : Runner
+        @jobs[name]
+      end
+
+      def each_value(& : Runner ->) : Nil
+        @jobs.each_value { |j| yield j }
+      end
+
+      def values : Array(Runner)
+        @jobs.values
+      end
+
+      def size : Int32
+        @jobs.size
+      end
+
+      def has_key?(name : String) : Bool
+        @jobs.has_key?(name)
+      end
+
+      def empty? : Bool
+        @jobs.empty?
+      end
+
+      def self.validate_config!(config : JSON::Any, user : Auth::BaseUser?, vhost : VHost? = nil) : Nil
+        unless config.as_h?
+          raise ConfigError.new("Config must be a JSON object")
+        end
+        cron_str = require_string!(config, "cron", alias_key: "schedule", allow_empty: false)
+        begin
+          Cron.parse(cron_str)
+        rescue ex : Cron::ParseError
+          raise ConfigError.new("Invalid cron expression: #{ex.message}")
+        end
+        optional_string!(config, "exchange")
+        require_string!(config, "routing-key", alias_key: "routing_key", allow_empty: false)
+        require_string!(config, "body", allow_empty: true)
+        optional_string!(config, "content-type")
+        optional_string!(config, "content-encoding")
+        if headers = config["headers"]?
+          raise ConfigError.new("'headers' must be a JSON object") unless headers.as_h?
+        end
+        if user && vhost
+          exchange = normalize_exchange(config["exchange"]?.try(&.as_s?))
+          unless user.can_write?(vhost.name, exchange) && user.can_config?(vhost.name, exchange)
+            raise ConfigError.new("#{user.name} can't publish to exchange '#{exchange}' in #{vhost.name}")
+          end
+        end
+      end
+
+      def create(name : String, config : JSON::Any) : Runner
+        Store.validate_config!(config, user: nil)
+        @jobs[name]?.try &.terminate
+        cron_str = Store.require_string!(config, "cron", alias_key: "schedule", allow_empty: false)
+        cron = Cron.parse(cron_str)
+        exchange = Store.normalize_exchange(config["exchange"]?.try(&.as_s?))
+        routing_key = Store.require_string!(config, "routing-key", alias_key: "routing_key", allow_empty: false)
+        body = Store.require_string!(config, "body", allow_empty: true)
+        properties = build_properties(config)
+        runner = Runner.new(name, @vhost, cron, exchange, routing_key, body, properties,
+          on_state_change: ->(r : Runner) { persist_runner_state(r) })
+        if existing = @stats[name]?
+          runner.restore_stats(existing.run_count, existing.last_run_at,
+            existing.last_error, existing.last_duration_ms)
+        end
+        @jobs[name] = runner
+        spawn runner.run, name: "ScheduledJob #{name} vhost=#{@vhost.name}"
+        runner
+      end
+
+      # Returns the value of the required string field. Raises ConfigError with
+      # a precise reason when the field is missing, the wrong JSON type, or
+      # (when allow_empty: false) an empty string.
+      protected def self.require_string!(config : JSON::Any, key : String,
+                                         *, alias_key : String? = nil,
+                                         allow_empty : Bool) : String
+        present_key, raw = if v = config[key]?
+                             {key, v}
+                           elsif alias_key && (v = config[alias_key]?)
+                             {alias_key, v}
+                           else
+                             missing = alias_key ? "'#{key}' (or '#{alias_key}')" : "'#{key}'"
+                             raise ConfigError.new("Field #{missing} is required")
+                           end
+        s = raw.as_s? || raise ConfigError.new("Field '#{present_key}' must be a string")
+        if !allow_empty && s.empty?
+          raise ConfigError.new("Field '#{present_key}' must not be empty")
+        end
+        s
+      end
+
+      # Validates an optional string field's type. Returns the value or nil.
+      protected def self.optional_string!(config : JSON::Any, key : String) : String?
+        v = config[key]? || return nil
+        v.as_s? || raise ConfigError.new("Field '#{key}' must be a string")
+      end
+
+      # The AMQP default exchange is the empty string; tools commonly write
+      # "amq.default" to mean the same thing. Normalize both.
+      protected def self.normalize_exchange(name : String?) : String
+        return "" if name.nil?
+        return "" if name == "amq.default"
+        name
+      end
+
+      protected def self.lookup_string(config : JSON::Any, *keys : String) : String?
+        keys.each do |k|
+          if v = config[k]?
+            if s = v.as_s?
+              return s
+            end
+          end
+        end
+        nil
+      end
+
+      def delete(name : String) : Runner?
+        if job = @jobs.delete name
+          job.delete
+          @stats.delete(name)
+          @dirty.set(true)
+          flush! # delete is rare and we want it durable immediately
+          job
+        end
+      end
+
+      private def build_properties(config : JSON::Any) : AMQ::Protocol::Properties
+        headers = nil
+        if h = config["headers"]?.try(&.as_h?)
+          headers = AMQ::Protocol::Table.new
+          h.each { |k, v| headers[k] = coerce_header_value(v) }
+        end
+        AMQ::Protocol::Properties.new(
+          content_type: config["content-type"]?.try(&.as_s?),
+          content_encoding: config["content-encoding"]?.try(&.as_s?),
+          headers: headers,
+          delivery_mode: 2_u8, # always persistent
+        )
+      end
+
+      private def coerce_header_value(v : JSON::Any) : AMQ::Protocol::Field
+        case raw = v.raw
+        when String  then raw
+        when Int64   then raw
+        when Int32   then raw.to_i64
+        when Float64 then raw
+        when Bool    then raw
+        when Nil     then ""
+        else
+          v.to_json
+        end
+      end
+
+      private def persist_runner_state(runner : Runner) : Nil
+        @stats[runner.name] = PersistedStats.new(
+          run_count: runner.run_count,
+          last_run_at: runner.last_run_at,
+          last_error: runner.last_error,
+          last_duration_ms: runner.last_duration_ms,
+        )
+        @dirty.set(true)
+      end
+
+      private def run_flusher : Nil
+        loop do
+          select
+          when timeout FLUSH_INTERVAL
+            flush!
+          when @flusher_stopped.when_true.receive?
+            return
+          end
+        end
+      end
+
+      private def save_state! : Nil
+        tmp = "#{@state_path}.tmp"
+        File.open(tmp, "w") do |f|
+          JSON.build(f) do |json|
+            json.object do
+              json.field "jobs" do
+                json.object do
+                  @stats.each do |name, s|
+                    json.field name do
+                      s.to_json(json)
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+        File.rename tmp, @state_path
+        @vhost.replicator.try &.replace_file @state_path
+      rescue ex
+        Log.error(exception: ex) { "Failed to persist scheduled job state" }
+      end
+
+      private def load_state! : Nil
+        return unless File.exists?(@state_path)
+        File.open(@state_path) do |f|
+          payload = StatePayload.from_json(f)
+          @stats = payload.jobs
+          @vhost.replicator.try &.register_file f
+        end
+      rescue ex
+        Log.error(exception: ex) { "Failed to load scheduled job state; starting fresh" }
+        @stats = Hash(String, PersistedStats).new
+      end
+
+      struct PersistedStats
+        include JSON::Serializable
+
+        property run_count : UInt64
+        property last_run_at : Time?
+        property last_error : String?
+        property last_duration_ms : Int64?
+
+        def initialize(@run_count : UInt64, @last_run_at : Time?,
+                       @last_error : String?, @last_duration_ms : Int64?)
+        end
+      end
+
+      struct StatePayload
+        include JSON::Serializable
+
+        property jobs : Hash(String, PersistedStats) = Hash(String, PersistedStats).new
+      end
+    end
+  end
+end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -5,6 +5,7 @@ require "./policy"
 require "./parameter_store"
 require "./parameter"
 require "./shovel/store"
+require "./scheduled_job/store"
 require "./federation/upstream_store"
 require "./sortable_json"
 require "./amqp/exchange/*"
@@ -28,7 +29,7 @@ module LavinMQ
                 "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
                 "redeliver", "reject", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
 
-    getter name, data_dir, operator_policies, policies, parameters, shovels, dir, users
+    getter name, data_dir, operator_policies, policies, parameters, shovels, dir, users, replicator
     getter closed = BoolChannel.new(true)
     property max_connections : Int32?
     property max_queues : Int32?
@@ -37,6 +38,7 @@ module LavinMQ
     @direct_reply_consumers = DirectReplyConsumerStore.new
     @definitions : DefinitionsStore?
     @shovels : Shovel::Store?
+    @scheduled_jobs : ScheduledJob::Store?
     @upstreams : Federation::UpstreamStore?
     @connections = ConnectionStore.new
 
@@ -177,6 +179,7 @@ module LavinMQ
       @policies = ParameterStore(Policy).new(@data_dir, "policies.json", @replicator, vhost: @name)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator, vhost: @name)
       @shovels = Shovel::Store.new(self)
+      @scheduled_jobs = ScheduledJob::Store.new(self)
       @upstreams = Federation::UpstreamStore.new(self)
       @definitions = DefinitionsStore.new(self, @data_dir, @replicator, @log)
       load!
@@ -385,6 +388,7 @@ module LavinMQ
     end
 
     SHOVEL                  = "shovel"
+    SCHEDULED_JOB           = "scheduled-job"
     FEDERATION_UPSTREAM     = "federation-upstream"
     FEDERATION_UPSTREAM_SET = "federation-upstream-set"
 
@@ -401,6 +405,8 @@ module LavinMQ
       case component_name
       when SHOVEL
         shovels.delete(parameter_name)
+      when SCHEDULED_JOB
+        scheduled_jobs.delete(parameter_name)
       when FEDERATION_UPSTREAM
         upstreams.delete_upstream(parameter_name)
       when FEDERATION_UPSTREAM_SET
@@ -414,6 +420,10 @@ module LavinMQ
       shovels.each_value &.terminate
     end
 
+    def stop_scheduled_jobs
+      scheduled_jobs.close
+    end
+
     def stop_upstream_links
       upstreams.stop_all
     end
@@ -421,6 +431,7 @@ module LavinMQ
     def close(reason = "Broker shutdown")
       return if @closed.swap(true)
       stop_shovels
+      stop_scheduled_jobs
       stop_upstream_links
 
       @log.info { "Closing connections" }
@@ -473,6 +484,8 @@ module LavinMQ
         case p.component_name
         when SHOVEL
           shovels.create(p.parameter_name, p.value)
+        when SCHEDULED_JOB
+          scheduled_jobs.create(p.parameter_name, p.value)
         when FEDERATION_UPSTREAM
           upstreams.create_upstream(p.parameter_name, p.value)
         when FEDERATION_UPSTREAM_SET
@@ -505,6 +518,10 @@ module LavinMQ
 
     def shovels
       @shovels.not_nil!
+    end
+
+    def scheduled_jobs
+      @scheduled_jobs.not_nil!
     end
 
     def event_tick(event_type)

--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -75,6 +75,10 @@ components:
       "$ref": "./schemas/shovels.yaml#/ShovelList"
     Shovel:
       "$ref": "./schemas/shovels.yaml#/Shovel"
+    ScheduledJobList:
+      "$ref": "./schemas/scheduled-jobs.yaml#/ScheduledJobList"
+    ScheduledJob:
+      "$ref": "./schemas/scheduled-jobs.yaml#/ScheduledJob"
     main-federation-links:
       "$ref": "./schemas/main.yaml#/federation-links"
     main-extensions:
@@ -214,6 +218,18 @@ paths:
     "$ref": "./paths/shovels.yaml#/~1api~1shovels~1{vhost}~1{name}~1pause"
   "/api/shovels/{vhost}/{name}/resume":
     "$ref": "./paths/shovels.yaml#/~1api~1shovels~1{vhost}~1{name}~1resume"
+  "/api/scheduled-jobs":
+    "$ref": "./paths/scheduled-jobs.yaml#/~1api~1scheduled-jobs"
+  "/api/scheduled-jobs/{vhost}":
+    "$ref": "./paths/scheduled-jobs.yaml#/~1api~1scheduled-jobs~1{vhost}"
+  "/api/scheduled-jobs/{vhost}/{name}":
+    "$ref": "./paths/scheduled-jobs.yaml#/~1api~1scheduled-jobs~1{vhost}~1{name}"
+  "/api/scheduled-jobs/{vhost}/{name}/pause":
+    "$ref": "./paths/scheduled-jobs.yaml#/~1api~1scheduled-jobs~1{vhost}~1{name}~1pause"
+  "/api/scheduled-jobs/{vhost}/{name}/resume":
+    "$ref": "./paths/scheduled-jobs.yaml#/~1api~1scheduled-jobs~1{vhost}~1{name}~1resume"
+  "/api/scheduled-jobs/{vhost}/{name}/run":
+    "$ref": "./paths/scheduled-jobs.yaml#/~1api~1scheduled-jobs~1{vhost}~1{name}~1run"
   "/federation-links":
     "$ref": "./paths/main.yaml#/~1federation-links"
   "/federation-links/{vhost}":
@@ -307,6 +323,8 @@ tags:
     description: Query the server for various information (e.g. federation links, extensions).
   - name: shovels
     description: Manage shovels.
+  - name: scheduled-jobs
+    description: Manage scheduled jobs.
   - name: nodes
     description: Get node statistics.
   - name: parameters

--- a/static/docs/paths/scheduled-jobs.yaml
+++ b/static/docs/paths/scheduled-jobs.yaml
@@ -1,0 +1,170 @@
+"/api/scheduled-jobs":
+  get:
+    tags:
+      - scheduled-jobs
+    description: List all scheduled jobs across all vhosts the user can access.
+    summary: List all scheduled jobs
+    operationId: GetScheduledJobs
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ScheduledJobList"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+
+"/api/scheduled-jobs/{vhost}":
+  parameters:
+    - in: path
+      name: vhost
+      required: true
+      schema:
+        type: string
+        description: Name of vhost.
+  get:
+    tags:
+      - scheduled-jobs
+    description: List scheduled jobs for the given vhost.
+    summary: List scheduled jobs by vhost
+    operationId: GetScheduledJobsByVhost
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ScheduledJobList"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+
+"/api/scheduled-jobs/{vhost}/{name}":
+  parameters:
+    - in: path
+      name: vhost
+      required: true
+      schema:
+        type: string
+    - in: path
+      name: name
+      required: true
+      schema:
+        type: string
+  get:
+    tags:
+      - scheduled-jobs
+    description: Get a scheduled job's configuration and runtime stats.
+    summary: Get scheduled job details
+    operationId: GetScheduledJob
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ScheduledJob"
+      '404':
+        description: Not Found
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+
+"/api/scheduled-jobs/{vhost}/{name}/pause":
+  parameters:
+    - in: path
+      name: vhost
+      required: true
+      schema:
+        type: string
+    - in: path
+      name: name
+      required: true
+      schema:
+        type: string
+  put:
+    tags:
+      - scheduled-jobs
+    description: Pause a scheduled job. The next-run timer is cleared; runs resume on resume.
+    summary: Pause scheduled job
+    operationId: PauseScheduledJob
+    responses:
+      '204':
+        description: Paused
+      '404':
+        description: Not Found
+      '422':
+        description: Job is not currently scheduled
+
+"/api/scheduled-jobs/{vhost}/{name}/resume":
+  parameters:
+    - in: path
+      name: vhost
+      required: true
+      schema:
+        type: string
+    - in: path
+      name: name
+      required: true
+      schema:
+        type: string
+  put:
+    tags:
+      - scheduled-jobs
+    description: Resume a paused scheduled job.
+    summary: Resume scheduled job
+    operationId: ResumeScheduledJob
+    responses:
+      '204':
+        description: Resumed
+      '404':
+        description: Not Found
+      '422':
+        description: Job is not paused
+
+"/api/scheduled-jobs/{vhost}/{name}/run":
+  parameters:
+    - in: path
+      name: vhost
+      required: true
+      schema:
+        type: string
+    - in: path
+      name: name
+      required: true
+      schema:
+        type: string
+  post:
+    tags:
+      - scheduled-jobs
+    description: Manually trigger the scheduled job to fire once, immediately.
+    summary: Run scheduled job now
+    operationId: RunScheduledJobNow
+    responses:
+      '202':
+        description: Trigger accepted
+      '404':
+        description: Not Found
+      '422':
+        description: Job is not in a runnable state (paused or terminated)

--- a/static/docs/schemas/scheduled-jobs.yaml
+++ b/static/docs/schemas/scheduled-jobs.yaml
@@ -1,0 +1,68 @@
+---
+ScheduledJobList:
+  type: array
+  description: List of scheduled jobs
+  items:
+    "$ref": "#/ScheduledJob"
+
+ScheduledJob:
+  type: object
+  description: A scheduled job configuration and runtime stats
+  properties:
+    name:
+      type: string
+      description: Name of the scheduled job
+      example: "nightly-report"
+    vhost:
+      type: string
+      description: Name of the virtual host
+      example: "/"
+    exchange:
+      type: string
+      description: Target exchange. Empty string means the default exchange.
+      example: "amq.topic"
+    routing_key:
+      type: string
+      description: Routing key used when publishing
+      example: "reports.nightly"
+    cron:
+      type: string
+      description: Standard 5-field cron expression, interpreted as UTC
+      example: "0 2 * * *"
+    state:
+      type: string
+      description: Current state
+      enum:
+        - Scheduled
+        - Paused
+        - Terminated
+      example: "Scheduled"
+    run_count:
+      type: integer
+      description: Number of times the job has been fired since creation
+      minimum: 0
+      example: 42
+    last_run_at:
+      type: string
+      format: date-time
+      nullable: true
+      description: Timestamp (RFC3339, UTC) of the last completed fire
+    next_run_at:
+      type: string
+      format: date-time
+      nullable: true
+      description: Timestamp (RFC3339, UTC) of the next planned fire
+    last_error:
+      type: string
+      nullable: true
+      description: Error message from the most recent fire, if any
+    last_duration_ms:
+      type: integer
+      nullable: true
+      description: Wall-clock duration of the most recent fire, in milliseconds
+  required:
+    - name
+    - vhost
+    - cron
+    - state
+    - run_count

--- a/static/js/scheduled-jobs.js
+++ b/static/js/scheduled-jobs.js
@@ -1,0 +1,169 @@
+import * as HTTP from './http.js'
+import * as Table from './table.js'
+import * as Helpers from './helpers.js'
+import * as DOM from './dom.js'
+import * as Form from './form.js'
+import { UrlDataSource } from './datasource.js'
+
+Helpers.addVhostOptions('createScheduledJob')
+
+const vhost = window.sessionStorage.getItem('vhost')
+let url = 'api/parameters/scheduled-job'
+let statusUrl = 'api/scheduled-jobs'
+if (vhost && vhost !== '_all') {
+  url += HTTP.url`/${vhost}`
+  statusUrl += HTTP.url`/${vhost}`
+}
+
+class ScheduledJobsDataSource extends UrlDataSource {
+  constructor (url, statusUrl) {
+    super(url)
+    this.statusUrl = statusUrl
+  }
+
+  _reload () {
+    const p1 = super._reload()
+    const p2 = HTTP.request('GET', this.statusUrl)
+    return Promise.all([p1, p2]).then(values => {
+      const params = values[0].items ?? values[0]
+      const statuses = values[1].items ?? values[1]
+      return params.map(item => {
+        const s = statuses.find(s => s.name === item.name && s.vhost === item.vhost) || {}
+        item.state = s.state
+        item.runCount = s.run_count
+        item.lastRunAt = s.last_run_at
+        item.nextRunAt = s.next_run_at
+        item.lastError = s.last_error
+        return item
+      })
+    })
+  }
+}
+
+const dataSource = new ScheduledJobsDataSource(url, statusUrl)
+const tableOptions = { keyColumns: ['vhost', 'name'], columnSelector: false, dataSource }
+
+function fmtTime (iso) {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString()
+  } catch (e) {
+    return iso
+  }
+}
+
+function renderState (item) {
+  if (item.lastError) {
+    const wrap = document.createElement('span')
+    wrap.classList.add('arg-tooltip')
+    wrap.appendChild(document.createTextNode(item.state || '—'))
+    const tt = document.createElement('span')
+    tt.classList.add('tooltiptext')
+    tt.textContent = item.lastError
+    wrap.appendChild(tt)
+    return wrap
+  }
+  return item.state || '—'
+}
+
+Table.renderTable('table', tableOptions, (tr, item, _all) => {
+  Table.renderCell(tr, 0, item.vhost)
+  Table.renderCell(tr, 1, item.name)
+  Table.renderCell(tr, 2, item.value.exchange || '(default)')
+  Table.renderCell(tr, 3, item.value['routing-key'])
+  Table.renderCell(tr, 4, item.value.cron)
+  Table.renderCell(tr, 5, fmtTime(item.lastRunAt))
+  Table.renderCell(tr, 6, fmtTime(item.nextRunAt))
+  Table.renderCell(tr, 7, item.runCount ?? 0)
+  Table.renderCell(tr, 8, renderState(item))
+
+  const btns = document.createElement('div')
+  btns.classList.add('buttons')
+
+  const runBtn = DOM.button.edit({
+    click: function () {
+      const url = HTTP.url`api/scheduled-jobs/${item.vhost}/${item.name}/run`
+      HTTP.request('POST', url)
+        .then(() => { dataSource.reload(); DOM.toast(`Job ${item.name} dispatched`) })
+        .catch((err) => { console.error(err); DOM.toast.error(`Failed to dispatch ${item.name}`) })
+    },
+    text: 'Run now'
+  })
+
+  const pauseLabel = item.state === 'Scheduled' ? 'Pause' : 'Resume'
+  const pauseBtn = DOM.button.edit({
+    click: function () {
+      const isScheduled = item.state === 'Scheduled'
+      const action = isScheduled ? 'pause' : 'resume'
+      const url = HTTP.url`api/scheduled-jobs/${item.vhost}/${item.name}/${action}`
+      HTTP.request('PUT', url)
+        .then(() => { dataSource.reload(); DOM.toast(`Job ${item.name} ${action}d`) })
+        .catch((err) => { console.error(err); DOM.toast.error(`Failed to ${action} ${item.name}`) })
+    },
+    text: pauseLabel
+  })
+
+  const editBtn = DOM.button.edit({
+    click: function () {
+      Form.editItem('#createScheduledJob', item, {
+        cron: (item) => item.value.cron,
+        exchange: (item) => item.value.exchange,
+        'routing-key': (item) => item.value['routing-key'],
+        body: (item) => item.value.body,
+        'content-type': (item) => item.value['content-type'],
+        headers: (item) => item.value.headers ? JSON.stringify(item.value.headers) : ''
+      })
+    }
+  })
+
+  const deleteBtn = DOM.button.delete({
+    click: function () {
+      const url = HTTP.url`api/parameters/scheduled-job/${item.vhost}/${item.name}`
+      if (window.confirm('Are you sure? This scheduled job will be permanently removed.')) {
+        HTTP.request('DELETE', url)
+          .then(() => { tr.parentNode.removeChild(tr); DOM.toast(`Job ${item.name} deleted`) })
+      }
+    }
+  })
+
+  btns.append(runBtn, pauseBtn, editBtn, deleteBtn)
+  Table.renderCell(tr, 9, btns, 'right')
+})
+
+document.querySelector('#createScheduledJob').addEventListener('submit', function (evt) {
+  evt.preventDefault()
+  const data = new window.FormData(this)
+  const name = data.get('name').trim()
+  const vhost = data.get('vhost')
+  const url = HTTP.url`api/parameters/scheduled-job/${vhost}/${name}`
+
+  const value = {
+    cron: data.get('cron'),
+    exchange: data.get('exchange') || '',
+    'routing-key': data.get('routing-key'),
+    body: data.get('body')
+  }
+  const ct = data.get('content-type')
+  if (ct) value['content-type'] = ct
+  const headersRaw = data.get('headers')
+  if (headersRaw && headersRaw.trim().length) {
+    try {
+      const parsed = JSON.parse(headersRaw)
+      if (typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('not an object')
+      value.headers = parsed
+    } catch (e) {
+      DOM.toast.error('Headers must be a JSON object')
+      return
+    }
+  }
+  HTTP.request('PUT', url, { body: { value } })
+    .then(() => {
+      dataSource.reload()
+      evt.target.reset()
+      DOM.toast(`Scheduled job ${name} saved`)
+    })
+    .catch((err) => {
+      console.error(err)
+      DOM.toast.error(`Failed to save: ${err.message || err}`)
+    })
+})

--- a/views/partials/header.shtml
+++ b/views/partials/header.shtml
@@ -116,6 +116,11 @@
         <span class="menu-item-label menu-tooltip-label">Federation</span>
       </a>
     </li>
+    <li class="scheduled-jobs">
+      <a href="scheduled-jobs" class="menu-tooltip">
+        <span class="menu-item-label menu-tooltip-label">Scheduled jobs</span>
+      </a>
+    </li>
 
     <li class="menu-group"><span>Administration</span></li>
     <li class="vhosts">

--- a/views/scheduled-jobs.shtml
+++ b/views/scheduled-jobs.shtml
@@ -1,0 +1,88 @@
+<!--#set var="TITLE" value="Scheduled jobs" -->
+<!DOCTYPE html>
+<html lang="en" class="scheduled-jobs">
+  <head>
+    <!--#include file="partials/head.shtml" -->
+    <script type="module" src="js/scheduled-jobs.js"></script>
+  </head>
+  <body>
+    <!--#include file="partials/header.shtml" -->
+    <main class="main-grid">
+      <div id="breadcrumbs" class="cols-12">
+          <h2 class="page-title"><span><!--#echo var="TITLE" --></span><div class="tiny-badge" id="pagename-label"></div></h2>
+      </div>
+      <section class="card">
+        <div class="table-header">
+          <h2>Manage scheduled jobs</h2>
+        </div>
+        <div class="table-subheader">
+          <span class="table-page-info"></span>
+        </div>
+        <div class="table-wrapper">
+          <div id="table-error"></div>
+          <table id="table" class="table">
+            <thead>
+              <tr>
+                <th>Virtual host</th>
+                <th class="left" data-sort-key="name">Name<span></span></th>
+                <th>Exchange</th>
+                <th>Routing key</th>
+                <th>Cron (UTC)</th>
+                <th>Last run</th>
+                <th>Next run</th>
+                <th>Runs</th>
+                <th>State</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+      <form method="put" id="createScheduledJob" class="form card">
+        <h3>
+          <span class="when-create">Add a new scheduled job</span>
+          <span class="when-edit">Edit scheduled job</span>
+        </h3>
+        <label class="when-create">
+          <span>Virtual host</span>
+          <select class="dropdown" name="vhost" required></select>
+        </label>
+        <label>
+          <span>Name</span>
+          <input type="text" name="name" required data-primary-key="">
+        </label>
+        <label>
+          <span>Cron expression (UTC, 5 fields: min hour dom mon dow)</span>
+          <input type="text" name="cron" required placeholder="*/5 * * * *">
+        </label>
+        <label>
+          <span>Exchange</span>
+          <input type="text" name="exchange" placeholder="default exchange if empty">
+        </label>
+        <label>
+          <span>Routing key</span>
+          <input type="text" name="routing-key" required>
+        </label>
+        <label>
+          <span>Body</span>
+          <textarea name="body" rows="4" required></textarea>
+        </label>
+        <label>
+          <span>Content type</span>
+          <input type="text" name="content-type" placeholder="application/json">
+        </label>
+        <label>
+          <span>Headers (JSON object)</span>
+          <input type="text" name="headers" placeholder='{"x-foo":"bar"}'>
+        </label>
+        <button type="submit" class="btn btn-green when-create">Add scheduled job</button>
+        <div class="when-edit flex gap-2">
+          <button type="submit" class="btn btn-green">Update</button>
+          <button type="reset" class="btn btn-outlined cancel">Cancel</button>
+        </div>
+      </form>
+    </main>
+    <!--#include file="partials/footer.shtml" -->
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Per-vhost named jobs that publish a configured message body to an exchange on a cron schedule. Reuses the existing parameter system for storage and replication — jobs are persisted as parameters with `component_name = "scheduled-job"`, so create/update/delete + HA replication come for free.

### Backend
- `ScheduledJob::Cron` — small in-tree 5-field parser (no shard). Bitset per field, bounded `next_after`, UTC-only.
- `ScheduledJob::Runner` — one fiber per job, BoolChannel-driven pause/terminate, buffered manual-trigger channel, paused-file marker for restart durability (same pattern as shovels). Publishes via `vhost.publish` directly (no AMQP client, no socket).
- `ScheduledJob::Store` — runner lifecycle, strict config validation with precise error messages (distinguishes missing / wrong-type / empty), accepts both `cron`/`schedule` and `routing-key`/`routing_key` field-name conventions, normalizes `amq.default` to the default exchange.
- **Debounced stats writes**: a 1s flusher fiber coalesces fires into at most one disk write per second per vhost. Decouples fire latency from fsync latency, drops replicator chatter from O(fires) to O(1)/sec. `close` does a final synchronous flush. Deletes are still synchronously persisted.

All messages are sent persistent (delivery_mode=2). Jobs always start Scheduled; pause is done via the API.

### HTTP API
CRUD reuses `/api/parameters/scheduled-job/:vhost/:name` (with new validation hook). New action endpoints:

| Method | Path | Action |
|---|---|---|
| GET  | `/api/scheduled-jobs[/{vhost}[/{name}]]` | list / show |
| PUT  | `/api/scheduled-jobs/{vhost}/{name}/pause`  | 204/422/404 |
| PUT  | `/api/scheduled-jobs/{vhost}/{name}/resume` | 204/422/404 |
| POST | `/api/scheduled-jobs/{vhost}/{name}/run`    | 202/422/404 |

OpenAPI paths + schemas added.

### UI
New "Scheduled jobs" page under the Bridges menu group with a table (last/next run, runs, state) and a create/edit form. Per-row Run now / Pause / Resume / Edit / Delete buttons.

### HA
Followers don't run vhosts, so runner fibers only spawn on the leader. Config + stats files replicate via the existing replicator; on failover the new leader resumes scheduling from `Time.utc` (missed ticks during failover are skipped, not backfilled).

### Out of scope (v1)
Timezones (UTC only), `@hourly`/seconds/`L`/`W` cron extensions, run history beyond `last_*` counters, missed-run backfill.

## Test plan

- [x] `make lint` — clean
- [x] `make test SPEC=spec/scheduled_job/` — 65/65 pass
- [x] `make test SPEC=spec/api/scheduled_jobs_spec.cr` — 16/16 pass
- [x] Full `make test` — pre-existing 392 + new 81 specs, 0 failures (one pre-existing pending, one unrelated abort from the clustering spec that requires `etcd`)
- [x] End-to-end smoke against a real broker (`/opt/homebrew/var/lavinmq`) with the exact field shape from a real customer parameter (`schedule`/`routing_key`/`amq.default`): PUT 201, GET shows `state=Scheduled` + `next_run_at`, POST run → 202 + `run_count=1`, pause → 204, resume → 204, state file persisted.

Cron parser coverage: every-minute, fixed-interval, weekday-only, Sun=0/7 equivalence, yearly, Feb-29 leap-year skip, DoM∪DoW union, stepped ranges, comma lists, boundary values, whitespace tolerance, monotonicity, all malformed-input paths.

Validation coverage: missing required fields, wrong type per field, empty cron / routing-key (rejected), empty body (allowed), `amq.default` normalization, alternate field names (`schedule`, `routing_key`).

Persistence coverage: no synchronous disk write per fire, 100 fires coalesce into one flush, delete is sync-flushed, `close` flushes pending stats, `run_count` survives store reload.