### PR TITLE
Serialize Stream consumer-offset access under @msg_store_lock for MT safety

### DIFF
--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -94,7 +94,13 @@ module LavinMQ::AMQP
       end
     end
 
-    delegate last_offset, new_messages, find_offset, to: @msg_store.as(StreamMessageStore)
+    delegate last_offset, new_messages, to: @msg_store.as(StreamMessageStore)
+
+    def find_offset(offset, tag = nil, track_offset = false) : Tuple(Int64, UInt32, UInt32)
+      @msg_store_lock.synchronize do
+        stream_msg_store.find_offset(offset, tag, track_offset)
+      end
+    end
 
     private def message_expire_loop
       # Streams doesn't handle message expiration
@@ -165,7 +171,9 @@ module LavinMQ::AMQP
     end
 
     def store_consumer_offset(consumer_tag : String, offset : Int64) : Nil
-      stream_msg_store.store_consumer_offset(consumer_tag, offset)
+      @msg_store_lock.synchronize do
+        stream_msg_store.store_consumer_offset(consumer_tag, offset)
+      end
     end
 
     # yield the next message in the ready queue

--- a/src/lavinmq/amqp/stream/stream_reader.cr
+++ b/src/lavinmq/amqp/stream/stream_reader.cr
@@ -11,7 +11,7 @@ module LavinMQ::AMQP
     def each(&)
       stream = @stream
       store = stream.stream_msg_store
-      offset, segment, position = store.find_offset(@start_offset)
+      offset, segment, position = stream.find_offset(@start_offset)
       loop do
         break if store.closed
         env = store.read(segment, position)


### PR DESCRIPTION
## Summary

Two paths in `StreamMessageStore` touch `@consumer_offset_positions` (`Hash(String, Int64)`) and `@consumer_offsets` (`MFile`) outside any lock, while the publisher path mutates the same state under `@msg_store_lock`.

**Publisher path** (under `@msg_store_lock`): `publish_internal → push → write_to_disk → open_new_segment → drop_overflow → cleanup_consumer_offsets`, which iterates `@consumer_offset_positions` and rewrites the file via `replace_offsets_file` (close + rename, swapping `@consumer_offsets` to a fresh `MFile`).

**Consumer ack path** (NOT under `@msg_store_lock`): `StreamConsumer#ack → Stream#store_consumer_offset → StreamMessageStore#store_consumer_offset`, which mutates `@consumer_offset_positions[consumer_tag]` and writes to `@consumer_offsets`.

**Consumer attach path** (NOT under `@msg_store_lock`): `StreamConsumer.new → Stream#find_offset → StreamMessageStore#find_offset → last_offset_by_consumer_tag`, which reads `@consumer_offset_positions[ctag]?` and `@consumer_offsets.to_slice(pos, 8)`.

## Observed crash (ack path)

A publisher iterating the hash collided with an ack inserting into it; the rehash relocated the bucket array and the iterator's `ctag` String reference pointed at reused memory, so `String#hash → to_slice → to_unsafe` deref'd a torn pointer and SIGSEGV'd:

```
#0 to_slice            string.cr:5598
#1 Crystal::Hasher#string hasher.cr:242
#2 String#hash         string.cr:5419
#4 Hash#key_hash       hash.cr:994
#5 Hash#upsert         hash.cr:367
#6 Hash#[]=            hash.cr:1073
#7 cleanup_consumer_offsets:204
#8 drop_overflow:353
#9 open_new_segment:318
#10 write_to_disk:313
#11 push:299
```

The attach path is the same class of bug: a reader can hold a stale `@consumer_offsets` reference (and a `pos` from the old positions hash) while the publisher swaps the MFile out under `replace_offsets_file` and closes the old one.

## Fix

Wrap both `Stream#store_consumer_offset` and `Stream#find_offset` in `@msg_store_lock.synchronize`. The lock is `:reentrant`, so the `last_offset_by_consumer_tag` self-call from inside `cleanup_consumer_offsets` (already under the lock on the publisher path) is safe. Segment-side reads in `find_offset_in_segments` still rely on the defensive torn-snapshot handling in `offset_at` (see 43a58649); only the consumer-offset state needed serialization.

`find_offset` is invoked at consumer-attach time, not per message, so the added contention is negligible.

### Follow-up: route `StreamReader#find_offset` through the locked wrapper

`StreamReader#each` called `store.find_offset` directly, bypassing the lock. `find_offset` reads `@segments`/`@last_offset`/`@segment_first_offset`, which races with concurrent publish. Switch the call to `stream.find_offset` so the read is taken under `@msg_store_lock` like the other call sites.

## Validation

- `spec/stream_queue_spec.cr` — 38/38 pass
- `ameba src/lavinmq/amqp/stream/stream.cr` — clean
