### PR TITLE
ci: build shared artifact with --release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build lavinmq
-        run: make -j bin/lavinmq bin/lavinmqctl bin/stress DOCS= CRYSTAL_FLAGS="--release --error-on-warnings -Dbake_static"
+        run: make -j bin/lavinmq bin/lavinmqctl bin/stress DOCS= CRYSTAL_FLAGS="--release --error-on-warnings"
 
       - name: Print build info
         run: bin/lavinmq --build-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build lavinmq
-        run: make -j bin/lavinmq bin/lavinmqctl bin/stress DOCS= CRYSTAL_FLAGS="--error-on-warnings -Dbake_static"
+        run: make -j bin/lavinmq bin/lavinmqctl bin/stress DOCS= CRYSTAL_FLAGS="--release --error-on-warnings -Dbake_static"
 
       - name: Print build info
         run: bin/lavinmq --build-info


### PR DESCRIPTION
## Build the shared CI artifact with `--release`

The Makefile defaults `CRYSTAL_FLAGS` to `--release`, but the compile job overrides it on the make command line and only passed `--error-on-warnings -Dbake_static`, so `--release` was dropped. The shared `bin` artifact (used by stress, the language client jobs, and the `release-mode-test` job) has therefore been unoptimized. Add `--release` so downstream jobs - in particular the stress test - actually exercise an optimized build.