### PR TITLE
fix: smooth pacing in lavinmqperf AMQP throughput

### DIFF
--- a/spec/lavinmqperf_spec.cr
+++ b/spec/lavinmqperf_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "../src/lavinmqperf/perf"
+require "../src/lavinmqperf/ticker"
 require "../src/lavinmqperf/amqp/*"
 require "../src/lavinmqperf/mqtt/*"
 
@@ -104,6 +105,47 @@ describe "LavinMQPerf" do
 
         tcp_server.close
       end
+    end
+  end
+
+  describe "Ticker" do
+    # Bursty pacing puts all ops in the first bucket; smooth pacing spreads
+    # them evenly. Lower bounds only, so a slow CI just stretches the run.
+    it "paces evenly across the configured rate window" do
+      rate = 500
+      total_ops = 250
+      ticker = LavinMQPerf::Ticker.new(rate)
+      timestamps = Array(Time::Span).new(total_ops)
+      start = Time.monotonic
+      total_ops.times do
+        ticker.tick
+        timestamps << Time.monotonic - start
+      end
+      elapsed = Time.monotonic - start
+
+      target = (total_ops.to_f64 / rate).seconds
+      elapsed.should be >= target * 0.7
+
+      bucket_count = 10
+      bucket_width = elapsed / bucket_count
+      buckets = Array(Int32).new(bucket_count, 0)
+      timestamps.each do |ts|
+        idx = (ts.total_nanoseconds / bucket_width.total_nanoseconds).to_i
+        idx = bucket_count - 1 if idx >= bucket_count
+        buckets[idx] += 1
+      end
+      buckets.max.should be < total_ops // 2
+    end
+
+    # The consume path hands the ticker to a helper method per message, so it
+    # must keep state across calls — a value type would reset every call and
+    # skip pacing. Ticking through an indirection locks that in.
+    it "keeps pacing when ticked through another method" do
+      ticker = LavinMQPerf::Ticker.new(500)
+      tick = ->(t : LavinMQPerf::Ticker) { t.tick }
+      start = Time.monotonic
+      250.times { tick.call(ticker) }
+      (Time.monotonic - start).should be >= (250.0 / 500).seconds * 0.7
     end
   end
 

--- a/src/lavinmqperf.cr
+++ b/src/lavinmqperf.cr
@@ -1,5 +1,6 @@
 require "log"
 require "./lavinmq/version"
+require "./lavinmqperf/ticker"
 require "./lavinmqperf/amqp/*"
 require "./lavinmqperf/mqtt/*"
 require "./stdlib/*"

--- a/src/lavinmqperf/amqp/throughput.cr
+++ b/src/lavinmqperf/amqp/throughput.cr
@@ -350,8 +350,7 @@ module LavinMQPerf
           ch.tx_select if @pub_in_transaction > 0
           ch.confirm_select if @max_unconfirm > 0
           wait_until_all_are_connected(connected)
-          start = Time.instant
-          pubs_this_second = 0
+          ticker = Ticker.new(@rate)
           queues = queue_names
           queue_idx = 0
           local_pubs = 0_u64
@@ -387,18 +386,7 @@ module LavinMQPerf
             local_pubs &+= 1
             ch.tx_commit if @pub_in_transaction > 0 && (local_pubs % @pub_in_transaction) == 0
             break if pubs >= @pmessages > 0
-            Fiber.yield if @rate.zero? && local_pubs % (128*1024) == 0
-            unless @rate.zero?
-              pubs_this_second += 1
-              if pubs_this_second >= @rate
-                until_next_second = (start + 1.seconds) - Time.instant
-                if until_next_second > Time::Span.zero
-                  sleep until_next_second
-                end
-                start = Time.instant
-                pubs_this_second = 0
-              end
-            end
+            ticker.tick
           end
         end
       end
@@ -420,16 +408,16 @@ module LavinMQPerf
           end
           q.bind(@exchange, @routing_key) unless @exchange.empty?
           wait_until_all_are_connected(connected)
-          rate_limiter = RateLimiter.new(@consume_rate)
+          ticker = Ticker.new(@consume_rate)
           local_consumes = 0_u64
           q.subscribe(tag: "c", no_ack: @ack.zero?, block: true, args: @consumer_args) do |m|
             local_consumes &+= 1
-            handle_consumed_message(ch, m, data, rate_limiter, local_consumes)
+            handle_consumed_message(ch, m, data, ticker, local_consumes)
           end
         end
       end
 
-      private def handle_consumed_message(ch, m, data, rate_limiter, local_consumes : UInt64)
+      private def handle_consumed_message(ch, m, data, ticker : Ticker, local_consumes : UInt64)
         consumes = @consumes.add(1, :relaxed) + 1
         body = m.body_io.to_slice
         record_latency(body) if @measure_latency
@@ -439,7 +427,7 @@ module LavinMQPerf
         if @stopped || consumes >= @cmessages > 0
           ch.close
         end
-        rate_limiter.limit
+        ticker.tick
       end
 
       private def poll_consume(connected, queue_name : String)
@@ -457,7 +445,7 @@ module LavinMQPerf
           end
           q.bind(@exchange, @routing_key) unless @exchange.empty?
           wait_until_all_are_connected(connected)
-          rate_limiter = RateLimiter.new(@consume_rate)
+          ticker = Ticker.new(@consume_rate)
           local_consumes = 0_u64
           loop do
             if msg = q.get(no_ack: @ack.zero?)
@@ -466,7 +454,7 @@ module LavinMQPerf
               record_latency(msg.body_io.to_slice) if @measure_latency
               msg.ack(multiple: true) if @ack > 0 && local_consumes % @ack == 0
               break if @stopped || consumes >= @cmessages > 0
-              rate_limiter.limit
+              ticker.tick
             end
           end
         end
@@ -490,31 +478,6 @@ module LavinMQPerf
         connected.wait
       rescue
         # when we reconnect a broker the waitgroup will have a negative counter
-      end
-
-      private class RateLimiter
-        def initialize(@rate : Int32)
-          @consumes_this_second = 0
-          @start = Time.instant
-          @total_consumes = 0_u64
-        end
-
-        def limit
-          @total_consumes &+= 1
-          if @rate.zero?
-            # When no rate limiting, yield periodically to avoid blocking other fibers
-            Fiber.yield if @total_consumes % (128*1024) == 0
-            return
-          end
-
-          @consumes_this_second += 1
-          if @consumes_this_second >= @rate
-            until_next_second = (@start + 1.seconds) - Time.instant
-            sleep until_next_second if until_next_second > Time::Span.zero
-            @start = Time.instant
-            @consumes_this_second = 0
-          end
-        end
       end
     end
   end

--- a/src/lavinmqperf/ticker.cr
+++ b/src/lavinmqperf/ticker.cr
@@ -1,0 +1,33 @@
+module LavinMQPerf
+  # Smooth per-iteration pacer; when @rate is zero just yields periodically.
+  # Reference type so the consume callback shares one instance across calls.
+  class Ticker
+    SLEEP_GRANULARITY = 1.millisecond
+    YIELD_INTERVAL    = 128 * 1024
+
+    @check_interval : UInt64
+
+    def initialize(@rate : Int32)
+      @start = Time.instant
+      @ops_done = 0_u64
+      # Check the schedule about once per ms of work instead of every op. A clock
+      # read is cheap on a healthy (vDSO) clocksource but slow on VMs that fall
+      # back to a degraded one, where per-op reads would cap throughput. Robust
+      # either way, and pacing is unaffected since the skip stays under SLEEP_GRANULARITY.
+      @check_interval = @rate <= 1_000 ? 1_u64 : (@rate // 1_000).to_u64
+    end
+
+    def tick : Nil
+      @ops_done &+= 1
+      if @rate.zero?
+        Fiber.yield if (@ops_done % YIELD_INTERVAL).zero?
+        return
+      end
+      return unless (@ops_done % @check_interval).zero?
+
+      target_ns = @ops_done.to_i64 &* 1_000_000_000_i64 // @rate.to_i64
+      delay = (@start + target_ns.nanoseconds) - Time.instant
+      sleep delay if delay >= SLEEP_GRANULARITY
+    end
+  end
+end


### PR DESCRIPTION
With --rate set, the limiter sent a full second's worth of messages in a burst and then slept to the next second. That bunched sends at the broker, so the later messages queued and when combined with --measure-latency their measured latency was inflated, we were timing lavinmqperf's own send queue, not the broker.

Now each message sleeps until its scheduled send time, spreading sends evenly across the second. To keep that cheap, the clock is read about once per millisecond of work rather than on every message (a clock read can be slow on VMs with a degraded clocksource).

The pacing now lives in a Ticker class.

Fixes #1970