### PR TITLE
Detach Stream envelope body off mmap to survive segment drop

### DIFF
--- a/spec/stream_reader_spec.cr
+++ b/spec/stream_reader_spec.cr
@@ -54,6 +54,53 @@ describe LavinMQ::AMQP::StreamReader do
       end
     end
   end
+  it "envelope body survives concurrent segment drop" do
+    # Regression: shift? / read returned BytesMessage whose body pointed
+    # directly into the segment's mmap. drop_segments_while munmaps the
+    # segment, and a slow consumer that's still copying bytes into the
+    # socket would SIGSEGV in pointer copy_from. The fix detaches the body
+    # off mmap before returning the envelope.
+    with_amqp_server do |s|
+      queue_name = ""
+      with_channel(s) do |ch|
+        q = ch.queue("", args: AMQP::Client::Arguments.new({
+          "x-queue-type" => "stream",
+        }))
+        queue_name = q.name
+        # Each message fills a segment so the next publish rolls a new one.
+        data = Bytes.new(LavinMQ::Config.instance.segment_size)
+        data[0] = 0xAA_u8
+        data[-1] = 0xBB_u8
+        3.times { q.publish_confirm data }
+      end
+
+      stream = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Stream)
+      reader = stream.reader "first"
+
+      saved_env : LavinMQ::Envelope? = nil
+      reader.each do |env|
+        saved_env = env
+        break
+      end
+
+      # Drop every segment but the last while we still hold an env from the
+      # first segment — without the fix, mmap is gone and the next body
+      # access SIGSEGVs.
+      stream.@msg_store_lock.synchronize do
+        store = stream.stream_msg_store
+        store.max_length_bytes = 1_i64
+        store.drop_overflow
+      end
+
+      saved_env.should_not be_nil
+      env = saved_env.not_nil!
+      env.message.bodysize.should eq LavinMQ::Config.instance.segment_size
+      env.message.body.size.should eq LavinMQ::Config.instance.segment_size
+      env.message.body[0].should eq 0xAA_u8
+      env.message.body[-1].should eq 0xBB_u8
+    end
+  end
+
   it "should read over multiple segments" do
     with_amqp_server do |s|
       with_channel(s) do |ch|

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -220,7 +220,7 @@ module LavinMQ::AMQP
       begin
         msg = BytesMessage.from_bytes(rfile.to_slice + position)
         sp = SegmentPosition.new(segment, position, msg.bytesize.to_u32)
-        Envelope.new(sp, msg, redelivered: false)
+        Envelope.new(sp, detach_from_mmap(msg), redelivered: false)
       rescue ex
         puts "read segment=#{segment} position=#{position}"
         raise Error.new(rfile, cause: ex)
@@ -247,7 +247,7 @@ module LavinMQ::AMQP
         consumer.pos += sp.bytesize
         consumer.offset += 1
         return unless consumer.filter_match?(msg.properties.headers)
-        Envelope.new(sp, msg, redelivered: false)
+        Envelope.new(sp, detach_from_mmap(msg), redelivered: false)
       rescue ex
         raise Error.new(rfile, cause: ex)
       end
@@ -260,12 +260,26 @@ module LavinMQ::AMQP
             msg = BytesMessage.from_bytes(segment.to_slice + sp.position)
             offset, _, _ = offset_at(sp.segment, sp.position)
             msg.properties.headers = add_offset_header(msg.properties.headers, offset)
-            return Envelope.new(sp, msg, redelivered: true)
+            return Envelope.new(sp, detach_from_mmap(msg), redelivered: true)
           rescue ex
             raise Error.new(segment, cause: ex)
           end
         end
       end
+    end
+
+    # Returns a BytesMessage whose body lives on the GC heap rather than in
+    # the segment's mmap. Stream consumers release @msg_store_lock before
+    # delivering, and drop_segments_while can munmap a segment while a
+    # consumer is still copying body bytes into the socket — that's a
+    # use-after-unmap SIGSEGV. add_offset_header already promotes the
+    # headers Table to a heap buffer via Table#check_writeable, so only the
+    # body slice needs detaching here.
+    private def detach_from_mmap(msg : BytesMessage) : BytesMessage
+      body = Bytes.new(msg.bodysize)
+      msg.body.copy_to(body)
+      BytesMessage.new(msg.timestamp, msg.exchange_name, msg.routing_key,
+        msg.properties, msg.bodysize, body)
     end
 
     def next_segment_id(segment) : UInt32?

--- a/src/lavinmq/amqp/stream/stream_reader.cr
+++ b/src/lavinmq/amqp/stream/stream_reader.cr
@@ -14,7 +14,11 @@ module LavinMQ::AMQP
       offset, segment, position = store.find_offset(@start_offset)
       loop do
         break if store.closed
-        env = store.read(segment, position)
+        # `read` returns a BytesMessage whose body has been detached off
+        # mmap, but the lookup of @segments[segment] itself races with
+        # drop_segments_while — hold @msg_store_lock for the duration of
+        # the read so the segment can't be unmapped under us.
+        env = stream.@msg_store_lock.synchronize { store.read(segment, position) }
         if env
           if headers = env.message.properties.headers
             headers["x-stream-offset"] = offset


### PR DESCRIPTION
## Summary
- `StreamMessageStore#read` and `#shift?` returned `BytesMessage` envelopes whose body slice pointed directly into the segment's mmap.
- Stream consumers release `@msg_store_lock` before delivering, so `drop_segments_while` could `munmap` the segment while a consumer was still copying body bytes — leading to SIGBUS or garbled deliveries.
- Detach the body onto a heap-allocated buffer before returning the envelope so it survives a concurrent segment drop.

## Test plan
- [x] Regression spec added in `spec/stream_reader_spec.cr` reproducing the segment-drop race
- [ ] `make test SPEC=spec/stream_reader_spec.cr`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)