### PR TITLE
Wait TTL + 2 seconds before retrying etcd lease grant

### DIFF
--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -99,7 +99,8 @@ module LavinMQ
       begin
         json = post("/v3/lease/grant", body: %({"TTL":"#{ttl}","ID":#{id}}))
       rescue LeaseAlreadyExists
-        expires_in = lease_ttl(id) + 1
+        # Add two seconds to the TTL to make sure it has expired before we try again.
+        expires_in = lease_ttl(id) + 2
         Log.warn { "Cluster ID #{id.to_s(36)} already leased, waits #{expires_in}s for it to expire" }
         sleep expires_in.seconds
         json = post("/v3/lease/grant", body: %({"TTL":"#{ttl}","ID":#{id}}))


### PR DESCRIPTION
### WHAT is this pull request doing?

When LavinMQ want's to create a new lease there may be a lease for the given ID already. LavinMQ waits the remaining TTL for the existing lease before retrying. Before this PR LavinMQ added 1 second to the returned TTL value to make sure it has been revoked before retrying, but it sometimes fails.

It seems that the returned TTL in the response is the remaning TTL truncated to seconds

https://github.com/etcd-io/etcd/blob/8ad92a0dc801a8347b281f43a348efa84365708d/server/etcdserver/v3_server.go#L650

and expired leases are revoked every 500ms

https://github.com/etcd-io/etcd/blob/8ad92a0dc801a8347b281f43a348efa84365708d/server/lease/lessor.go#L623

meaning the existing lease should be revoked within 1.5 seconds, not 1 second.

This PR will change the wait from `TTL + 1` second to `TTL + 2` seconds.

Resolves #1964

### Testing
Manually by following the steps in the issue.