### PR TITLE
Bound TCP read/write so dead AMQP peers don't leak connections

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -99,6 +99,8 @@ describe LavinMQ::Config do
           tcp_keepalive = 120:20:5
           tcp_recv_buffer_size = 65536
           tcp_send_buffer_size = 65536
+          tcp_write_timeout = 30
+          tcp_read_timeout = 90
           log_exchange = true
           free_disk_min = 1073741824
           free_disk_warn = 5368709120
@@ -182,6 +184,8 @@ describe LavinMQ::Config do
       config.tcp_keepalive.should eq({120, 20, 5})
       config.tcp_recv_buffer_size.should eq 65536
       config.tcp_send_buffer_size.should eq 65536
+      config.tcp_write_timeout.should eq 30
+      config.tcp_read_timeout.should eq 90
       config.log_exchange?.should be_true
       config.free_disk_min.should eq 1073741824
       config.free_disk_warn.should eq 5368709120

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -230,6 +230,11 @@ module LavinMQ
       end
 
       private def send_heartbeat
+        # heartbeat=0: client declined heartbeats, but read_timeout still fires
+        # via tcp_read_timeout. Treat the heartbeat as a liveness probe — if
+        # the peer is dead the write hangs and tcp_write_timeout kills it.
+        return send AMQP::Frame::Heartbeat.new if @heartbeat_timeout.zero?
+
         now = RoughTime.instant
         if @last_recv_frame + (@heartbeat_timeout + 5).seconds < now
           @log.info { "Heartbeat timeout (#{@heartbeat_timeout}), last seen frame #{(now - @last_recv_frame).total_seconds} s ago, sent frame #{(now - @last_sent_frame).total_seconds} s ago" }

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -25,7 +25,12 @@ module LavinMQ
             if user = authenticate(stream, connection_info.remote_address, start_ok, logger)
               if tune_ok = tune(stream, logger)
                 if vhost = open(stream, user, logger)
-                  socket.read_timeout = heartbeat_timeout(tune_ok)
+                  # heartbeat>0: replace the accept-time default with heartbeat/2.
+                  # heartbeat=0: leave the fallback set by Server#set_io_timeouts
+                  # so dead peers still get caught by the liveness probe.
+                  if t = heartbeat_timeout(tune_ok)
+                    socket.read_timeout = t
+                  end
                   return LavinMQ::AMQP::Client.new(socket, connection_info, vhost, user, tune_ok, start_ok)
                 end
               end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -196,6 +196,24 @@ module LavinMQ
       @[IniOpt(section: "main")]
       property tcp_send_buffer_size : Int32? = nil
 
+      # Bounds the time a single socket write may block. Without it, a slow or
+      # half-dead peer can wedge `Client#deliver` indefinitely while holding
+      # `@write_lock`, which in turn blocks the read loop, HTTP DELETE-on-
+      # connection, and `cleanup` — leaking the connection until the kernel
+      # TCP retransmit timer fires (minutes to hours). Set to 0 / negative to
+      # disable.
+      @[IniOpt(section: "main")]
+      property tcp_write_timeout : Int32 = 15 # seconds, 0 disables
+
+      # Fallback read_timeout for AMQP connections that negotiated heartbeat=0.
+      # When it fires, the read loop sends a Heartbeat frame as a liveness
+      # probe; if the write times out (`tcp_write_timeout`), the connection is
+      # torn down. Idle-but-alive clients are unaffected because heartbeats
+      # round-trip silently. Set to 0 / negative to keep the legacy behavior of
+      # never timing out reads when heartbeat=0.
+      @[IniOpt(section: "main")]
+      property tcp_read_timeout : Int32 = 60 # seconds, 0 disables
+
       @[IniOpt(section: "amqp")]
       property max_message_size = 128 * 1024**2
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -184,6 +184,7 @@ module LavinMQ
       spawn(name: "Accept UNIX socket") do
         remote_address = client.remote_address
         set_buffer_size(client)
+        set_io_timeouts(client)
         conn_info =
           case @config.unix_proxy_protocol
           when 1 then ProxyProtocol::V1.parse(client)
@@ -319,6 +320,16 @@ module LavinMQ
       socket.tcp_nodelay = true if @config.tcp_nodelay?
       @config.tcp_recv_buffer_size.try { |v| socket.recv_buffer_size = v }
       @config.tcp_send_buffer_size.try { |v| socket.send_buffer_size = v }
+      set_io_timeouts(socket)
+    end
+
+    private def set_io_timeouts(socket)
+      if (t = @config.tcp_write_timeout).positive?
+        socket.write_timeout = t.seconds
+      end
+      if (t = @config.tcp_read_timeout).positive?
+        socket.read_timeout = t.seconds
+      end
     end
 
     private def set_buffer_size(socket)


### PR DESCRIPTION
## Summary
Two new `[main]` options:

```
tcp_write_timeout = 15  # seconds, 0 disables
tcp_read_timeout  = 60  # seconds, 0 disables
```

`Server#set_io_timeouts` applies both at accept time (TCP and UNIX). Without `tcp_write_timeout` a slow or half-dead peer wedged `Client#deliver` inside `socket.write_bytes` while holding `@write_lock`, which in turn blocked the read loop, `HTTP DELETE /api/connections`, and cleanup — leaking the connection until kernel TCP retransmit fired (~15 min to hours).

`ConnectionFactory` now overrides `read_timeout` only when negotiated heartbeat > 0; for `heartbeat=0` it keeps the accept-time `tcp_read_timeout` as a fallback. `Client#send_heartbeat` short-circuits when `@heartbeat_timeout == 0` and sends a Heartbeat frame as a liveness probe; if the peer is dead the write blocks and `tcp_write_timeout` converts it to `IO::TimeoutError` → `close_socket` → break. Idle-but-alive clients are unaffected (amqp-client echoes received heartbeats).

Worst-case dead-peer detection now ~75s (read_timeout + write_timeout) instead of TCP-retransmit-many-minutes.

## Test plan
- [x] `spec/config_spec.cr` updated to cover the new options
- [ ] `make test SPEC=spec/config_spec.cr`
- [ ] `make test`
- [ ] Manual: simulate half-dead peer (e.g. `iptables -j DROP` on a connected client), confirm cleanup within ~75s

🤖 Generated with [Claude Code](https://claude.com/claude-code)