### PR TITLE
Add Clustering::Coordinator abstraction over etcd

### DIFF
--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "../../src/lavinmq/clustering/server"
+require "../../src/lavinmq/clustering/etcd_coordinator"
 
 describe LavinMQ::Clustering::Server, tags: "etcd" do
   add_etcd_around_each
@@ -11,7 +12,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
         Dir.mkdir_p(data_dir)
         server = LavinMQ::Clustering::Server.new(
           LavinMQ::Config.instance,
-          LavinMQ::Etcd.new("localhost:12379"),
+          LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")),
           0)
         file = MFile.new(File.join(data_dir, "mfile_hash_test"), 1024)
         file.print "foo"
@@ -31,7 +32,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
         Dir.mkdir_p(data_dir)
         server = LavinMQ::Clustering::Server.new(
           LavinMQ::Config.instance,
-          LavinMQ::Etcd.new("localhost:12379"),
+          LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")),
           0)
         path = File.join(data_dir, "file_hash_test")
         file = File.open(path, "w")
@@ -54,7 +55,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
       Dir.mkdir_p(data_dir)
       server = LavinMQ::Clustering::Server.new(
         LavinMQ::Config.instance,
-        LavinMQ::Etcd.new("localhost:12379"),
+        LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")),
         0)
       path = File.join(data_dir, "path_only_file")
       File.write(path, "data")
@@ -74,7 +75,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
       Dir.mkdir_p(data_dir)
       server = LavinMQ::Clustering::Server.new(
         LavinMQ::Config.instance,
-        LavinMQ::Etcd.new("localhost:12379"),
+        LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")),
         0)
 
       mfiles = Array(MFile).new
@@ -124,7 +125,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
       Dir.mkdir_p(data_dir)
       server = LavinMQ::Clustering::Server.new(
         LavinMQ::Config.instance,
-        LavinMQ::Etcd.new("localhost:12379"),
+        LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")),
         0)
 
       mfiles = Array(MFile).new

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -83,12 +83,13 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
   # files are registered in the new replicator (verifies that meta files are registered and replicated).
   it "registers meta files on startup" do
     etcd = LavinMQ::Etcd.new("localhost:12379")
+    coordinator = LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, etcd)
     msg_dir = File.join(LavinMQ::Config.instance.data_dir, "meta_test_queue")
     FileUtils.mkdir_p(msg_dir)
     node_id = 0
 
     begin
-      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, etcd, node_id)
+      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, coordinator, node_id)
       msg_store = LavinMQ::MessageStore.new(msg_dir, replicator)
       segment_size = LavinMQ::Config.instance.segment_size
       msg_size = 1000_u64
@@ -103,7 +104,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
       replicator.close
 
       # Re-open the message store and verify the same files are registered
-      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, etcd, node_id + 1)
+      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, coordinator, node_id + 1)
       msg_store = LavinMQ::MessageStore.new(msg_dir, replicator)
       msg_store.close
       files_after = replicator.@file_index.shared { |files, _| files.keys }.sort!
@@ -269,7 +270,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
 
   it "won't deadlock under high load when a follower disconnects [#926]" do
     LavinMQ::Config.instance.clustering_max_unsynced_actions = 1
-    replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379"), 0)
+    replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")), 0)
     tcp_server = TCPServer.new("localhost", 0)
     spawn(replicator.listen(tcp_server), name: "repli server spec")
 
@@ -443,7 +444,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
     it "succeeds when message store is already closed before sync" do
       msg_dir = File.join(LavinMQ::Config.instance.data_dir, "sync_after_close_test")
       FileUtils.mkdir_p(msg_dir)
-      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379"), 0)
+      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")), 0)
       msg_store = LavinMQ::MessageStore.new(msg_dir, replicator)
       populate_msg_store(msg_store)
 
@@ -463,7 +464,7 @@ describe LavinMQ::Clustering::Client, tags: "etcd" do
     it "is not aborted when message store is closed concurrently" do
       msg_dir = File.join(LavinMQ::Config.instance.data_dir, "sync_close_concurrent_test")
       FileUtils.mkdir_p(msg_dir)
-      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379"), 0)
+      replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")), 0)
       msg_store = LavinMQ::MessageStore.new(msg_dir, replicator)
       populate_msg_store(msg_store)
 

--- a/spec/follower_proxy_during_sync_spec.cr
+++ b/spec/follower_proxy_during_sync_spec.cr
@@ -1,6 +1,7 @@
 require "./spec_helper"
 require "../src/lavinmq/launcher"
 require "../src/lavinmq/clustering/client"
+require "../src/lavinmq/clustering/etcd_coordinator"
 require "../src/lavinmq/proxy_protocol"
 
 # Create a custom slow clustering server for testing
@@ -31,7 +32,7 @@ describe "extract_conn_info during full_sync with syncing_followers", tags: "etc
   it "should handle PROXY protocol from syncing followers during full_sync" do
     leader_config = LavinMQ::Config.instance.dup
     FileUtils.mkdir_p(leader_config.data_dir)
-    slow_replicator = SlowClusteringServer.new(leader_config, LavinMQ::Etcd.new("localhost:12379"), 0)
+    slow_replicator = SlowClusteringServer.new(leader_config, LavinMQ::Clustering::EtcdCoordinator.new(leader_config, LavinMQ::Etcd.new("localhost:12379")), 0)
     leader_tcp_server = TCPServer.new("localhost", 0)
     spawn(slow_replicator.listen(leader_tcp_server), name: "slow leader clustering")
 

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -358,7 +358,7 @@ describe LavinMQ::MessageStore do
 
         # With a replicator (no followers), close spawns a fiber that races
         # with the constructor — this should close gracefully, not crash
-        replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379"), 0)
+        replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")), 0)
         begin
           store = LavinMQ::MessageStore.new(dir, replicator)
           store.closed.should be_true
@@ -386,7 +386,7 @@ describe LavinMQ::MessageStore do
 
         # With a replicator (no followers), this should close gracefully
         # even though valid segments before the corrupt one were already loaded
-        replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379"), 0)
+        replicator = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, LavinMQ::Clustering::EtcdCoordinator.new(LavinMQ::Config.instance, LavinMQ::Etcd.new("localhost:12379")), 0)
         begin
           store = LavinMQ::MessageStore.new(dir, replicator)
           store.closed.should be_true

--- a/spec/support/clustering_helper.cr
+++ b/spec/support/clustering_helper.cr
@@ -1,5 +1,6 @@
 require "../../src/lavinmq/clustering/client"
 require "../../src/lavinmq/clustering/server"
+require "../../src/lavinmq/clustering/etcd_coordinator"
 
 class SpecClustering
   getter replicator, config, follower_config, repli
@@ -9,7 +10,7 @@ class SpecClustering
   @stopped = false
 
   def initialize(@config : LavinMQ::Config, follower_data_dir : String)
-    @replicator = LavinMQ::Clustering::Server.new(config, LavinMQ::Etcd.new("localhost:12379"), 0)
+    @replicator = LavinMQ::Clustering::Server.new(config, LavinMQ::Clustering::EtcdCoordinator.new(config, LavinMQ::Etcd.new("localhost:12379")), 0)
     tcp_server = TCPServer.new("localhost", 0)
 
     @follower_config = @config.dup.tap &.data_dir = follower_data_dir

--- a/src/lavinmq/clustering/coordinator.cr
+++ b/src/lavinmq/clustering/coordinator.cr
@@ -1,0 +1,13 @@
+module LavinMQ::Clustering
+  # What Clustering::Server uses to write ISR and read/write the shared
+  # replication secret.
+  #
+  # All methods are safe to call from any thread.
+  abstract class Coordinator
+    # Replace the ISR set wholesale with the given node ids.
+    abstract def update_isr(synced_node_ids : Set(Int32)) : Nil
+
+    # Read the cluster's shared replication secret, generating one if missing.
+    abstract def password : String
+  end
+end

--- a/src/lavinmq/clustering/etcd_coordinator.cr
+++ b/src/lavinmq/clustering/etcd_coordinator.cr
@@ -1,0 +1,27 @@
+require "./coordinator"
+require "../etcd"
+require "../config"
+require "random/secure"
+
+module LavinMQ::Clustering
+  class EtcdCoordinator < Coordinator
+    Log = LavinMQ::Log.for "clustering.etcd_coordinator"
+
+    def initialize(@config : Config, @etcd : Etcd)
+    end
+
+    def update_isr(synced_node_ids : Set(Int32)) : Nil
+      key = "#{@config.clustering_etcd_prefix}/isr"
+      ids = synced_node_ids.map(&.to_s(36)).join(",")
+      @etcd.put(key, ids)
+    end
+
+    def password : String
+      key = "#{@config.clustering_etcd_prefix}/clustering_secret"
+      secret = Random::Secure.base64(32)
+      stored = @etcd.put_or_get(key, secret)
+      Log.info { "Generated new clustering secret" } if stored == secret
+      stored
+    end
+  end
+end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -3,13 +3,13 @@ require "./file_index"
 require "./replicator"
 require "./follower"
 require "./checksums"
+require "./coordinator"
 require "../config"
 require "../message"
 require "../mfile"
 require "crypto/subtle"
 require "lz4"
 require "sync/shared"
-require "../etcd"
 
 module LavinMQ
   module Clustering
@@ -43,7 +43,7 @@ module LavinMQ
       # disk via fresh File handles; only the append hot path reads the mmap.
       @file_index : Sync::Shared(Tuple(Hash(String, MFile?), Checksums))
 
-      def initialize(config : Config, @etcd : Etcd, @id : Int32)
+      def initialize(config : Config, @coordinator : Coordinator, @id : Int32)
         Log.info { "ID: #{@id.to_s(36)}" }
         @config = config
         @data_dir = @config.data_dir
@@ -203,13 +203,7 @@ module LavinMQ
       end
 
       def password : String
-        key = "#{@config.clustering_etcd_prefix}/clustering_secret"
-        secret = Random::Secure.base64(32)
-        stored_secret = @etcd.put_or_get(key, secret)
-        if stored_secret == secret
-          Log.info { "Generated new clustering secret" }
-        end
-        stored_secret
+        @coordinator.password
       end
 
       @listeners = Array(TCPServer).new(1)
@@ -277,17 +271,13 @@ module LavinMQ
       end
 
       private def update_isr
-        isr_key = "#{@config.clustering_etcd_prefix}/isr"
-        ids = String.build do |str|
-          @followers.each do |f|
-            next unless f.synced?
-            f.id.to_s(str, 36)
-            str << ","
-          end
-          @id.to_s(str, 36)
+        ids = Set(Int32).new
+        @followers.each do |f|
+          ids.add(f.id) if f.synced?
         end
-        Log.info { "In-sync replicas: #{ids}" }
-        @etcd.put(isr_key, ids)
+        ids.add(@id)
+        Log.info { "In-sync replicas: #{ids.to_a}" }
+        @coordinator.update_isr(ids)
         @dirty_isr = false
       end
 

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -9,6 +9,7 @@ require "./data_dir_lock"
 require "./pidfile"
 require "./etcd"
 require "./clustering/controller"
+require "./clustering/etcd_coordinator"
 require "./standalone_runner"
 require "./definitions"
 require "../stdlib/openssl_on_server_name"
@@ -41,7 +42,8 @@ module LavinMQ
       if @config.clustering?
         etcd = Etcd.new(@config.clustering_etcd_endpoints)
         @runner = controller = Clustering::Controller.new(@config, etcd)
-        @replicator = Clustering::Server.new(@config, etcd, controller.id)
+        coordinator = Clustering::EtcdCoordinator.new(@config, etcd)
+        @replicator = Clustering::Server.new(@config, coordinator, controller.id)
       else
         @runner = StandaloneRunner.new
       end


### PR DESCRIPTION
## Summary

- Introduces `Clustering::Coordinator`, a thin abstract base with two methods (`update_isr`, `password`) that captures what `Clustering::Server` actually needs from its coordination backend.
- Adds `Clustering::EtcdCoordinator`, the etcd-backed implementation that owns the `clustering_etcd_prefix/isr` and `clustering_etcd_prefix/clustering_secret` keys, base-36 ISR encoding, and secret generation (incl. the existing "Generated new clustering secret" log).
- `Clustering::Server` no longer references `Etcd` — it takes a `Coordinator` in its constructor, delegates `password`, and hands `update_isr` a `Set(Int32)`. `Controller` still uses `Etcd` directly for leases / leader election.

The motivation is to make `Server`'s coordination dependency narrow and swappable without changing its file-replication logic.

## Test plan

- [ ] `make lint` (clean locally)
- [ ] `make test` against existing clustering specs (`spec/clustering/server_spec.cr`, `spec/clustering_spec.cr`, `spec/follower_proxy_during_sync_spec.cr`, `spec/message_store_spec.cr`) — call sites updated to wrap `Etcd` in `EtcdCoordinator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)