### PR TITLE
fix: handle past segments and requeued msgs in purge_all

### DIFF
--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -694,4 +694,72 @@ describe LavinMQ::MessageStore do
       end
     end
   end
+
+  describe "#purge_all" do
+    it "purges multiple segments of unread messages" do
+      with_store do |store|
+        half_seg = LavinMQ::Config.instance.segment_size.to_u64 // 2 + 1
+        big = LavinMQ::Message.new(RoughTime.unix_ms, "e", "k",
+          AMQ::Protocol::Properties.new, half_seg, IO::Memory.new("a" * half_seg))
+        5.times { store.push(big) }
+        store.@segments.size.should eq 5
+        store.purge_all
+        store.empty?.should be_true
+      end
+    end
+
+    it "does not raise when an older segment has in-flight messages" do
+      with_store do |store|
+        half_seg = LavinMQ::Config.instance.segment_size.to_u64 // 2 + 1
+        big = LavinMQ::Message.new(RoughTime.unix_ms, "e", "k",
+          AMQ::Protocol::Properties.new, half_seg, IO::Memory.new("a" * half_seg))
+
+        # One big msg per segment; second shift advances rfile to seg 2.
+        store.push(big)
+        store.push(big)
+        store.shift?.should_not be_nil
+        store.shift?.should_not be_nil
+
+        store.@segments.keys.should contain(1u32)
+        store.@rfile_id.should eq 2u32
+        store.@size.should eq 0u32
+
+        store.purge_all
+        store.empty?.should be_true
+      end
+    end
+
+    it "does not raise when @requeued points to a segment that gets deleted" do
+      with_store do |store|
+        half_seg = LavinMQ::Config.instance.segment_size.to_u64 // 2 + 1
+        big = LavinMQ::Message.new(RoughTime.unix_ms, "e", "k",
+          AMQ::Protocol::Properties.new, half_seg, IO::Memory.new("a" * half_seg))
+        small = LavinMQ::Message.new("ex", "rk", "body")
+
+        # Layout: seg 1 = [big], seg 2 = [big, small], seg 3 = [big].
+        store.push(big)
+        store.push(big)
+        store.push(small)
+        store.push(big)
+
+        # Ack M1 -> seg 1 auto-deletes. Shift the rest; ack M4 (wfile, kept).
+        env = store.shift?.not_nil!
+        store.delete(env.segment_position)
+        env_m2 = store.shift?.not_nil!
+        env_m3 = store.shift?.not_nil!
+        env_m4 = store.shift?.not_nil!
+        store.delete(env_m4.segment_position)
+
+        # Requeue m2/m3 -> @requeued holds sps to seg 2, no longer rfile/wfile.
+        store.requeue(env_m2.segment_position)
+        store.requeue(env_m3.segment_position)
+
+        store.@segments.keys.should contain(2u32)
+        store.@rfile_id.should eq 3u32
+
+        store.purge_all
+        store.empty?.should be_true
+      end
+    end
+  end
 end

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -930,7 +930,7 @@ module LavinMQ::AMQP
 
     def purge(max_count : Int = UInt32::MAX) : UInt32
       delete_count = 0u32
-      @msg_store_lock.synchronize {
+      @msg_store_lock.synchronize do
         if unacked_count == 0 && max_count >= message_count
           # If there's no unacked and we're purging all messages, we can purge faster by deleting files
           delete_count = message_count
@@ -938,7 +938,7 @@ module LavinMQ::AMQP
         else
           delete_count = @msg_store.purge(max_count)
         end
-      }
+      end
       @log.info { "Purged #{delete_count} messages" }
       # Signal expire loop to recalculate wait time for next message
       if delete_count > 0

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -929,13 +929,16 @@ module LavinMQ::AMQP
     end
 
     def purge(max_count : Int = UInt32::MAX) : UInt32
-      if unacked_count == 0 && max_count >= message_count
-        # If there's no unacked and we're purging all messages, we can purge faster by deleting files
-        delete_count = message_count
-        @msg_store_lock.synchronize { @msg_store.purge_all }
-      else
-        delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
-      end
+      delete_count = 0u32
+      @msg_store_lock.synchronize {
+        if unacked_count == 0 && max_count >= message_count
+          # If there's no unacked and we're purging all messages, we can purge faster by deleting files
+          delete_count = message_count
+          @msg_store.purge_all
+        else
+          delete_count = @msg_store.purge(max_count)
+        end
+      }
       @log.info { "Purged #{delete_count} messages" }
       # Signal expire loop to recalculate wait time for next message
       if delete_count > 0

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -203,14 +203,20 @@ module LavinMQ
     end
 
     def purge_all
+      # Clear any requeued messages and adjust stats accordingly
+      while sp = @requeued.shift?
+        @size -= 1
+        @bytesize -= sp.bytesize
+      end
+
       # Delete all segments except the current rfile and wfile
       @segments.reject! do |seg_id, file|
         next false if seg_id == @rfile_id || seg_id == @wfile_id
 
         delete_file(file, including_meta: true)
-        if msg_count = @segment_msg_count.delete(seg_id)
-          @size -= msg_count
-        end
+        msg_count = @segment_msg_count.delete(seg_id)
+        # Only decrement @size for segments that haven't been read yet
+        @size -= msg_count if msg_count && seg_id > @rfile_id
         if afile = @acks.delete(seg_id)
           delete_file(afile)
         end
@@ -223,8 +229,9 @@ module LavinMQ
         delete(env.segment_position)
       end
 
-      @requeued.clear
+      @size = 0_u32
       @bytesize = 0_u64
+      @empty.set(true)
     end
 
     def delete


### PR DESCRIPTION
## Summary

`purge_all` crashed in two ways when segments other than rfile/wfile were present:

- `OverflowError`: `@size -= @segment_msg_count[seg]` underflowed when a segment had been read past but not fully acked. `@segment_msg_count` counts msgs ever written; `@size` only counts ready+requeued.
- `KeyError`: `@requeued.clear` ran at the end of `purge_all`, so the `while shift?` drain looked up an sp's segment after step 1 had already deleted it.

Drain `@requeued` upfront (keeping `@size`/`@bytesize` in sync) so the `shift?` loop never sees a stale sp. Only decrement `@size` by `msg_count` for segments rfile hasn't reached yet. Reset `@size`/`@bytesize` and signal `@empty` at the end (the drain loop won't run when there are no ready msgs left).

Seen in production at LavinMQ 2.7.3 when purging a paused queue with previously-requeued msgs.

## Test plan

Three regression specs in `spec/message_store_spec.cr`:

- [x] `purges multiple segments of unread messages` - catches the EOF regression if the conditional `@size -= msg_count` were dropped.
- [x] `does not raise when an older segment has in-flight messages` - reproduces the original `OverflowError`.
- [x] `does not raise when @requeued points to a segment that gets deleted` - reproduces the original `KeyError`.