### PR TITLE
Split federation Link#terminate into stop and delete

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -524,9 +524,28 @@ describe LavinMQ::Federation::Upstream do
           wait_for { link.state.running? }
           upstream_vhost.queue_exists?(federation_name).should eq true
           upstream_vhost.exchange_exists?(federation_name).should eq true
-          link.terminate
+          link.delete
           upstream_vhost.queue_exists?(federation_name).should eq false
           upstream_vhost.exchange_exists?(federation_name).should eq false
+        end
+      end
+    end
+
+    it "should keep internal exchange and queue after broker shutdown" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        upstream, upstream_vhost = UpstreamSpecHelpers.setup_federation(s, "qf test upstream shutdown", "upstream_ex", "upstream_q")
+        federation_name = "federation: upstream_ex -> #{System.hostname}:downstream:downstream_ex"
+
+        with_channel(s) do |ch|
+          downstream_ex = ch.exchange("downstream_ex", "topic")
+          link = upstream.link(vhost.exchange(downstream_ex.name))
+          wait_for { link.state.running? }
+          upstream_vhost.queue_exists?(federation_name).should eq true
+          upstream_vhost.exchange_exists?(federation_name).should eq true
+          upstream.close # broker shutdown path — must not delete upstream resources
+          upstream_vhost.queue_exists?(federation_name).should eq true
+          upstream_vhost.exchange_exists?(federation_name).should eq true
         end
       end
     end

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -67,11 +67,20 @@ module LavinMQ
           loop { @state_changed.try_send?(state) || break }
         end
 
-        # Does not trigger reconnect, but a graceful close
-        def terminate
+        # Graceful close of the link without removing any upstream resources.
+        # Use on broker shutdown — the upstream queue/exchange must survive a
+        # restart so buffered messages aren't lost.
+        def stop
           return if @state.terminated?
           state(State::Terminating)
           @upstream_connection.try &.close
+        end
+
+        # Permanently remove the link, including any resources it created on
+        # the upstream broker. Use when the federation, federated resource or
+        # upstream itself is being deleted.
+        def delete
+          stop
         end
 
         private def run_loop
@@ -250,7 +259,7 @@ module LavinMQ
           @federated_q.name
         end
 
-        def terminate
+        def stop
           @federated_q.unregister_observer(self)
           super
           @consumer_available.close
@@ -388,9 +397,13 @@ module LavinMQ
           end
         end
 
-        def terminate
+        def stop
           super
           @federated_ex.unregister_observer(self)
+        end
+
+        def delete
+          stop
           cleanup
         end
 

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -28,11 +28,11 @@ module LavinMQ
       # delete x-federation-upstream exchange on upstream
       # delete queue on upstream
       def stop_link(federated_exchange : Exchange)
-        @ex_links.delete(federated_exchange.name).try(&.terminate)
+        @ex_links.delete(federated_exchange.name).try(&.delete)
       end
 
       def stop_link(federated_q : Queue)
-        @q_links.delete(federated_q.name).try(&.terminate)
+        @q_links.delete(federated_q.name).try(&.delete)
       end
 
       def links : Array(Link)
@@ -79,8 +79,17 @@ module LavinMQ
         link
       end
 
+      # Stop all links without touching upstream resources. Use on broker shutdown.
       def close
-        links.each(&.terminate)
+        links.each(&.stop)
+        @ex_links.clear
+        @q_links.clear
+      end
+
+      # Stop all links and remove the resources they created on the upstream broker.
+      # Use when the upstream is being explicitly deleted.
+      def delete
+        links.each(&.delete)
         @ex_links.clear
         @q_links.clear
       end

--- a/src/lavinmq/federation/upstream_store.cr
+++ b/src/lavinmq/federation/upstream_store.cr
@@ -51,11 +51,11 @@ module LavinMQ
       end
 
       private def do_delete_upstream(name)
-        @upstreams.delete(name).try(&.close)
+        @upstreams.delete(name).try(&.delete)
         @upstream_sets.each do |_, set|
           set.reject! do |upstream|
             return false unless upstream.name == name
-            upstream.close
+            upstream.delete
             true
           end
         end


### PR DESCRIPTION
## Summary
On broker shutdown, `ExchangeLink#terminate` opened a new AMQP connection to the upstream URI to delete its federation queue/exchange. With self-federation (upstream points at the same broker), the local listener is already closed by the time `vhost.close` runs, so the cleanup raised "Connection refused" and printed a noisy stack trace. More importantly, upstream resources should survive a broker restart so buffered messages aren't lost.

Replace the single `terminate` method with two:
- `stop` — graceful close, no upstream cleanup. Used by broker shutdown and add-replacement (`close → stop`).
- `delete` — also removes the upstream queue/exchange. Used by `delete_upstream` and `stop_link` (local resource deleted).

## Test plan
- [x] `spec/upstream_spec.cr` updated with regression coverage
- [ ] `make test SPEC=spec/upstream_spec.cr`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)