### PR TITLE
Fix Stream queue crash when delivery-limit policy is applied

### DIFF
--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -349,6 +349,42 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
+    # Regression: a `delivery-limit` policy matching a stream queue used to
+    # fall through to AMQP::Queue#apply_policy_argument, which spawned a
+    # drop_redelivered fiber. That fiber called the inherited
+    # MessageStore#first? and dereferenced the legacy `@rfile` — which
+    # streams don't maintain through `drop_segments_while` — pointing at
+    # a closed mfile from a long-dropped segment. The spawn died with
+    # IO::Error("Closed mfile"). Stream now rejects the policy key
+    # alongside the declare-time validation.
+    it "ignores delivery-limit policy on streams" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream"}
+          q = ch.queue("stream-delivery-limit-policy", args: AMQP::Client::Arguments.new(args))
+          # Roll a few segments, then drop them via max-length-bytes so the
+          # inherited @rfile is left dangling at a closed mfile — the same
+          # state observed in the production crash.
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          3.times { q.publish_confirm data }
+          s.vhosts["/"].add_policy("mlb", "stream-delivery-limit-policy", "queues",
+            {"max-length-bytes" => JSON::Any.new(1_i64)}, 0i8)
+          q.message_count.should eq 1
+          # Now apply delivery-limit. Pre-fix this spawned drop_redelivered
+          # and crashed; post-fix it's skipped entirely.
+          s.vhosts["/"].add_policy("dl", "stream-delivery-limit-policy", "queues",
+            {"delivery-limit" => JSON::Any.new(5_i64)}, 1i8)
+          stream = s.vhosts["/"].queue("stream-delivery-limit-policy").as(LavinMQ::AMQP::Stream)
+          stream.effective_policy_args.should_not contain "delivery-limit"
+          # Give the (non-existent post-fix) spawn fiber a chance to run and
+          # verify the queue is still functional.
+          Fiber.yield
+          q.publish_confirm "ok"
+          q.message_count.should eq 2
+        end
+      end
+    end
+
     it "meta files should be removed when segment is removed" do
       with_amqp_server do |s|
         with_channel(s) do |ch|

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -5,6 +5,21 @@ require "./stream_reader"
 
 module LavinMQ::AMQP
   class Stream < DurableQueue
+    # Arguments that have no meaning for streams. Rejected at queue declare
+    # AND when matched by a policy — otherwise a policy can quietly install
+    # state (e.g. `delivery-limit` spawning the inherited drop_redelivered
+    # fiber, which dereferences the legacy `@rfile` that streams don't
+    # maintain) and crash the server.
+    INVALID_ARGUMENTS = {
+      "x-dead-letter-exchange",
+      "x-dead-letter-routing-key",
+      "x-expires",
+      "x-delivery-limit",
+      "x-overflow",
+      "x-single-active-consumer",
+      "x-max-priority",
+    }
+
     def self.create(vhost : VHost, name : String,
                     exclusive : Bool = false, auto_delete : Bool = false,
                     arguments : AMQP::Table = AMQP::Table.new)
@@ -17,18 +32,8 @@ module LavinMQ::AMQP
     end
 
     def self.validate_arguments!(arguments)
-      invalid_arguments = {
-        "x-dead-letter-exchange",
-        "x-dead-letter-routing-key",
-        "x-expires",
-        "x-delivery-limit",
-        "x-overflow",
-        "x-single-active-consumer",
-        "x-max-priority",
-      }
-
       arguments.each do |key, value|
-        if invalid_arguments.includes?(key)
+        if INVALID_ARGUMENTS.includes?(key)
           raise LavinMQ::Error::PreconditionFailed.new("Argument #{key} not allowed for streams")
         end
         if key == "x-max-age"
@@ -46,6 +51,14 @@ module LavinMQ::AMQP
     end
 
     private def apply_policy_argument(key : String, value : JSON::Any) : Bool
+      # Reject policy keys that are forbidden as queue arguments, so a
+      # matching policy can't install state the stream doesn't honor.
+      # Policy keys are `arguments` keys without the `x-` prefix.
+      if INVALID_ARGUMENTS.includes?("x-#{key}")
+        @log.debug { "Policy argument #{key} not applicable to streams; skipping" }
+        return false
+      end
+
       case key
       when "max-age"
         if max_age_policy = parse_max_age(value.as_s?)

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -101,6 +101,7 @@ module LavinMQ
         return if @size.zero?
         raise Error.new(@rfile, cause: ex)
       rescue ex
+        @log.error(exception: ex) { "first? failed: #{state_snapshot}" }
         raise Error.new(@rfile, cause: ex)
       end
     end
@@ -147,6 +148,7 @@ module LavinMQ
         return if @size.zero?
         raise Error.new(@rfile, cause: ex)
       rescue ex
+        @log.error(exception: ex) { "shift? failed: #{state_snapshot}" }
         raise Error.new(@rfile, cause: ex)
       end
     end
@@ -173,7 +175,7 @@ module LavinMQ
         ack_count = afile.size // sizeof(UInt32)
         msg_count = @segment_msg_count[sp.segment]
         if ack_count == msg_count
-          @log.debug { "Deleting segment #{sp.segment}" }
+          @log.debug { "Deleting segment #{sp.segment} (delete sp): #{state_snapshot}" }
           select_next_read_segment if sp.segment == @rfile_id
           if a = @acks.delete(sp.segment)
             delete_file(a)
@@ -246,11 +248,13 @@ module LavinMQ
             wg.wait
           ensure
             File.delete?(meta_file_name(file)) if including_meta
+            @log.debug { "delete_file (async close): path=#{file.path}" }
             file.close
           end
         end
       else
         File.delete?(meta_file_name(file)) if including_meta
+        @log.debug { "delete_file (sync close): path=#{file.path}" }
         file.close
       end
     end
@@ -296,14 +300,31 @@ module LavinMQ
       (@bytesize / @size).to_u32
     end
 
+    private def state_snapshot : String
+      String.build do |io|
+        io << "store_closed=" << @closed
+        io << " rfile_id=" << @rfile_id
+        io << " rfile=" << @rfile.path << "(closed=" << @rfile.closed? << " pos=" << @rfile.pos << " size=" << @rfile.size << ")"
+        io << " wfile_id=" << @wfile_id
+        io << " segments=" << @segments.keys
+        io << " size=" << @size
+      end
+    end
+
     private def select_next_read_segment : MFile?
       @rfile.dontneed unless @rfile.closed?
+      prev_id = @rfile_id
       # Expect @segments to be ordered
       if id = @segments.each_key.find { |sid| sid > @rfile_id }
         rfile = @segments[id]
         rfile.advise(MFile::Advice::Sequential)
         @rfile_id = id
         @rfile = rfile
+        @log.debug { "select_next_read_segment: #{prev_id} -> #{id}, segments=#{@segments.keys}" }
+        rfile
+      else
+        @log.debug { "select_next_read_segment: no segment > #{prev_id}, segments=#{@segments.keys}, rfile_closed=#{@rfile.closed?}" }
+        nil
       end
     end
 
@@ -635,7 +656,7 @@ module LavinMQ
         next if seg == current_seg # don't the delete the segment still being written to
 
         if (acks = @acks[seg]?) && @segment_msg_count[seg] <= (acks.size // sizeof(UInt32))
-          @log.debug { "Deleting unused segment #{seg}" }
+          @log.debug { "Deleting unused segment #{seg}: #{state_snapshot}" }
           select_next_read_segment if seg == @rfile_id
           @segment_msg_count.delete seg
           @deleted.delete seg


### PR DESCRIPTION
## Summary
- A `delivery-limit` policy matching a stream queue fell through to `AMQP::Queue#apply_policy_argument`, which spawned the `drop_redelivered` fiber.
- That fiber called the inherited `MessageStore#first?` and dereferenced the legacy `@rfile` — which streams don't maintain through `drop_segments_while` — pointing at a closed mfile from a long-dropped segment. The spawn died with `IO::Error("Closed mfile")`.
- Lift Stream's invalid-args set to a single `INVALID_ARGUMENTS` constant shared between declare-time `validate_arguments!` and `apply_policy_argument`. What's forbidden as a queue argument is now also a no-op as a matching policy key.
- Also adds `MessageStore` diagnostic logging (`state_snapshot` in `first?`/`shift?` rescues, debug logs around `select_next_read_segment`).

## Test plan
- [x] Regression spec added in `spec/stream_queue_spec.cr`
- [ ] `make test SPEC=spec/stream_queue_spec.cr`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)