### PR TITLE
ci: capture docs-check verdict via --json-schema

### DIFF
--- a/.claude/docs-check-criteria.md
+++ b/.claude/docs-check-criteria.md
@@ -1,8 +1,5 @@
 Decide if this PR's code changes require updates to `docs/`.
 
-Verdicts:
-- `pass`: no user-facing changes, OR every user-facing change has a matching entry in `docs/` (presence only, do not grade quality)
-- `fail`: at least one user-facing change has no corresponding entry in `docs/`
-
-Write the verdict (`pass` or `fail`) to `/tmp/docs-verdict`.
-Print to stdout: a one-sentence reason naming the specific flag, feature, or file.
+Return:
+- `verdict`: `pass` (no user-facing changes, OR every user-facing change has a matching entry in `docs/`) or `fail` (at least one user-facing change has no corresponding entry in `docs/`)
+- `reason`: one sentence naming the specific flag, feature, or file

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -43,6 +43,7 @@ jobs:
             echo "model=$MODEL"
           } >> "$GITHUB_OUTPUT"
       - uses: anthropics/claude-code-action@v1
+        id: claude
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -53,20 +54,23 @@ jobs:
           claude_args: |
             --model ${{ steps.config.outputs.model }}
             --max-turns 15
-            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep,Write(/tmp/docs-verdict)"
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+            --json-schema '{"type":"object","properties":{"verdict":{"enum":["pass","fail"]},"reason":{"type":"string"}},"required":["verdict","reason"]}'
       - name: Apply verdict
         run: |
-          verdict=$(cat /tmp/docs-verdict 2>/dev/null || echo missing)
+          out='${{ steps.claude.outputs.structured_output }}'
+          verdict=$(jq -r .verdict <<< "$out")
+          reason=$(jq -r .reason <<< "$out")
           case "$verdict" in
             pass)
-              echo "::notice::Docs check passed"
+              echo "Docs check passed: $reason"
               ;;
             fail)
-              echo "::error::Docs check failed: user-facing changes missing docs/ entry"
+              echo "::error::$reason"
               exit 1
               ;;
             *)
-              echo "::error::Docs check could not produce a verdict (got: '$verdict')"
+              echo "::error::Could not produce a verdict (got: '$verdict')"
               exit 1
               ;;
           esac


### PR DESCRIPTION
Follow-up to #1984.

The previous design asked Claude to write the verdict to /tmp/docs-verdict with Write(/tmp/docs-verdict) in allowedTools. Empirically that pattern gets denied in claude-code-action's default permission mode regardless of single- or double-slash syntax. Local repro confirmed Claude tries Write and Bash printf>file in the same run and all attempts are refused.

This switches to --json-schema, which constrains Claude's output to {verdict, reason}. The claude-code-action exposes that as steps.claude.outputs.structured_output. No file write happens at all, so no Write permission is needed.

Side benefits:
- Verdict failure message in the PR check now comes from Claude's actual reason text instead of a generic "user-facing changes missing docs/ entry" string.
- Schema enforces a strict pass|fail enum, so a malformed Claude response surfaces as an obvious parse failure rather than a silent wrong answer.
- Removes the prompt-injection concern of granting Write permissions: Claude has Read/Glob/Grep and the gh pr diff/view commands, that is all.

Tested locally with the same scenario set; structured_output reliably populates with the expected JSON.