### PR TITLE
Fix MQTT perf packet ID overflow

### DIFF
--- a/spec/lavinmqperf_spec.cr
+++ b/spec/lavinmqperf_spec.cr
@@ -150,6 +150,15 @@ describe "LavinMQPerf" do
   end
 
   describe "MQTT::Throughput" do
+    it "wraps packet ids without overflowing" do
+      generator = LavinMQPerf::MQTT::Throughput::PacketIdGenerator.new
+
+      (UInt16::MAX - 1).times { generator.next }
+
+      generator.next.should eq(UInt16::MAX)
+      generator.next.should eq(1_u16)
+    end
+
     it "should accept IO parameter" do
       io = IO::Memory.new
       throughput = LavinMQPerf::MQTT::Throughput.new(io)

--- a/spec/lavinmqperf_spec.cr
+++ b/spec/lavinmqperf_spec.cr
@@ -150,15 +150,6 @@ describe "LavinMQPerf" do
   end
 
   describe "MQTT::Throughput" do
-    it "wraps packet ids without overflowing" do
-      generator = LavinMQPerf::MQTT::Throughput::PacketIdGenerator.new
-
-      (UInt16::MAX - 1).times { generator.next }
-
-      generator.next.should eq(UInt16::MAX)
-      generator.next.should eq(1_u16)
-    end
-
     it "should accept IO parameter" do
       io = IO::Memory.new
       throughput = LavinMQPerf::MQTT::Throughput.new(io)

--- a/src/lavinmqperf/mqtt/throughput.cr
+++ b/src/lavinmqperf/mqtt/throughput.cr
@@ -8,16 +8,6 @@ require "openssl"
 module LavinMQPerf
   module MQTT
     class Throughput < Perf
-      class PacketIdGenerator
-        @next = 1_u16
-
-        def next : UInt16
-          id = @next
-          @next = id == UInt16::MAX ? 1_u16 : id + 1_u16
-          id
-        end
-      end
-
       @publishers = 1
       @consumers = 1
       @size = 16
@@ -243,11 +233,11 @@ module LavinMQPerf
 
         start = Time.instant
         pubs_this_second = 0
-        packet_id_generator = PacketIdGenerator.new
+        packet_id_generator = (1_u16..UInt16::MAX).cycle
         wait_until_all_are_connected(connected)
         until @stopped
           @random.random_bytes(data) if @random_bodies
-          packet_id = @qos > 0 ? packet_id_generator.next : nil
+          packet_id = @qos > 0 ? packet_id_generator.next.as(UInt16) : nil
 
           publish = LavinMQ::MQTT::Publish.new(
             topic: @topic,

--- a/src/lavinmqperf/mqtt/throughput.cr
+++ b/src/lavinmqperf/mqtt/throughput.cr
@@ -8,6 +8,16 @@ require "openssl"
 module LavinMQPerf
   module MQTT
     class Throughput < Perf
+      class PacketIdGenerator
+        @next = 1_u16
+
+        def next : UInt16
+          id = @next
+          @next = id == UInt16::MAX ? 1_u16 : id + 1_u16
+          id
+        end
+      end
+
       @publishers = 1
       @consumers = 1
       @size = 16
@@ -233,11 +243,11 @@ module LavinMQPerf
 
         start = Time.instant
         pubs_this_second = 0
-        packet_id_generator = (1_u16..).each
+        packet_id_generator = PacketIdGenerator.new
         wait_until_all_are_connected(connected)
         until @stopped
           @random.random_bytes(data) if @random_bodies
-          packet_id = @qos > 0 ? packet_id_generator.next.as(UInt16) : nil
+          packet_id = @qos > 0 ? packet_id_generator.next : nil
 
           publish = LavinMQ::MQTT::Publish.new(
             topic: @topic,


### PR DESCRIPTION
## What

Fixes #1942.

`lavinmqperf mqtt throughput --qos=1` could eventually log `Arithmetic overflow` and reconnect the publisher.

The MQTT publisher generated packet IDs from an unbounded `UInt16` range. After packet ID `65535`, Crystal raised on overflow instead of wrapping. MQTT packet IDs are valid in the range `1..65535`, so after `65535` the publisher should wrap back to `1`.

This adds a small packet ID generator for the MQTT throughput publisher that wraps from `65535` to `1`, plus a regression spec for the wraparound case.

## Testing

- `crystal tool format --check src/lavinmqperf/mqtt/throughput.cr spec/lavinmqperf_spec.cr`
- `crystal spec spec/lavinmqperf_spec.cr:156 -Dpreview_mt -Dexecution_context`
- `make bin/lavinmqperf`
- Manual QoS 1 throughput run against a local broker