### PR TITLE
deps: bump amq-protocol to 1.2.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   amq-protocol:
     git: https://github.com/cloudamqp/amq-protocol.cr.git
-    version: 1.1.22
+    version: 1.2.0
 
   amqp-client:
     git: https://github.com/cloudamqp/amqp-client.cr.git


### PR DESCRIPTION
Updates the `amq-protocol` shard from 1.1.22 to 1.2.0.

Upstream changes: https://github.com/cloudamqp/amq-protocol.cr/pull/37

The new release reduces allocations and speeds up frame encoding/decoding, which shows up as broad throughput gains across the perf suite.

## Benchmark comparison (`lavinmqperf`, publish / consume msgs/s)

| Scenario | main | 1.2.0 | Δ pub |
|---|---|---|---|
| Baseline 1-to-1 (16 B) | 1396791 / 1389730 | 1496046 / 1494469 | +7.1% |
| 1-to-1 with properties | 1088564 / 1084720 | 1243230 / 1239341 | +14.2% |
| Publish only (no consumer) | 2636539 / – | 2738582 / – | +3.9% |
| Consume only (drain prefilled) | – / 2410267 | – / 2570625 | +6.7% |
| Fanout 1→4 queues/consumers | 448499 / 1782270 | 449202 / 1798580 | +0.2% |
| Large messages (100 KB) | 8999 / 8995 | 8715 / 8714 | -3.2% |
| Prefetch 1000, ack every 100 | 2227701 / 111138 | 2322581 / 120604 | +4.3% |
| Publish confirm (max 1000) | 114636 / 114608 | 124050 / 124039 | +8.2% |
| Publish in tx (commit /100) | 28466 / 28396 | 31958 / 31878 | +12.3% |
| Ack in tx (prefetch 100) | 1737173 / 910 | 2133466 / 870 | +22.8% |
| Stream 1-to-1 (offset=first) | 2179423 / 101253 | 2346168 / 91380 | +7.6% |
| Stream + properties | 1643664 / 137810 | 1972754 / 132826 | +20.0% |
| Fan-in 64 pub, 1 cons | 2376337 / 265338 | 2480833 / 303744 | +4.4% |
| Competing 1 pub, 64 cons | 1108507 / 1102617 | 1129135 / 1121566 | +1.9% |
| Symmetric 64 pub, 64 cons | 1665788 / 1289176 | 1726817 / 1319586 | +3.7% |
| Sharded 64 pub, 64 cons, 64 q | 1558410 / 1160901 | 1636278 / 1199593 | +5.0% |
| Stream multi-consumer 1→64 | 252046 / 1518168 | 424082 / 1734293 | +68.3% |

### Churn benchmarks (ops/s, fastest of pair)

| Benchmark | main | 1.2.0 |
|---|---|---|
| open-close connection+channel | 5.52k | 5.56k |
| create/delete transient queue | 1.09k | 1.29k |
| bind non-durable queue | 91.59k | 99.13k |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
