### PR TITLE
fix: delete empty queue dirs on followers during streaming

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -520,6 +520,55 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
     end
   end
 
+  it "removes empty queue dir from follower when queue is deleted" do
+    with_clustering do |cluster|
+      with_amqp_server(replicator: cluster.replicator) do |s|
+        wait_for { cluster.replicator.followers.first?.try &.synced? }
+        with_channel(s) do |ch|
+          q = ch.queue("dirdelete_test", durable: true)
+          q.publish_confirm "hello"
+          qdir = s.vhosts["/"].queue("dirdelete_test").as(LavinMQ::AMQP::Queue).@data_dir
+          qdir_relative = qdir[(s.data_dir.size + 1)..]
+          replicated_qdir = File.join(cluster.follower_config.data_dir, qdir_relative)
+          wait_for { cluster.replicator.followers.first?.try &.lag_in_bytes == 0 }
+          wait_for { Dir.exists?(replicated_qdir) }
+          q.delete
+          wait_for { !Dir.exists?(replicated_qdir) }
+        end
+      end
+    end
+  end
+
+  it "keeps the queue dir on follower when a segment is deleted but the queue isn't" do
+    with_clustering do |cluster|
+      with_amqp_server(replicator: cluster.replicator) do |s|
+        wait_for { cluster.replicator.followers.first?.try &.synced? }
+        with_channel(s) do |ch|
+          q = ch.queue("segdelete_test", durable: true)
+          body = "x" * (LavinMQ::Config.instance.segment_size // 100)
+          # publish enough to span more than one segment, so an older fully-acked
+          # segment can be deleted while the active write segment + .queue remain
+          101.times { q.publish_confirm body }
+
+          dq = s.vhosts["/"].queue("segdelete_test").as(LavinMQ::AMQP::DurableQueue)
+          dq.@msg_store.@segments.size.should be > 1
+          repl_qdir = File.join(cluster.follower_config.data_dir, dq.@data_dir[(s.data_dir.size + 1)..])
+          wait_for { cluster.replicator.followers.first?.try &.lag_in_bytes == 0 }
+          files_before = Dir.children(repl_qdir).size
+
+          # consume and ack everything; fully-acked non-write segments get deleted
+          q.subscribe(no_ack: false, &.ack)
+          wait_for { dq.message_count == 0 && dq.@msg_store.@segments.size == 1 }
+          wait_for { cluster.replicator.followers.first?.try &.lag_in_bytes == 0 }
+
+          # a segment file was deleted, but the queue dir exists
+          Dir.exists?(repl_qdir).should be_true
+          Dir.children(repl_qdir).size.should be < files_before
+        end
+      end
+    end
+  end
+
   it "does not replicate .queue file for non-durable queue" do
     with_clustering do |cluster|
       with_amqp_server(replicator: cluster.replicator) do |s|

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -338,12 +338,12 @@ module LavinMQ
       private def delete_empty_dirs(dir)
         while dir != "."
           path = File.join(@data_dir, dir)
-          Dir.delete(path)
+          Dir.delete?(path) || break
           Log.debug { "Deleted empty dir #{dir}" }
           dir = File.dirname(dir)
         end
       rescue ex : File::Error
-        Log.debug { "Stopped deleting empty dirs at #{dir}: #{ex.message}" }
+        Log.error(exception: ex) { "Could not delete #{dir}: #{ex.message}" }
       end
 
       private def replace(filename, len, lz4)

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -324,6 +324,27 @@ module LavinMQ
         end
         @checksums.delete(filename)
         @file_digests.delete(filename)
+        delete_empty_dirs File.dirname(filename)
+      end
+
+      # Removes now-empty parent directories (e.g. an emptied queue dir) after a
+      # file delete. The leader only streams file deletes, not directory deletes,
+      # so without this empty queue dirs would linger until the next full sync.
+      #
+      # We walk up one level per iteration until a non-empty dir, stopping when
+      # File.dirname reaches ".". A non-force Dir.delete and the rescue stop the
+      # walk safely if a dir still has files or is already gone. Both append and
+      # replace file re-create the full path if needed.
+      private def delete_empty_dirs(dir)
+        while dir != "."
+          path = File.join(@data_dir, dir)
+          break unless Dir.empty?(path)
+          Dir.delete(path)
+          Log.debug { "Deleted empty dir #{dir}" }
+          dir = File.dirname(dir)
+        end
+      rescue ex : File::Error
+        Log.debug { "Stopped deleting empty dirs at #{dir}: #{ex.message}" }
       end
 
       private def replace(filename, len, lz4)

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -331,14 +331,13 @@ module LavinMQ
       # file delete. The leader only streams file deletes, not directory deletes,
       # so without this empty queue dirs would linger until the next full sync.
       #
-      # We walk up one level per iteration until a non-empty dir, stopping when
-      # File.dirname reaches ".". A non-force Dir.delete and the rescue stop the
-      # walk safely if a dir still has files or is already gone. Both append and
-      # replace file re-create the full path if needed.
+      # We walk up one level per iteration until File.dirname reaches ".". The
+      # non-recursive Dir.delete raises File::Error if the dir still has files
+      # (or is already gone), and the rescue stops the walk safely. Both append
+      # and replace file re-create the full path if needed.
       private def delete_empty_dirs(dir)
         while dir != "."
           path = File.join(@data_dir, dir)
-          break unless Dir.empty?(path)
           Dir.delete(path)
           Log.debug { "Deleted empty dir #{dir}" }
           dir = File.dirname(dir)


### PR DESCRIPTION
Part of #1854.

The leader streams individual file deletes to followers but never a directory delete, so an emptied queue dir lingered on followers until the next full sync (which already cleans up empty dirs).

After a streamed file delete, walk up from the file's parent removing now-empty dirs, stopping at the first non-empty dir. Paths are relative to the data dir and the walk stops when `File.dirname` reaches `"."`, so it never touches the data dir root. A non-force `Dir.delete` (plus `rescue`) keeps it safe; appends/replaces recreate the full path via `mkdir_p`.

## Test plan

- `removes empty queue dir from follower when queue is deleted`
- `keeps the queue dir on follower when a segment is deleted but the queue isn't`