### PR TITLE
fix: resolve -q flag collision between QoS and quiet in mqttperf

### DIFF
--- a/src/lavinmqperf/mqtt/throughput.cr
+++ b/src/lavinmqperf/mqtt/throughput.cr
@@ -41,7 +41,7 @@ module LavinMQPerf
         @parser.on("-V", "--verify", "Verify the message body") do
           @verify = true
         end
-        @parser.on("-q qos", "--qos=level", "QoS level (0 or 1)") do |v|
+        @parser.on("--qos=level", "QoS level (0 or 1)") do |v|
           @qos = v.to_i
         end
         @parser.on("-t topic", "--topic=name", "Topic name (default perf-test)") do |v|


### PR DESCRIPTION
### WHAT is this pull request doing?

The mqttperf throughput command registered `-q qos` for QoS and `-q`/`--quiet` for quiet output. The two share the short `-q` flag, so the later `--quiet` definition wins and `-q 1` is parsed as quiet plus an invalid `1` argument, printing usage and exiting (issue #1932).

This drops the colliding short alias from the QoS option, leaving `--qos=level`. `-q` now unambiguously means `--quiet`, matching the AMQP throughput tool, which uses `-q` for quiet only.

### HOW can this pull request be tested?

Before: `lavinmqperf mqtt throughput -q 1` exits with usage. After: `--qos 1` sets QoS 1 and `-q` toggles quiet. Verified the OptionParser behavior in isolation: `--qos 1` => qos=1, `-q` => quiet=true, no invalid-option error.

Closes #1932