### PR TITLE
Consistency: use `:vhost` named parameter for `DELETE` vhost-limits route

### DIFF
--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -199,6 +199,17 @@ describe LavinMQ::HTTP::Server do
     end
   end
 
+  describe "DELETE /api/vhost-limits/vhost/type" do
+    it "clears the limit" do
+      with_http_server do |http, s|
+        s.vhosts["/"].max_connections = 100
+        response = http.delete("/api/vhost-limits/%2f/max-connections")
+        response.status_code.should eq 204
+        s.vhosts["/"].max_connections.should be_nil
+      end
+    end
+  end
+
   describe "Pagination" do
     it "should page results" do
       with_http_server do |http, _|

--- a/src/lavinmq/http/controller/vhost-limits.cr
+++ b/src/lavinmq/http/controller/vhost-limits.cr
@@ -40,10 +40,10 @@ module LavinMQ
           context
         end
 
-        delete "/api/vhost-limits/:name/:type" do |context, params|
+        delete "/api/vhost-limits/:vhost/:type" do |context, params|
           context.response.status_code = 400
           refuse_unless_administrator(context, user(context))
-          with_vhost(context, params, vhost_key: "name") do |vhost|
+          with_vhost(context, params) do |vhost|
             case params["type"]
             when "max-connections"
               context.response.status_code = 204


### PR DESCRIPTION
I was looking at out OpenAPI docs, to see what our practices were regarding which endpoints are documented and which aren't and Claude brought this discrepancy to my attention.

The `DELETE` `/api/vhost-limits` route used a `:name` named parameter and compensated with `vhost_key: "name"`, while the sibling `GET` and `PUT` routes use `:vhost`. 

The OpenAPI spec already documented this path as `/vhost-limits/{vhost}/{type}`, so the route was out of step with its own docs; this brings the code in line with the spec.

### WHAT is this pull request doing?

Aligns the placeholder with the OpenAPI documentation and siblong routes and drop the override. Adds a regression spec for the endpoint.

### HOW can this pull request be tested?

Specs
