### PR TITLE
refactor: extract consumer offset state into ConsumerOffsets class

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -855,13 +855,13 @@ describe LavinMQ::Clustering::Client, tags: %w[etcd slow] do
         end
 
         store = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Queue).@msg_store.as(LavinMQ::AMQP::StreamMessageStore)
-        offsets_path = store.@consumer_offsets.path
+        offsets_path = store.@consumer_offsets.@mfile.path
         follower_offsets_path = File.join(cluster.follower_config.data_dir, offsets_path[(s.data_dir.size + 1)..])
 
         # Fill consumer_offsets past its capacity to trigger compaction. Before
         # #2068's fix the first compaction raised ArgumentError because the
         # rebuilt .tmp MFile was never replication-registered.
-        cap = store.@consumer_offsets.capacity
+        cap = store.@consumer_offsets.@mfile.capacity
         entry = 1 + ctag.bytesize + 8
         ((cap // entry) + 10).times do |i|
           store.store_consumer_offset(ctag, i.to_i64 + 1)
@@ -874,7 +874,7 @@ describe LavinMQ::Clustering::Client, tags: %w[etcd slow] do
         store.last_offset_by_consumer_tag(ctag).should eq 9999_i64
 
         wait_for { cluster.replicator.followers.first?.try &.lag_in_bytes == 0 }
-        expected = store.@consumer_offsets.to_slice.dup
+        expected = store.@consumer_offsets.@mfile.to_slice.dup
       end
 
       # The follower received the compacted file verbatim — its real data

--- a/src/lavinmq/amqp/stream/consumer_offsets.cr
+++ b/src/lavinmq/amqp/stream/consumer_offsets.cr
@@ -1,8 +1,133 @@
+require "amq-protocol"
+require "../../mfile"
+require "../../clustering/replicator"
+
 module LavinMQ::AMQP
-  # Stateless helpers for the consumer-offset entry encoding and size-capping
-  module ConsumerOffsets
+  # Owns a stream's `consumer_offsets` file: an append-only log of
+  # {consumer_tag, offset} entries used to resume consumers where they left
+  # off. The file is compacted (via `cleanup`) to drop offsets that have fallen
+  # out of the stream and to keep the file size bounded.
+  class ConsumerOffsets
+    Log = LavinMQ::Log.for "consumer_offsets"
+
     ENTRY_OVERHEAD = 1 + 8                # ShortString length byte + Int64 offset
     MAX_ENTRY_SIZE = 255 + ENTRY_OVERHEAD # Largest possible entry: 255-byte tag + Int64
+
+    # Size bounds for the compacted consumer_offsets file.
+    MAX_FILE_SIZE = 64_i64 * 1024 * 1024 # 64 MiB
+    MIN_FILE_SIZE = 8_i64 * 1024         # 8 KiB
+
+    @mfile : MFile
+    @positions = Hash(String, Int64).new # consumer_tag => file position of its offset
+
+    def initialize(dir : String, capacity : Int, @replicator : Clustering::Replicator?)
+      @mfile = MFile.new(File.join(dir, "consumer_offsets"), capacity)
+      @replicator.try &.register_file @mfile
+      restore_positions
+    end
+
+    # Current size of the offsets file on disk.
+    def size
+      @mfile.size
+    end
+
+    def close : Nil
+      @mfile.close
+    end
+
+    def delete : Nil
+      @mfile.delete(raise_on_missing: false)
+      @replicator.try &.delete_file(@mfile.path)
+      @mfile.close
+    end
+
+    def last_offset_by_tag(consumer_tag)
+      if pos = @positions[consumer_tag]?
+        tx = @mfile.to_slice(pos, 8)
+        return IO::ByteFormat::LittleEndian.decode(Int64, tx)
+      end
+    end
+
+    # Appends `new_offset` for `consumer_tag`. Compacts the file first if the
+    # append wouldn't fit; the block yields the lowest offset still in the
+    # stream so stale offsets can be dropped during compaction.
+    def store(consumer_tag : String, new_offset : Int64, & : -> Int64)
+      cleanup { yield } if full?(consumer_tag)
+      write(consumer_tag, new_offset)
+    end
+
+    # Compacts the file, dropping offsets that are no longer in the stream and
+    # capping the file size. The block yields the lowest offset still in the
+    # stream; it is only evaluated when there is something to compact.
+    def cleanup(& : -> Int64)
+      return if @mfile.size.zero?
+
+      lowest_offset_in_stream = yield
+
+      # Offsets still within the stream (higher position == more recently committed).
+      tracked_offsets = Array(Tuple(String, Int64, Int64)).new
+      @positions.each do |ctag, pos|
+        if (offset = last_offset_by_tag(ctag)) && offset >= lowest_offset_in_stream
+          tracked_offsets << {ctag, offset, pos}
+        end
+      end
+
+      # Reserve room for one max-length entry so the append that triggered
+      # cleanup always fits in the rewritten file.
+      budget = MAX_FILE_SIZE - MAX_ENTRY_SIZE
+      offsets_to_save = ConsumerOffsets.trim_to_size(tracked_offsets, budget)
+      if (dropped = tracked_offsets.size - offsets_to_save.size) > 0
+        Log.warn { "Consumer offsets file #{@mfile.path} is full, dropped #{dropped} oldest consumer offset(s)" }
+      end
+      used_bytes = offsets_to_save.sum { |ctag, _offset, _pos| ConsumerOffsets.entry_size(ctag) }
+      # Allocate 1000x the used size as headroom for future appends, bounded by the min/max file size.
+      new_capacity = (used_bytes * 1000).clamp(MIN_FILE_SIZE, MAX_FILE_SIZE)
+      replace_file(new_capacity, offsets_to_save)
+    end
+
+    private def write(consumer_tag : String, new_offset : Int64)
+      start_pos = @mfile.size
+      @mfile.write_bytes AMQ::Protocol::ShortString.new(consumer_tag)
+      @positions[consumer_tag] = @mfile.size
+      @mfile.write_bytes new_offset
+      @replicator.try &.append(@mfile.path, start_pos, ConsumerOffsets.entry_size(consumer_tag))
+    end
+
+    private def full?(consumer_tag)
+      (@mfile.size + ConsumerOffsets.entry_size(consumer_tag)) >= @mfile.capacity
+    end
+
+    private def replace_file(capacity : Int, offsets_to_save : Array(Tuple(String, Int64, Int64)))
+      old_mfile = @mfile
+      @positions = Hash(String, Int64).new
+      @mfile = MFile.new("#{old_mfile.path}.tmp", capacity)
+      # Write entries directly rather than via `write`, which would replicate
+      # each append against the not-yet-registered .tmp file (the #2068 crash).
+      offsets_to_save.each do |consumer_tag, offset, _pos|
+        @mfile.write_byte consumer_tag.bytesize.to_u8
+        @mfile.write consumer_tag.to_slice
+        @positions[consumer_tag] = @mfile.size
+        @mfile.write_bytes offset
+      end
+      @mfile.rename(old_mfile.path)
+      @replicator.try &.replace_file(@mfile) # ship the compacted file whole; keeps the MFile registered
+      old_mfile.close(truncate_to_size: false)
+    end
+
+    private def restore_positions : Nil
+      return if @mfile.size.zero?
+
+      loop do
+        ctag = AMQ::Protocol::ShortString.from_io(@mfile)
+        break if ctag.empty?
+        @positions[ctag] = @mfile.pos
+        @mfile.skip(8)
+      rescue IO::EOFError
+        break
+      end
+      @mfile.pos = 0 if @mfile.pos == 1
+      @mfile.resize(@mfile.pos)
+    end
 
     # Encoded size of one {consumer_tag, offset} entry in the offsets file.
     def self.entry_size(consumer_tag : String) : Int64

--- a/src/lavinmq/amqp/stream/consumer_offsets.cr
+++ b/src/lavinmq/amqp/stream/consumer_offsets.cr
@@ -44,7 +44,7 @@ module LavinMQ::AMQP
     def last_offset_by_tag(consumer_tag)
       if pos = @positions[consumer_tag]?
         tx = @mfile.to_slice(pos, 8)
-        return IO::ByteFormat::LittleEndian.decode(Int64, tx)
+        IO::ByteFormat::LittleEndian.decode(Int64, tx)
       end
     end
 

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -4,10 +4,6 @@ require "./consumer_offsets"
 
 module LavinMQ::AMQP
   class StreamMessageStore < MessageStore
-    # Size bounds for the compacted consumer_offsets file.
-    MAX_CONSUMER_OFFSETS_FILE_SIZE = 64_i64 * 1024 * 1024 # 64 MiB
-    MIN_CONSUMER_OFFSETS_FILE_SIZE = 8_i64 * 1024         # 8 KiB
-
     getter new_messages = ::Channel(Bool).new
     property max_length : Int64?
     property max_length_bytes : Int64?
@@ -16,15 +12,12 @@ module LavinMQ::AMQP
     @segment_last_ts = Hash(UInt32, Int64).new(0i64) # used for max-age
     @segment_first_offset = Hash(UInt32, Int64).new  # segment_id => offset of first msg
     @segment_first_ts = Hash(UInt32, Int64).new      # segment_id => ts of first msg
-    @consumer_offsets : MFile
-    @consumer_offset_positions = Hash(String, Int64).new # used for consumer offsets
+    @consumer_offsets : ConsumerOffsets
 
     def initialize(*args, **kwargs)
       super
       @last_offset = get_last_offset
-      @consumer_offsets = MFile.new(File.join(@msg_dir, "consumer_offsets"), Config.instance.segment_size)
-      @replicator.try &.register_file @consumer_offsets
-      @consumer_offset_positions = restore_consumer_offset_positions
+      @consumer_offsets = ConsumerOffsets.new(@msg_dir, Config.instance.segment_size, @replicator)
       drop_overflow
     end
 
@@ -35,7 +28,7 @@ module LavinMQ::AMQP
 
     def delete
       super
-      delete_file(@consumer_offsets)
+      @consumer_offsets.delete
     end
 
     private def get_last_offset : Int64
@@ -163,86 +156,22 @@ module LavinMQ::AMQP
     end
 
     def last_offset_by_consumer_tag(consumer_tag)
-      if pos = @consumer_offset_positions[consumer_tag]?
-        tx = @consumer_offsets.to_slice(pos, 8)
-        IO::ByteFormat::LittleEndian.decode(Int64, tx)
-      end
-    end
-
-    private def restore_consumer_offset_positions : Hash(String, Int64)
-      positions = Hash(String, Int64).new
-      return positions if @consumer_offsets.size.zero?
-
-      loop do
-        ctag = AMQ::Protocol::ShortString.from_io(@consumer_offsets)
-        break if ctag.empty?
-        positions[ctag] = @consumer_offsets.pos
-        @consumer_offsets.skip(8)
-      rescue IO::EOFError
-        break
-      end
-      @consumer_offsets.pos = 0 if @consumer_offsets.pos == 1
-      @consumer_offsets.resize(@consumer_offsets.pos)
-      positions
+      @consumer_offsets.last_offset_by_tag(consumer_tag)
     end
 
     def store_consumer_offset(consumer_tag : String, new_offset : Int64)
       raise ClosedError.new if @closed
-      cleanup_consumer_offsets if consumer_offset_file_full?(consumer_tag)
-      write_consumer_offset(consumer_tag, new_offset)
-    end
-
-    private def write_consumer_offset(consumer_tag : String, new_offset : Int64)
-      start_pos = @consumer_offsets.size
-      @consumer_offsets.write_bytes AMQ::Protocol::ShortString.new(consumer_tag)
-      @consumer_offset_positions[consumer_tag] = @consumer_offsets.size
-      @consumer_offsets.write_bytes new_offset
-      @replicator.try &.append(@consumer_offsets.path, start_pos, ConsumerOffsets.entry_size(consumer_tag))
-    end
-
-    def consumer_offset_file_full?(consumer_tag)
-      (@consumer_offsets.size + ConsumerOffsets.entry_size(consumer_tag)) >= @consumer_offsets.capacity
+      @consumer_offsets.store(consumer_tag, new_offset) { lowest_offset_in_stream }
     end
 
     def cleanup_consumer_offsets
-      return if @consumer_offsets.size.zero?
-
-      lowest_offset_in_stream, _seg, _pos = offset_at(@segments.first_key, 4u32)
-
-      # Offsets still within the stream (higher position == more recently committed).
-      tracked_offsets = Array(Tuple(String, Int64, Int64)).new
-      @consumer_offset_positions.each do |ctag, pos|
-        if (offset = last_offset_by_consumer_tag(ctag)) && offset >= lowest_offset_in_stream
-          tracked_offsets << {ctag, offset, pos}
-        end
-      end
-
-      # Reserve room for one max-length entry so the append that triggered
-      # cleanup always fits in the rewritten file.
-      budget = MAX_CONSUMER_OFFSETS_FILE_SIZE - ConsumerOffsets::MAX_ENTRY_SIZE
-      offsets_to_save = ConsumerOffsets.trim_to_size(tracked_offsets, budget)
-      if (dropped = tracked_offsets.size - offsets_to_save.size) > 0
-        Log.warn { "Consumer offsets file for #{@msg_dir} is full, dropped #{dropped} oldest consumer offset(s)" }
-      end
-      used_bytes = offsets_to_save.sum { |ctag, _offset, _pos| ConsumerOffsets.entry_size(ctag) }
-      # Allocate 1000x the used size as headroom for future appends, bounded by the min/max file size.
-      new_capacity = (used_bytes * 1000).clamp(MIN_CONSUMER_OFFSETS_FILE_SIZE, MAX_CONSUMER_OFFSETS_FILE_SIZE)
-      replace_offsets_file(new_capacity, offsets_to_save)
+      @consumer_offsets.cleanup { lowest_offset_in_stream }
     end
 
-    private def replace_offsets_file(capacity : Int, offsets_to_save : Array(Tuple(String, Int64, Int64)))
-      old_consumer_offsets = @consumer_offsets
-      @consumer_offset_positions = Hash(String, Int64).new
-      @consumer_offsets = MFile.new("#{old_consumer_offsets.path}.tmp", capacity)
-      offsets_to_save.each do |consumer_tag, offset, _pos|
-        @consumer_offsets.write_byte consumer_tag.bytesize.to_u8
-        @consumer_offsets.write consumer_tag.to_slice
-        @consumer_offset_positions[consumer_tag] = @consumer_offsets.size
-        @consumer_offsets.write_bytes offset
-      end
-      @consumer_offsets.rename(old_consumer_offsets.path)
-      @replicator.try &.replace_file(@consumer_offsets)
-      old_consumer_offsets.close(truncate_to_size: false)
+    # Lowest offset still retained in the stream, used to discard consumer
+    # offsets that have fallen out of the stream during cleanup.
+    private def lowest_offset_in_stream : Int64
+      offset_at(@segments.first_key, 4u32).first
     end
 
     def read(segment : UInt32, position : UInt32) : Envelope?


### PR DESCRIPTION
Stacked on #1995.

Extracts the remaining consumer-offset state and behaviour out of `StreamMessageStore` into the `ConsumerOffsets` class (which #1995 introduced as a stateless helper module).

The class now owns the `consumer_offsets` MFile, its position index, and replication. `StreamMessageStore` keeps thin delegators (`store_consumer_offset`, `last_offset_by_consumer_tag`, `cleanup_consumer_offsets`) and supplies the stream's lowest live offset via a block, so the offsets file knows nothing about segments.

The block is only evaluated when there's something to compact (file non-empty + append wouldn't fit), keeping `store_consumer_offset` allocation-free on the hot path and avoiding an `offset_at` call / MFile position mutation on every commit.

No behaviour change. The warning log source moves from `lmq.message_store` to `lmq.consumer_offsets`.

## Test plan
- `make test SPEC=spec/stream_queue_spec.cr` (40 examples, all consumer-offset specs unchanged and green)
- `make lint`