### PR TITLE
ci: pin @stoplight/spectral-rulesets to 1.22.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint-js:
 
 .PHONY: lint-openapi
 lint-openapi:
-	npx --package=@stoplight/spectral-cli spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
+	npx --yes -p @stoplight/spectral-cli -p @stoplight/spectral-rulesets@1.22.2 spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
 
 .PHONY: test
 test: lib views

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint-js:
 
 .PHONY: lint-openapi
 lint-openapi:
-	npx --yes -p @stoplight/spectral-cli -p @stoplight/spectral-rulesets@1.22.2 spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
+	npx --yes --package=@stoplight/spectral-cli -p @stoplight/spectral-rulesets@1.22.2 spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
 
 .PHONY: test
 test: lib views

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint-js:
 
 .PHONY: lint-openapi
 lint-openapi:
-	npx --yes --package=@stoplight/spectral-cli -p @stoplight/spectral-rulesets@1.22.2 spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
+	npx --yes --package=@stoplight/spectral-cli --package=@stoplight/spectral-rulesets@1.22.2 spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
 
 .PHONY: test
 test: lib views


### PR DESCRIPTION
## Summary
- Pin `@stoplight/spectral-rulesets` to `1.22.2` in the `lint-openapi` target.
- `1.22.3` introduced a regression in the `duplicated-entry-in-enum` rule that crashes Spectral with `Cannot read properties of null (reading 'enum')`. See [stoplightio/spectral#2959](https://github.com/stoplightio/spectral/issues/2959).
- Fix is in flight upstream ([#2960](https://github.com/stoplightio/spectral/pull/2960) / [#2963](https://github.com/stoplightio/spectral/pull/2963))

## Test plan
- [x] `make lint-openapi` passes locally with the pin (0 errors, pre-existing warnings only).
- [x] Lint OpenAPI passes in CI