### PR TITLE
test: trigger docs-check fail verdict

### DIFF
--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -220,6 +220,11 @@ module LavinMQ
       @[IniOpt(section: "main")]
       property consumer_timeout_loop_interval = 60 # seconds
 
+      @[CliOpt("", "--connection-idle-timeout=SECONDS", "Close idle client connections after SECONDS of inactivity (default: 0, disabled)", section: "options")]
+      @[IniOpt(section: "main")]
+      @[EnvOpt("LAVINMQ_CONNECTION_IDLE_TIMEOUT")]
+      property connection_idle_timeout : UInt32 = 0
+
       @[IniOpt(section: "experimental")]
       property yield_each_received_bytes = 131_072 # max number of bytes to read from a client connection without letting other tasks in the server do any work
 


### PR DESCRIPTION
Test PR for #1975. Adds a new user-facing config flag (`--connection-idle-timeout`, env var `LAVINMQ_CONNECTION_IDLE_TIMEOUT`, ini option in [main]) without touching any docs.

Expected verdict from the Docs check workflow: fail. The check summary should name the new flag.

Do not merge.