### PR TITLE
docs: fill operational gaps in TLS, clustering, and shovels

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -82,7 +82,9 @@ The proxy is transparent and runs on every follower for:
 - MQTT and MQTTS (TCP and Unix socket)
 - HTTP/management (TCP and Unix socket)
 
-For AMQP TCP traffic, the proxy prepends a PROXY protocol v1 header so the leader sees the original client address. No configuration is needed; the proxy starts and stops automatically as leadership changes.
+TCP listeners always proxy; Unix-socket proxying activates per protocol when the matching `unix_path` is configured in `[amqp]`, `[mqtt]`, or `[mgmt]`. The same setting controls both the listener on the leader and the proxy socket on a follower, so configuring `unix_path` once gives clients a consistent Unix socket on every node.
+
+For AMQP TCP traffic, the proxy prepends a PROXY protocol v1 header so the leader sees the original client address. No further configuration is needed; the proxy starts and stops automatically as leadership changes.
 
 ## Security
 

--- a/docs/shovels.md
+++ b/docs/shovels.md
@@ -41,13 +41,26 @@ A shovel consists of:
 
 ## HTTP Destination
 
-Shovels can POST messages to an HTTP endpoint:
+A shovel with an `http://` or `https://` `dest-uri` POSTs each consumed message to the endpoint instead of republishing it over AMQP. Useful for delivering broker traffic to webhook receivers, serverless handlers, or any HTTP service.
 
 | Parameter | Description |
 |-----------|-------------|
-| `dest-uri` | HTTP/HTTPS URL to POST to |
+| `dest-uri` | HTTP/HTTPS URL to POST to. Userinfo (`user:password@host`) is sent as HTTP Basic Auth. |
 
-The message body is sent as the request body.
+The AMQP message is mapped to the HTTP request as follows:
+
+| HTTP element | Source |
+|--------------|--------|
+| Method | `POST` |
+| Path | The `dest-uri` path if set, else the message header `uri_path`, else `/` |
+| Body | The raw AMQP message body |
+| `Content-Type` | The message `content_type` property, if set |
+| `X-Message-Id` | The message `message_id` property, if set |
+| `X-Shovel` | The shovel name |
+| `X-<header>` | One header per AMQP header on the message |
+| `User-Agent` | `LavinMQ` |
+
+For `on-confirm` and `on-publish` ack modes, the source delivery is acked only when the destination returns a 2xx response; any other status triggers the shovel's reconnect/retry path. `no-ack` skips the check.
 
 ## Multi-Destination
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -55,12 +55,39 @@ Per-hostname TLS certificates can be configured using `[sni:hostname]` sections 
 tls_cert = /etc/lavinmq/app1.crt
 tls_key = /etc/lavinmq/app1.key
 
-[sni:app2.example.com]
-tls_cert = /etc/lavinmq/app2.crt
-tls_key = /etc/lavinmq/app2.key
+[sni:*.example.com]
+tls_cert = /etc/lavinmq/wildcard.crt
+tls_key = /etc/lavinmq/wildcard.key
 ```
 
-During the TLS handshake the client may include a `server_name` extension naming the host it intends to reach. LavinMQ looks the name up in the configured `[sni:hostname]` sections (exact match), and the matching section's certificate, ciphers, minimum version, and mTLS settings are used for that connection. If no SNI section matches — or the client sends no `server_name` at all — the server falls back to the certificate and settings from `[main]`.
+During the TLS handshake the client may include a `server_name` extension naming the host it intends to reach. LavinMQ looks the name up in the configured `[sni:hostname]` sections, and the matching section's certificate, ciphers, minimum version, and mTLS settings are used for that connection. If no SNI section matches, or the client sends no `server_name` at all, the server falls back to the certificate and settings from `[main]`.
+
+Lookup tries an exact match first, then a wildcard. Wildcard sections use the `*.domain` syntax and match a single label only: `[sni:*.example.com]` matches `foo.example.com` but not `bar.foo.example.com` and not the bare `example.com`.
+
+### Per-protocol overrides
+
+Inside an `[sni:hostname]` section, any TLS setting can be overridden for a single protocol by prefixing the key with `amqp_`, `mqtt_`, or `http_`. The protocol-specific value wins for that protocol; the unprefixed value covers the rest. Useful when, for example, only one protocol on a hostname should enforce mTLS, or when one protocol needs its own key log file.
+
+```ini
+[sni:app1.example.com]
+tls_cert = /etc/lavinmq/app1.crt
+tls_key = /etc/lavinmq/app1.key
+amqp_tls_verify_peer = true
+amqp_tls_ca_cert = /etc/lavinmq/clients-ca.pem
+mqtt_tls_keylog_file = /var/log/lavinmq/mqtt-keys.log
+```
+
+The following keys accept a prefix: `tls_cert`, `tls_key`, `tls_min_version`, `tls_ciphers`, `tls_verify_peer`, `tls_ca_cert`, `tls_keylog_file`.
+
+## Reloading certificates
+
+Send `SIGHUP` to the LavinMQ process to reload the configuration file and rebuild every TLS context (main and all SNI sections) without dropping existing connections. New connections pick up the renewed certificates immediately; connections already established keep using the certificate that was active when they handshook. This is the supported path for certificate rotation in production.
+
+```sh
+kill -HUP $(pidof lavinmq)
+```
+
+On a systemd unit, `systemctl reload lavinmq` issues the same signal.
 
 ## kTLS (Kernel TLS)
 


### PR DESCRIPTION
Triggered by review feedback from a separate pass that was integrating these partials on the website. Each item below was verified against current source before being added; no website-only behavior leaked in.

tls.md
- New "Reloading certificates" section. SIGHUP triggers reload_server in launcher.cr, which calls config.reload and reload_tls_context (rebuilds main contexts and calls sni_manager.reload). Documented as the supported cert rotation path.
- SNI section now shows wildcard sections (*.example.com) and explains the matching rules: exact match first, then single-label wildcard suffix. Backed by SNIManager#get_wildcard_host in sni_config.cr.
- New "Per-protocol overrides" subsection lists the amqp_, mqtt_, and http_ prefixed keys (tls_cert, tls_key, tls_min_version, tls_ciphers, tls_verify_peer, tls_ca_cert, tls_keylog_file) that override the unprefixed value for a single protocol.

clustering.md
- Clarified that the per-protocol unix_path setting also wires up the follower-to-leader Unix-socket proxy. Same setting controls the listener on the leader and the proxy socket on a follower, see clustering/client.cr.

shovels.md
- Expanded the HTTP destination section. Documents POST body, path resolution (dest-uri path, then uri_path header, then /), header mapping (Content-Type, X-Message-Id, X-Shovel, X-<header>, User-Agent), basic auth via userinfo, and the on-confirm/on-publish 2xx requirement. Sourced from shovel/http_destination.cr.

Deferred for a separate pass: a structural split of users-permissions.md and authentication.md so the user model (users, tags, vhost permissions, default user loopback) is cleanly separated from the auth backend chain.