### PR TITLE
Exit if etcd lease expires while waiting to be in sync

### DIFF
--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -94,7 +94,7 @@ describe LavinMQ::Etcd, tags: "etcd" do
     end
   end
 
-  it "will lose leadership when loosing quorum" do
+  it "will lose lease when loosing quorum" do
     cluster = EtcdCluster.new
     cluster.run do |etcds|
       etcd = LavinMQ::Etcd.new(cluster.endpoints)
@@ -104,6 +104,41 @@ describe LavinMQ::Etcd, tags: "etcd" do
 
       expect_raises(LavinMQ::Etcd::Lease::Expired) do
         lease.wait(20.seconds)
+      end
+    end
+  end
+
+  it "signals expired channel with the underlying error" do
+    cluster = EtcdCluster.new
+    cluster.run do |etcds|
+      etcd = LavinMQ::Etcd.new(cluster.endpoints)
+      key = "foo/#{rand}"
+      lease = etcd.elect(key, "bar", ttl: 1)
+      etcds.first(2).each &.terminate(graceful: false)
+
+      select
+      when err = lease.expired.receive?
+        err.should be_a(LavinMQ::Etcd::Error)
+      when timeout(20.seconds)
+        fail "lease.expired channel never signaled"
+      end
+    end
+  end
+
+  it "signals expired channel when all lease is revoked" do
+    cluster = EtcdCluster.new(1)
+    cluster.run do
+      etcd = LavinMQ::Etcd.new(cluster.endpoints)
+      key = "foo/#{rand}"
+      lease = etcd.elect(key, "bar", ttl: 10)
+
+      etcd.lease_revoke(lease.id)
+
+      select
+      when err = lease.expired.receive?
+        err.should be_a(LavinMQ::Etcd::Error)
+      when timeout(20.seconds)
+        fail "lease.expired channel never signaled"
       end
     end
   end

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -102,7 +102,7 @@ describe LavinMQ::Etcd, tags: "etcd" do
       lease = etcd.elect(key, "bar", ttl: 1)
       etcds.first(2).each &.terminate(graceful: false)
 
-      expect_raises(LavinMQ::Etcd::Lease::Lost) do
+      expect_raises(LavinMQ::Etcd::Lease::Expired) do
         lease.wait(20.seconds)
       end
     end

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -28,7 +28,7 @@ class LavinMQ::Clustering::Controller
   def run(&)
     lease = @lease = @etcd.lease_grant(id: @id)
     spawn(follow_leader, name: "Follower monitor")
-    wait_to_be_insync
+    wait_to_be_insync(lease)
     @etcd.election_campaign("#{@config.clustering_etcd_prefix}/leader", @advertised_uri, lease: @id) # blocks until becoming leader
     @is_leader.set(true)
     execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
@@ -39,10 +39,10 @@ class LavinMQ::Clustering::Controller
       lease.wait(30.seconds)
       GC.collect
     end
-  rescue Etcd::Lease::Lost
+  rescue Etcd::Lease::Expired
     execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
     unless @stopped
-      Log.fatal { "Lost cluster leadership" }
+      Log.fatal { "Lease expired, lost leadership" }
       exit 3
     end
   rescue Etcd::LeaseAlreadyExists
@@ -122,15 +122,31 @@ class LavinMQ::Clustering::Controller
     exit 36 # 36 for CF (Cluster Follower)
   end
 
-  def wait_to_be_insync
+  def wait_to_be_insync(lease)
     if isr = @etcd.get("#{@config.clustering_etcd_prefix}/isr")
       unless isr.split(",").map(&.to_i(36)).includes?(@id)
         Log.info { "ISR: #{isr}" }
         Log.info { "Not in sync, waiting for a leader" }
-        @etcd.watch("#{@config.clustering_etcd_prefix}/isr") do |value|
-          break if value.try &.split(",").map(&.to_i(36)).includes?(@id)
+        in_sync = Channel(Nil).new
+        spawn do
+          @etcd.watch("#{@config.clustering_etcd_prefix}/isr") do |value|
+            if value.try &.split(",").map(&.to_i(36)).includes?(@id)
+              in_sync.close
+              break
+            end
+          end
         end
-        Log.info { "In sync with leader" }
+        select
+        when err = lease.expired.receive?
+          if err
+            Log.fatal { "Lease expired while waiting to be in sync: #{err.message}" }
+          else
+            Log.fatal { "Lease expired while waiting to be in sync" }
+          end
+          exit 3
+        when in_sync.receive?
+          Log.info { "In sync with leader" }
+        end
       end
     end
   end

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -100,7 +100,7 @@ module LavinMQ
       if ttl = json.dig?("result", "TTL")
         ttl.as_s.to_i
       else
-        raise Error.new("Lease #{id} expired")
+        raise LeaseExpired.new(id)
       end
     end
 
@@ -354,7 +354,7 @@ module LavinMQ
       when "etcdserver: no leader"
         raise NoLeader.new(error_msg)
       when "etcdserver: lease already exists"
-        raise LeaseAlreadyExists.new
+        raise LeaseAlreadyExists.new(error_msg)
       when "etcdserver: requested lease not found"
         raise LeaseNotFound.new(error_msg)
       else
@@ -369,5 +369,12 @@ module LavinMQ
     class LeaseAlreadyExists < Error; end
 
     class LeaseNotFound < Error; end
+
+    class LeaseExpired < Error
+      def initialize(@id : Int64)
+        # to_s(16) to match output from etcdctl list lease
+        super("Lease #{@id.to_s(16)} expired")
+      end
+    end
   end
 end

--- a/src/lavinmq/etcd/lease.cr
+++ b/src/lavinmq/etcd/lease.cr
@@ -3,27 +3,27 @@ module LavinMQ
     # Represents holding a Lease
     # Can be revoked or wait until lost
     class Lease
-      getter id
+      getter id, expired
 
       def initialize(@etcd : Etcd, @id : Int64, ttl : Int32)
-        @lost_leadership = Channel(Nil).new
+        @expired = Channel(Exception?).new
         Fiber::ExecutionContext::Isolated.new("Etcd::Lease") do
           keepalive_loop(ttl)
         end
       end
 
-      # Force release leadership
+      # Force release of lease (and leadership)
       def release
-        @lost_leadership.close
+        @expired.close
         @etcd.lease_revoke(@id)
       end
 
-      # Wait until loses leadership
-      # Raises `Lost` if lost leadership, otherwise returns after `timeout`
+      # Wait until lease expires (if leader, leadership is lost)
+      # Raises `Expired` if lease expired, otherwise returns after `timeout`
       def wait(timeout : Time::Span) : Nil
         select
-        when @lost_leadership.receive?
-          raise Lost.new
+        when err = @expired.receive?
+          raise Expired.new(cause: err)
         when timeout(timeout)
         end
       end
@@ -33,13 +33,19 @@ module LavinMQ
           sleep (ttl / 3).seconds
           ttl = @etcd.lease_keepalive(@id)
         end
+        error : Exception? = nil
       rescue ex : Etcd::Error # only rescue etcd errors
-        Log.error(exception: ex) { "Lost leadership because of #{ex.message}" } unless @lost_leadership.closed?
+        unless @expired.closed?
+          error = ex
+          while @expired.try_send?(error)
+          end
+        end
+        Log.debug(exception: ex) { "Lease expired: '#{ex.message}'" }
       ensure
-        @lost_leadership.close
+        @expired.close
       end
 
-      class Lost < Exception; end
+      class Expired < Exception; end
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
A follower that wasn't in the ISR would block indefinitely in `wait_to_be_insync`, even if its etcd lease expired underneath it. If the leader never came back to add this node to the ISR, the process would hang forever instead of exiting and letting the supervisor restart it.

This change makes lease expiry observable: the keepalive loop now publishes the underlying error on a channel instead of just closing it, so callers can react both to expiry and to the reason for it. `wait_to_be_insync` selects on both the ISR watch and the lease's expiry channel, exiting with code 3 if the lease drops while waiting.                                                                            

Also renames `Lease::Lost` to `Lease::Expired` since the exception is about the lease itself, not leadership — a node can lose its lease before it ever becomes leader.
          
Fixes #1952                     

### HOW can this pull request be tested?
Specs
