### PR TITLE
Remove badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-[![Build Status](https://github.com/cloudamqp/lavinmq/workflows/CI/badge.svg)](https://github.com/cloudamqp/lavinmq/actions)
-[![Build Status](https://api.cirrus-ci.com/github/cloudamqp/lavinmq.svg)](https://cirrus-ci.com/github/cloudamqp/lavinmq)
-[![License](https://img.shields.io/github/license/cloudamqp/lavinmq)](https://github.com/cloudamqp/lavinmq/blob/master/LICENSE)
-[![GitHub release](https://img.shields.io/github/v/release/cloudamqp/lavinmq)](https://github.com/cloudamqp/lavinmq/releases)
-
 # ![LavinMQ](static/img/banner-lavinmq.svg)
 
 LavinMQ is a high-performance message queue & streaming server implementing the AMQP 0-9-1 and MQTT 3.1.0, 3.1.1 protocols.


### PR DESCRIPTION
GitHub UI shows this in other places nowadays, in the past it made sense to have these buttons but IMO mostly noise now.

License is a tab just above the README preview:

<img width="979" height="156" alt="Screenshot 2026-06-04 at 10 47 01" src="https://github.com/user-attachments/assets/4e2bcb82-c259-40bc-a711-3053123ebd0d" />

Latest release is on the right side:

<img width="347" height="152" alt="Screenshot 2026-06-04 at 10 47 03" src="https://github.com/user-attachments/assets/b37fd3f8-7896-48e7-90d9-5be226db45f7" />
