### PR TITLE
test: fix flaky policy and deduplication specs

### DIFF
--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -189,10 +189,7 @@ describe LavinMQ::Deduplication::Deduper do
           # Publish a message and verify it has been delayed and not thrown away
           x.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
 
-          select
-          when delay_q.empty.when_false.receive
-          end
-
+          wait_for { !delay_q.empty? }
           exchange.dedup_count.should eq 0
 
           # Publish a second message, verify that it's thrown away
@@ -202,9 +199,7 @@ describe LavinMQ::Deduplication::Deduper do
 
           # wait for the delayed message to be delivered
           # the expire time in the deduplication cache should not be affected
-          select
-          when delay_q.empty.when_true.receive
-          end
+          wait_for { delay_q.empty? }
           # by sleeping 20 milliseconds time should have moved at least cache_ttl
           # + 10 milliseconds (we did - 10 in the hdrs) and therefore the cache
           # should not be empty.
@@ -214,12 +209,7 @@ describe LavinMQ::Deduplication::Deduper do
           # Publish a third message and verify it's not thrown away
           x.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
 
-          select
-          when delay_q.empty.when_false.receive
-          when timeout 1.second
-            fail "no message in delay_q?!"
-          end
-
+          wait_for { !delay_q.empty? }
           exchange.dedup_count.should eq 1
         end
       end

--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -258,16 +258,17 @@ describe LavinMQ::VHost do
           3.times do
             q.publish_confirm "body"
           end
-          ch.queue_declare(q.name, passive: true)[:message_count].should eq 2
+          queue = s.vhosts["/"].queue(q.name).as(LavinMQ::AMQP::Queue)
+          queue.message_count.should eq 2
           s.vhosts["/"].add_operator_policy("ml1", ".*", "all", ml_1, 0_i8)
-          ch.queue_declare(q.name, passive: true)[:message_count].should eq 1
+          wait_for { queue.message_count == 1 }
 
           # deleting operator policy should make normal policy active again
           s.vhosts["/"].delete_operator_policy("ml1")
           3.times do
             q.publish_confirm "body"
           end
-          ch.queue_declare(q.name, passive: true)[:message_count].should eq 2
+          queue.message_count.should eq 2
         end
       end
     end


### PR DESCRIPTION
Fixes two timing-dependent flakes seen in CI on unrelated branches.

## `deduplication_spec.cr:164`
`should not reset x-cache-ttl on expire when using delayed exchange`

CI failure: `spec timed out after 15s`. The example used edge-triggered `select` on `delay_q.empty.when_false`/`when_true` with no timeout. If the empty↔non-empty transition fired before the `select` subscribed, it blocked forever and hit the 15s global spec timeout (#1982).

Fixed by replacing the edge-triggered `select`s with level-triggered `wait_for { ... }` polling, so a missed edge can't hang.

Failed runs:
- https://github.com/cloudamqp/lavinmq/actions/runs/26768296251/job/78900598493
- https://github.com/cloudamqp/lavinmq/actions/runs/26659866331/job/78579413133

## `policies_spec.cr:263`
`operator policies merges with normal polices`

CI failure: `message_count` got 2, expected 1. The example asserted `message_count.should eq 1` immediately after `add_operator_policy("ml1", max-length 1)`. Applying a policy that has to drop messages from an already-populated queue is async, so under load the queue could still read 2.

Fixed with `wait_for { queue.message_count == 1 }`. Also reads `message_count` directly instead of via a passive `queue_declare` round-trip.

Failed runs:
- https://github.com/cloudamqp/lavinmq/actions/runs/26695385393/job/78678929920
- https://github.com/cloudamqp/lavinmq/actions/runs/26751021898/job/78838735286

## Test plan
- `make test SPEC=spec/policies_spec.cr` - 29 examples, 0 failures
- `make test SPEC=spec/deduplication_spec.cr` - 13 examples, 0 failures