### PR TITLE
ci: pass github_token to docs-check action

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}


### PR DESCRIPTION
Follow-up to #1975. The first real test on PR #1977 ran Claude successfully but Claude hit 4 permission denials and never published the "Docs check" check run.

Cause: the GitHub App that claude-code-action authenticates with lacks checks: write. Our workflow already declares checks: write in its permissions block, but that only applies to secrets.GITHUB_TOKEN, not to the app token the action uses by default. Passing github_token: secrets.GITHUB_TOKEN overrides the app token with the workflow's own token, which has the right scope.

The existing Claude code review does not hit this because it only calls gh pr comment, which is within the app's standard pull-requests: write scope.

Tested locally; can only be fully validated end-to-end after this lands on main and a fresh test PR runs against it.