### PR TITLE
ci: simplify docs-check to binary pass/fail

### DIFF
--- a/.claude/docs-check-criteria.md
+++ b/.claude/docs-check-criteria.md
@@ -1,9 +1,8 @@
-Decide if this PR's code changes require updates to `docs/`. Publish the result as a check run.
+Decide if this PR's code changes require updates to `docs/`.
 
 Verdicts:
-- `success`: no user-facing changes, OR docs are updated sufficiently
-- `neutral`: user-facing changes exist, docs were touched but are incomplete
-- `failure`: user-facing changes exist, no `docs/` files touched
+- `pass`: no user-facing changes, OR every user-facing change has a matching entry in `docs/` (presence only, do not grade quality)
+- `fail`: at least one user-facing change has no corresponding entry in `docs/`
 
-Publish with:
-`gh api -X POST /repos/$REPO/check-runs -f name="Docs check" -f head_sha=$HEAD_SHA -f status=completed -f conclusion=<verdict> -f "output[title]=Docs check" -f "output[summary]=<one sentence naming the specific flag, feature, or file>"`
+Write the verdict (`pass` or `fail`) to `/tmp/docs-verdict`.
+Print to stdout: a one-sentence reason naming the specific flag, feature, or file.

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      checks: write
       id-token: write
     timeout-minutes: 10
     steps:
@@ -46,14 +45,28 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-            HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
             ${{ steps.config.outputs.criteria }}
           claude_args: |
             --model ${{ steps.config.outputs.model }}
             --max-turns 15
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Write(/tmp/docs-verdict)"
+      - name: Apply verdict
+        run: |
+          verdict=$(cat /tmp/docs-verdict 2>/dev/null || echo missing)
+          case "$verdict" in
+            pass)
+              echo "::notice::Docs check passed"
+              ;;
+            fail)
+              echo "::error::Docs check failed: user-facing changes missing docs/ entry"
+              exit 1
+              ;;
+            *)
+              echo "::error::Docs check could not produce a verdict (got: '$verdict')"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
Follow-up to #1975 and #1979.

Today the docs check produces two rows on every PR: a workflow job (always green if Claude runs) and a published check run (the real verdict). Confusing UX.

This collapses them into a single signal driven by the workflow job's own exit code. Claude writes pass or fail to /tmp/docs-verdict, a follow-up step reads it and exits non-zero on fail. The workflow row becomes the check.

Other changes that fall out of this:
- Drops the 3-state verdict. We no longer judge whether docs are sufficient, only whether each user-facing change has a docs/ entry. Reviewers comment on quality in PR comments.
- Drops checks: write permission and the github_token override added in #1979. Neither is needed without the gh api check-run call.
- Swaps Bash(gh api:*) for Write(/tmp/docs-verdict) in allowedTools.

Validated locally with the same set of synthetic and real-PR scenarios used previously. Cannot fully validate the Write(/tmp/docs-verdict) permission in CI before merging due to the action's workflow-validation gate, but if Claude can't write the file the "Apply verdict" step exits with a loud "could not produce a verdict" failure.