### PR TITLE
fix: prevent OverflowError in StreamMessageStore#cleanup_consumer_offsets

### DIFF
--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -943,6 +943,44 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
+    it "cleanup_consumer_offsets does not overflow with many consumer offsets" do
+      queue_name = Random::Secure.hex
+      with_amqp_server do |s|
+        StreamSpecHelpers.publish(s, queue_name, 1)
+        data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest queue_name)
+        msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
+
+        # Enough fixed-width entries that the summed size exceeds
+        # Int32::MAX // 1000 (~2.1 MB), which overflowed the old `capacity * 1000`.
+        tag_prefix = "c" * 240
+        entry_size = (tag_prefix.bytesize + 5) + 1 + 8
+        count = Int32::MAX // 1000 // entry_size + 2
+        count.times do |i|
+          msg_store.store_consumer_offset("#{tag_prefix}#{i.to_s.rjust(5, '0')}", i.to_i64)
+        end
+
+        msg_store.cleanup_consumer_offsets # raised OverflowError before the fix
+        msg_store.close
+      end
+    end
+
+    it "ConsumerOffsets.trim_to_size drops the oldest offsets when over the cap" do
+      # {consumer_tag, offset, file_position}; higher position == more recent.
+      # Each entry is 6 + 1 + 8 = 15 bytes.
+      tracked_offsets = [
+        {"oldest", 1_i64, 0_i64},
+        {"middle", 2_i64, 100_i64},
+        {"newest", 3_i64, 200_i64},
+      ]
+      # 30-byte cap fits one entry (`>=` stays strictly below), keeps newest only.
+      kept = LavinMQ::AMQP::ConsumerOffsets.trim_to_size(tracked_offsets, max_size: 30_i64)
+      kept.map(&.first).should eq ["newest"]
+
+      # Larger cap keeps more, oldest-first, still dropping the oldest.
+      kept = LavinMQ::AMQP::ConsumerOffsets.trim_to_size(tracked_offsets, max_size: 45_i64)
+      kept.map(&.first).should eq ["middle", "newest"]
+    end
+
     it "runs cleanup when removing segment" do
       consumer_tag = "ctag-1"
       queue_name = Random::Secure.hex

--- a/src/lavinmq/amqp/stream/consumer_offsets.cr
+++ b/src/lavinmq/amqp/stream/consumer_offsets.cr
@@ -1,0 +1,29 @@
+module LavinMQ::AMQP
+  # Stateless helpers for the consumer-offset entry encoding and size-capping
+  module ConsumerOffsets
+    ENTRY_OVERHEAD = 1 + 8                # ShortString length byte + Int64 offset
+    MAX_ENTRY_SIZE = 255 + ENTRY_OVERHEAD # Largest possible entry: 255-byte tag + Int64
+
+    # Encoded size of one {consumer_tag, offset} entry in the offsets file.
+    def self.entry_size(consumer_tag : String) : Int64
+      (consumer_tag.bytesize + ENTRY_OVERHEAD).to_i64
+    end
+
+    # Drops the oldest (lowest position) offsets until the set fits in
+    # `max_size`. Survivors are returned oldest first so rewriting them keeps
+    # file position reflecting commit recency. Usually drops nothing.
+    def self.trim_to_size(offsets : Array(Tuple(String, Int64, Int64)),
+                          max_size : Int64) : Array(Tuple(String, Int64, Int64))
+      offsets.sort_by! { |_ctag, _offset, pos| pos } # oldest (lowest position) first
+
+      total_size = offsets.sum { |ctag, _offset, _pos| entry_size(ctag) }
+      drop_count = 0
+      # `>=` so the kept set stays strictly below the cap, leaving headroom.
+      while total_size >= max_size
+        total_size -= entry_size(offsets[drop_count][0])
+        drop_count += 1
+      end
+      offsets[drop_count..]
+    end
+  end
+end

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -1,8 +1,13 @@
 require "./stream"
 require "./stream_consumer"
+require "./consumer_offsets"
 
 module LavinMQ::AMQP
   class StreamMessageStore < MessageStore
+    # Size bounds for the compacted consumer_offsets file.
+    MAX_CONSUMER_OFFSETS_FILE_SIZE = 64_i64 * 1024 * 1024 # 64 MiB
+    MIN_CONSUMER_OFFSETS_FILE_SIZE = 8_i64 * 1024         # 8 KiB
+
     getter new_messages = ::Channel(Bool).new
     property max_length : Int64?
     property max_length_bytes : Int64?
@@ -184,38 +189,52 @@ module LavinMQ::AMQP
     def store_consumer_offset(consumer_tag : String, new_offset : Int64)
       raise ClosedError.new if @closed
       cleanup_consumer_offsets if consumer_offset_file_full?(consumer_tag)
+      write_consumer_offset(consumer_tag, new_offset)
+    end
+
+    private def write_consumer_offset(consumer_tag : String, new_offset : Int64)
       start_pos = @consumer_offsets.size
       @consumer_offsets.write_bytes AMQ::Protocol::ShortString.new(consumer_tag)
       @consumer_offset_positions[consumer_tag] = @consumer_offsets.size
       @consumer_offsets.write_bytes new_offset
-      len = 1 + consumer_tag.bytesize + 8
-      @replicator.try &.append(@consumer_offsets.path, start_pos, len)
+      @replicator.try &.append(@consumer_offsets.path, start_pos, ConsumerOffsets.entry_size(consumer_tag))
     end
 
     def consumer_offset_file_full?(consumer_tag)
-      (@consumer_offsets.size + 1 + consumer_tag.bytesize + 8) >= @consumer_offsets.capacity
+      (@consumer_offsets.size + ConsumerOffsets.entry_size(consumer_tag)) >= @consumer_offsets.capacity
     end
 
     def cleanup_consumer_offsets
       return if @consumer_offsets.size.zero?
 
-      offsets_to_save = Hash(String, Int64).new
       lowest_offset_in_stream, _seg, _pos = offset_at(@segments.first_key, 4u32)
-      capacity = 0
-      @consumer_offset_positions.each do |ctag, _pos|
-        if offset = last_offset_by_consumer_tag(ctag)
-          offsets_to_save[ctag] = offset if offset >= lowest_offset_in_stream
-          capacity += ctag.bytesize + 1 + 8
+
+      # Offsets still within the stream (higher position == more recently committed).
+      tracked_offsets = Array(Tuple(String, Int64, Int64)).new
+      @consumer_offset_positions.each do |ctag, pos|
+        if (offset = last_offset_by_consumer_tag(ctag)) && offset >= lowest_offset_in_stream
+          tracked_offsets << {ctag, offset, pos}
         end
       end
-      replace_offsets_file(capacity * 1000, offsets_to_save)
+
+      # Reserve room for one max-length entry so the append that triggered
+      # cleanup always fits in the rewritten file.
+      budget = MAX_CONSUMER_OFFSETS_FILE_SIZE - ConsumerOffsets::MAX_ENTRY_SIZE
+      offsets_to_save = ConsumerOffsets.trim_to_size(tracked_offsets, budget)
+      if (dropped = tracked_offsets.size - offsets_to_save.size) > 0
+        Log.warn { "Consumer offsets file for #{@msg_dir} is full, dropped #{dropped} oldest consumer offset(s)" }
+      end
+      used_bytes = offsets_to_save.sum { |ctag, _offset, _pos| ConsumerOffsets.entry_size(ctag) }
+      # Allocate 1000x the used size as headroom for future appends, bounded by the min/max file size.
+      new_capacity = (used_bytes * 1000).clamp(MIN_CONSUMER_OFFSETS_FILE_SIZE, MAX_CONSUMER_OFFSETS_FILE_SIZE)
+      replace_offsets_file(new_capacity, offsets_to_save)
     end
 
-    private def replace_offsets_file(capacity : Int, offsets_to_save : Hash(String, Int64))
+    private def replace_offsets_file(capacity : Int, offsets_to_save : Array(Tuple(String, Int64, Int64)))
       old_consumer_offsets = @consumer_offsets
       @consumer_offset_positions = Hash(String, Int64).new
       @consumer_offsets = MFile.new("#{old_consumer_offsets.path}.tmp", capacity)
-      offsets_to_save.each do |consumer_tag, offset|
+      offsets_to_save.each do |consumer_tag, offset, _pos|
         @consumer_offsets.write_byte consumer_tag.bytesize.to_u8
         @consumer_offsets.write consumer_tag.to_slice
         @consumer_offset_positions[consumer_tag] = @consumer_offsets.size


### PR DESCRIPTION
Fixes #1953.

On startup, `drop_overflow` calls `cleanup_consumer_offsets`, which computed the rewritten file size as `capacity * 1000` where `capacity` was an `Int32`. When a stream's `consumer_offsets` file is near full (~8 MiB), `capacity * 1000` overflows `Int32::MAX` and raises `OverflowError`, which fails vhost load and prevents the server from starting. The on-disk data is fine; the crash is purely in-memory during metadata setup.

## Changes
- `entry_size` returns `Int64`, so the size math no longer overflows.
- The rewritten file is bounded by `MIN`/`MAX_CONSUMER_OFFSETS_FILE_SIZE` (8 KiB / 64 MiB). When the live set exceeds the max, the oldest (least recently committed) offsets are dropped and a warning is logged.
- Size/encoding helpers (`entry_size`, `trim_to_size`) are extracted into a new `ConsumerOffsets` module so the size-cap logic is unit-testable without a store instance.

## Test plan
- New regression spec stores enough offsets to push the accumulator past `Int32::MAX // 1000` and asserts `cleanup_consumer_offsets` no longer raises.
- New unit spec for `ConsumerOffsets.trim_to_size` covering the drop-oldest behaviour.
- `make test` and `make lint` pass.

---

Pulling the consumer-offset encoding into its own file is a first step: a follow-up PR could move the rest of the consumer-offset handling out of `StreamMessageStore` and into `ConsumerOffsets` - #1998 