### PR TITLE
Coalesce policy-driven Queue spawn loops

### DIFF
--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -204,6 +204,39 @@ describe LavinMQ::VHost do
     end
   end
 
+  it "repeated policy applies do not spawn duplicate Queue loops" do
+    # Regression for the stress driver finding 15+ zombie
+    # Queue#queue_expire_loop / drop_overflow fibers for the same queue.
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.queue("repeat")
+        s.vhosts["/"].queue("repeat").as(LavinMQ::AMQP::Queue)
+        defs = {
+          "expires"          => JSON::Any.new(60_000_i64),
+          "max-length"       => JSON::Any.new(100_i64),
+          "max-length-bytes" => JSON::Any.new(1_000_000_i64),
+          "delivery-limit"   => JSON::Any.new(10_i64),
+        } of String => JSON::Any
+        20.times do |i|
+          s.vhosts["/"].add_policy("p#{i}", "^repeat$", "queues", defs, i.to_i8)
+        end
+        Fiber.yield
+        loop_count = ->(needle : String) do
+          c = 0
+          Fiber.list do |f|
+            n = f.@name
+            c += 1 if n && n.includes?(needle) && n.includes?("/repeat")
+          end
+          c
+        end
+        loop_count.call("queue_expire_loop").should eq 1
+        loop_count.call("drop_overflow").should be <= 1
+        loop_count.call("drop_redelivered").should be <= 1
+        20.times { |i| s.vhosts["/"].delete_policy("p#{i}") }
+      end
+    end
+  end
+
   it "should drop messages if above delivery-limit" do
     with_amqp_server do |s|
       defs = {"delivery-limit" => JSON::Any.new(0_i64)} of String => JSON::Any

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -120,6 +120,17 @@ module LavinMQ::AMQP
     @queue_expiration_ttl_change = ::Channel(Nil).new
     @effective_args = Array(String).new
 
+    # Idempotency guards for spawn sites driven by policy/argument application.
+    # Without these, every `apply_policy_argument` call spawned a fresh fiber,
+    # so heavy policy churn against the same queue (the stress driver hits
+    # `stress.q` hundreds of times) accumulated zombie loops parked on
+    # `@consumers_empty.when_true` etc.
+    @queue_expire_loop_running = Atomic(Bool).new(false)
+    @drop_overflow_loop_running = Atomic(Bool).new(false)
+    @drop_overflow_pending = Atomic(Bool).new(false)
+    @drop_redelivered_loop_running = Atomic(Bool).new(false)
+    @drop_redelivered_pending = Atomic(Bool).new(false)
+
     getter? internal = false
 
     private def queue_expire_loop
@@ -139,6 +150,43 @@ module LavinMQ::AMQP
         end
       end
     rescue ::Channel::ClosedError
+    ensure
+      @queue_expire_loop_running.set(false)
+    end
+
+    private def start_queue_expire_loop
+      return if @queue_expire_loop_running.swap(true)
+      spawn queue_expire_loop, name: "Queue#queue_expire_loop #{@vhost.name}/#{@name}"
+    end
+
+    # Coalescing scheduler for drop_overflow. Multiple back-to-back policy
+    # applies (or the same one re-applied) share a single in-flight fiber:
+    # the pending flag bridges races where a request arrives mid-run.
+    private def schedule_drop_overflow
+      @drop_overflow_pending.set(true)
+      return if @drop_overflow_loop_running.swap(true)
+      spawn(name: "Queue#drop_overflow #{@vhost.name}/#{@name}") do
+        @vhost.closed.when_false.receive?
+        while @drop_overflow_pending.swap(false)
+          drop_overflow
+        end
+        @drop_overflow_loop_running.set(false)
+        # Re-trigger if a request slipped in after the last swap.
+        schedule_drop_overflow if @drop_overflow_pending.get
+      end
+    end
+
+    private def schedule_drop_redelivered
+      @drop_redelivered_pending.set(true)
+      return if @drop_redelivered_loop_running.swap(true)
+      spawn(name: "Queue#drop_redelivered #{@vhost.name}/#{@name}") do
+        @vhost.closed.when_false.receive?
+        while @drop_redelivered_pending.swap(false)
+          drop_redelivered
+        end
+        @drop_redelivered_loop_running.set(false)
+        schedule_drop_redelivered if @drop_redelivered_pending.get
+      end
     end
 
     private def message_expire_loop
@@ -222,7 +270,7 @@ module LavinMQ::AMQP
           @paused.set(true)
         end
         handle_arguments
-        spawn queue_expire_loop, name: "Queue#queue_expire_loop #{@vhost.name}/#{@name}" if @expires
+        start_queue_expire_loop if @expires
         spawn message_expire_loop, name: "Queue#message_expire_loop #{@vhost.name}/#{@name}"
         true
       end
@@ -302,20 +350,14 @@ module LavinMQ::AMQP
         unless @max_length.try &.< value.as_i64
           @max_length = value.as_i64
           @effective_args.delete("x-max-length")
-          spawn do
-            @vhost.closed.when_false.receive?
-            drop_overflow
-          end
+          schedule_drop_overflow
           return true
         end
       when "max-length-bytes"
         unless @max_length_bytes.try &.< value.as_i64
           @max_length_bytes = value.as_i64
           @effective_args.delete("x-max-length-bytes")
-          spawn do
-            @vhost.closed.when_false.receive?
-            drop_overflow
-          end
+          schedule_drop_overflow
           return true
         end
       when "message-ttl"
@@ -328,7 +370,7 @@ module LavinMQ::AMQP
       when "expires"
         unless @expires.try &.< value.as_i64
           @expires = value.as_i64
-          spawn queue_expire_loop, name: "Queue#queue_expire_loop #{@vhost.name}/#{@name}"
+          start_queue_expire_loop
           @queue_expiration_ttl_change.try_send? nil
           @effective_args.delete("x-expires")
           return true
@@ -356,10 +398,7 @@ module LavinMQ::AMQP
         unless @delivery_limit.try &.< value.as_i64
           @delivery_limit = value.as_i64
           @effective_args.delete("x-delivery-limit")
-          spawn do
-            @vhost.closed.when_false.receive?
-            drop_redelivered
-          end
+          schedule_drop_redelivered
           return true
         end
       when "federation-upstream"


### PR DESCRIPTION
## Summary
Heavy policy churn against the same queue accumulated zombie fibers: each call to `apply_policy_argument` for `expires` / `max-length` / `max-length-bytes` / `delivery-limit` did `spawn ...` with no idempotency check. Stress driver dumps showed 15+ `Queue#queue_expire_loop` fibers parked on `@consumers_empty.when_true` for a single queue, plus a long tail of unnamed `drop_overflow` / `drop_redelivered` fibers contending for `@msg_store_lock`.

Add atomic running-flag guards plus pending-flag bridges so multiple back-to-back applies share a single in-flight fiber. `queue_expire_loop` now resets its running flag in `ensure` so it can be restarted if the loop exits (e.g. `@expires` cleared then re-set by a new policy).

## Test plan
- [x] Regression spec applies 20 policies hitting the same queue and asserts only one `queue_expire_loop` / `drop_overflow` / `drop_redelivered` fiber exists afterward
- [ ] `make test SPEC=spec/policies_spec.cr`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)