### PR TITLE
fix: bake static assets as string literals to reduce compile memory

### DIFF
--- a/src/lavinmq/http/controller/static/bake.cr
+++ b/src/lavinmq/http/controller/static/bake.cr
@@ -27,7 +27,7 @@ def recursive_bake(dir)
             deflated = false
           end
         end
-        puts %(when #{path.lchop(ARGV[0]).inspect}\n  {Bytes.literal(#{data.bytes.join(", ")}), #{etag.inspect}, #{deflated}})
+        puts %(when #{path.lchop(ARGV[0]).inspect}\n  {#{data.inspect}.to_slice, #{etag.inspect}, #{deflated}})
       end
     end
   end


### PR DESCRIPTION
## Summary

- `Bytes.literal(b1, b2, ...)` in `bake.cr` (introduced in #1742) creates one AST node per byte across every baked static asset, adding ~700 MB to peak compile-time RSS. This is the most likely cause of the recent intermittent rpm.yml keepalive timeouts on Depot.
- Emit `"...".to_slice` instead. Runtime behaviour is equivalent: bytes still live in `.rodata` and the slice has `read_only: true`. #1742's `case`/`lookup` structure is preserved, so no `Hash` is allocated at startup.
- Upstream tracking issue for a real slice-literal syntax: crystal-lang/crystal#2886.

Local `--release` builds, average of 3 runs each:

| Metric | Before | After |
|---|---|---|
| Peak RSS | ~3.20 GB | ~2.51 GB |
| Wall time | ~2:14 | ~2:14 |

## Test plan

- [x] CI rpm.yml succeeds across the matrix (motivation for this fix)
- [x] frontend specs passes
- [x] Local `--release` smoke test of the management UI: ETag, `304 Not Modified`, `Accept-Encoding: deflate` all work