### PR TITLE
Handle empty trailing stream segment on load

### DIFF
--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -797,5 +797,34 @@ describe LavinMQ::AMQP::Stream do
         StreamSpecHelpers.offset_from_headers(msg.properties.headers).should eq 2
       end
     end
+
+    it "loads when trailing segment has only the 4-byte schema header" do
+      with_datadir do |data_dir|
+        # Push 2 large msgs so segment 1 fills and segment 2 is opened.
+        store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
+        msg_size = LavinMQ::Config.instance.segment_size.to_u64 - (LavinMQ::BytesMessage::MIN_BYTESIZE + 5)
+        msg = LavinMQ::Message.new(RoughTime.unix_ms, "e", "k",
+          AMQ::Protocol::Properties.new, msg_size, IO::Memory.new("a" * msg_size))
+        2.times { store.push(msg) }
+        store.@segments.size.should be >= 2
+        last_seg_path = store.@segments.last_value.path
+        store.close
+
+        # Simulate "killed after open_new_segment but before first message":
+        # truncate the trailing segment to its 4-byte schema header and remove
+        # its meta file so produce_metadata runs on reload.
+        File.open(last_seg_path, "r+", &.truncate(4))
+        meta_path = last_seg_path.sub("msgs.", "meta.")
+        File.delete(meta_path) if File.exists?(meta_path)
+
+        # Reload must not raise IndexError on the empty trailing segment.
+        store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
+        last_seg_id = store.@segments.last_key
+        store.@segment_msg_count[last_seg_id].should eq 0
+        store.push(msg) # the trailing segment should still be writable
+        store.@segment_msg_count[last_seg_id].should eq 1
+        store.close
+      end
+    end
   end
 end

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -36,7 +36,11 @@ module LavinMQ::AMQP
     private def get_last_offset : Int64
       return 0i64 if @size.zero?
       offset = @segment_first_offset.last_value
-      offset += @segment_msg_count.last_value - 1
+      # to_i64 first: when the trailing segment was opened but has no messages
+      # yet (4-byte schema header only) @segment_msg_count is 0_u32 and the
+      # subtraction would underflow UInt32. -1 here means "one before this
+      # segment's first offset", which is the last assigned offset.
+      offset += @segment_msg_count.last_value.to_i64 - 1
       offset
     end
 
@@ -368,8 +372,13 @@ module LavinMQ::AMQP
 
     private def produce_metadata(seg, mfile)
       super
-      if empty?
-        @segment_first_offset[seg] = @last_offset + 1
+      if empty? || @segment_msg_count[seg].zero?
+        # Whole queue empty, or this trailing segment was opened (4-byte
+        # Schema::VERSION header written by open_new_segment) but no message
+        # was written before shutdown — don't parse a msg out of an empty file.
+        previous_segment_first_offset = @segment_first_offset[seg - 1]? || 1i64
+        previous_segment_msg_count = @segment_msg_count[seg - 1]? || 0i64
+        @segment_first_offset[seg] = previous_segment_first_offset + previous_segment_msg_count
         @segment_first_ts[seg] = RoughTime.unix_ms
         @segment_last_ts[seg] = RoughTime.unix_ms
       else


### PR DESCRIPTION
## Summary
- A stream segment file may contain only the 4-byte Schema::VERSION header when the server was killed after `open_new_segment` wrote the header but before any message was pushed.
- On restart, `StreamMessageStore#produce_metadata` fell into the else branch (since `empty?` checks whole-queue size, not just the segment) and failed to load.
- Detect the empty-trailing-segment case and treat it as a valid but empty terminal segment.

## Test plan
- [x] Regression spec added in `spec/stream_queue_spec.cr` covering crash-after-header-but-before-message
- [ ] `make test SPEC=spec/stream_queue_spec.cr`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)