### PR TITLE
ci: add docs check action

### DIFF
--- a/.claude/docs-check-criteria.md
+++ b/.claude/docs-check-criteria.md
@@ -1,0 +1,68 @@
+# Docs Check Criteria
+
+## Your job
+
+Decide whether this PR's code changes require accompanying updates to `docs/`. Emit a single JSON verdict to `/tmp/docs-verdict.json`. Do not post any comments. Do not push code changes.
+
+## Steps
+
+1. Run `gh pr diff $PR_NUMBER` to read the changes.
+2. Identify any user-facing surfaces affected by the diff (see "What counts as user-facing" below).
+3. If no user-facing changes are detected, write a `pass` verdict and stop.
+4. If user-facing changes are detected, inspect the relevant `docs/` files (see "Doc surface map") and any docs touched in this PR's diff.
+5. Decide between `pass` (docs updated and sufficient), `neutral` (docs touched but incomplete), or `fail` (docs not touched at all).
+6. Write the verdict to `/tmp/docs-verdict.json` with the exact shape shown under "Output".
+
+You have a maximum of 20 turns. Finish well within that limit. Only read code or docs that you actually need to make the judgment.
+
+## What counts as user-facing
+
+A change is user-facing if it affects any of:
+
+- Configuration values (env vars, config file keys, defaults, valid value ranges).
+- CLI commands or flags for `lavinmqctl`, `lavinmqperf`, or the `lavinmq` server itself.
+- HTTP API endpoints, request parameters, response shapes, or status codes.
+- AMQP 0-9-1 or MQTT 3.1.1 protocol behavior visible to clients (frame handling, error responses, supported features).
+- Observable runtime behavior users may rely on: log fields, log levels for known events, metric names, error messages surfaced to users, on-disk file or directory layout in the data directory.
+- New user-discoverable features (delayed queues, deduplication, federation, shovels, etc.).
+- Default value changes for any of the above.
+
+## What does NOT count as user-facing
+
+- Internal refactors with no observable behavior change.
+- Performance optimizations that don't change semantics or surfaces.
+- Test-only changes (anything under `spec/`).
+- Comment or typo fixes in code.
+- Build, CI, or tooling changes.
+- Changes to private or internal classes not exposed through any user-facing surface above.
+
+## Doc surface map
+
+When deciding sufficiency, check the file in `docs/` that matches the changed surface:
+
+- `docs/configuration.md` for config values and defaults.
+- `docs/lavinmqctl.md` for `lavinmqctl` commands and flags.
+- `docs/lavinmqperf.md` for `lavinmqperf` flags and behavior.
+- `docs/monitoring.md` for metrics, log fields, and observability surfaces.
+- `docs/amqp.md` for AMQP protocol behavior.
+- `docs/mqtt.md` for MQTT protocol behavior.
+- For any other surface, glob `docs/*.md` and pick the file whose title matches the changed component. If no matching doc file exists for a new user-facing feature, that counts as missing documentation.
+
+## Verdict rules
+
+- `pass`: no user-facing changes detected, OR user-facing changes exist and are documented sufficiently in this PR.
+- `neutral`: user-facing changes detected, the PR touches at least one file under `docs/`, but the documentation updates are incomplete (for example: new flag added but its description is missing; default value changed but old value still shown; new feature added but only mentioned in a single line without explaining usage).
+- `fail`: user-facing changes detected and no file under `docs/` was touched in this PR.
+
+## Output
+
+Write exactly this file:
+
+Path: `/tmp/docs-verdict.json`
+Content:
+
+```json
+{"verdict": "pass" | "neutral" | "fail", "reason": "<one sentence explaining the decision, max 200 characters>"}
+```
+
+The `reason` text appears verbatim in the PR check summary. Be specific: name the file, feature, or flag that triggered the verdict.

--- a/.claude/docs-check-criteria.md
+++ b/.claude/docs-check-criteria.md
@@ -1,68 +1,9 @@
-# Docs Check Criteria
+Decide if this PR's code changes require updates to `docs/`. Publish the result as a check run.
 
-## Your job
+Verdicts:
+- `success`: no user-facing changes, OR docs are updated sufficiently
+- `neutral`: user-facing changes exist, docs were touched but are incomplete
+- `failure`: user-facing changes exist, no `docs/` files touched
 
-Decide whether this PR's code changes require accompanying updates to `docs/`. Emit a single JSON verdict to `/tmp/docs-verdict.json`. Do not post any comments. Do not push code changes.
-
-## Steps
-
-1. Run `gh pr diff $PR_NUMBER` to read the changes.
-2. Identify any user-facing surfaces affected by the diff (see "What counts as user-facing" below).
-3. If no user-facing changes are detected, write a `pass` verdict and stop.
-4. If user-facing changes are detected, inspect the relevant `docs/` files (see "Doc surface map") and any docs touched in this PR's diff.
-5. Decide between `pass` (docs updated and sufficient), `neutral` (docs touched but incomplete), or `fail` (docs not touched at all).
-6. Write the verdict to `/tmp/docs-verdict.json` with the exact shape shown under "Output".
-
-You have a maximum of 20 turns. Finish well within that limit. Only read code or docs that you actually need to make the judgment.
-
-## What counts as user-facing
-
-A change is user-facing if it affects any of:
-
-- Configuration values (env vars, config file keys, defaults, valid value ranges).
-- CLI commands or flags for `lavinmqctl`, `lavinmqperf`, or the `lavinmq` server itself.
-- HTTP API endpoints, request parameters, response shapes, or status codes.
-- AMQP 0-9-1 or MQTT 3.1.1 protocol behavior visible to clients (frame handling, error responses, supported features).
-- Observable runtime behavior users may rely on: log fields, log levels for known events, metric names, error messages surfaced to users, on-disk file or directory layout in the data directory.
-- New user-discoverable features (delayed queues, deduplication, federation, shovels, etc.).
-- Default value changes for any of the above.
-
-## What does NOT count as user-facing
-
-- Internal refactors with no observable behavior change.
-- Performance optimizations that don't change semantics or surfaces.
-- Test-only changes (anything under `spec/`).
-- Comment or typo fixes in code.
-- Build, CI, or tooling changes.
-- Changes to private or internal classes not exposed through any user-facing surface above.
-
-## Doc surface map
-
-When deciding sufficiency, check the file in `docs/` that matches the changed surface:
-
-- `docs/configuration.md` for config values and defaults.
-- `docs/lavinmqctl.md` for `lavinmqctl` commands and flags.
-- `docs/lavinmqperf.md` for `lavinmqperf` flags and behavior.
-- `docs/monitoring.md` for metrics, log fields, and observability surfaces.
-- `docs/amqp.md` for AMQP protocol behavior.
-- `docs/mqtt.md` for MQTT protocol behavior.
-- For any other surface, glob `docs/*.md` and pick the file whose title matches the changed component. If no matching doc file exists for a new user-facing feature, that counts as missing documentation.
-
-## Verdict rules
-
-- `pass`: no user-facing changes detected, OR user-facing changes exist and are documented sufficiently in this PR.
-- `neutral`: user-facing changes detected, the PR touches at least one file under `docs/`, but the documentation updates are incomplete (for example: new flag added but its description is missing; default value changed but old value still shown; new feature added but only mentioned in a single line without explaining usage).
-- `fail`: user-facing changes detected and no file under `docs/` was touched in this PR.
-
-## Output
-
-Write exactly this file:
-
-Path: `/tmp/docs-verdict.json`
-Content:
-
-```json
-{"verdict": "pass" | "neutral" | "fail", "reason": "<one sentence explaining the decision, max 200 characters>"}
-```
-
-The `reason` text appears verbatim in the PR check summary. Be specific: name the file, feature, or flag that triggered the verdict.
+Publish with:
+`gh api -X POST /repos/$REPO/check-runs -f name="Docs check" -f head_sha=$HEAD_SHA -f status=completed -f conclusion=<verdict> -f "output[title]=Docs check" -f "output[summary]=<one sentence naming the specific flag, feature, or file>"`

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,7 +21,6 @@ jobs:
       pull-requests: read
       checks: write
       id-token: write
-      actions: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,127 @@
+name: Docs Check
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "src/**/*.cr"
+      - "docs/**/*.md"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to check'
+        required: true
+        type: string
+
+jobs:
+  docs-check:
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+      id-token: write
+      actions: read
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Determine PR number
+        id: pr
+        run: echo "number=${{ inputs.pr_number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect docs-only PR
+        id: docs_only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          files=$(gh pr diff "$PR_NUMBER" --name-only)
+          if [[ -z "$files" ]]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          non_docs=$(echo "$files" | grep -v '^docs/' || true)
+          if [[ -z "$non_docs" ]]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            mkdir -p /tmp
+            printf '%s' '{"verdict":"pass","reason":"Documentation-only PR, no code changes to evaluate."}' > /tmp/docs-verdict.json
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Load config
+        if: steps.docs_only.outputs.docs_only != 'true'
+        id: config
+        run: |
+          source .review-config
+          if [[ -z "$MODEL" || -z "$DOCS_CRITERIA" ]]; then
+            echo "::error::.review-config must define MODEL and DOCS_CRITERIA"
+            exit 1
+          fi
+          {
+            DELIM="EOF_$(openssl rand -hex 16)"
+            echo "criteria<<$DELIM"
+            cat "$DOCS_CRITERIA"
+            echo "$DELIM"
+            echo "model=$MODEL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run docs check
+        if: steps.docs_only.outputs.docs_only != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR_NUMBER: ${{ steps.pr.outputs.number }}
+
+            ${{ steps.config.outputs.criteria }}
+
+          claude_args: |
+            --model ${{ steps.config.outputs.model }}
+            --max-turns 20
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Write(/tmp/docs-verdict.json)"
+
+      - name: Publish check run
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ ! -f /tmp/docs-verdict.json ]]; then
+            verdict="neutral"
+            reason="docs check could not run, see action logs"
+          else
+            verdict=$(jq -r '.verdict' /tmp/docs-verdict.json)
+            reason=$(jq -r '.reason' /tmp/docs-verdict.json)
+            if [[ -z "$verdict" || "$verdict" == "null" ]]; then
+              verdict="neutral"
+              reason="docs check returned no verdict, see action logs"
+            fi
+          fi
+
+          case "$verdict" in
+            pass) conclusion="success" ;;
+            neutral) conclusion="neutral" ;;
+            fail) conclusion="failure" ;;
+            *)
+              conclusion="neutral"
+              reason="docs check returned unknown verdict: $verdict"
+              ;;
+          esac
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/check-runs" \
+            -f name="Docs check" \
+            -f head_sha="$PR_HEAD_SHA" \
+            -f status="completed" \
+            -f conclusion="$conclusion" \
+            -f "output[title]=Docs check" \
+            -f "output[summary]=$reason"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -29,33 +29,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-
-      - name: Determine PR number
-        id: pr
-        run: echo "number=${{ inputs.pr_number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-
-      - name: Detect docs-only PR
-        id: docs_only
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: |
-          files=$(gh pr diff "$PR_NUMBER" --name-only)
-          if [[ -z "$files" ]]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          non_docs=$(echo "$files" | grep -v '^docs/' || true)
-          if [[ -z "$non_docs" ]]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-            mkdir -p /tmp
-            printf '%s' '{"verdict":"pass","reason":"Documentation-only PR, no code changes to evaluate."}' > /tmp/docs-verdict.json
-          else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Load config
-        if: steps.docs_only.outputs.docs_only != 'true'
+      - name: Load review config
         id: config
         run: |
           source .review-config
@@ -70,58 +44,16 @@ jobs:
             echo "$DELIM"
             echo "model=$MODEL"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Run docs check
-        if: steps.docs_only.outputs.docs_only != 'true'
-        uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR_NUMBER: ${{ steps.pr.outputs.number }}
+            PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+            HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
             ${{ steps.config.outputs.criteria }}
-
           claude_args: |
             --model ${{ steps.config.outputs.model }}
-            --max-turns 20
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Write(/tmp/docs-verdict.json)"
-
-      - name: Publish check run
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [[ ! -f /tmp/docs-verdict.json ]]; then
-            verdict="neutral"
-            reason="docs check could not run, see action logs"
-          else
-            verdict=$(jq -r '.verdict' /tmp/docs-verdict.json)
-            reason=$(jq -r '.reason' /tmp/docs-verdict.json)
-            if [[ -z "$verdict" || "$verdict" == "null" ]]; then
-              verdict="neutral"
-              reason="docs check returned no verdict, see action logs"
-            fi
-          fi
-
-          case "$verdict" in
-            pass) conclusion="success" ;;
-            neutral) conclusion="neutral" ;;
-            fail) conclusion="failure" ;;
-            *)
-              conclusion="neutral"
-              reason="docs check returned unknown verdict: $verdict"
-              ;;
-          esac
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${{ github.repository }}/check-runs" \
-            -f name="Docs check" \
-            -f head_sha="$PR_HEAD_SHA" \
-            -f status="completed" \
-            -f conclusion="$conclusion" \
-            -f "output[title]=Docs check" \
-            -f "output[summary]=$reason"
+            --max-turns 15
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"

--- a/.review-config
+++ b/.review-config
@@ -1,2 +1,3 @@
 MODEL=claude-opus-4-7
 CRITERIA=.claude/review-criteria.md
+DOCS_CRITERIA=.claude/docs-check-criteria.md


### PR DESCRIPTION
Adds a GitHub Action that runs on every PR and decides whether the code changes require accompanying updates to `docs/`. Publishes a 3-state check run (success / neutral / failure) with a one-line reason in the summary. Non-blocking at rollout.

Pieces:

- `.github/workflows/docs-check.yml` runs `anthropics/claude-code-action@v1` with `claude-opus-4-7`, short-circuits docs-only PRs, and creates a check run via `gh api`.
- `.claude/docs-check-criteria.md` is the prompt Claude follows to judge user-impact and emit a JSON verdict at `/tmp/docs-verdict.json`.
- `.review-config` gains a `DOCS_CRITERIA` line so the workflow can locate the criteria file. The existing review continues to use `CRITERIA`. `MODEL` is shared.

Draft for now so we can validate accuracy against real PRs before flipping it to required.