### PR TITLE
OpenAPI docs fixes

### DIFF
--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -35,6 +35,8 @@ components:
       "$ref": "./schemas/channels.yaml#/channel-with-consumer-details"
     channels:
       "$ref": "./schemas/channels.yaml#/channels"
+    channels-PutChannelRequestBody:
+      "$ref": "./schemas/channels.yaml#/PutChannelRequestBody"
     connection:
       "$ref": "./schemas/connections.yaml#/connection"
     connections:

--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -125,6 +125,8 @@ components:
       "$ref": "./schemas/queues.yaml#/PutQueueRequestBody"
     queues-GetQueueMessagesRequestBody:
       "$ref": "./schemas/queues.yaml#/GetQueueMessagesRequestBody"
+    queues-StreamQueueMessagesRequestBody:
+      "$ref": "./schemas/queues.yaml#/StreamQueueMessagesRequestBody"
     user:
       "$ref": "./schemas/users.yaml#/user"
     users:
@@ -242,6 +244,12 @@ paths:
     "$ref": "./paths/policies.yaml#/~1policies~1{vhost}"
   "/policies/{vhost}/{name}":
     "$ref": "./paths/policies.yaml#/~1policies~1{vhost}~1{name}"
+  "/operator-policies":
+    "$ref": "./paths/operator-policies.yaml#/~1operator-policies"
+  "/operator-policies/{vhost}":
+    "$ref": "./paths/operator-policies.yaml#/~1operator-policies~1{vhost}"
+  "/operator-policies/{vhost}/{name}":
+    "$ref": "./paths/operator-policies.yaml#/~1operator-policies~1{vhost}~1{name}"
   "/permissions":
     "$ref": "./paths/permissions.yaml#/~1permissions"
   "/permissions/{vhost}/{user}":
@@ -264,6 +272,8 @@ paths:
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1contents"
   "/queues/{vhost}/{name}/get":
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1get"
+  "/queues/{vhost}/{name}/stream":
+    "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1stream"
   "/queues/{vhost}/{name}/unacked":
     "$ref": "./paths/queues.yaml#/~1queues~1{vhost}~1{name}~1unacked"
   "/users":
@@ -313,6 +323,8 @@ tags:
     description: Manage parameters.
   - name: policies
     description: Manage policies.
+  - name: operator-policies
+    description: Manage operator policies.
   - name: permissions
     description: Manage permissions.
   - name: queues

--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -174,7 +174,7 @@ paths:
     "$ref": "./paths/connections.yaml#/~1connections~1{name}"
   "/connections/{name}/channels":
     "$ref": "./paths/connections.yaml#/~1connections~1{name}~1channels"
-  "/api/connections/username/{username}":
+  "/connections/username/{username}":
     "$ref": "./paths/connections.yaml#/~1connections~1username~1{username}"
   "/consumers":
     "$ref": "./paths/consumers.yaml#/~1consumers"
@@ -208,16 +208,16 @@ paths:
     "$ref": "./paths/main.yaml#/~1whoami"
   "/aliveness-test/{vhost}":
     "$ref": "./paths/main.yaml#/~1aliveness-test~1{vhost}"
-  "/api/shovels":
-    "$ref": "./paths/shovels.yaml#/~1api~1shovels"
-  "/api/shovels/{vhost}":
-    "$ref": "./paths/shovels.yaml#/~1api~1shovels~1{vhost}"
-  "/api/shovels/{vhost}/{name}":
-    "$ref": "./paths/shovels.yaml#/~1api~1shovels~1{vhost}~1{name}"
-  "/api/shovels/{vhost}/{name}/pause":
-    "$ref": "./paths/shovels.yaml#/~1api~1shovels~1{vhost}~1{name}~1pause"
-  "/api/shovels/{vhost}/{name}/resume":
-    "$ref": "./paths/shovels.yaml#/~1api~1shovels~1{vhost}~1{name}~1resume"
+  "/shovels":
+    "$ref": "./paths/shovels.yaml#/~1shovels"
+  "/shovels/{vhost}":
+    "$ref": "./paths/shovels.yaml#/~1shovels~1{vhost}"
+  "/shovels/{vhost}/{name}":
+    "$ref": "./paths/shovels.yaml#/~1shovels~1{vhost}~1{name}"
+  "/shovels/{vhost}/{name}/pause":
+    "$ref": "./paths/shovels.yaml#/~1shovels~1{vhost}~1{name}~1pause"
+  "/shovels/{vhost}/{name}/resume":
+    "$ref": "./paths/shovels.yaml#/~1shovels~1{vhost}~1{name}~1resume"
   "/federation-links":
     "$ref": "./paths/main.yaml#/~1federation-links"
   "/federation-links/{vhost}":

--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -141,6 +141,8 @@ components:
       "$ref": "./schemas/vhosts.yaml#/vhost"
     vhosts:
       "$ref": "./schemas/vhosts.yaml#/vhosts"
+    vhosts-PutVhostRequestBody:
+      "$ref": "./schemas/vhosts.yaml#/PutVhostRequestBody"
     auth-PutHashPasswordRequestBody:
       "$ref": "./schemas/auth.yaml#/PutHashPasswordRequestBody"
     auth-PasswordHash:

--- a/static/docs/paths/bindings.yaml
+++ b/static/docs/paths/bindings.yaml
@@ -258,6 +258,12 @@
     description: Create a binding between two exchanges.
     summary: Create exchange binding
     operationId: PostBindingsExchange
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            "$ref": "../openapi.yaml#/components/schemas/bindings-PostBindingsExchangeQueueRequestBody"
     responses:
       '201':
         description: The binding was created successfully.

--- a/static/docs/paths/channels.yaml
+++ b/static/docs/paths/channels.yaml
@@ -91,3 +91,30 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+  put:
+    tags:
+    - channels
+    description: Update a channel's settings. Currently only the consumer prefetch count can be changed.
+    summary: Update channel
+    operationId: PutChannel
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            "$ref": "../openapi.yaml#/components/schemas/channels-PutChannelRequestBody"
+    responses:
+      '204':
+        description: The channel was updated successfully.
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"

--- a/static/docs/paths/operator-policies.yaml
+++ b/static/docs/paths/operator-policies.yaml
@@ -1,0 +1,148 @@
+"/operator-policies":
+  get:
+    tags:
+    - operator-policies
+    description: List all operator policies.
+    summary: List all operator policies
+    operationId: GetOperatorPolicies
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/policies"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/operator-policies/{vhost}":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  get:
+    tags:
+    - operator-policies
+    description: List all operator policies for a specific vhost.
+    summary: List operator policies for vhost
+    operationId: GetOperatorPoliciesVhost
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/policies"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/operator-policies/{vhost}/{name}":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  - in: path
+    name: name
+    required: true
+    schema:
+      type: string
+      description: Name of operator policy.
+  get:
+    tags:
+    - operator-policies
+    description: List a specific operator policy.
+    summary: List operator policy
+    operationId: GetOperatorPolicy
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/policy"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+  put:
+    tags:
+    - operator-policies
+    description: Create or update an operator policy.
+    summary: Create/update operator policy
+    operationId: PutOperatorPolicy
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            "$ref": "../openapi.yaml#/components/schemas/policies-PutPolicyRequestBody"
+    responses:
+      '201':
+        description: The operator policy was created successfully.
+      '204':
+        description: The operator policy was updated successfully.
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+  delete:
+    tags:
+    - operator-policies
+    description: Delete an operator policy.
+    summary: Delete operator policy
+    operationId: DeleteOperatorPolicy
+    responses:
+      '204':
+        description: The operator policy was deleted successfully.
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"

--- a/static/docs/paths/queues.yaml
+++ b/static/docs/paths/queues.yaml
@@ -386,6 +386,50 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/queues/{vhost}/{name}/stream":
+  parameters:
+  - in: path
+    name: vhost
+    required: true
+    schema:
+      type: string
+      description: Name of vhost.
+  - in: path
+    name: name
+    required: true
+    schema:
+      type: string
+      description: Name of queue.
+  post:
+    tags:
+    - queues
+    description: Read messages from a stream queue without consuming them. The queue must be a stream and in running or paused state.
+    summary: Read messages from a stream queue
+    operationId: StreamQueueMessages
+    requestBody:
+      content:
+        application/json:
+          schema:
+            "$ref": "../openapi.yaml#/components/schemas/queues-StreamQueueMessagesRequestBody"
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/queue-messages"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
 "/queues/{vhost}/{name}/unacked":
   parameters:
   - in: path

--- a/static/docs/paths/shovels.yaml
+++ b/static/docs/paths/shovels.yaml
@@ -1,5 +1,5 @@
 ---
-"/api/shovels":
+"/shovels":
   get:
     tags:
       - shovels
@@ -26,7 +26,7 @@
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
 
-"/api/shovels/{vhost}":
+"/shovels/{vhost}":
   parameters:
     - in: path
       name: vhost
@@ -60,7 +60,7 @@
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
 
-"/api/shovels/{vhost}/{name}":
+"/shovels/{vhost}/{name}":
   parameters:
     - in: path
       name: vhost
@@ -106,7 +106,7 @@
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
 
-"/api/shovels/{vhost}/{name}/pause":
+"/shovels/{vhost}/{name}/pause":
   parameters:
     - in: path
       name: vhost
@@ -154,7 +154,7 @@
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
 
-"/api/shovels/{vhost}/{name}/resume":
+"/shovels/{vhost}/{name}/resume":
   parameters:
     - in: path
       name: vhost

--- a/static/docs/paths/vhosts.yaml
+++ b/static/docs/paths/vhosts.yaml
@@ -64,6 +64,11 @@
     description: Create a new vhost, or update an existing vhost.
     summary: Create/update vhost
     operationId: PutVhost
+    requestBody:
+      content:
+        application/json:
+          schema:
+            "$ref": "../openapi.yaml#/components/schemas/vhosts-PutVhostRequestBody"
     responses:
       '201':
         description: The vhost was created successfully.

--- a/static/docs/schemas/channels.yaml
+++ b/static/docs/schemas/channels.yaml
@@ -110,3 +110,11 @@ float_stats_details:
       type: array
       items:
         type: number
+PutChannelRequestBody:
+  type: object
+  properties:
+    prefetch:
+      type: integer
+      minimum: 0
+      maximum: 65535
+      description: Consumer prefetch count for the channel.

--- a/static/docs/schemas/queues.yaml
+++ b/static/docs/schemas/queues.yaml
@@ -252,3 +252,23 @@ GetQueueMessagesRequestBody:
       type: string
     requeue:
       type: boolean
+StreamQueueMessagesRequestBody:
+  type: object
+  properties:
+    count:
+      type: integer
+      default: 1
+      description: Maximum number of messages to return.
+    offset:
+      type: string
+      default: first
+      description: Where to start reading. Accepts "first", "next", "last", a numeric offset, or a timestamp.
+    encoding:
+      type: string
+      default: auto
+      enum:
+      - auto
+      - base64
+    truncate:
+      type: integer
+      description: Truncate payloads to this number of bytes.

--- a/static/docs/schemas/queues.yaml
+++ b/static/docs/schemas/queues.yaml
@@ -249,7 +249,7 @@ GetQueueMessagesRequestBody:
       - auto
       - base64
     truncate:
-      type: string
+      type: integer
     requeue:
       type: boolean
 StreamQueueMessagesRequestBody:

--- a/static/docs/schemas/vhosts.yaml
+++ b/static/docs/schemas/vhosts.yaml
@@ -42,3 +42,12 @@ vhost:
           type: integer
         return_unroutable:
           type: integer
+PutVhostRequestBody:
+  type: object
+  properties:
+    description:
+      type: string
+      description: Optional description of the vhost.
+    tags:
+      type: string
+      description: Optional comma-separated list of tags.


### PR DESCRIPTION
### WHAT is this pull request doing?

Improving the OpenAPI docs.

- document operator-policies and queue stream endpoints
- correct GetQueueMessages truncate type to integer
- document PUT /channels/{name} endpoint
- drop erroneous /api prefix from shovels and connections paths
- document request body for exchange-to-exchange binding
- document PUT /vhosts request body

### HOW can this pull request be tested?

Browsing the docs
