### PR TITLE
test: trigger docs-check failure verdict

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ Alternatively, set the `LAVINMQ_CONFIGURATION_DIRECTORY` environment variable (o
 | `max_deleted_definitions` | — | — | Int | `8192` | Deleted definitions before compaction |
 | `consumer_timeout` | — | — | UInt64 | (none) | Consumer idle timeout (ms) |
 | `consumer_timeout_loop_interval` | — | — | Int | `60` | Consumer timeout check interval (s) |
+| `connection_idle_timeout` | `--connection-idle-timeout` | `LAVINMQ_CONNECTION_IDLE_TIMEOUT` | UInt32 | `0` | Close idle client connections after this many seconds of inactivity. `0` disables the timeout. |
 | `log_exchange` | — | — | Bool | `false` | Enable the log exchange |
 | `auth_backends` | — | — | Array | `[]` | Authentication backends |
 | `default_consumer_prefetch` | `--default-consumer-prefetch` | `LAVINMQ_DEFAULT_CONSUMER_PREFETCH` | UInt16 | `65535` | Default consumer prefetch |

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -220,6 +220,11 @@ module LavinMQ
       @[IniOpt(section: "main")]
       property consumer_timeout_loop_interval = 60 # seconds
 
+      @[CliOpt("", "--connection-idle-timeout=SECONDS", "Close idle client connections after SECONDS of inactivity (default: 0, disabled)", section: "options")]
+      @[IniOpt(section: "main")]
+      @[EnvOpt("LAVINMQ_CONNECTION_IDLE_TIMEOUT")]
+      property connection_idle_timeout : UInt32 = 0
+
       @[IniOpt(section: "experimental")]
       property yield_each_received_bytes = 131_072 # max number of bytes to read from a client connection without letting other tasks in the server do any work
 


### PR DESCRIPTION
Test PR for the docs check action that just landed on main. Adds a new user-facing config flag (`--connection-idle-timeout`, env `LAVINMQ_CONNECTION_IDLE_TIMEOUT`, ini option in [main]) without touching any docs.

Expected verdict from the Docs check: failure. The check summary should name the new flag.

Do not merge.