### PR TITLE
Print clean error messages on boot failures instead of stacktraces

### DIFF
--- a/src/lavinmq.cr
+++ b/src/lavinmq.cr
@@ -3,7 +3,11 @@ require "./stdlib/*"
 require "./lavinmq/config"
 
 config = LavinMQ::Config.instance
-config.parse # both ARGV and config file
+begin
+  config.parse # both ARGV and config file
+rescue ex : OptionParser::Exception
+  abort "Error: #{ex.message}\nTry '#{PROGRAM_NAME} --help' for more information."
+end
 
 {% unless flag?(:gc_none) %}
   if config.raise_gc_warn?

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -70,6 +70,8 @@ module LavinMQ
       Fiber.yield # Yield to let listeners spawn before logging startup time
       Log.info { "Finished startup in #{(Time.instant - started_at).total_seconds}s" }
       self
+    rescue ex : Socket::BindError
+      abort "Error: #{ex.message}"
     end
 
     def run

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -204,8 +204,14 @@ module LavinMQ
     end
 
     def listen(bind = "::", port = 5672, protocol : Protocol = :amqp)
-      s = TCPServer.new(bind, port)
-      listen(s, protocol)
+      listen(bind_tcp(bind, port), protocol)
+    end
+
+    # Bind a TCP server, aborting with a clean message (no stacktrace) if the address is unavailable
+    private def bind_tcp(bind, port) : TCPServer
+      TCPServer.new(bind, port)
+    rescue ex : Socket::BindError
+      abort "Error: #{ex.message}"
     end
 
     def listen_tls(s : TCPServer, context, protocol : Protocol)
@@ -245,7 +251,7 @@ module LavinMQ
     end
 
     def listen_tls(bind, port, context, protocol : Protocol = :amqp)
-      listen_tls(TCPServer.new(bind, port), context, protocol)
+      listen_tls(bind_tcp(bind, port), context, protocol)
     end
 
     def listen_unix(path : String, protocol : Protocol)
@@ -253,10 +259,12 @@ module LavinMQ
       s = UNIXServer.new(path)
       File.chmod(path, 0o666)
       listen(s, protocol)
+    rescue ex : Socket::BindError
+      abort "Error: #{ex.message}"
     end
 
     def listen_clustering(bind, port)
-      @replicator.try &.listen(TCPServer.new(bind, port))
+      @replicator.try &.listen(bind_tcp(bind, port))
     end
 
     def close


### PR DESCRIPTION
## Problem

Two common boot-time failures dumped a full unhandled-exception stacktrace at the user, which is noise rather than signal:

```
✗ bin/lavinmq -D /mnt/xfs/amqp --log-file
Unhandled exception: Invalid option: --log-file (OptionParser::InvalidOption)
  from /usr/share/crystal/src/option_parser.cr:130:45 in '->'
  ...
```

```
Unhandled exception: Could not bind to '127.0.0.1:15672': Address already in use (Socket::BindError)
  from /usr/share/crystal/src/socket/addrinfo.cr:94:9 in 'initialize:reuse_port'
  ...
```

## Change

- **Invalid/missing CLI options:** rescue `OptionParser::Exception` at the binary entrypoint (`src/lavinmq.cr`) and `abort` with a clean message plus a `--help` hint. `Config#parse` still raises, so the existing CLI spec stays valid.
- **Address in use:** rescue `Socket::BindError` where listeners bind their sockets — `Server#listen`/`listen_tls`/`listen_unix`/`listen_clustering` (run in spawned fibers) via a small `bind_tcp` helper, and the synchronous HTTP/metrics binds in `Launcher#start`. Each aborts with the underlying message, no stacktrace.

Now:

```
$ bin/lavinmq -D /tmp/x --log-file
Error: Invalid option: --log-file
Try 'bin/lavinmq --help' for more information.

$ bin/lavinmq ...   # second instance, port taken
Error: Could not bind to '127.0.0.1:15672': Address already in use
Error: Could not bind to '127.0.0.1:5672': Address already in use
```

## Testing

- `make lint` passes.
- Verified both messages manually (invalid flag; second instance binding to an occupied port).

Note: these are `abort`/process-exit boot paths with no in-process test seam and no subprocess-spec precedent in the suite, so no automated spec was added. The existing `config_spec.cr` case still covers that an invalid CLI option raises `OptionParser::InvalidOption`, which this change relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)