### PR TITLE
Add cross-region disaster recovery via cascading replication

### DIFF
--- a/spec/api/cluster_spec.cr
+++ b/spec/api/cluster_spec.cr
@@ -1,0 +1,62 @@
+require "../spec_helper"
+
+DR_SPEC_PREFIX = "drspec"
+
+private def enable_dr_clustering
+  LavinMQ::Config.instance.clustering = true
+  LavinMQ::Config.instance.clustering_etcd_endpoints = "localhost:12379"
+  LavinMQ::Config.instance.clustering_etcd_prefix = DR_SPEC_PREFIX
+end
+
+# DR promotion/demotion front door: the /api/cluster/dr endpoint drives the
+# region's {prefix}/upstream_etcd key so failover doesn't need etcdctl surgery.
+describe LavinMQ::HTTP::ClusterController, tags: "etcd" do
+  add_etcd_around_each
+
+  it "promotes, demotes and reverts a region via /api/cluster/dr" do
+    with_http_server do |http, _|
+      enable_dr_clustering
+      etcd = LavinMQ::Etcd.new("localhost:12379")
+      etcd.del("#{DR_SPEC_PREFIX}/upstream_etcd")
+
+      # Promote: set the "primary" sentinel.
+      resp = http.put("/api/cluster/dr", body: {upstream_etcd: "primary"}.to_json)
+      resp.status_code.should eq 204
+      etcd.get("#{DR_SPEC_PREFIX}/upstream_etcd").should eq "primary"
+
+      body = JSON.parse(http.get("/api/cluster/dr").body)
+      body["primary"].as_bool.should be_true
+      body["effective_upstream"].as_s.should eq ""
+
+      # Demote: set foreign etcd endpoints.
+      resp = http.put("/api/cluster/dr", body: {upstream_etcd: "etcd-a:2379"}.to_json)
+      resp.status_code.should eq 204
+      etcd.get("#{DR_SPEC_PREFIX}/upstream_etcd").should eq "etcd-a:2379"
+
+      body = JSON.parse(http.get("/api/cluster/dr").body)
+      body["primary"].as_bool.should be_false
+      body["effective_upstream"].as_s.should eq "etcd-a:2379"
+
+      # Revert to the config fallback (empty -> primary).
+      resp = http.delete("/api/cluster/dr")
+      resp.status_code.should eq 204
+      etcd.get("#{DR_SPEC_PREFIX}/upstream_etcd").should be_nil
+      JSON.parse(http.get("/api/cluster/dr").body)["primary"].as_bool.should be_true
+    end
+  end
+
+  it "rejects a PUT body without upstream_etcd" do
+    with_http_server do |http, _|
+      enable_dr_clustering
+      resp = http.put("/api/cluster/dr", body: {foo: "bar"}.to_json)
+      resp.status_code.should eq 400
+    end
+  end
+
+  it "returns 409 when clustering is not enabled" do
+    with_http_server do |http, _|
+      resp = http.get("/api/cluster/dr")
+      resp.status_code.should eq 409
+    end
+  end
+end

--- a/spec/api/relay_http_spec.cr
+++ b/spec/api/relay_http_spec.cr
@@ -1,11 +1,14 @@
 require "../spec_helper"
 
-# The barebones HTTP API a DR relay serves instead of the full management API:
-# follower Prometheus metrics, a readiness /health, and the DR control routes.
+# The barebones HTTP API a DR relay serves on its externally bound management
+# port instead of the full management API: only unauthenticated, read-only
+# endpoints — follower Prometheus metrics and a readiness /health. The DR
+# control routes are deliberately NOT exposed here (they mutate cluster state
+# and this port has no auth); they live on the local internal unix socket.
 describe "LavinMQ::HTTP::Server.relay_api", tags: "etcd" do
   add_etcd_around_each
 
-  it "serves /health (readiness), /metrics and /api/cluster/dr" do
+  it "serves /health (readiness) and /metrics" do
     LavinMQ::Config.instance.clustering = true
     LavinMQ::Config.instance.clustering_etcd_endpoints = "localhost:12379"
     LavinMQ::Config.instance.clustering_etcd_prefix = "relayhttpspec"
@@ -29,14 +32,60 @@ describe "LavinMQ::HTTP::Server.relay_api", tags: "etcd" do
     resp.status_code.should eq 200
     resp.body.should contain "lavinmq"
 
-    # /api/cluster/dr is served locally (DR control during failover)
-    resp = HTTP::Client.get("#{base}/api/cluster/dr")
-    resp.status_code.should eq 200
-    JSON.parse(resp.body)["primary"]?.should_not be_nil
+    # DR control is NOT reachable on the unauthenticated TCP API: a client that
+    # can reach this port must not be able to promote/demote the region.
+    HTTP::Client.get("#{base}/api/cluster/dr").status_code.should eq 404
+    HTTP::Client.put("#{base}/api/cluster/dr",
+      body: {upstream_etcd: "primary"}.to_json).status_code.should eq 404
+    HTTP::Client.delete("#{base}/api/cluster/dr").status_code.should eq 404
 
     # unknown paths -> 404 (no full management API)
     HTTP::Client.get("#{base}/api/queues").status_code.should eq 404
   ensure
     server.try &.close
+  end
+end
+
+# The DR control routes (promote/demote) are served on a local unix socket
+# (filesystem-permission gated) instead of the unauthenticated TCP API.
+describe "LavinMQ::HTTP::FollowerDRHandler over a unix socket", tags: "etcd" do
+  add_etcd_around_each
+
+  it "serves /api/cluster/dr (GET/PUT/DELETE) on a unix socket" do
+    LavinMQ::Config.instance.clustering = true
+    LavinMQ::Config.instance.clustering_etcd_endpoints = "localhost:12379"
+    LavinMQ::Config.instance.clustering_etcd_prefix = "relaysockspec"
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    etcd.del("relaysockspec/upstream_etcd")
+
+    sock_path = File.tempname("lavinmqctl", ".sock")
+    server = ::HTTP::Server.new([LavinMQ::HTTP::FollowerDRHandler.new] of ::HTTP::Handler) do |context|
+      context.response.status_code = 503
+    end
+    server.bind_unix(sock_path)
+    spawn(name: "dr sock spec listen") { server.listen }
+    Fiber.yield
+
+    client = -> { HTTP::Client.new(UNIXSocket.new(sock_path)) }
+
+    # Promote via PUT, read it back via GET, revert via DELETE.
+    resp = client.call.put("/api/cluster/dr", body: {upstream_etcd: "primary"}.to_json)
+    resp.status_code.should eq 204
+    etcd.get("relaysockspec/upstream_etcd").should eq "primary"
+
+    body = JSON.parse(client.call.get("/api/cluster/dr").body)
+    body["primary"].as_bool.should be_true
+
+    client.call.delete("/api/cluster/dr").status_code.should eq 204
+    etcd.get("relaysockspec/upstream_etcd").should be_nil
+
+    # A PUT without upstream_etcd is rejected.
+    client.call.put("/api/cluster/dr", body: {foo: "bar"}.to_json).status_code.should eq 400
+
+    # Non-DR paths fall through to the 503 follower fallback.
+    client.call.get("/api/queues").status_code.should eq 503
+  ensure
+    server.try &.close
+    File.delete?(sock_path) if sock_path
   end
 end

--- a/spec/api/relay_http_spec.cr
+++ b/spec/api/relay_http_spec.cr
@@ -1,0 +1,42 @@
+require "../spec_helper"
+
+# The barebones HTTP API a DR relay serves instead of the full management API:
+# follower Prometheus metrics, a readiness /health, and the DR control routes.
+describe "LavinMQ::HTTP::Server.relay_api", tags: "etcd" do
+  add_etcd_around_each
+
+  it "serves /health (readiness), /metrics and /api/cluster/dr" do
+    LavinMQ::Config.instance.clustering = true
+    LavinMQ::Config.instance.clustering_etcd_endpoints = "localhost:12379"
+    LavinMQ::Config.instance.clustering_etcd_prefix = "relayhttpspec"
+
+    ready = false
+    server = LavinMQ::HTTP::Server.relay_api(-> { ready })
+    addr = server.bind_tcp("127.0.0.1", 0)
+    spawn(name: "relay api spec listen") { server.listen }
+    Fiber.yield
+    base = "http://#{addr}"
+
+    # /health reflects readiness
+    HTTP::Client.get("#{base}/health").status_code.should eq 503
+    ready = true
+    resp = HTTP::Client.get("#{base}/health")
+    resp.status_code.should eq 200
+    resp.body.should contain "ok"
+
+    # /metrics returns follower Prometheus metrics
+    resp = HTTP::Client.get("#{base}/metrics")
+    resp.status_code.should eq 200
+    resp.body.should contain "lavinmq"
+
+    # /api/cluster/dr is served locally (DR control during failover)
+    resp = HTTP::Client.get("#{base}/api/cluster/dr")
+    resp.status_code.should eq 200
+    JSON.parse(resp.body)["primary"]?.should_not be_nil
+
+    # unknown paths -> 404 (no full management API)
+    HTTP::Client.get("#{base}/api/queues").status_code.should eq 404
+  ensure
+    server.try &.close
+  end
+end

--- a/spec/clustering/dr_role_spec.cr
+++ b/spec/clustering/dr_role_spec.cr
@@ -1,0 +1,51 @@
+require "../spec_helper"
+require "../../src/lavinmq/clustering/controller"
+
+# The region's role (primary vs DR follower) is implied by the
+# {prefix}/upstream_etcd key in its own etcd, with the config option as a
+# fallback. Clearing the key promotes a region to primary; setting it to a
+# foreign region's etcd makes it a DR follower of that region.
+describe LavinMQ::Clustering::Controller, tags: "etcd" do
+  add_etcd_around_each
+
+  describe "#effective_upstream" do
+    it "is empty (primary) when neither the key nor the fallback is set" do
+      with_datadir do |data_dir|
+        config = LavinMQ::Config.instance.dup
+        config.data_dir = data_dir
+        config.clustering_etcd_prefix = "regionB"
+        controller = LavinMQ::Clustering::Controller.new(config, LavinMQ::Etcd.new("localhost:12379"))
+        controller.effective_upstream.should eq ""
+      end
+    end
+
+    it "falls back to the config option when the key is absent" do
+      with_datadir do |data_dir|
+        config = LavinMQ::Config.instance.dup
+        config.data_dir = data_dir
+        config.clustering_etcd_prefix = "regionB"
+        config.clustering_upstream_etcd_endpoints = "etcd-a1:2379,etcd-a2:2379"
+        controller = LavinMQ::Clustering::Controller.new(config, LavinMQ::Etcd.new("localhost:12379"))
+        controller.effective_upstream.should eq "etcd-a1:2379,etcd-a2:2379"
+      end
+    end
+
+    it "uses the etcd key (DR mode) and lets it override the fallback" do
+      with_datadir do |data_dir|
+        etcd = LavinMQ::Etcd.new("localhost:12379")
+        config = LavinMQ::Config.instance.dup
+        config.data_dir = data_dir
+        config.clustering_etcd_prefix = "regionB"
+        config.clustering_upstream_etcd_endpoints = "from-config:2379"
+        controller = LavinMQ::Clustering::Controller.new(config, etcd)
+
+        etcd.put("regionB/upstream_etcd", "etcd-a1:2379")
+        controller.effective_upstream.should eq "etcd-a1:2379"
+
+        # The "primary" sentinel (failover/promotion) overrides the fallback
+        etcd.put("regionB/upstream_etcd", LavinMQ::Clustering::Controller::UPSTREAM_PRIMARY)
+        controller.effective_upstream.should eq ""
+      end
+    end
+  end
+end

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -365,6 +365,9 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     flipped = Channel(Nil).new(1)
     # The real callback gracefully stops and exits 38; the spec just records it.
     controller.on_role_change = -> { flipped.try_send?(nil); nil }
+    # The real callback starts the relay's reject listeners + barebones HTTP API.
+    relay_started = Channel(Nil).new(1)
+    controller.on_relay_start = -> { relay_started.try_send?(nil); nil }
 
     spawn(name: "role change controller spec") do
       controller.run { }
@@ -375,6 +378,14 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     # watch_upstream has already captured dr_now = true (key unset -> config
     # fallback). Only then flip to primary.
     wait_for { relay_server.relay_mode? }
+
+    # Entering relay mode invokes on_relay_start (where the launcher starts the
+    # relay's barebones services).
+    select
+    when relay_started.receive
+    when timeout(5.seconds)
+      fail "on_relay_start was not invoked when entering relay mode"
+    end
 
     # Flip the role to primary. Re-put so we don't race watch_upstream's etcd
     # watch stream being established (it only delivers changes after it starts).

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -335,4 +335,63 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     FileUtils.rm_rf relay_dir if relay_dir
     FileUtils.rm_rf downstream_dir if downstream_dir
   end
+
+  # A role flip (here: relay -> primary, by setting upstream_etcd to the
+  # "primary" sentinel) invokes the on_role_change callback the Launcher
+  # installs to gracefully restart, rather than an abrupt exit 38.
+  it "invokes on_role_change when the region's role flips" do
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    base = LavinMQ::Config.instance.dup
+    base.metrics_http_port = -1
+
+    relay_dir = File.tempname("lavinmq", "relay")
+    Dir.mkdir_p relay_dir
+
+    relay_port = TCPServer.open("localhost", 0, &.local_address.port)
+    config = base.dup
+    config.data_dir = relay_dir
+    config.clustering_etcd_prefix = "regionB"
+    config.clustering_upstream_etcd_endpoints = "localhost:12379" # makes this a DR follower
+    config.clustering_upstream_etcd_prefix = "regionA"
+    config.clustering_bind = "localhost"
+    config.clustering_port = relay_port
+    config.clustering_advertised_uri = "tcp://localhost:#{relay_port}"
+
+    etcd.del("regionB/upstream_etcd")
+    controller = LavinMQ::Clustering::Controller.new(config, etcd)
+    relay_server = LavinMQ::Clustering::Server.new(config, LavinMQ::Clustering::EtcdCoordinator.new(config, etcd), controller.id)
+    controller.replicator = relay_server
+
+    flipped = Channel(Nil).new(1)
+    # The real callback gracefully stops and exits 38; the spec just records it.
+    controller.on_role_change = -> { flipped.try_send?(nil); nil }
+
+    spawn(name: "role change controller spec") do
+      controller.run { }
+    rescue SpecExit
+    end
+
+    # Wait until the controller has won its election and entered relay mode, so
+    # watch_upstream has already captured dr_now = true (key unset -> config
+    # fallback). Only then flip to primary.
+    wait_for { relay_server.relay_mode? }
+
+    # Flip the role to primary. Re-put so we don't race watch_upstream's etcd
+    # watch stream being established (it only delivers changes after it starts).
+    got = false
+    20.times do
+      etcd.put("regionB/upstream_etcd", LavinMQ::Clustering::Controller::UPSTREAM_PRIMARY)
+      select
+      when flipped.receive
+        got = true
+      when timeout(0.5.seconds)
+      end
+      break if got
+    end
+    got.should be_true
+  ensure
+    controller.try &.stop
+    relay_server.try &.close
+    FileUtils.rm_rf relay_dir if relay_dir
+  end
 end

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -1,0 +1,92 @@
+require "../spec_helper"
+require "../../src/lavinmq/clustering/server"
+require "../../src/lavinmq/clustering/client"
+
+# A relay is a node that follows an upstream (foreign-region) leader as a
+# Clustering::Client while re-serving the same stream to its own downstream
+# followers via a Clustering::Server. This is the building block for
+# cross-region disaster recovery: only one node per DR region crosses the
+# region boundary, the rest replicate from it locally.
+describe "Clustering relay (DR cascade)", tags: "etcd" do
+  add_etcd_around_each
+
+  it "cascades changes from an upstream leader through a relay to a downstream follower" do
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    base = LavinMQ::Config.instance.dup
+    base.metrics_http_port = -1 # don't start a metrics server per client
+
+    leader_dir = File.tempname("lavinmq", "leader")
+    relay_dir = File.tempname("lavinmq", "relay")
+    downstream_dir = File.tempname("lavinmq", "downstream")
+    Dir.mkdir_p leader_dir
+    Dir.mkdir_p relay_dir
+    Dir.mkdir_p downstream_dir
+
+    # --- Upstream "region A" leader ---
+    leader_config = base.dup
+    leader_config.data_dir = leader_dir
+    leader_config.clustering_etcd_prefix = "regionA"
+    leader = LavinMQ::Clustering::Server.new(leader_config, LavinMQ::Clustering::EtcdCoordinator.new(leader_config, etcd), 0)
+    leader_tcp = TCPServer.new("localhost", 0)
+    spawn(leader.listen(leader_tcp), name: "leader listen spec")
+
+    # A file that exists before the relay connects; it must reach the
+    # downstream follower through the relay's full-sync, exercising
+    # register_data_dir.
+    File.write(File.join(leader_dir, "definitions.json"), "hello")
+    leader.replace_file(File.join(leader_dir, "definitions.json"))
+
+    # --- "region B" relay: a downstream server fed by an upstream client ---
+    relay_config = base.dup
+    relay_config.data_dir = relay_dir
+    relay_config.clustering_etcd_prefix = "regionB"
+    relay_server = LavinMQ::Clustering::Server.new(relay_config, LavinMQ::Clustering::EtcdCoordinator.new(relay_config, etcd), 1)
+    relay_tcp = TCPServer.new("localhost", 0)
+    spawn(relay_server.listen(relay_tcp), name: "relay listen spec")
+
+    relay_client = LavinMQ::Clustering::Client.new(
+      relay_config, 1, leader.password, proxy: false, relay: relay_server)
+    spawn(relay_client.follow("localhost", leader_tcp.local_address.port), name: "relay follow spec")
+
+    wait_for { leader.followers.size == 1 }    # relay fully synced to the leader
+    wait_for { relay_server.nr_of_files >= 1 } # relay registered its data dir
+
+    # --- "region B" downstream follower of the relay ---
+    downstream_config = base.dup
+    downstream_config.data_dir = downstream_dir
+    downstream_config.clustering_etcd_prefix = "regionB"
+    downstream_client = LavinMQ::Clustering::Client.new(
+      downstream_config, 2, relay_server.password, proxy: false)
+    spawn(downstream_client.follow("localhost", relay_tcp.local_address.port), name: "downstream follow spec")
+
+    wait_for { relay_server.followers.size == 1 } # downstream fully synced to relay
+
+    # The pre-existing file made it all the way through the cascade via full-sync.
+    wait_for { File.exists?(File.join(downstream_dir, "definitions.json")) }
+    File.read(File.join(downstream_dir, "definitions.json")).should eq "hello"
+
+    # A streamed append on the leader cascades through the relay to downstream.
+    leader.append(File.join(leader_dir, "messages.dat"), "ABC".to_slice)
+    wait_for do
+      path = File.join(downstream_dir, "messages.dat")
+      File.exists?(path) && File.read(path) == "ABC"
+    end
+
+    # A streamed file replace cascades too.
+    File.write(File.join(leader_dir, "definitions.json"), "world")
+    leader.replace_file(File.join(leader_dir, "definitions.json"))
+    wait_for { (File.read(File.join(downstream_dir, "definitions.json")) == "world") rescue false }
+
+    # A streamed delete cascades too.
+    leader.delete_file(File.join(leader_dir, "messages.dat"))
+    wait_for { !File.exists?(File.join(downstream_dir, "messages.dat")) }
+  ensure
+    downstream_client.try &.close
+    relay_client.try &.close
+    relay_server.try &.close
+    leader.try &.close
+    FileUtils.rm_rf leader_dir if leader_dir
+    FileUtils.rm_rf relay_dir if relay_dir
+    FileUtils.rm_rf downstream_dir if downstream_dir
+  end
+end

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -405,4 +405,69 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     relay_server.try &.close
     FileUtils.rm_rf relay_dir if relay_dir
   end
+
+  # The region stays a DR follower, but its upstream_etcd changes from one
+  # foreign etcd to another. The role boolean is unchanged, yet the relay must
+  # restart so follow_foreign_leader rebinds to the new upstream instead of
+  # streaming from the stale region until the next process restart.
+  it "invokes on_role_change when the upstream region changes (still a DR follower)" do
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    base = LavinMQ::Config.instance.dup
+    base.metrics_http_port = -1
+
+    relay_dir = File.tempname("lavinmq", "relay")
+    Dir.mkdir_p relay_dir
+
+    relay_port = TCPServer.open("localhost", 0, &.local_address.port)
+    config = base.dup
+    config.data_dir = relay_dir
+    config.clustering_etcd_prefix = "regionB"
+    config.clustering_upstream_etcd_endpoints = "localhost:12379" # makes this a DR follower
+    config.clustering_upstream_etcd_prefix = "regionA"
+    config.clustering_bind = "localhost"
+    config.clustering_port = relay_port
+    config.clustering_advertised_uri = "tcp://localhost:#{relay_port}"
+
+    etcd.del("regionB/upstream_etcd")
+    controller = LavinMQ::Clustering::Controller.new(config, etcd)
+    relay_server = LavinMQ::Clustering::Server.new(config, LavinMQ::Clustering::EtcdCoordinator.new(config, etcd), controller.id)
+    controller.replicator = relay_server
+
+    flipped = Channel(Nil).new(1)
+    controller.on_role_change = -> { flipped.try_send?(nil); nil }
+    relay_started = Channel(Nil).new(1)
+    controller.on_relay_start = -> { relay_started.try_send?(nil); nil }
+
+    spawn(name: "upstream change controller spec") do
+      controller.run { }
+    rescue SpecExit
+    end
+
+    # Wait until the controller has entered relay mode, so watch_upstream has
+    # captured upstream_now = "localhost:12379" (the config fallback).
+    wait_for { relay_server.relay_mode? }
+    select
+    when relay_started.receive
+    when timeout(5.seconds)
+      fail "on_relay_start was not invoked when entering relay mode"
+    end
+
+    # Point upstream_etcd at a *different* foreign etcd. The region is still a DR
+    # follower (non-empty upstream), but of a new region, so on_role_change fires.
+    got = false
+    20.times do
+      etcd.put("regionB/upstream_etcd", "other-region-etcd:2379")
+      select
+      when flipped.receive
+        got = true
+      when timeout(0.5.seconds)
+      end
+      break if got
+    end
+    got.should be_true
+  ensure
+    controller.try &.stop
+    relay_server.try &.close
+    FileUtils.rm_rf relay_dir if relay_dir
+  end
 end

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -1,6 +1,7 @@
 require "../spec_helper"
 require "../../src/lavinmq/clustering/server"
 require "../../src/lavinmq/clustering/client"
+require "../../src/lavinmq/clustering/controller"
 
 # A relay is a node that follows an upstream (foreign-region) leader as a
 # Clustering::Client while re-serving the same stream to its own downstream
@@ -231,6 +232,92 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     relay_server.try &.close
     leader.try &.close
     FileUtils.rm_rf leader_dir if leader_dir
+    FileUtils.rm_rf relay_dir if relay_dir
+    FileUtils.rm_rf downstream_dir if downstream_dir
+  end
+
+  # End-to-end through a real relay Controller (not just a bare Client+Server):
+  # the controller wins its region's election, enters relay mode, and runs the
+  # local leader monitor (follow_leader) and the foreign monitor
+  # (follow_foreign_leader) concurrently. The foreign relay client lives in its
+  # own @relay_client state, so the local monitor — which closes @repli_client on
+  # a local leader change — can never tear down the upstream link. This exercises
+  # that the relay controller path establishes and keeps the upstream link alive
+  # while cascading to a downstream follower.
+  it "keeps the upstream relay link alive under a relay controller and cascades downstream" do
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    base = LavinMQ::Config.instance.dup
+    base.metrics_http_port = -1
+
+    upstream_dir = File.tempname("lavinmq", "upstream")
+    relay_dir = File.tempname("lavinmq", "relay")
+    downstream_dir = File.tempname("lavinmq", "downstream")
+    Dir.mkdir_p upstream_dir
+    Dir.mkdir_p relay_dir
+    Dir.mkdir_p downstream_dir
+
+    # --- Upstream "region A" leader: a Server (its initialize publishes
+    # regionA/clustering_secret) plus an etcd election advertising its address.
+    upstream_config = base.dup
+    upstream_config.data_dir = upstream_dir
+    upstream_config.clustering_etcd_prefix = "regionA"
+    upstream = LavinMQ::Clustering::Server.new(upstream_config, LavinMQ::Clustering::EtcdCoordinator.new(upstream_config, etcd), 0)
+    upstream_tcp = TCPServer.new("localhost", 0)
+    upstream_port = upstream_tcp.local_address.port
+    spawn(upstream.listen(upstream_tcp), name: "upstream listen spec")
+    File.write(File.join(upstream_dir, "definitions.json"), "hello")
+    upstream.replace_file(File.join(upstream_dir, "definitions.json"))
+
+    upstream_lease = etcd.lease_grant(60)
+    spawn(name: "upstream election spec") do
+      etcd.election_campaign("regionA/leader", "tcp://localhost:#{upstream_port}", upstream_lease.id)
+    rescue SpecExit
+    end
+
+    # --- "region B" relay controller, fed by region A ---
+    relay_port = TCPServer.open("localhost", 0, &.local_address.port)
+    relay_config = base.dup
+    relay_config.data_dir = relay_dir
+    relay_config.clustering_etcd_prefix = "regionB"
+    relay_config.clustering_upstream_etcd_endpoints = "localhost:12379"
+    relay_config.clustering_upstream_etcd_prefix = "regionA"
+    relay_config.clustering_bind = "localhost"
+    relay_config.clustering_port = relay_port
+    relay_config.clustering_advertised_uri = "tcp://localhost:#{relay_port}"
+    controller = LavinMQ::Clustering::Controller.new(relay_config, etcd)
+    relay_server = LavinMQ::Clustering::Server.new(relay_config, LavinMQ::Clustering::EtcdCoordinator.new(relay_config, etcd), controller.id)
+    controller.replicator = relay_server
+    spawn(name: "relay controller spec") do
+      controller.run { }
+    rescue SpecExit
+    end
+
+    # --- "region B" downstream follower of the relay controller ---
+    downstream_config = base.dup
+    downstream_config.data_dir = downstream_dir
+    downstream_config.clustering_etcd_prefix = "regionB"
+    downstream_client = LavinMQ::Clustering::Client.new(
+      downstream_config, 99, relay_server.password, proxy: false)
+    spawn(downstream_client.follow("localhost", relay_port), name: "downstream follow spec")
+
+    # The pre-existing upstream file cascades all the way to the downstream.
+    wait_for { File.exists?(File.join(downstream_dir, "definitions.json")) }
+    File.read(File.join(downstream_dir, "definitions.json")).should eq "hello"
+
+    # A later streamed change proves the upstream relay client stays alive and
+    # streaming (it was not torn down by the local leader monitor).
+    upstream.append(File.join(upstream_dir, "messages.dat"), "ABC".to_slice)
+    wait_for do
+      path = File.join(downstream_dir, "messages.dat")
+      (File.read(path) == "ABC") rescue false
+    end
+  ensure
+    downstream_client.try &.close
+    controller.try &.stop
+    upstream_lease.try &.release
+    relay_server.try &.close
+    upstream.try &.close
+    FileUtils.rm_rf upstream_dir if upstream_dir
     FileUtils.rm_rf relay_dir if relay_dir
     FileUtils.rm_rf downstream_dir if downstream_dir
   end

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -165,9 +165,10 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
 
   # When the relay loses its upstream link and later reconnects, its catch-up
   # full-sync can replace/delete files that were never streamed to already
-  # connected downstream followers. The relay must force those followers to
-  # re-sync so the DR copy doesn't silently diverge.
-  it "re-syncs connected downstream followers after the relay reconnects to upstream" do
+  # connected downstream followers. The relay streams those catch-up deltas to
+  # them over their existing connection, so the DR copy converges without a
+  # disconnect/full resync.
+  it "streams reconnect catch-up deltas to connected downstream followers" do
     etcd = LavinMQ::Etcd.new("localhost:12379")
     base = LavinMQ::Config.instance.dup
     base.metrics_http_port = -1
@@ -187,6 +188,8 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     spawn(leader.listen(leader_tcp), name: "leader listen spec")
     File.write(File.join(leader_dir, "definitions.json"), "hello")
     leader.replace_file(File.join(leader_dir, "definitions.json"))
+    File.write(File.join(leader_dir, "messages.dat"), "ABC")
+    leader.replace_file(File.join(leader_dir, "messages.dat"))
 
     relay_config = base.dup
     relay_config.data_dir = relay_dir
@@ -209,22 +212,33 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     spawn(downstream_client.follow("localhost", relay_tcp.local_address.port), name: "downstream follow spec")
     wait_for { relay_server.followers.size == 1 }
     wait_for { (File.read(File.join(downstream_dir, "definitions.json")) == "hello") rescue false }
+    wait_for { (File.read(File.join(downstream_dir, "messages.dat")) == "ABC") rescue false }
 
-    # Simulate an upstream outage during which a change is missed: drop the
+    # The live downstream follower; it must survive the reconnect (no disconnect).
+    follower = relay_server.followers.first
+
+    # Simulate an upstream outage during which changes are missed: drop the
     # relay's upstream link while the downstream stays connected to the relay,
-    # then mutate the leader. This change is never streamed to the relay.
+    # then both replace and delete files on the leader. These never reach the
+    # relay as streamed changes.
     relay_client.close
     File.write(File.join(leader_dir, "definitions.json"), "world")
     leader.replace_file(File.join(leader_dir, "definitions.json"))
+    leader.delete_file(File.join(leader_dir, "messages.dat"))
 
-    # The relay reconnects with the same downstream Server. Its catch-up
-    # full-sync pulls "world" and, being a reconnect, forces the downstream to
-    # re-sync rather than leaving it stale on "hello".
+    # The relay reconnects with the same downstream Server. Its catch-up sync
+    # pulls "world" and drops messages.dat, streaming both deltas to the still
+    # connected downstream follower.
     relay_client2 = LavinMQ::Clustering::Client.new(
       relay_config, 1, leader.password, proxy: false, relay: relay_server)
     spawn(relay_client2.follow("localhost", leader_tcp.local_address.port), name: "relay follow spec 2")
 
     wait_for { (File.read(File.join(downstream_dir, "definitions.json")) == "world") rescue false }
+    wait_for { !File.exists?(File.join(downstream_dir, "messages.dat")) }
+
+    # The same follower received the deltas over its existing connection — it was
+    # never disconnected and forced to full-resync.
+    relay_server.followers.first.should be(follower)
   ensure
     downstream_client.try &.close
     relay_client2.try &.close

--- a/spec/clustering/relay_spec.cr
+++ b/spec/clustering/relay_spec.cr
@@ -89,4 +89,149 @@ describe "Clustering relay (DR cascade)", tags: "etcd" do
     FileUtils.rm_rf relay_dir if relay_dir
     FileUtils.rm_rf downstream_dir if downstream_dir
   end
+
+  # A downstream follower that connects before the relay has synced from its
+  # upstream leader must not full-sync against the relay's empty/stale index and
+  # wipe its own data dir. In DR mode the relay gates downstream full-syncs until
+  # its first upstream sync completes.
+  it "does not serve a downstream full-sync until the relay has synced from upstream" do
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    base = LavinMQ::Config.instance.dup
+    base.metrics_http_port = -1
+
+    leader_dir = File.tempname("lavinmq", "leader")
+    relay_dir = File.tempname("lavinmq", "relay")
+    downstream_dir = File.tempname("lavinmq", "downstream")
+    Dir.mkdir_p leader_dir
+    Dir.mkdir_p relay_dir
+    Dir.mkdir_p downstream_dir
+
+    # --- Upstream "region A" leader with a pre-existing file ---
+    leader_config = base.dup
+    leader_config.data_dir = leader_dir
+    leader_config.clustering_etcd_prefix = "regionA"
+    leader = LavinMQ::Clustering::Server.new(leader_config, LavinMQ::Clustering::EtcdCoordinator.new(leader_config, etcd), 0)
+    leader_tcp = TCPServer.new("localhost", 0)
+    spawn(leader.listen(leader_tcp), name: "leader listen spec")
+    File.write(File.join(leader_dir, "definitions.json"), "hello")
+    leader.replace_file(File.join(leader_dir, "definitions.json"))
+
+    # --- "region B" relay in DR mode: gates downstream until upstream sync ---
+    relay_config = base.dup
+    relay_config.data_dir = relay_dir
+    relay_config.clustering_etcd_prefix = "regionB"
+    relay_server = LavinMQ::Clustering::Server.new(relay_config, LavinMQ::Clustering::EtcdCoordinator.new(relay_config, etcd), 1)
+    relay_server.relay_mode!
+    relay_tcp = TCPServer.new("localhost", 0)
+    spawn(relay_server.listen(relay_tcp), name: "relay listen spec")
+
+    # --- Downstream follower connects BEFORE the relay has synced upstream ---
+    # It carries a sentinel file that exists nowhere upstream.
+    File.write(File.join(downstream_dir, "sentinel"), "keep")
+    downstream_config = base.dup
+    downstream_config.data_dir = downstream_dir
+    downstream_config.clustering_etcd_prefix = "regionB"
+    downstream_client = LavinMQ::Clustering::Client.new(
+      downstream_config, 2, relay_server.password, proxy: false)
+    spawn(downstream_client.follow("localhost", relay_tcp.local_address.port), name: "downstream follow spec")
+
+    # The gate holds: no full-sync runs, so the downstream data dir is untouched.
+    sleep 0.2.seconds
+    relay_server.followers.size.should eq 0
+    File.exists?(File.join(downstream_dir, "sentinel")).should be_true
+
+    # Now let the relay sync from the upstream leader.
+    relay_client = LavinMQ::Clustering::Client.new(
+      relay_config, 1, leader.password, proxy: false, relay: relay_server)
+    spawn(relay_client.follow("localhost", leader_tcp.local_address.port), name: "relay follow spec")
+
+    # Once the relay is synced the gate opens and the downstream full-syncs the
+    # correct dataset: it gets the leader's file and drops its sentinel (absent
+    # upstream) — not an empty wipe against an unready relay.
+    wait_for { relay_server.followers.size == 1 }
+    wait_for { File.exists?(File.join(downstream_dir, "definitions.json")) }
+    File.read(File.join(downstream_dir, "definitions.json")).should eq "hello"
+    wait_for { !File.exists?(File.join(downstream_dir, "sentinel")) }
+  ensure
+    downstream_client.try &.close
+    relay_client.try &.close
+    relay_server.try &.close
+    leader.try &.close
+    FileUtils.rm_rf leader_dir if leader_dir
+    FileUtils.rm_rf relay_dir if relay_dir
+    FileUtils.rm_rf downstream_dir if downstream_dir
+  end
+
+  # When the relay loses its upstream link and later reconnects, its catch-up
+  # full-sync can replace/delete files that were never streamed to already
+  # connected downstream followers. The relay must force those followers to
+  # re-sync so the DR copy doesn't silently diverge.
+  it "re-syncs connected downstream followers after the relay reconnects to upstream" do
+    etcd = LavinMQ::Etcd.new("localhost:12379")
+    base = LavinMQ::Config.instance.dup
+    base.metrics_http_port = -1
+
+    leader_dir = File.tempname("lavinmq", "leader")
+    relay_dir = File.tempname("lavinmq", "relay")
+    downstream_dir = File.tempname("lavinmq", "downstream")
+    Dir.mkdir_p leader_dir
+    Dir.mkdir_p relay_dir
+    Dir.mkdir_p downstream_dir
+
+    leader_config = base.dup
+    leader_config.data_dir = leader_dir
+    leader_config.clustering_etcd_prefix = "regionA"
+    leader = LavinMQ::Clustering::Server.new(leader_config, LavinMQ::Clustering::EtcdCoordinator.new(leader_config, etcd), 0)
+    leader_tcp = TCPServer.new("localhost", 0)
+    spawn(leader.listen(leader_tcp), name: "leader listen spec")
+    File.write(File.join(leader_dir, "definitions.json"), "hello")
+    leader.replace_file(File.join(leader_dir, "definitions.json"))
+
+    relay_config = base.dup
+    relay_config.data_dir = relay_dir
+    relay_config.clustering_etcd_prefix = "regionB"
+    relay_server = LavinMQ::Clustering::Server.new(relay_config, LavinMQ::Clustering::EtcdCoordinator.new(relay_config, etcd), 1)
+    relay_server.relay_mode!
+    relay_tcp = TCPServer.new("localhost", 0)
+    spawn(relay_server.listen(relay_tcp), name: "relay listen spec")
+
+    relay_client = LavinMQ::Clustering::Client.new(
+      relay_config, 1, leader.password, proxy: false, relay: relay_server)
+    spawn(relay_client.follow("localhost", leader_tcp.local_address.port), name: "relay follow spec")
+    wait_for { leader.followers.size == 1 }
+
+    downstream_config = base.dup
+    downstream_config.data_dir = downstream_dir
+    downstream_config.clustering_etcd_prefix = "regionB"
+    downstream_client = LavinMQ::Clustering::Client.new(
+      downstream_config, 2, relay_server.password, proxy: false)
+    spawn(downstream_client.follow("localhost", relay_tcp.local_address.port), name: "downstream follow spec")
+    wait_for { relay_server.followers.size == 1 }
+    wait_for { (File.read(File.join(downstream_dir, "definitions.json")) == "hello") rescue false }
+
+    # Simulate an upstream outage during which a change is missed: drop the
+    # relay's upstream link while the downstream stays connected to the relay,
+    # then mutate the leader. This change is never streamed to the relay.
+    relay_client.close
+    File.write(File.join(leader_dir, "definitions.json"), "world")
+    leader.replace_file(File.join(leader_dir, "definitions.json"))
+
+    # The relay reconnects with the same downstream Server. Its catch-up
+    # full-sync pulls "world" and, being a reconnect, forces the downstream to
+    # re-sync rather than leaving it stale on "hello".
+    relay_client2 = LavinMQ::Clustering::Client.new(
+      relay_config, 1, leader.password, proxy: false, relay: relay_server)
+    spawn(relay_client2.follow("localhost", leader_tcp.local_address.port), name: "relay follow spec 2")
+
+    wait_for { (File.read(File.join(downstream_dir, "definitions.json")) == "world") rescue false }
+  ensure
+    downstream_client.try &.close
+    relay_client2.try &.close
+    relay_client.try &.close
+    relay_server.try &.close
+    leader.try &.close
+    FileUtils.rm_rf leader_dir if leader_dir
+    FileUtils.rm_rf relay_dir if relay_dir
+    FileUtils.rm_rf downstream_dir if downstream_dir
+  end
 end

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -5,6 +5,25 @@ require "http/client"
 require "./spec_helper"
 
 describe LavinMQ::Etcd, tags: "etcd" do
+  describe "connection failure" do
+    it "raises instead of exiting when fail_fast is false and no endpoint responds" do
+      etcd = LavinMQ::Etcd.new("127.0.0.1:1", fail_fast: false)
+      expect_raises(LavinMQ::Etcd::Error, "No etcd endpoint responded") do
+        etcd.get("foo")
+      end
+    end
+
+    it "still works against a live etcd when fail_fast is false" do
+      cluster = EtcdCluster.new(1)
+      cluster.run do
+        etcd = LavinMQ::Etcd.new(cluster.endpoints, fail_fast: false)
+        etcd.del("foo")
+        etcd.put("foo", "bar").should eq nil
+        etcd.get("foo").should eq "bar"
+      end
+    end
+  end
+
   it "can put and get" do
     cluster = EtcdCluster.new(1)
     cluster.run do

--- a/spec/relay_rejecter_spec.cr
+++ b/spec/relay_rejecter_spec.cr
@@ -21,6 +21,33 @@ describe "relay client rejecters" do
     ensure
       tcp.try &.close
     end
+
+    # Regression: when TCP delivers the 8-byte protocol header in more than one
+    # read, the rejecter must read the full header before comparing it, then
+    # still send Connection.Start rather than closing the socket on a short read.
+    it "handles a protocol header split across multiple reads" do
+      tcp = TCPServer.new("localhost", 0)
+      spawn(name: "amqp rejecter split spec") do
+        while socket = tcp.accept?
+          spawn LavinMQ::AMQP.reject_relay(socket)
+        end
+      end
+
+      client = TCPSocket.new("localhost", tcp.local_address.port)
+      header = Bytes[65, 77, 81, 80, 0, 0, 9, 1] # "AMQP" 0 0 9 1
+      client.write header[0, 3]                  # first fragment, less than the full header
+      client.flush
+      sleep 50.milliseconds # give the server a chance to read the short fragment
+      client.write header[3, header.size - 3]
+      client.flush
+
+      # Server must respond with a frame (Connection.Start, frame type 1), not EOF.
+      client.read_timeout = 5.seconds
+      client.read_byte.should eq 1_u8
+    ensure
+      client.try &.close
+      tcp.try &.close
+    end
   end
 
   describe "LavinMQ::MQTT.reject_relay" do

--- a/spec/relay_rejecter_spec.cr
+++ b/spec/relay_rejecter_spec.cr
@@ -1,0 +1,55 @@
+require "./spec_helper"
+require "../src/lavinmq/amqp/relay_rejecter"
+require "../src/lavinmq/mqtt/relay_rejecter"
+
+# A DR relay node must not serve application clients, but rather than leaving the
+# ports closed it rejects connections at the protocol level so clients get a
+# clear reason and disconnect cleanly.
+describe "relay client rejecters" do
+  describe "LavinMQ::AMQP.reject_relay" do
+    it "closes an AMQP connection with reason 'server in relay mode'" do
+      tcp = TCPServer.new("localhost", 0)
+      spawn(name: "amqp rejecter spec") do
+        while socket = tcp.accept?
+          spawn LavinMQ::AMQP.reject_relay(socket)
+        end
+      end
+
+      expect_raises(AMQP::Client::Connection::ClosedException, /server in relay mode/) do
+        AMQP::Client.new(host: "localhost", port: tcp.local_address.port).connect
+      end
+    ensure
+      tcp.try &.close
+    end
+  end
+
+  describe "LavinMQ::MQTT.reject_relay" do
+    it "replies CONNACK ServerUnavailable to an MQTT CONNECT" do
+      tcp = TCPServer.new("localhost", 0)
+      spawn(name: "mqtt rejecter spec") do
+        while socket = tcp.accept?
+          spawn LavinMQ::MQTT.reject_relay(socket, 8192_u32)
+        end
+      end
+
+      client = TCPSocket.new("localhost", tcp.local_address.port)
+      # Minimal MQTT 3.1.1 CONNECT: protocol "MQTT" v4, clean session, empty client id.
+      connect = Bytes[0x10, 0x0C,
+        0x00, 0x04, 0x4D, 0x51, 0x54, 0x54, # "MQTT"
+        0x04,                               # protocol level 4 (3.1.1)
+        0x02,                               # connect flags: clean session
+        0x00, 0x3C,                         # keepalive 60s
+        0x00, 0x00]                         # empty client id
+      client.write connect
+      client.flush
+
+      connack = Bytes.new(4)
+      client.read_fully(connack)
+      connack[0].should eq 0x20_u8                                                      # CONNACK packet type
+      connack[3].should eq MQTT::Protocol::Connack::ReturnCode::ServerUnavailable.value # return code 3
+    ensure
+      client.try &.close
+      tcp.try &.close
+    end
+  end
+end

--- a/src/lavinmq/amqp/relay_rejecter.cr
+++ b/src/lavinmq/amqp/relay_rejecter.cr
@@ -9,7 +9,7 @@ module LavinMQ
     # Connection.Start -> Connection.Close(320) — so the client gets a clean,
     # explainable rejection ("server in relay mode") and disconnects.
     def self.reject_relay(socket) : Nil
-      socket.read_timeout = 15.seconds
+      socket.read_timeout = 15.seconds if socket.responds_to?(:read_timeout=)
       proto = uninitialized UInt8[8]
       return if socket.read(proto.to_slice).zero? # EOF, client went away
       return unless proto == AMQP::PROTOCOL_START_0_9_1 || proto == AMQP::PROTOCOL_START_0_9

--- a/src/lavinmq/amqp/relay_rejecter.cr
+++ b/src/lavinmq/amqp/relay_rejecter.cr
@@ -11,7 +11,7 @@ module LavinMQ
     def self.reject_relay(socket) : Nil
       socket.read_timeout = 15.seconds if socket.responds_to?(:read_timeout=)
       proto = uninitialized UInt8[8]
-      return if socket.read(proto.to_slice).zero? # EOF, client went away
+      return if socket.read_fully?(proto.to_slice).nil? # EOF/short read, client went away
       return unless proto == AMQP::PROTOCOL_START_0_9_1 || proto == AMQP::PROTOCOL_START_0_9
       stream = AMQ::Protocol::Stream.new(socket)
       stream.write_bytes AMQP::Frame::Connection::Start.new(server_properties: ConnectionFactory::SERVER_PROPERTIES),

--- a/src/lavinmq/amqp/relay_rejecter.cr
+++ b/src/lavinmq/amqp/relay_rejecter.cr
@@ -1,0 +1,36 @@
+require "./connection_factory"
+require "./connection_reply_code"
+
+module LavinMQ
+  module AMQP
+    # Used by a DR relay node, which must not serve application clients. Instead
+    # of leaving the AMQP port closed (raw connection-refused) it accepts the
+    # connection and performs the minimal handshake — protocol header ->
+    # Connection.Start -> Connection.Close(320) — so the client gets a clean,
+    # explainable rejection ("server in relay mode") and disconnects.
+    def self.reject_relay(socket) : Nil
+      socket.read_timeout = 15.seconds
+      proto = uninitialized UInt8[8]
+      return if socket.read(proto.to_slice).zero? # EOF, client went away
+      return unless proto == AMQP::PROTOCOL_START_0_9_1 || proto == AMQP::PROTOCOL_START_0_9
+      stream = AMQ::Protocol::Stream.new(socket)
+      stream.write_bytes AMQP::Frame::Connection::Start.new(server_properties: ConnectionFactory::SERVER_PROPERTIES),
+        ::IO::ByteFormat::NetworkEndian
+      stream.flush
+      begin
+        stream.next_frame # read Start-Ok so the client is ready to receive the Close
+      rescue IO::Error | AMQ::Protocol::Error
+      end
+      stream.write_bytes AMQP::Frame::Connection::Close.new(
+        ConnectionReplyCode::CONNECTION_FORCED.value,
+        "CONNECTION_FORCED - server in relay mode",
+        0_u16, 0_u16),
+        ::IO::ByteFormat::NetworkEndian
+      stream.flush
+    rescue IO::Error | AMQ::Protocol::Error
+      # client disconnected mid-handshake; nothing to do
+    ensure
+      socket.close rescue nil
+    end
+  end
+end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -99,10 +99,16 @@ module LavinMQ
           socket.read_buffering = false # use lz4 buffering
           lz4 = Compress::LZ4::Reader.new(socket)
           sync(socket, lz4)
-          # A relay must be able to serve downstream full-syncs for files that
-          # existed before any streamed change, so register them now that the
-          # initial sync has written them to disk.
-          @relay.try &.register_data_dir
+          if relay = @relay
+            # A relay must be able to serve downstream full-syncs for files that
+            # existed before any streamed change, so register them now that the
+            # sync has written them to disk...
+            relay.register_data_dir
+            # ...then signal readiness (first sync, opens the downstream gate) or
+            # force a downstream resync (reconnect/failover, where this sync may
+            # have replaced/deleted files never streamed to connected followers).
+            relay.upstream_synced
+          end
           Log.info { "Streaming changes" }
           stream_changes(socket, lz4)
         rescue ex : IO::Error

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -12,6 +12,9 @@ module LavinMQ
       Log = LavinMQ::Log.for "clustering.client"
       @data_dir_lock : DataDirLock
       @closed = false
+      # True while connected to the leader and actively streaming changes, i.e.
+      # past the initial sync. Used by a DR relay's readiness probe.
+      @streaming = false
       @amqp_proxy : Proxy?
       @http_proxy : Proxy?
       @mqtt_proxy : Proxy?
@@ -113,6 +116,7 @@ module LavinMQ
             sync(socket, lz4)
           end
           Log.info { "Streaming changes" }
+          @streaming = true
           stream_changes(socket, lz4)
         rescue ex : IO::Error
           lz4.try &.close
@@ -120,9 +124,16 @@ module LavinMQ
           break if @closed
           Log.info { "Disconnected from server #{host}:#{port} (#{ex}), retrying..." }
           sleep 1.seconds
+        ensure
+          @streaming = false
         end
       ensure
         @follower_done.send(nil)
+      end
+
+      # True when connected to the leader and past the initial sync (streaming).
+      def connected? : Bool
+        @streaming
       end
 
       def follows?(_nil : Nil) : Bool

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -53,7 +53,11 @@ module LavinMQ
           @unix_mqtt_proxy = Proxy.new(@config.mqtt_unix_path) unless @config.mqtt_unix_path.empty?
         end
         start_metrics_server unless @config.metrics_http_port == -1
-        HTTP::Server.follower_internal_socket_http_server
+        # A relay's internal unix socket (which serves the DR control routes) is
+        # bound once by the launcher at relay start, not per upstream client, so
+        # promotion stays available even before this client connects and so a new
+        # client on every upstream leader change doesn't re-bind it.
+        HTTP::Server.follower_internal_socket_http_server if @relay.nil?
       end
 
       private def start_metrics_server

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -98,16 +98,19 @@ module LavinMQ
           socket.sync = true
           socket.read_buffering = false # use lz4 buffering
           lz4 = Compress::LZ4::Reader.new(socket)
-          sync(socket, lz4)
           if relay = @relay
-            # A relay must be able to serve downstream full-syncs for files that
-            # existed before any streamed change, so register them now that the
-            # sync has written them to disk...
-            relay.register_data_dir
-            # ...then signal readiness (first sync, opens the downstream gate) or
-            # force a downstream resync (reconnect/failover, where this sync may
-            # have replaced/deleted files never streamed to connected followers).
-            relay.upstream_synced
+            # Hold the relay's sync lock for the whole upstream sync so no
+            # downstream follower full-syncs against our half-applied state, and
+            # register the synced files so later downstream full-syncs can serve
+            # them. The deltas applied during the sync are streamed to already
+            # connected followers from within sync_files.
+            relay.syncing_from_upstream do
+              sync(socket, lz4)
+              relay.register_data_dir
+            end
+            relay.upstream_synced # open the downstream gate (first sync; idempotent)
+          else
+            sync(socket, lz4)
           end
           Log.info { "Streaming changes" }
           stream_changes(socket, lz4)
@@ -212,6 +215,8 @@ module LavinMQ
         files_to_delete.each do |path|
           Log.debug { "File not on leader: #{path}" }
           File.delete path
+          # A relay cascades the delete to its already-connected downstream followers.
+          @relay.try &.delete_file(path)
         rescue ex : File::Error
           Log.warn(exception: ex) { "Failed to delete #{path}" }
         end
@@ -232,6 +237,9 @@ module LavinMQ
         log_limiter = RateLimiter.new(2.seconds)
         requested_files.each do |filename|
           file_from_socket(filename, lz4)
+          # A relay cascades the freshly written file to its already-connected
+          # downstream followers (replace_file re-reads it from local disk).
+          @relay.try &.replace_file(File.join(@data_dir, filename))
           received_count &+= 1
           log_limiter.do { Log.info { "Received #{received_count}/#{requested_files.size} files" } }
         end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -3,6 +3,7 @@ require "../clustering"
 require "../rate_limiter"
 require "./checksums"
 require "./proxy"
+require "./server"
 require "lz4"
 
 module LavinMQ
@@ -22,7 +23,10 @@ module LavinMQ
       @file_digests = Hash(String, Digest::SHA1).new
       @follower_done = Channel(Nil).new
 
-      def initialize(@config : Config, @id : Int32, @password : String, proxy = true)
+      # When `relay` is set this client acts as a relay: every change it applies
+      # locally is also forwarded to the relay's downstream followers. Used by a
+      # DR-region leader to re-serve the cross-region stream within its region.
+      def initialize(@config : Config, @id : Int32, @password : String, proxy = true, @relay : Clustering::Server? = nil)
         System.maximize_fd_limit
         @data_dir = config.data_dir
         @files = Hash(String, File).new do |h, k|
@@ -95,6 +99,10 @@ module LavinMQ
           socket.read_buffering = false # use lz4 buffering
           lz4 = Compress::LZ4::Reader.new(socket)
           sync(socket, lz4)
+          # A relay must be able to serve downstream full-syncs for files that
+          # existed before any streamed change, so register them now that the
+          # initial sync has written them to disk.
+          @relay.try &.register_data_dir
           Log.info { "Streaming changes" }
           stream_changes(socket, lz4)
         rescue ex : IO::Error
@@ -311,7 +319,16 @@ module LavinMQ
       private def append(filename, len, lz4)
         Log.debug { "Appending #{len.abs} bytes to #{filename}" }
         f = @files[filename]
-        stream_with_checksum(filename, lz4, f, len.abs)
+        if relay = @relay
+          # Buffer the appended bytes so they can also be forwarded downstream.
+          bytes = Bytes.new(len.abs.to_i32)
+          lz4.read_fully(bytes)
+          f.write(bytes)
+          (@file_digests[filename] ||= Digest::SHA1.new).update(bytes)
+          relay.relay_append(File.join(@data_dir, filename), bytes)
+        else
+          stream_with_checksum(filename, lz4, f, len.abs)
+        end
       end
 
       private def delete(filename)
@@ -324,6 +341,7 @@ module LavinMQ
         end
         @checksums.delete(filename)
         @file_digests.delete(filename)
+        @relay.try &.delete_file(File.join(@data_dir, filename))
       end
 
       private def replace(filename, len, lz4)
@@ -340,6 +358,9 @@ module LavinMQ
           stream_with_checksum(filename, lz4, f, len)
           f.rename f.path[0..-5]
         end
+        # Forward the freshly written file to downstream followers; replace_file
+        # re-reads it from the relay's local disk.
+        @relay.try &.replace_file(File.join(@data_dir, filename))
       end
 
       # Read from lz4, update SHA1, and write to file incrementally

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -20,7 +20,7 @@ module LavinMQ
       @unix_mqtt_proxy : Proxy?
       @socket : TCPSocket?
       @streamed_bytes = 0_u64
-      @file_digests = Hash(String, Digest::SHA1).new
+      @file_digests = Hash(String, Digest::SHA1).new { |h, filename| h[filename] = Digest::SHA1.new }
       @follower_done = Channel(Nil).new
 
       # When `relay` is set this client acts as a relay: every change it applies
@@ -338,7 +338,7 @@ module LavinMQ
           bytes = Bytes.new(len.abs.to_i32)
           lz4.read_fully(bytes)
           f.write(bytes)
-          (@file_digests[filename] ||= Digest::SHA1.new).update(bytes)
+          @file_digests[filename].update(bytes)
           relay.relay_append(File.join(@data_dir, filename), bytes)
         else
           stream_with_checksum(filename, lz4, f, len.abs)
@@ -380,7 +380,7 @@ module LavinMQ
       # Read from lz4, update SHA1, and write to file incrementally
       private def stream_with_checksum(filename : String, lz4 : IO, file : IO, length : Int64) : Nil
         # Get or create SHA1 digest for this file
-        sha1 = @file_digests[filename] ||= Digest::SHA1.new
+        sha1 = @file_digests[filename]
 
         # Read, hash, and write incrementally
         buffer = uninitialized UInt8[IO::DEFAULT_BUFFER_SIZE]

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -11,7 +11,14 @@ class LavinMQ::Clustering::Controller
   # message store.
   property replicator : Clustering::Server? = nil
 
+  # The client replicating from this region's own leader, managed solely by
+  # the `follow_leader` monitor.
   @repli_client : Client? = nil
+  # The client replicating from the foreign region's leader in DR/relay mode,
+  # managed solely by `follow_foreign_leader`. Kept separate from
+  # `@repli_client` so the local leader monitor (which closes `@repli_client`
+  # on a local leader change) can never tear down the upstream relay link.
+  @relay_client : Client? = nil
 
   def self.new(config : Config)
     etcd = Etcd.new(config.clustering_etcd_endpoints)
@@ -70,6 +77,7 @@ class LavinMQ::Clustering::Controller
   def stop
     @stopped = true
     @repli_client.try &.close
+    @relay_client.try &.close
     @lease.try &.release
   end
 
@@ -190,7 +198,7 @@ class LavinMQ::Clustering::Controller
     prefix = @config.clustering_upstream_etcd_prefix.presence || @config.clustering_etcd_prefix
     foreign = Etcd.new(upstream)
     foreign.elect_listen("#{prefix}/leader") do |uri|
-      if client = @repli_client
+      if client = @relay_client
         if client.follows? uri
           next
         else
@@ -211,10 +219,11 @@ class LavinMQ::Clustering::Controller
           break
         end
       end
-      @repli_client = c = Clustering::Client.new(@config, @id, secret, proxy: false, relay: replicator)
+      @relay_client = c = Clustering::Client.new(@config, @id, secret, proxy: false, relay: replicator)
       spawn c.follow(uri), name: "Relay client #{uri}"
     end
   rescue ex
+    return if @stopped # don't crash the foreign monitor during graceful shutdown
     Log.fatal(exception: ex) { "Unhandled exception while following upstream leader" }
     exit 36
   end

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -6,6 +6,11 @@ class LavinMQ::Clustering::Controller
 
   getter id : Int32
 
+  # The downstream replication server. Set by the Launcher. In DR (relay) mode
+  # the controller feeds this server from the upstream region instead of a local
+  # message store.
+  property replicator : Clustering::Server? = nil
+
   @repli_client : Client? = nil
 
   def self.new(config : Config)
@@ -28,16 +33,23 @@ class LavinMQ::Clustering::Controller
   def run(&)
     lease = @lease = @etcd.lease_grant(id: @id)
     spawn(follow_leader, name: "Follower monitor")
+    spawn(watch_upstream, name: "Upstream region watcher")
     wait_to_be_insync(lease)
     @etcd.election_campaign("#{@config.clustering_etcd_prefix}/leader", @advertised_uri, lease: @id) # blocks until becoming leader
     @is_leader.set(true)
-    execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
     @repli_client.try &.close
-    # TODO: make sure we still are in the ISR set
-    yield
-    loop do
-      lease.wait(30.seconds)
-      GC.collect
+    if upstream = effective_upstream.presence
+      # DR (relay) mode: don't serve clients, replicate from the foreign region
+      # and re-serve the stream to our own region's followers.
+      run_relay(lease, upstream)
+    else
+      execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
+      # TODO: make sure we still are in the ISR set
+      yield
+      loop do
+        lease.wait(30.seconds)
+        GC.collect
+      end
     end
   rescue Etcd::Lease::Expired
     execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
@@ -120,6 +132,111 @@ class LavinMQ::Clustering::Controller
   rescue ex
     Log.fatal(exception: ex) { "Unhandled exception while following leader" }
     exit 36 # 36 for CF (Cluster Follower)
+  end
+
+  # Sentinel value for {prefix}/upstream_etcd that explicitly marks this region
+  # as the primary, overriding the config fallback. Used to promote a DR region
+  # durably (survives restart) — etcd's JSON omits empty values, so an empty
+  # string is indistinguishable from an absent key and can't serve this purpose.
+  UPSTREAM_PRIMARY = "primary"
+
+  # The foreign region's etcd endpoints to replicate from, or "" when this
+  # region is the primary. The {prefix}/upstream_etcd key in this region's own
+  # etcd is authoritative; the config option is only a fallback for bootstrap.
+  # Set the key to the foreign etcd endpoints to make this region a DR follower,
+  # or to "primary" to promote it (failover).
+  def effective_upstream : String
+    upstream_from(@etcd.get(upstream_etcd_key))
+  end
+
+  private def upstream_from(value : String?) : String
+    value ||= @config.clustering_upstream_etcd_endpoints
+    value == UPSTREAM_PRIMARY ? "" : value
+  end
+
+  private def upstream_etcd_key : String
+    "#{@config.clustering_etcd_prefix}/upstream_etcd"
+  end
+
+  # This node won its region's election while the region is a DR follower, so it
+  # becomes the relay: it serves its own region's followers (downstream) and
+  # replicates from the foreign region's leader (upstream), teeing the stream.
+  private def run_relay(lease, upstream : String)
+    replicator = @replicator
+    unless replicator
+      Log.fatal { "DR relay mode requires a clustering replicator" }
+      exit 1
+    end
+    Log.info { "Region is a DR follower of #{upstream}" }
+    start_downstream_listener(replicator)
+    execute_shell_command(@config.clustering_on_demoted, "demoted")
+    spawn(follow_foreign_leader(upstream, replicator), name: "Foreign leader monitor")
+    SystemD.notify_ready
+    loop do
+      lease.wait(30.seconds)
+      GC.collect
+    end
+  end
+
+  private def start_downstream_listener(replicator : Clustering::Server)
+    server = TCPServer.new(@config.clustering_bind, @config.clustering_port)
+    spawn(replicator.listen(server), name: "Clustering listener")
+  end
+
+  # Watch the foreign region's etcd for its current leader and replicate from it,
+  # forwarding the stream to our own region's followers via the replicator.
+  private def follow_foreign_leader(upstream : String, replicator : Clustering::Server)
+    prefix = @config.clustering_upstream_etcd_prefix.presence || @config.clustering_etcd_prefix
+    foreign = Etcd.new(upstream)
+    foreign.elect_listen("#{prefix}/leader") do |uri|
+      if client = @repli_client
+        if client.follows? uri
+          next
+        else
+          client.close
+        end
+      end
+      if uri.nil?
+        Log.warn { "No upstream leader available" }
+        next
+      end
+      Log.info { "Upstream leader: #{uri}" }
+      key = "#{prefix}/clustering_secret"
+      secret = foreign.get(key)
+      until secret
+        Log.debug { "Upstream clustering secret is missing, watching for it" }
+        foreign.watch(key) do |value|
+          secret = value
+          break
+        end
+      end
+      @repli_client = c = Clustering::Client.new(@config, @id, secret, proxy: false, relay: replicator)
+      spawn c.follow(uri), name: "Relay client #{uri}"
+    end
+  rescue ex
+    Log.fatal(exception: ex) { "Unhandled exception while following upstream leader" }
+    exit 36
+  end
+
+  # Restart (via the supervisor) when this region's role flips, so the node
+  # re-derives whether it's a primary or a DR relay on the next boot. Failover =
+  # clear {prefix}/upstream_etcd; reversal = set it to the new primary's etcd.
+  private def watch_upstream
+    dr_now = !effective_upstream.empty?
+    @etcd.watch(upstream_etcd_key) do |value|
+      dr_after = !upstream_from(value).empty?
+      next if dr_after == dr_now
+      if dr_after
+        Log.fatal { "Region demoted to DR follower (upstream_etcd=#{value}); restarting to switch role" }
+        execute_shell_command(@config.clustering_on_demoted, "demoted")
+      else
+        Log.fatal { "Region promoted to primary; restarting to switch role" }
+        execute_shell_command(@config.clustering_on_promoted, "promoted")
+      end
+      exit 38 # 38 for region role change; supervisor restarts into the new role
+    end
+  rescue ex
+    Log.error(exception: ex) { "Unhandled exception while watching upstream region" } unless @stopped
   end
 
   def wait_to_be_insync(lease)

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -168,6 +168,7 @@ class LavinMQ::Clustering::Controller
       exit 1
     end
     Log.info { "Region is a DR follower of #{upstream}" }
+    replicator.relay_mode! # gate downstream full-syncs until the upstream sync completes
     start_downstream_listener(replicator)
     execute_shell_command(@config.clustering_on_demoted, "demoted")
     spawn(follow_foreign_leader(upstream, replicator), name: "Foreign leader monitor")

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -196,31 +196,42 @@ class LavinMQ::Clustering::Controller
   # forwarding the stream to our own region's followers via the replicator.
   private def follow_foreign_leader(upstream : String, replicator : Clustering::Server)
     prefix = @config.clustering_upstream_etcd_prefix.presence || @config.clustering_etcd_prefix
-    foreign = Etcd.new(upstream)
-    foreign.elect_listen("#{prefix}/leader") do |uri|
-      if client = @relay_client
-        if client.follows? uri
+    # fail_fast: false so an unreachable foreign etcd raises (and we retry below)
+    # instead of taking this DR region's relay process down with it.
+    foreign = Etcd.new(upstream, fail_fast: false)
+    loop do
+      foreign.elect_listen("#{prefix}/leader") do |uri|
+        if client = @relay_client
+          if client.follows? uri
+            next
+          else
+            client.close
+          end
+        end
+        if uri.nil?
+          Log.warn { "No upstream leader available" }
           next
-        else
-          client.close
         end
-      end
-      if uri.nil?
-        Log.warn { "No upstream leader available" }
-        next
-      end
-      Log.info { "Upstream leader: #{uri}" }
-      key = "#{prefix}/clustering_secret"
-      secret = foreign.get(key)
-      until secret
-        Log.debug { "Upstream clustering secret is missing, watching for it" }
-        foreign.watch(key) do |value|
-          secret = value
-          break
+        Log.info { "Upstream leader: #{uri}" }
+        key = "#{prefix}/clustering_secret"
+        secret = foreign.get(key)
+        until secret
+          Log.debug { "Upstream clustering secret is missing, watching for it" }
+          foreign.watch(key) do |value|
+            secret = value
+            break
+          end
         end
+        @relay_client = c = Clustering::Client.new(@config, @id, secret, proxy: false, relay: replicator)
+        spawn c.follow(uri), name: "Relay client #{uri}"
       end
-      @relay_client = c = Clustering::Client.new(@config, @id, secret, proxy: false, relay: replicator)
-      spawn c.follow(uri), name: "Relay client #{uri}"
+    rescue ex : Etcd::Error
+      break if @stopped
+      # The upstream region's etcd is unreachable. Keep the relay alive — its
+      # existing @relay_client keeps streaming from the upstream leader over its
+      # own TCP link — and retry watching for leader changes.
+      Log.warn(exception: ex) { "Upstream etcd unreachable, retrying in 5s" }
+      sleep 5.seconds
     end
   rescue ex
     return if @stopped # don't crash the foreign monitor during graceful shutdown

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -16,6 +16,11 @@ class LavinMQ::Clustering::Controller
   # supervisor restarts into the re-derived role. Unset = a bare exit 38.
   property on_role_change : (-> Nil)? = nil
 
+  # Invoked once when this node enters DR/relay mode (run_relay). The Launcher
+  # sets it to start the relay's barebones services: AMQP/MQTT connection
+  # rejecters and a minimal HTTP API (metrics + health + DR control).
+  property on_relay_start : (-> Nil)? = nil
+
   # The client replicating from this region's own leader, managed solely by
   # the `follow_leader` monitor.
   @repli_client : Client? = nil
@@ -24,6 +29,12 @@ class LavinMQ::Clustering::Controller
   # `@repli_client` so the local leader monitor (which closes `@repli_client`
   # on a local leader change) can never tear down the upstream relay link.
   @relay_client : Client? = nil
+
+  # Readiness for a DR relay: true when the upstream relay client is connected
+  # and past its initial sync (so the relay can serve its downstream followers).
+  def relay_ready? : Bool
+    @relay_client.try(&.connected?) || false
+  end
 
   def self.new(config : Config)
     etcd = Etcd.new(config.clustering_etcd_endpoints)
@@ -183,6 +194,7 @@ class LavinMQ::Clustering::Controller
     Log.info { "Region is a DR follower of #{upstream}" }
     replicator.relay_mode! # gate downstream full-syncs until the upstream sync completes
     start_downstream_listener(replicator)
+    @on_relay_start.try &.call # start the relay's reject listeners + barebones HTTP API
     execute_shell_command(@config.clustering_on_demoted, "demoted")
     spawn(follow_foreign_leader(upstream, replicator), name: "Foreign leader monitor")
     SystemD.notify_ready

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -11,6 +11,11 @@ class LavinMQ::Clustering::Controller
   # message store.
   property replicator : Clustering::Server? = nil
 
+  # Invoked when this region's role flips (primary <-> DR follower). The Launcher
+  # sets it to gracefully stop the node's subsystems and then exit 38, so the
+  # supervisor restarts into the re-derived role. Unset = a bare exit 38.
+  property on_role_change : (-> Nil)? = nil
+
   # The client replicating from this region's own leader, managed solely by
   # the `follow_leader` monitor.
   @repli_client : Client? = nil
@@ -254,7 +259,14 @@ class LavinMQ::Clustering::Controller
         Log.fatal { "Region promoted to primary; restarting to switch role" }
         execute_shell_command(@config.clustering_on_promoted, "promoted")
       end
-      exit 38 # 38 for region role change; supervisor restarts into the new role
+      # The Launcher installs a callback that gracefully stops the node's
+      # subsystems before exiting 38; the supervisor restarts into the
+      # re-derived role. Fall back to a bare exit when unset (e.g. specs).
+      if cb = @on_role_change
+        cb.call
+      else
+        exit 38 # 38 for region role change; supervisor restarts into the new role
+      end
     end
   rescue ex
     Log.error(exception: ex) { "Unhandled exception while watching upstream region" } unless @stopped

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -256,20 +256,29 @@ class LavinMQ::Clustering::Controller
     exit 36
   end
 
-  # Restart (via the supervisor) when this region's role flips, so the node
-  # re-derives whether it's a primary or a DR relay on the next boot. Failover =
-  # clear {prefix}/upstream_etcd; reversal = set it to the new primary's etcd.
+  # Restart (via the supervisor) when this region's upstream changes, so the node
+  # re-derives its role and which upstream etcd to follow on the next boot.
+  # Failover = clear {prefix}/upstream_etcd (or set it to "primary"); reversal =
+  # set it to the new primary's etcd. A change from one foreign etcd to another
+  # (the region stays a DR follower but of a different upstream) also restarts,
+  # so follow_foreign_leader rebinds to the new region instead of streaming from
+  # the stale one until the next process restart.
   private def watch_upstream
-    dr_now = !effective_upstream.empty?
+    upstream_now = effective_upstream
     @etcd.watch(upstream_etcd_key) do |value|
-      dr_after = !upstream_from(value).empty?
-      next if dr_after == dr_now
-      if dr_after
+      upstream_after = upstream_from(value)
+      next if upstream_after == upstream_now
+      dr_now = !upstream_now.empty?
+      dr_after = !upstream_after.empty?
+      if dr_after && !dr_now
         Log.fatal { "Region demoted to DR follower (upstream_etcd=#{value}); restarting to switch role" }
         execute_shell_command(@config.clustering_on_demoted, "demoted")
-      else
+      elsif dr_now && !dr_after
         Log.fatal { "Region promoted to primary; restarting to switch role" }
         execute_shell_command(@config.clustering_on_promoted, "promoted")
+      else
+        # Still a DR follower, but of a different upstream region.
+        Log.fatal { "Upstream changed to #{upstream_after}; restarting to follow new upstream" }
       end
       # The Launcher installs a callback that gracefully stops the node's
       # subsystems before exiting 38; the supervisor restarts into the

--- a/src/lavinmq/clustering/dr_control.cr
+++ b/src/lavinmq/clustering/dr_control.cr
@@ -1,0 +1,51 @@
+require "../config"
+require "../etcd"
+require "./controller"
+
+module LavinMQ
+  module Clustering
+    # Reads and writes this region's `{prefix}/upstream_etcd` key — the durable
+    # source of truth for whether the region is a primary or a DR follower of a
+    # foreign region (see Controller#effective_upstream). Backs the HTTP API and
+    # `lavinmqctl` promotion/demotion commands so failover no longer requires
+    # manual etcdctl surgery.
+    #
+    # It talks to the LOCAL region's etcd, so it works on a relay node even while
+    # the foreign primary is down (the failover case). `fail_fast: false` is used
+    # so a transient local-etcd outage surfaces as an Etcd::Error to the API
+    # caller rather than exiting the process.
+    module DRControl
+      extend self
+
+      def key : String
+        "#{Config.instance.clustering_etcd_prefix}/upstream_etcd"
+      end
+
+      # Current DR role: the raw key value, the effective upstream after applying
+      # the "primary" sentinel and the config fallback, and whether the region is
+      # a primary. Mirrors Controller#effective_upstream.
+      def status
+        raw = local_etcd.get(key)
+        effective = raw || Config.instance.clustering_upstream_etcd_endpoints
+        effective = "" if effective == Controller::UPSTREAM_PRIMARY
+        {upstream_etcd: raw, effective_upstream: effective, primary: effective.empty?}
+      end
+
+      # Set the key. Pass Controller::UPSTREAM_PRIMARY ("primary") to promote this
+      # region, or a foreign region's etcd endpoints to demote it to a DR follower.
+      def set(value : String) : Nil
+        local_etcd.put(key, value)
+      end
+
+      # Remove the key, reverting to the config-file fallback
+      # (clustering_upstream_etcd_endpoints).
+      def clear : Nil
+        local_etcd.del(key)
+      end
+
+      private def local_etcd : Etcd
+        Etcd.new(Config.instance.clustering_etcd_endpoints, fail_fast: false)
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -127,6 +127,40 @@ module LavinMQ
         each_follower &.delete(path)
       end
 
+      # Used by a relay (a node fed by an upstream Clustering::Client rather than
+      # a local message store) to forward an append it received from the upstream
+      # leader to its own downstream followers. Unlike `append`, it registers the
+      # path if it's new so that a later downstream full-sync includes the file.
+      def relay_append(path : String, bytes : Bytes)
+        path = strip_datadir path
+        @file_index.lock do |files, checksums|
+          files[path] = nil unless files.has_key?(path)
+          checksums.delete(path)
+        end
+        each_follower &.append(path, bytes)
+      end
+
+      # Register every existing file in the data dir into the file index. A relay
+      # populates its index this way after its own initial sync from the upstream
+      # leader, so it can serve full-syncs (files_with_hash/with_file read from
+      # disk) to its downstream followers for files that predate any streamed
+      # change.
+      def register_data_dir
+        register_dir(@data_dir)
+      end
+
+      private def register_dir(dir : String)
+        Dir.each_child(dir) do |child|
+          path = File.join(dir, child)
+          if File.directory?(path)
+            register_dir(path)
+          else
+            next if child.in?(".lock", ".clustering_id")
+            register_file(path)
+          end
+        end
+      end
+
       def nr_of_files
         @file_index.shared { |files, _checksums| files.size }
       end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -164,23 +164,21 @@ module LavinMQ
         @relay_mode = true
       end
 
-      # Called by the relay client after every completed upstream (re)sync.
-      # First sync: open the gate so downstream full-syncs may proceed.
-      # Later syncs (reconnect/failover): force connected downstream followers
-      # to re-sync, since the catch-up full-sync replaced/deleted files on disk
-      # that were never streamed to them.
-      def upstream_synced
-        if @upstream_synced.value
-          disconnect_followers
-        else
-          @upstream_synced.set(true)
-        end
+      # Held by the relay client for the duration of its upstream (re)sync so a
+      # downstream follower can't full_sync against half-applied state. A
+      # connecting follower blocks in handle_socket (after the readiness gate,
+      # before full_sync) until this is released. Reuses the same lock that
+      # already serializes downstream full-syncs (one at a time).
+      def syncing_from_upstream(&)
+        @sync_lock.synchronize { yield }
       end
 
-      private def disconnect_followers
-        # Each follower's handle_socket ensure removes it from @followers; the
-        # downstream Client.follow loop then reconnects and full-syncs.
-        all_followers.each &.close
+      # Called by the relay client after its first completed upstream sync to
+      # open the gate so downstream full-syncs may proceed. Idempotent across
+      # reconnects; reconnect catch-up deltas are streamed to connected
+      # followers from the relay client's sync_files, so no resync is forced.
+      def upstream_synced
+        @upstream_synced.set(true)
       end
 
       private def register_dir(dir : String)

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -10,6 +10,7 @@ require "../mfile"
 require "crypto/subtle"
 require "lz4"
 require "sync/shared"
+require "../bool_channel"
 
 module LavinMQ
   module Clustering
@@ -42,6 +43,14 @@ module LavinMQ
       # mfile.to_slice to read from the mmap. Full-sync paths always read from
       # disk via fresh File handles; only the append hot path reads the mmap.
       @file_index : Sync::Shared(Tuple(Hash(String, MFile?), Checksums))
+
+      # Relay readiness. A relay Server is fed by an upstream Clustering::Client
+      # rather than a local message store; it must not serve a downstream
+      # full-sync until that client has completed its initial sync and called
+      # register_data_dir, or the follower would sync against an empty index and
+      # delete its local dataset. Primary (non-relay) servers never gate.
+      @relay_mode = false
+      @upstream_synced = BoolChannel.new(false)
 
       def initialize(config : Config, @coordinator : Coordinator, @id : Int32)
         Log.info { "ID: #{@id.to_s(36)}" }
@@ -147,6 +156,31 @@ module LavinMQ
       # change.
       def register_data_dir
         register_dir(@data_dir)
+      end
+
+      # Marked by the controller in DR/relay mode (run_relay) before the
+      # downstream listener starts accepting followers.
+      def relay_mode!
+        @relay_mode = true
+      end
+
+      # Called by the relay client after every completed upstream (re)sync.
+      # First sync: open the gate so downstream full-syncs may proceed.
+      # Later syncs (reconnect/failover): force connected downstream followers
+      # to re-sync, since the catch-up full-sync replaced/deleted files on disk
+      # that were never streamed to them.
+      def upstream_synced
+        if @upstream_synced.value
+          disconnect_followers
+        else
+          @upstream_synced.set(true)
+        end
+      end
+
+      private def disconnect_followers
+        # Each follower's handle_socket ensure removes it from @followers; the
+        # downstream Client.follow loop then reconnects and full-syncs.
+        all_followers.each &.close
       end
 
       private def register_dir(dir : String)
@@ -263,6 +297,13 @@ module LavinMQ
           Log.error { "Disconnecting follower with the clustering id of the leader" }
           return
         end
+        if @relay_mode
+          begin
+            @upstream_synced.when_true.receive # wait until the relay has synced upstream
+          rescue Channel::ClosedError
+            return # server is shutting down
+          end
+        end
         @lock.synchronize do
           if stale_follower = @followers.find { |f| f.id == follower.id }
             Log.error { "Disconnecting stale follower with id #{follower.id.to_s(36)}" }
@@ -316,6 +357,7 @@ module LavinMQ
       end
 
       def close
+        @upstream_synced.close # unblock any follower fiber parked on the relay gate
         @listeners.each &.close
         @lock.synchronize do
           @followers.each &.close

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -164,6 +164,10 @@ module LavinMQ
         @relay_mode = true
       end
 
+      def relay_mode?
+        @relay_mode
+      end
+
       # Held by the relay client for the duration of its upstream (re)sync so a
       # downstream follower can't full_sync against half-applied state. A
       # connecting follower blocks in handle_socket (after the readiness gate,

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -315,6 +315,28 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_CLUSTERING_PORT")]
       property clustering_port = 5679
 
+      # Disaster recovery: when set (here or via the {prefix}/upstream_etcd key in
+      # this region's own etcd), this cluster acts as a DR follower of the foreign
+      # region reachable at these etcd endpoints. The etcd key, when present,
+      # overrides this fallback. Empty = this region is the primary.
+      @[CliOpt("", "--clustering-upstream-etcd-endpoints=URIs", "Foreign region etcd endpoints to replicate from in DR mode (fallback for the {prefix}/upstream_etcd key)", section: "clustering")]
+      @[IniOpt(ini_name: upstream_etcd_endpoints, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_UPSTREAM_ETCD_ENDPOINTS")]
+      property clustering_upstream_etcd_endpoints = ""
+
+      @[CliOpt("", "--clustering-upstream-etcd-prefix=KEY", "Key prefix used in the foreign region's etcd (default: same as --clustering-etcd-prefix)", section: "clustering")]
+      @[IniOpt(ini_name: upstream_etcd_prefix, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_UPSTREAM_ETCD_PREFIX")]
+      property clustering_upstream_etcd_prefix = ""
+
+      @[IniOpt(ini_name: on_promoted, section: "clustering")]
+      @[CliOpt("", "--clustering-on-promoted=COMMAND", "Shell command to execute when this region becomes the primary", section: "clustering")]
+      property clustering_on_promoted = "" # shell command to execute when this region becomes primary
+
+      @[IniOpt(ini_name: on_demoted, section: "clustering")]
+      @[CliOpt("", "--clustering-on-demoted=COMMAND", "Shell command to execute when this region becomes a DR follower", section: "clustering")]
+      property clustering_on_demoted = "" # shell command to execute when this region becomes a DR follower
+
       @[IniOpt(section: "amqp")]
       property max_consumers_per_channel = 0
 

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -13,7 +13,12 @@ module LavinMQ
     record Connection, socket : IO, address : String, auth : String?
     @endpoints : Array(Endpoint)
 
-    def initialize(endpoints = "localhost:2379")
+    # When `fail_fast` is true (the default) a connection failure to all
+    # endpoints exits the process — correct for a node's own etcd, which it
+    # can't run without. A foreign etcd (e.g. a DR relay watching the upstream
+    # region) sets it false so connection failures raise instead, letting the
+    # caller retry without taking the whole process down.
+    def initialize(endpoints = "localhost:2379", @fail_fast = true)
       @endpoints = endpoints.split(',').map { |ep| parse_endpoint(ep) }
     end
 
@@ -307,7 +312,9 @@ module LavinMQ
         next
       end
       Log.fatal { "No etcd endpoint responded" }
-      exit 5 # 5th character in the alphabet is E(etcd)
+      exit 5 if @fail_fast # 5th character in the alphabet is E(etcd)
+      # Non-fail-fast (foreign) etcd: let the caller retry instead of exiting.
+      raise Error.new("No etcd endpoint responded")
     end
 
     private def create_tcp_socket(host, port)

--- a/src/lavinmq/http/controller/cluster.cr
+++ b/src/lavinmq/http/controller/cluster.cr
@@ -114,5 +114,29 @@ module LavinMQ
         {error: "etcd_unavailable", reason: ex.message}.to_json(context.response)
       end
     end
+
+    # Readiness probe for a DR relay's barebones HTTP API. `ready` reports whether
+    # the relay is connected to its upstream leader and past the initial sync.
+    # 200 when ready, 503 otherwise — for load balancers / orchestrators.
+    class RelayHealthController
+      include Router
+
+      def initialize(@ready : -> Bool)
+        register_routes
+      end
+
+      private def register_routes
+        get "/health" do |context, _params|
+          context.response.content_type = "text/plain"
+          if @ready.call
+            context.response.print "ok\n"
+          else
+            context.response.status_code = 503
+            context.response.print "not ready: relay not synced with upstream\n"
+          end
+          context
+        end
+      end
+    end
   end
 end

--- a/src/lavinmq/http/controller/cluster.cr
+++ b/src/lavinmq/http/controller/cluster.cr
@@ -1,0 +1,118 @@
+require "../controller"
+require "../../clustering/dr_control"
+
+module LavinMQ
+  module HTTP
+    # Cross-region DR control: read this region's role and promote/demote it by
+    # setting `{prefix}/upstream_etcd`. Served on the management API (admin auth).
+    # Promotion during a failover (primary down) is handled locally on every
+    # node's internal unix socket by FollowerDRHandler.
+    class ClusterController < Controller
+      private def register_routes
+        get "/api/cluster/dr" do |context, _params|
+          refuse_unless_management(context, user(context))
+          dr_guarded(context) do
+            context.response.content_type = "application/json"
+            Clustering::DRControl.status.to_json(context.response)
+          end
+          context
+        end
+
+        put "/api/cluster/dr" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          dr_guarded(context) do
+            body = parse_body(context)
+            value = body["upstream_etcd"]?.try &.as_s?
+            bad_request(context, "Field 'upstream_etcd' is required") if value.nil? || value.empty?
+            Clustering::DRControl.set(value)
+            context.response.status_code = 204
+          end
+          context
+        end
+
+        delete "/api/cluster/dr" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          dr_guarded(context) do
+            Clustering::DRControl.clear
+            context.response.status_code = 204
+          end
+          context
+        end
+      end
+
+      # Returns 409 when clustering is disabled and turns a local-etcd outage
+      # into a 503 instead of letting Etcd::Error bubble up.
+      private def dr_guarded(context, &)
+        unless Config.instance.clustering?
+          context.response.status_code = 409
+          {error: "clustering_disabled", reason: "Clustering is not enabled on this node"}.to_json(context.response)
+          return
+        end
+        yield
+      rescue ex : Etcd::Error
+        context.response.status_code = 503
+        {error: "etcd_unavailable", reason: ex.message}.to_json(context.response)
+      end
+    end
+
+    # Serves the DR control routes on a follower/relay node's internal unix
+    # socket (which otherwise just returns 503), so an operator can promote a DR
+    # region during failover even though the management API is proxied to the
+    # (down) primary. The socket is local and trusted (mode 0660), so no auth is
+    # applied here; non-DR paths fall through to the 503 fallback handler.
+    class FollowerDRHandler
+      include Router
+
+      def initialize
+        register_routes
+      end
+
+      private def register_routes
+        get "/api/cluster/dr" do |context, _params|
+          dr_guarded(context) do
+            context.response.content_type = "application/json"
+            Clustering::DRControl.status.to_json(context.response)
+          end
+          context
+        end
+
+        put "/api/cluster/dr" do |context, _params|
+          dr_guarded(context) do
+            value = upstream_from_body(context)
+            if value.nil? || value.empty?
+              context.response.status_code = 400
+              {error: "bad_request", reason: "Field 'upstream_etcd' is required"}.to_json(context.response)
+            else
+              Clustering::DRControl.set(value)
+              context.response.status_code = 204
+            end
+          end
+          context
+        end
+
+        delete "/api/cluster/dr" do |context, _params|
+          dr_guarded(context) do
+            Clustering::DRControl.clear
+            context.response.status_code = 204
+          end
+          context
+        end
+      end
+
+      private def upstream_from_body(context) : String?
+        if body = context.request.body
+          JSON.parse(body)["upstream_etcd"]?.try &.as_s?
+        end
+      rescue JSON::ParseException
+        nil
+      end
+
+      private def dr_guarded(context, &)
+        yield
+      rescue ex : Etcd::Error
+        context.response.status_code = 503
+        {error: "etcd_unavailable", reason: ex.message}.to_json(context.response)
+      end
+    end
+  end
+end

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -88,21 +88,27 @@ module LavinMQ
       end
 
       # A barebones HTTP API for a DR relay node, which doesn't run the full
-      # management server. Exposes follower Prometheus metrics (/metrics), a
-      # readiness probe (/health), and the DR control routes (/api/cluster/dr).
-      # `ready` reports whether the relay is synced with its upstream leader.
+      # management server. Exposes only unauthenticated, read-only endpoints on
+      # the externally bound management port: follower Prometheus metrics
+      # (/metrics) and a readiness probe (/health). `ready` reports whether the
+      # relay is synced with its upstream leader.
+      #
+      # The DR control routes (/api/cluster/dr) that promote/demote the region
+      # are deliberately NOT served here — they mutate cluster state and this
+      # port has no authentication. They are served on the local internal unix
+      # socket instead (see `follower_internal_socket_http_server`), where access
+      # is gated by filesystem permissions (mode 0660).
       def self.relay_api(ready : -> Bool) : ::HTTP::Server
         handlers = [
           ApiErrorHandler.new,
           ApiDefaultsHandler.new,
           FollowerPrometheusController.new,
           RelayHealthController.new(ready),
-          FollowerDRHandler.new,
         ] of ::HTTP::Handler
         handlers.unshift(::HTTP::LogHandler.new(log: Log)) if Log.level == ::Log::Severity::Debug
         ::HTTP::Server.new(handlers) do |context|
           context.response.status_code = 404
-          context.response.print "Not found. Relay node serves only /metrics, /health and /api/cluster/dr.\n"
+          context.response.print "Not found. Relay node serves only /metrics and /health.\n"
         end
       end
 

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -44,6 +44,7 @@ module LavinMQ
           ShovelsController.new(@amqp_server),
           NodesController.new(@amqp_server),
           LogsController.new(@amqp_server),
+          ClusterController.new(@amqp_server),
         ] of ::HTTP::Handler
         handlers.unshift(::HTTP::LogHandler.new(log: Log)) if Log.level == ::Log::Severity::Debug
         @http = ::HTTP::Server.new(handlers)
@@ -87,9 +88,11 @@ module LavinMQ
       end
 
       # Starts a HTTP server that binds to the internal UNIX socket used by lavinmqctl.
-      # The server returns 503 to signal that the node is a follower and can not handle the request.
+      # DR control routes (/api/cluster/dr) are handled locally so a region can be
+      # promoted during a failover even when the primary is down; everything else
+      # returns 503 to signal that the node is a follower and can not handle the request.
       def self.follower_internal_socket_http_server
-        http_server = ::HTTP::Server.new do |context|
+        http_server = ::HTTP::Server.new([FollowerDRHandler.new] of ::HTTP::Handler) do |context|
           context.response.status_code = 503
           context.response.print "This node is a follower and does not handle lavinmqctl commands. \n" \
                                  "Please connect to the leader node by using the --host option."

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -87,6 +87,25 @@ module LavinMQ
         File.delete?(INTERNAL_UNIX_SOCKET)
       end
 
+      # A barebones HTTP API for a DR relay node, which doesn't run the full
+      # management server. Exposes follower Prometheus metrics (/metrics), a
+      # readiness probe (/health), and the DR control routes (/api/cluster/dr).
+      # `ready` reports whether the relay is synced with its upstream leader.
+      def self.relay_api(ready : -> Bool) : ::HTTP::Server
+        handlers = [
+          ApiErrorHandler.new,
+          ApiDefaultsHandler.new,
+          FollowerPrometheusController.new,
+          RelayHealthController.new(ready),
+          FollowerDRHandler.new,
+        ] of ::HTTP::Handler
+        handlers.unshift(::HTTP::LogHandler.new(log: Log)) if Log.level == ::Log::Severity::Debug
+        ::HTTP::Server.new(handlers) do |context|
+          context.response.status_code = 404
+          context.response.print "Not found. Relay node serves only /metrics, /health and /api/cluster/dr.\n"
+        end
+      end
+
       # Starts a HTTP server that binds to the internal UNIX socket used by lavinmqctl.
       # DR control routes (/api/cluster/dr) are handled locally so a region can be
       # promoted during a failover even when the primary is down; everything else

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -150,6 +150,13 @@ module LavinMQ
         http.bind_tls(@config.http_bind, @config.https_port, ctx)
       end
       spawn(name: "Relay HTTP API listener") { http.listen }
+
+      # Serve the DR control routes (/api/cluster/dr) on the local internal unix
+      # socket so an operator can promote this region during a failover — even at
+      # boot while the upstream region (and its etcd) is down, before any relay
+      # client has connected. The socket is local and access-controlled by its
+      # filesystem permissions (mode 0660), unlike the unauthenticated TCP API.
+      LavinMQ::HTTP::Server.follower_internal_socket_http_server
     end
 
     private def spawn_relay_reject_listener(bind : String, port : Int32,

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -10,6 +10,8 @@ require "./pidfile"
 require "./etcd"
 require "./clustering/controller"
 require "./clustering/etcd_coordinator"
+require "./amqp/relay_rejecter"
+require "./mqtt/relay_rejecter"
 require "./standalone_runner"
 require "./definitions"
 require "../stdlib/openssl_on_server_name"
@@ -24,6 +26,10 @@ module LavinMQ
     @data_dir_lock : DataDirLock?
     @closed = false
     @replicator : Clustering::Server?
+    # DR relay services (AMQP/MQTT reject listeners + barebones HTTP API),
+    # started lazily when the node enters relay mode.
+    @relay_servers = Array(TCPServer).new
+    @relay_http_server : ::HTTP::Server?
 
     def initialize(@config : Config)
       print_environment_info
@@ -51,6 +57,9 @@ module LavinMQ
         # On a role flip, gracefully stop before the supervisor restarts us into
         # the re-derived role (instead of an abrupt exit 38).
         controller.on_role_change = -> { graceful_restart_for_role_change }
+        # In relay mode the node serves no clients: reject AMQP/MQTT connections
+        # and run only a barebones HTTP API (metrics + health + DR control).
+        controller.on_relay_start = -> { start_relay_services(controller) }
       else
         @runner = StandaloneRunner.new
       end
@@ -99,6 +108,8 @@ module LavinMQ
       @http_server.try &.close rescue nil
       @amqp_server.try &.close rescue nil
       @metrics_server.try &.close rescue nil
+      @relay_http_server.try &.close rescue nil
+      @relay_servers.each &.close rescue nil
       @runner.stop
     end
 
@@ -110,6 +121,56 @@ module LavinMQ
       stop
       Fiber.yield
       exit 38 # 38 for region role change; supervisor restarts into the new role
+    end
+
+    # A DR relay serves no application clients. Reject AMQP/MQTT connections with
+    # a clear protocol-level signal, and expose a barebones HTTP API (Prometheus
+    # metrics, a readiness /health, and the DR control routes) on the management
+    # port instead of the full management server.
+    private def start_relay_services(controller : Clustering::Controller) : Nil
+      if @config.amqp_port > 0
+        spawn_relay_reject_listener(@config.amqp_bind, @config.amqp_port, nil, "Relay AMQP rejecter") { |io| AMQP.reject_relay(io) }
+      end
+      if @config.amqps_port > 0 && (ctx = @amqp_tls_context)
+        spawn_relay_reject_listener(@config.amqp_bind, @config.amqps_port, ctx, "Relay AMQPS rejecter") { |io| AMQP.reject_relay(io) }
+      end
+      if @config.mqtt_port > 0
+        spawn_relay_reject_listener(@config.mqtt_bind, @config.mqtt_port, nil, "Relay MQTT rejecter") { |io| MQTT.reject_relay(io, @config.mqtt_max_packet_size) }
+      end
+      if @config.mqtts_port > 0 && (ctx = @mqtt_tls_context)
+        spawn_relay_reject_listener(@config.mqtt_bind, @config.mqtts_port, ctx, "Relay MQTTS rejecter") { |io| MQTT.reject_relay(io, @config.mqtt_max_packet_size) }
+      end
+
+      http = @relay_http_server = LavinMQ::HTTP::Server.relay_api(-> { controller.relay_ready? })
+      if @config.http_port > 0
+        addr = http.bind_tcp(@config.http_bind, @config.http_port)
+        Log.info { "Relay HTTP API listening on #{addr}" }
+      end
+      if @config.https_port > 0 && (ctx = @http_tls_context)
+        http.bind_tls(@config.http_bind, @config.https_port, ctx)
+      end
+      spawn(name: "Relay HTTP API listener") { http.listen }
+    end
+
+    private def spawn_relay_reject_listener(bind : String, port : Int32,
+                                            tls_ctx : OpenSSL::SSL::Context::Server?,
+                                            name : String, &reject : ::IO -> Nil) : Nil
+      server = TCPServer.new(bind, port)
+      @relay_servers << server
+      Log.info { "Relay #{name} listening on #{server.local_address}" }
+      spawn(name: name) do
+        while socket = server.accept?
+          spawn do
+            io = tls_ctx ? OpenSSL::SSL::Socket::Server.new(socket, tls_ctx, sync_close: true).as(::IO) : socket.as(::IO)
+            reject.call(io)
+          rescue ex
+            Log.warn(exception: ex) { "#{name} failed to reject connection" }
+            socket.close rescue nil
+          end
+        end
+      rescue IO::Error
+        # listener closed during shutdown
+      end
     end
 
     private def print_environment_info

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -43,7 +43,11 @@ module LavinMQ
         etcd = Etcd.new(@config.clustering_etcd_endpoints)
         @runner = controller = Clustering::Controller.new(@config, etcd)
         coordinator = Clustering::EtcdCoordinator.new(@config, etcd)
-        @replicator = Clustering::Server.new(@config, coordinator, controller.id)
+        @replicator = replicator = Clustering::Server.new(@config, coordinator, controller.id)
+        # In DR (relay) mode the controller drives this server itself (it listens
+        # for the region's followers and is fed by the upstream region) instead
+        # of the local message store, and never yields to start the amqp server.
+        controller.replicator = replicator
       else
         @runner = StandaloneRunner.new
       end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -48,6 +48,9 @@ module LavinMQ
         # for the region's followers and is fed by the upstream region) instead
         # of the local message store, and never yields to start the amqp server.
         controller.replicator = replicator
+        # On a role flip, gracefully stop before the supervisor restarts us into
+        # the re-derived role (instead of an abrupt exit 38).
+        controller.on_role_change = -> { graceful_restart_for_role_change }
       else
         @runner = StandaloneRunner.new
       end
@@ -97,6 +100,16 @@ module LavinMQ
       @amqp_server.try &.close rescue nil
       @metrics_server.try &.close rescue nil
       @runner.stop
+    end
+
+    # The region's DR role flipped. Gracefully tear down this node's subsystems
+    # (drains AMQP clients in primary mode; just closes the relay client in DR
+    # mode) and exit 38 so the supervisor restarts into the re-derived role.
+    private def graceful_restart_for_role_change : Nil
+      Log.warn { "Region role changed; gracefully restarting to switch role" }
+      stop
+      Fiber.yield
+      exit 38 # 38 for region role change; supervisor restarts into the new role
     end
 
     private def print_environment_info

--- a/src/lavinmq/mqtt/relay_rejecter.cr
+++ b/src/lavinmq/mqtt/relay_rejecter.cr
@@ -6,7 +6,7 @@ module LavinMQ
     # the client's CONNECT and replies CONNACK with return code ServerUnavailable
     # (0x03), so MQTT clients get a clean rejection instead of a dropped socket.
     def self.reject_relay(socket, max_packet_size) : Nil
-      socket.read_timeout = 15.seconds
+      socket.read_timeout = 15.seconds if socket.responds_to?(:read_timeout=)
       io = MQTT::IO.new(socket, max_packet_size)
       if io.read_packet.as?(Connect)
         Connack.new(false, Connack::ReturnCode::ServerUnavailable).to_io(io)

--- a/src/lavinmq/mqtt/relay_rejecter.cr
+++ b/src/lavinmq/mqtt/relay_rejecter.cr
@@ -1,0 +1,21 @@
+require "./protocol"
+
+module LavinMQ
+  module MQTT
+    # Used by a DR relay node, which must not serve application clients. It reads
+    # the client's CONNECT and replies CONNACK with return code ServerUnavailable
+    # (0x03), so MQTT clients get a clean rejection instead of a dropped socket.
+    def self.reject_relay(socket, max_packet_size) : Nil
+      socket.read_timeout = 15.seconds
+      io = MQTT::IO.new(socket, max_packet_size)
+      if io.read_packet.as?(Connect)
+        Connack.new(false, Connack::ReturnCode::ServerUnavailable).to_io(io)
+        io.flush
+      end
+    rescue ::IO::Error | ::MQTT::Protocol::Error
+      # client disconnected or sent an invalid packet; nothing to do
+    ensure
+      socket.close rescue nil
+    end
+  end
+end

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -278,6 +278,19 @@ class LavinMQCtl
       @cmd = "cluster_status"
     end
 
+    @parser.separator("\nDisaster recovery")
+    @parser.on("dr_status", "Show this region's DR role (primary or follower)") do
+      @cmd = "dr_status"
+    end
+    @parser.on("promote_region", "Promote this region to primary (DR failover)") do
+      @cmd = "promote_region"
+      self.banner = "Usage: #{PROGRAM_NAME} promote_region"
+    end
+    @parser.on("demote_region", "Demote this region to a DR follower of the given foreign etcd endpoints") do
+      @cmd = "demote_region"
+      self.banner = "Usage: #{PROGRAM_NAME} demote_region <upstream-etcd-endpoints>"
+    end
+
     @parser.invalid_option { |arg| abort "Invalid argument: #{arg}" }
   end
 
@@ -324,6 +337,9 @@ class LavinMQCtl
     when "delete_exchange"       then delete_exchange
     when "status"                then status
     when "cluster_status"        then cluster_status
+    when "dr_status"             then dr_status
+    when "promote_region"        then promote_region
+    when "demote_region"         then demote_region
     when "set_vhost_limits"      then set_vhost_limits
     when "set_permissions"       then set_permissions
     when "definitions"           then definitions
@@ -860,6 +876,27 @@ class LavinMQCtl
       }
       output cluster_status_obj
     end
+  end
+
+  private def dr_status
+    resp = http.get "/api/cluster/dr", @headers
+    handle_response(resp, 200)
+    output JSON.parse(resp.body).as_h
+  end
+
+  private def promote_region
+    # "primary" is the {prefix}/upstream_etcd sentinel (Clustering::Controller::UPSTREAM_PRIMARY)
+    resp = http.put "/api/cluster/dr", @headers, {upstream_etcd: "primary"}.to_json
+    handle_response(resp, 204)
+    @io.puts "Region promoted to primary." unless quiet?
+  end
+
+  private def demote_region
+    upstream = ARGV.shift?
+    abort @banner unless upstream
+    resp = http.put "/api/cluster/dr", @headers, {upstream_etcd: upstream}.to_json
+    handle_response(resp, 204)
+    @io.puts "Region demoted to DR follower of #{upstream}." unless quiet?
   end
 
   private def set_vhost_limits


### PR DESCRIPTION
## Summary

Adds a disaster-recovery (DR) mode where a second region continuously replicates from the primary region but **cannot be promoted to global primary on its own**.

Each region runs its **own independent etcd cluster** (no stretched quorum, no etcd learners, no `--force-new-cluster` surgery on failover). The regions are linked through the existing replication stream, **relayed by a single node per DR region**:

- The DR region's elected leader connects to the primary region's etcd (read-only) to discover its leader, replicates from it, applies changes locally, and re-serves ("tees") the same stream to its own region's followers.
- Only one node per DR region crosses the region boundary; the rest replicate from it locally.

Because the DR region has **no presence in the primary's etcd election, it is structurally non-promotable**. Failover is an operator break-glass operation.

## Role mechanism

A region's role is implied by the `{prefix}/upstream_etcd` key in its **own** etcd:

- empty / absent → **primary** (accepts client writes)
- foreign etcd endpoints → **DR follower** (relay against those endpoints)
- `"primary"` sentinel → **promoted** (failover; a sentinel is needed because etcd's JSON omits empty values, so empty is indistinguishable from absent)

So failover = set the key to `primary`; reversal = set it to the new primary's etcd — a single key flip with **no per-node config edits**. Role changes restart the node (`exit 38`) to re-derive its role, reusing the existing supervisor-restart pattern (cf. lease-loss `exit 3`). A `--clustering-upstream-etcd-endpoints` config option is only a fallback for initial deploy.

## Changes

- **`client.cr`**: optional downstream `Server` sink; forward each applied append/replace/delete to the relay's followers.
- **`server.cr`**: `relay_append` + `register_data_dir` so the relay can serve downstream full-syncs off its local data dir.
- **`controller.cr`**: role detection via `{prefix}/upstream_etcd`, relay orchestration (second etcd client + upstream `Client` teeing into the replicator), and a role-change watch.
- **`options.cr`**: `--clustering-upstream-etcd-endpoints` / `--clustering-upstream-etcd-prefix` and `--clustering-on-promoted` / `--clustering-on-demoted` hooks.
- **`launcher.cr`**: hand the replicator to the controller; relay mode never starts the amqp/client listeners (the relay node is headless).

## Observability

The cross-region replication lag (your RPO exposure) is **already visible** in the primary's existing `/api/nodes` `followers` list — the relay connects as an ordinary follower of the primary leader, so no API change was needed.

## Tests

- `spec/clustering/relay_spec.cr` — full leader→relay→downstream cascade: a pre-existing file via full-sync, plus streamed append, replace, and delete.
- `spec/clustering/dr_role_spec.cr` — role detection and the `primary` sentinel override.
- `make test` (full suite): **1698 examples, 0 failures, 0 errors**
- `make lint`: **353 inspected, 0 failures**

## Notes / follow-ups

- Role transitions rely on the supervisor restarting the process (`exit 38`) — assumes systemd `Restart=always` (or equivalent) in the DR deployment.
- Deferred (minor): an explicit `region_role` field in the HTTP API, and a guarded `lavinmqctl`/HTTP command to flip the key (operators can use `etcdctl` for now).
- Split-brain during a *pure* partition is unavoidable in software; failover is an operator break-glass gated on infrastructure fencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)