### PR TITLE
Handle reject-publish overflow in HTTP publish and multi-queue routes

### DIFF
--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -347,6 +347,53 @@ describe LavinMQ::HTTP::ExchangesController do
         end
       end
     end
+
+    it "should return routed:false instead of 500 when queue rejects on overflow" do
+      with_http_server do |http, s|
+        args = LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64, "x-overflow" => "reject-publish"})
+        s.vhosts["/"].declare_exchange("of_ex", "topic", false, false)
+        s.vhosts["/"].declare_queue("of_q", false, false, args)
+        s.vhosts["/"].bind_queue("of_q", "of_ex", "rk")
+        body = %({
+        "properties": {},
+        "routing_key": "rk",
+        "payload": "test",
+        "payload_encoding": "string"
+      })
+        response = http.post("/api/exchanges/%2f/of_ex/publish", body: body)
+        response.status_code.should eq 200
+        JSON.parse(response.body)["routed"].as_bool.should be_true
+        response = http.post("/api/exchanges/%2f/of_ex/publish", body: body)
+        response.status_code.should eq 200
+        JSON.parse(response.body)["routed"].as_bool.should be_false
+        s.vhosts["/"].queue("of_q").message_count.should eq 1
+      end
+    end
+
+    it "delivers to non-overflowing queues even when one bound queue rejects" do
+      with_http_server do |http, s|
+        args = LavinMQ::AMQP::Table.new({"x-max-length" => 1_i64, "x-overflow" => "reject-publish"})
+        s.vhosts["/"].declare_exchange("mof_ex", "topic", false, false)
+        s.vhosts["/"].declare_queue("mof_full", false, false, args)
+        s.vhosts["/"].declare_queue("mof_open", false, false)
+        s.vhosts["/"].bind_queue("mof_full", "mof_ex", "rk")
+        s.vhosts["/"].bind_queue("mof_open", "mof_ex", "rk")
+        body = %({
+        "properties": {},
+        "routing_key": "rk",
+        "payload": "test",
+        "payload_encoding": "string"
+      })
+        response = http.post("/api/exchanges/%2f/mof_ex/publish", body: body)
+        response.status_code.should eq 200
+        JSON.parse(response.body)["routed"].as_bool.should be_true
+        response = http.post("/api/exchanges/%2f/mof_ex/publish", body: body)
+        response.status_code.should eq 200
+        JSON.parse(response.body)["routed"].as_bool.should be_false
+        s.vhosts["/"].queue("mof_full").message_count.should eq 1
+        s.vhosts["/"].queue("mof_open").message_count.should eq 2
+      end
+    end
   end
 
   describe "GET /api/exchanges/vhost/name with x-hash-on argument" do

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -228,13 +228,13 @@ describe LavinMQ::Exchange do
             "x-deduplication-header" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).should eq true
+          ex.publish(msg, false).routed.should be_true
           ex.dedup_count.should eq 0
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).should eq false
+          ex.publish(msg, false).routed.should be_false
           ex.dedup_count.should eq 1
 
           q.message_count.should eq 1
@@ -257,13 +257,13 @@ describe LavinMQ::Exchange do
             "custom" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).should eq true
+          ex.publish(msg, false).routed.should be_true
           ex.dedup_count.should eq 0
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).should eq false
+          ex.publish(msg, false).routed.should be_false
           ex.dedup_count.should eq 1
 
           q.message_count.should eq 1

--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -228,13 +228,13 @@ describe LavinMQ::Exchange do
             "x-deduplication-header" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).routed.should be_true
+          ex.publish(msg, false).routed?.should be_true
           ex.dedup_count.should eq 0
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).routed.should be_false
+          ex.publish(msg, false).routed?.should be_false
           ex.dedup_count.should eq 1
 
           q.message_count.should eq 1
@@ -257,13 +257,13 @@ describe LavinMQ::Exchange do
             "custom" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).routed.should be_true
+          ex.publish(msg, false).routed?.should be_true
           ex.dedup_count.should eq 0
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",
           }))
           msg = LavinMQ::Message.new("ex", "rk", "body", props)
-          ex.publish(msg, false).routed.should be_false
+          ex.publish(msg, false).routed?.should be_false
           ex.dedup_count.should eq 1
 
           q.message_count.should eq 1

--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -121,9 +121,9 @@ module LavinMQ::AMQP
             else
               dst_q, msg = task
               begin
+                # Result intentionally discarded: if the destination queue is closed
+                # or rejects on overflow we drop the dead-lettered message.
                 dst_q.publish_internal(msg, dlx_tasks: @tasks)
-              rescue Queue::RejectOverFlow
-                # noop
               rescue ex : Exception
                 @log.error(exception: ex) { "Unexpected error when dead lettering to #{dst_q.name}, messages dropped" }
               end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -267,15 +267,15 @@ module LavinMQ
         end
 
         confirm do
-          ok = @client.vhost.publish msg, @next_publish_immediate, @visited, @found_queues
-          basic_return(msg, @next_publish_mandatory, @next_publish_immediate) unless ok
+          result = @client.vhost.publish msg, @next_publish_immediate, @visited, @found_queues
+          basic_return(msg, @next_publish_mandatory, @next_publish_immediate) unless result.routed
+          result
         rescue e : LavinMQ::Error::PreconditionFailed
           msg.body_io.skip(msg.bodysize)
           code = ChannelReplyCode::PRECONDITION_FAILED
           send AMQP::Frame::Channel::Close.new(@id, code.value, "#{code} - #{e.message}", 60_u16, 40_u16)
+          Exchange::PublishResult.new(routed: false, overflowed: false)
         end
-      rescue Queue::RejectOverFlow
-        # nack but then do nothing
       end
 
       private def validate_user_id(user_id)
@@ -287,12 +287,22 @@ module LavinMQ
         end
       end
 
+      # Yields to the block which must return an `Exchange::PublishResult`, then
+      # sends a publisher confirm based on the outcome:
+      # * if the block raises, send NACK and re-raise
+      # * if any matched queue rejected on overflow, send NACK
+      # * otherwise send ACK
+      # When publisher confirms are disabled the block is just yielded.
       private def confirm(&)
         if @confirm
           msgid = @confirm_total &+= 1
           begin
-            yield
-            confirm_ack(msgid)
+            result = yield
+            if result.overflowed
+              confirm_nack(msgid)
+            else
+              confirm_ack(msgid)
+            end
           rescue ex
             confirm_nack(msgid)
             raise ex
@@ -324,6 +334,8 @@ module LavinMQ
               msg.exchange_name,
               msg.routing_key)
             ch.deliver(deliver, msg)
+            # Direct reply delivery is always a routed publish with no overflow
+            Exchange::PublishResult.new(routed: true, overflowed: false)
           end
           true
         else
@@ -785,8 +797,8 @@ module LavinMQ
         next_msg_body_file.rewind
         @tx_publishes.each do |tx_msg|
           tx_msg.message.timestamp = RoughTime.unix_ms
-          ok = @client.vhost.publish(tx_msg.message, tx_msg.immediate, @visited, @found_queues)
-          basic_return(tx_msg.message, tx_msg.mandatory, tx_msg.immediate) unless ok
+          result = @client.vhost.publish(tx_msg.message, tx_msg.immediate, @visited, @found_queues)
+          basic_return(tx_msg.message, tx_msg.mandatory, tx_msg.immediate) unless result.routed
           # skip to next msg body in the next_msg_body_file
           tx_msg.message.body_io.seek(tx_msg.message.bodysize, IO::Seek::Current)
         end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -268,13 +268,13 @@ module LavinMQ
 
         confirm do
           result = @client.vhost.publish msg, @next_publish_immediate, @visited, @found_queues
-          basic_return(msg, @next_publish_mandatory, @next_publish_immediate) unless result.routed
+          basic_return(msg, @next_publish_mandatory, @next_publish_immediate) unless result.routed?
           result
         rescue e : LavinMQ::Error::PreconditionFailed
           msg.body_io.skip(msg.bodysize)
           code = ChannelReplyCode::PRECONDITION_FAILED
           send AMQP::Frame::Channel::Close.new(@id, code.value, "#{code} - #{e.message}", 60_u16, 40_u16)
-          Exchange::PublishResult.new(routed: false, overflowed: false)
+          Exchange::PublishResult::None
         end
       end
 
@@ -298,7 +298,7 @@ module LavinMQ
           msgid = @confirm_total &+= 1
           begin
             result = yield
-            if result.overflowed
+            if result.overflowed?
               confirm_nack(msgid)
             else
               confirm_ack(msgid)
@@ -335,7 +335,7 @@ module LavinMQ
               msg.routing_key)
             ch.deliver(deliver, msg)
             # Direct reply delivery is always a routed publish with no overflow
-            Exchange::PublishResult.new(routed: true, overflowed: false)
+            Exchange::PublishResult::Routed
           end
           true
         else
@@ -798,7 +798,7 @@ module LavinMQ
         @tx_publishes.each do |tx_msg|
           tx_msg.message.timestamp = RoughTime.unix_ms
           result = @client.vhost.publish(tx_msg.message, tx_msg.immediate, @visited, @found_queues)
-          basic_return(tx_msg.message, tx_msg.mandatory, tx_msg.immediate) unless result.routed
+          basic_return(tx_msg.message, tx_msg.mandatory, tx_msg.immediate) unless result.routed?
           # skip to next msg body in the next_msg_body_file
           tx_msg.message.body_io.seek(tx_msg.message.bodysize, IO::Seek::Current)
         end

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -236,14 +236,20 @@ module LavinMQ
         end
 
         count = 0u32
+        overflow = false
         queues.each do |queue|
-          if queue.publish(msg)
-            count += 1
-            msg.body_io.seek(-msg.bodysize.to_i64, IO::Seek::Current) # rewind
+          begin
+            if queue.publish(msg)
+              count += 1
+              msg.body_io.seek(-msg.bodysize.to_i64, IO::Seek::Current) # rewind
+            end
+          rescue Queue::RejectOverFlow
+            overflow = true
           end
         end
         @publish_out_count.add(count, :relaxed)
-        @unroutable_count.add(1, :relaxed) if count.zero?
+        @unroutable_count.add(1, :relaxed) if count.zero? && !overflow
+        raise Queue::RejectOverFlow.new if overflow
         count.positive?
       end
 

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -199,14 +199,23 @@ module LavinMQ
       abstract def bindings_details : Array(BindingDetails)
       abstract def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
 
+      # Result of routing a message through an exchange.
+      # `routed` is true if at least one queue accepted the message.
+      # `overflowed` is true if at least one matched queue rejected the message
+      # due to a reject-publish overflow policy. The two flags are independent:
+      # a publish can be both routed (one queue accepted) and overflowed
+      # (another queue rejected), in which case the publisher should still be
+      # nack'ed on confirm channels.
+      record PublishResult, routed : Bool, overflowed : Bool
+
       def publish(msg : Message, immediate : Bool,
                   queues : Set(LavinMQ::Queue) = Set(LavinMQ::Queue).new,
-                  exchanges : Set(LavinMQ::Exchange) = Set(LavinMQ::Exchange).new) : Bool
+                  exchanges : Set(LavinMQ::Exchange) = Set(LavinMQ::Exchange).new) : PublishResult
         @publish_in_count.add(1, :relaxed)
         if d = @deduper
           if d.duplicate?(msg)
             @dedup_count.add(1, :relaxed)
-            return false
+            return PublishResult.new(routed: false, overflowed: false)
           end
           d.add(msg)
         end
@@ -214,43 +223,43 @@ module LavinMQ
           if q = @delayed_queue
             q.delay(msg)
             @publish_out_count.add(1, :relaxed)
-            return true
+            return PublishResult.new(routed: true, overflowed: false)
           else
             @unroutable_count.add(1, :relaxed)
-            return false
+            return PublishResult.new(routed: false, overflowed: false)
           end
         end
         route_msg(msg, immediate, queues, exchanges)
       end
 
-      def route_msg(msg : Message) : Bool
+      def route_msg(msg : Message) : PublishResult
         route_msg(msg, false, Set(LavinMQ::Queue).new, Set(LavinMQ::Exchange).new)
       end
 
-      private def route_msg(msg : Message, immediate : Bool, queues : Set(LavinMQ::Queue), exchanges : Set(LavinMQ::Exchange)) : Bool
+      private def route_msg(msg : Message, immediate : Bool, queues : Set(LavinMQ::Queue), exchanges : Set(LavinMQ::Exchange)) : PublishResult
         headers = msg.properties.headers
         find_queues(msg.routing_key, headers, queues, exchanges)
         if queues.empty? || (immediate && !queues.any? &.immediate_delivery?)
           @unroutable_count.add(1, :relaxed)
-          return false
+          return PublishResult.new(routed: false, overflowed: false)
         end
 
         count = 0u32
         overflow = false
         queues.each do |queue|
-          begin
-            if queue.publish(msg)
-              count += 1
-              msg.body_io.seek(-msg.bodysize.to_i64, IO::Seek::Current) # rewind
-            end
-          rescue Queue::RejectOverFlow
+          case queue.publish(msg)
+          in .ok?
+            count += 1
+            msg.body_io.seek(-msg.bodysize.to_i64, IO::Seek::Current) # rewind
+          in .overflow?
             overflow = true
+          in .dropped?
+            # queue was closed or message was a duplicate; nothing to do
           end
         end
         @publish_out_count.add(count, :relaxed)
         @unroutable_count.add(1, :relaxed) if count.zero? && !overflow
-        raise Queue::RejectOverFlow.new if overflow
-        count.positive?
+        PublishResult.new(routed: count.positive?, overflowed: overflow)
       end
 
       def find_queues(routing_key : String, headers : AMQP::Table?,

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -200,13 +200,17 @@ module LavinMQ
       abstract def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
 
       # Result of routing a message through an exchange.
-      # `routed` is true if at least one queue accepted the message.
-      # `overflowed` is true if at least one matched queue rejected the message
+      # `Routed` is set if at least one queue accepted the message.
+      # `Overflowed` is set if at least one matched queue rejected the message
       # due to a reject-publish overflow policy. The two flags are independent:
       # a publish can be both routed (one queue accepted) and overflowed
       # (another queue rejected), in which case the publisher should still be
       # nack'ed on confirm channels.
-      record PublishResult, routed : Bool, overflowed : Bool
+      @[Flags]
+      enum PublishResult
+        Routed
+        Overflowed
+      end
 
       def publish(msg : Message, immediate : Bool,
                   queues : Set(LavinMQ::Queue) = Set(LavinMQ::Queue).new,
@@ -215,7 +219,7 @@ module LavinMQ
         if d = @deduper
           if d.duplicate?(msg)
             @dedup_count.add(1, :relaxed)
-            return PublishResult.new(routed: false, overflowed: false)
+            return PublishResult::None
           end
           d.add(msg)
         end
@@ -223,10 +227,10 @@ module LavinMQ
           if q = @delayed_queue
             q.delay(msg)
             @publish_out_count.add(1, :relaxed)
-            return PublishResult.new(routed: true, overflowed: false)
+            return PublishResult::Routed
           else
             @unroutable_count.add(1, :relaxed)
-            return PublishResult.new(routed: false, overflowed: false)
+            return PublishResult::None
           end
         end
         route_msg(msg, immediate, queues, exchanges)
@@ -241,7 +245,7 @@ module LavinMQ
         find_queues(msg.routing_key, headers, queues, exchanges)
         if queues.empty? || (immediate && !queues.any? &.immediate_delivery?)
           @unroutable_count.add(1, :relaxed)
-          return PublishResult.new(routed: false, overflowed: false)
+          return PublishResult::None
         end
 
         count = 0u32
@@ -259,7 +263,11 @@ module LavinMQ
         end
         @publish_out_count.add(count, :relaxed)
         @unroutable_count.add(1, :relaxed) if count.zero? && !overflow
-        PublishResult.new(routed: count.positive?, overflowed: overflow)
+
+        result = PublishResult::None
+        result |= PublishResult::Routed if count.positive?
+        result |= PublishResult::Overflowed if overflow
+        result
       end
 
       def find_queues(routing_key : String, headers : AMQP::Table?,

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -142,12 +142,12 @@ module LavinMQ::AMQP
     private def queue_expire_loop
     end
 
-    def publish(message : Message) : Bool
-      false
+    def publish(message : Message) : PublishResult
+      PublishResult::Dropped
     end
 
-    protected def publish_internal(message : Message, dlx_tasks : Argument::DeadLettering::Tasks?) : Bool
-      false
+    protected def publish_internal(message : Message, dlx_tasks : Argument::DeadLettering::Tasks?) : PublishResult
+      PublishResult::Dropped
     end
 
     def basic_get(no_ack, force = false, & : Envelope -> Nil) : Bool

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -549,51 +549,56 @@ module LavinMQ::AMQP
       }
     end
 
-    class RejectOverFlow < Exception; end
+    enum PublishResult
+      Ok       # message accepted and stored
+      Dropped  # queue closed or message was a duplicate
+      Overflow # rejected by max-length / max-length-bytes (overflow=reject-publish)
+    end
 
     class Closed < Exception; end
 
-    def publish(msg : Message) : Bool
+    def publish(msg : Message) : PublishResult
       publish_internal(msg)
     end
 
-    protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks? = nil) : Bool
-      return false if @closed
+    protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks? = nil) : PublishResult
+      return PublishResult::Dropped if @closed
       if d = @deduper
         if d.duplicate?(msg)
           @dedup_count.add(1, :relaxed)
-          return false
+          return PublishResult::Dropped
         end
         d.add(msg)
       end
-      reject_on_overflow(msg)
+      return PublishResult::Overflow if reject_on_overflow?(msg)
       @msg_store_lock.synchronize do
         @msg_store.push(msg)
         drop_overflow(dlx_tasks)
       end
       @publish_count.add(1, :relaxed)
-      true
+      PublishResult::Ok
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
       close
       raise ex
     end
 
-    private def reject_on_overflow(msg) : Nil
-      return unless @reject_on_overflow
+    private def reject_on_overflow?(msg) : Bool
+      return false unless @reject_on_overflow
       if ml = @max_length
         if @msg_store.size >= ml
           @log.debug { "Overflow reject message msg=#{msg}" }
-          raise RejectOverFlow.new
+          return true
         end
       end
 
       if mlb = @max_length_bytes
         if @msg_store.bytesize + msg.bytesize >= mlb
           @log.debug { " Overflow reject message msg=#{msg}" }
-          raise RejectOverFlow.new
+          return true
         end
       end
+      false
     end
 
     # ameba:disable Metrics/CyclomaticComplexity

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -110,20 +110,20 @@ module LavinMQ::AMQP
       @msg_store.as(StreamMessageStore)
     end
 
-    def publish(msg : Message) : Bool
+    def publish(msg : Message) : PublishResult
       publish_internal(msg, nil)
     end
 
     # save message id / segment position
-    protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks?) : Bool
-      return false if @state.closed?
+    protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks?) : PublishResult
+      return PublishResult::Dropped if @state.closed?
       @msg_store_lock.synchronize do
         @msg_store.push(msg)
         @publish_count.add(1, :relaxed)
       end
       # Notify all waiting stream consumers about new messages
       notify_all_stream_consumers
-      true
+      PublishResult::Ok
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
       close

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -128,7 +128,7 @@ module LavinMQ
           state.in?(State::Terminating, State::Terminated)
         end
 
-        private def federate(msg, exchange, routing_key, *, immediate = false)
+        private def federate(msg, exchange, routing_key, *, immediate = false) : Bool
           @log.debug { "Federating routing_key=#{routing_key} exchange=#{exchange}" }
           @upstream.vhost.publish(
             Message.new(
@@ -136,7 +136,7 @@ module LavinMQ
               msg.body_io.bytesize.to_u64, msg.body_io,
             ),
             immediate
-          )
+          ).routed
         end
 
         private def try_passive(client, ch = nil, &)

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -136,7 +136,7 @@ module LavinMQ
               msg.body_io.bytesize.to_u64, msg.body_io,
             ),
             immediate
-          ).routed
+          ).routed?
         end
 
         private def try_passive(client, ch = nil, &)

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -145,7 +145,11 @@ module LavinMQ
               size,
               IO::Memory.new(content))
             Log.debug { "Post to exchange=#{e.name} on vhost=#{e.vhost.name} with routing_key=#{routing_key} payload_encoding=#{payload_encoding} properties=#{properties} size=#{size}" }
-            ok = e.vhost.publish(msg)
+            ok = begin
+              e.vhost.publish(msg)
+            rescue AMQP::Queue::RejectOverFlow
+              false
+            end
             e.vhost.event_tick(EventType::ClientPublish)
             e.vhost.add_recv_bytes(size)
             {routed: ok}.to_json(context.response)

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -151,7 +151,7 @@ module LavinMQ
             # Report overflow as not-routed so HTTP callers see the same signal a
             # publisher-confirms client would: any reject-publish overflow turns
             # the publish into "not routed", even if other bound queues accepted.
-            {routed: result.routed && !result.overflowed}.to_json(context.response)
+            {routed: result.routed? && !result.overflowed?}.to_json(context.response)
           end
         end
       end

--- a/src/lavinmq/http/controller/exchanges.cr
+++ b/src/lavinmq/http/controller/exchanges.cr
@@ -145,14 +145,13 @@ module LavinMQ
               size,
               IO::Memory.new(content))
             Log.debug { "Post to exchange=#{e.name} on vhost=#{e.vhost.name} with routing_key=#{routing_key} payload_encoding=#{payload_encoding} properties=#{properties} size=#{size}" }
-            ok = begin
-              e.vhost.publish(msg)
-            rescue AMQP::Queue::RejectOverFlow
-              false
-            end
+            result = e.vhost.publish(msg)
             e.vhost.event_tick(EventType::ClientPublish)
             e.vhost.add_recv_bytes(size)
-            {routed: ok}.to_json(context.response)
+            # Report overflow as not-routed so HTTP callers see the same signal a
+            # publisher-confirms client would: any reject-publish overflow turns
+            # the publish into "not routed", even if other bound queues accepted.
+            {routed: result.routed && !result.overflowed}.to_json(context.response)
           end
         end
       end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -132,10 +132,10 @@ module LavinMQ
               AMQP::Properties.new,
               4_u64,
               IO::Memory.new("test"))
-            ok = vhost.publish(msg)
+            routed = vhost.publish(msg).routed
             env = nil
             vhost.queue("aliveness-test").basic_get(true) { |e| env = e }
-            ok = ok && env && String.new(env.message.body) == "test"
+            ok = routed && env && String.new(env.message.body) == "test"
             {status: ok ? "ok" : "failed"}.to_json(context.response)
           end
         end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -132,7 +132,7 @@ module LavinMQ
               AMQP::Properties.new,
               4_u64,
               IO::Memory.new("test"))
-            routed = vhost.publish(msg).routed
+            routed = vhost.publish(msg).routed?
             env = nil
             vhost.queue("aliveness-test").basic_get(true) { |e| env = e }
             ok = routed && env && String.new(env.message.body) == "test"

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -57,7 +57,7 @@ module LavinMQ
         count = 0u32
         @tree.each_entry(packet.topic) do |queue, qos|
           msg.properties.delivery_mode = qos
-          if queue.publish(msg)
+          if queue.publish(msg).ok?
             count += 1
             msg.body_io.rewind
           end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -99,9 +99,9 @@ module LavinMQ
         end
       end
 
-      def publish(msg : Message) : Bool
+      def publish(msg : Message) : PublishResult
         # Do not enqueue messages with QoS 0 if there are no consumers subscribed to the session
-        return true if msg.properties.delivery_mode == 0 && @consumers.empty?
+        return PublishResult::Ok if msg.properties.delivery_mode == 0 && @consumers.empty?
         super
       end
 

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -236,19 +236,22 @@ module LavinMQ
       io << "#<" << self.class << ": " << "@name=" << @name << ">"
     end
 
-    # Queue#publish can raise RejectPublish which should trigger a Nack. All other confirm scenarios
-    # should be Acks, apart from Exceptions.
-    # As long as at least one queue reject the publish due to overflow a Nack should be sent,
-    # even if other queues accepts the message. Behaviour confirmed with RabbitMQ.
-    # True if it also succesfully wrote to one or more queues
-    # False if no queue was able to receive the message because they're
-    # closed
+    # Routes a message through the named exchange.
+    # Returns an `AMQP::Exchange::PublishResult` describing whether the message
+    # was routed to at least one queue, and whether any matched queue rejected
+    # it due to a reject-publish overflow policy. As long as at least one queue
+    # rejects the publish, the caller should NACK the publisher on confirm
+    # channels, even if other queues accepted the message (behaviour confirmed
+    # with RabbitMQ).
     # The position of the msg.body_io should be at the start of the body
     # When this method finishes, the position will be the same, start of the body
     def publish(msg : Message, immediate = false,
-                visited = Set(LavinMQ::Exchange).new, found_queues = Set(LavinMQ::Queue).new) : Bool
-      ex = exchange?(msg.exchange_name) || return false
-      ex.publish(msg, immediate, found_queues, visited)
+                visited = Set(LavinMQ::Exchange).new, found_queues = Set(LavinMQ::Queue).new) : AMQP::Exchange::PublishResult
+      if ex = exchange?(msg.exchange_name)
+        ex.publish(msg, immediate, found_queues, visited)
+      else
+        AMQP::Exchange::PublishResult.new(routed: false, overflowed: false)
+      end
     ensure
       visited.clear
       found_queues.clear

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -250,7 +250,7 @@ module LavinMQ
       if ex = exchange?(msg.exchange_name)
         ex.publish(msg, immediate, found_queues, visited)
       else
-        AMQP::Exchange::PublishResult.new(routed: false, overflowed: false)
+        AMQP::Exchange::PublishResult::None
       end
     ensure
       visited.clear


### PR DESCRIPTION
## Summary
- Fix the original bug: `HTTP POST /api/exchanges/:vhost/:name/publish` returned 500 when a bound queue rejected a publish due to a reject-publish overflow policy. Now reported as `{routed: false}`, matching what publisher-confirms clients see (NACK).
- Same treatment for the fan-out case where one bound queue overflows but others accept.
- Refactor: replace the `Queue::RejectOverFlow` exception with explicit return types so overflow is no longer signalled via raise/rescue.
  - `Queue#publish` now returns a `Queue::PublishResult` enum (`Ok` / `Dropped` / `Overflow`).
  - `Exchange#publish` and `VHost#publish` return an `Exchange::PublishResult` `@[Flags]` enum (`Routed`, `Overflowed`) — the two are independent, so a publish can be both `Routed` and `Overflowed`.
  - `AMQP::Channel#confirm` now NACKs based on `result.overflowed?` instead of relying on `RejectOverFlow` propagating up.
  - HTTP, federation, MQTT, and dead-lettering call sites branch on the new fields directly.

## Test plan
- [x] Regression spec in `spec/api/exchanges_spec.cr` (HTTP overflow + fan-out)
- [x] `make test` — 1675 examples, 0 failures
- [x] `make lint`