### PR TITLE
Anchor server uptime and CPU counters to OS process lifetime

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -113,6 +113,13 @@ describe LavinMQ::HTTP::PrometheusController do
         mfile_metric.not_nil![:value].should be >= 0
       end
     end
+
+    it "should report uptime anchored to PROCESS_START, surviving Server re-creation" do
+      with_metrics_server do |_, server|
+        expected = Time.instant - LavinMQ::PROCESS_START
+        (server.uptime - expected).abs.should be < 100.milliseconds
+      end
+    end
   end
 
   describe "vhost access control" do

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -115,9 +115,12 @@ describe LavinMQ::HTTP::PrometheusController do
     end
 
     it "should report uptime anchored to PROCESS_START, surviving Server re-creation" do
+      uptime1 = uninitialized Time::Span
       with_metrics_server do |_, server|
-        expected = Time.instant - LavinMQ::PROCESS_START
-        (server.uptime - expected).abs.should be < 100.milliseconds
+        uptime1 = server.uptime
+      end
+      with_metrics_server do |_, server|
+        server.uptime.should be > uptime1
       end
     end
   end

--- a/src/lavinmq/process_start.cr
+++ b/src/lavinmq/process_start.cr
@@ -1,0 +1,4 @@
+module LavinMQ
+  # Anchors Server#uptime to OS process; survives leader transitions.
+  PROCESS_START = Time.instant
+end

--- a/src/lavinmq/process_start.cr
+++ b/src/lavinmq/process_start.cr
@@ -1,4 +1,0 @@
-module LavinMQ
-  # Anchors Server#uptime to OS process; survives leader transitions.
-  PROCESS_START = Time.instant
-end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -4,6 +4,7 @@ require "systemd"
 require "./amqp"
 require "./mqtt/protocol"
 require "./rough_time"
+require "./process_start"
 require "../stdlib/*"
 require "./persister"
 require "./vhost_store"
@@ -32,7 +33,6 @@ module LavinMQ
     getter vhosts, users, data_dir, parameters, authenticator
     include ParameterTarget
 
-    @start = Time.instant
     @closed = BoolChannel.new(false)
     @flow = true
 
@@ -50,6 +50,13 @@ module LavinMQ
     Log = LavinMQ::Log.for "server"
 
     def initialize(@config : Config, @replicator = nil)
+      # Seed from rusage so counters survive Server re-creation on leader transitions.
+      rusage = System.resource_usage
+      @user_time = rusage.user_time.total_milliseconds.to_i64
+      @sys_time = rusage.sys_time.total_milliseconds.to_i64
+      @blocks_in = rusage.blocks_in.to_i64
+      @blocks_out = rusage.blocks_out.to_i64
+
       @data_dir = @config.data_dir
       Dir.mkdir_p @data_dir
       Schema.migrate(@data_dir, @replicator)
@@ -479,7 +486,7 @@ module LavinMQ
     METRICS = {:user_time, :sys_time, :blocks_out, :blocks_in}
 
     {% for m in METRICS %}
-      getter {{ m.id }} = 0_i64
+      getter {{ m.id }} : Int64
       getter {{ m.id }}_log = Deque(Float64).new(Config.instance.stats_log_size)
     {% end %}
     getter mem_limit = 0_i64
@@ -528,7 +535,7 @@ module LavinMQ
     end
 
     def uptime
-      Time.instant - @start
+      Time.instant - LavinMQ::PROCESS_START
     end
   end
 end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -4,7 +4,6 @@ require "systemd"
 require "./amqp"
 require "./mqtt/protocol"
 require "./rough_time"
-require "./process_start"
 require "../stdlib/*"
 require "./persister"
 require "./vhost_store"
@@ -25,6 +24,8 @@ require "./auth/jwt/jwks_fetcher"
 
 module LavinMQ
   class Server
+    PROCESS_START = Time.instant
+
     enum Protocol
       AMQP
       MQTT
@@ -535,7 +536,7 @@ module LavinMQ
     end
 
     def uptime
-      Time.instant - LavinMQ::PROCESS_START
+      Time.instant - PROCESS_START
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?

Anchors `lavinmq_uptime` and the counters `@user_time` / `@sys_time` / `@blocks_in` / `@blocks_out (which feed both `/metrics` and `/api/nodes/{name}` with e.g. the metrics lavinmq_cpu_user_time_total` and `lavinmq_cpu_system_time_total`) to the process lifetime instead of the `Server` instance lifetime.

`launcher.start` constructs a fresh `Server` on every leader election. Before this change, that reset:

- `@start = Time.instant` → `Server#uptime` dropped to ~0 on every leader transition.
- `@user_time = 0_i64` (macro default) → cached counter dropped to 0 until `stats_loop`'s first tick repopulated it.

Which also reset prometheus cpu counters `lavinmq_cpu_user_time_total` and `lavinmq_cpu_system_time_total`. 

Noticed this while calculating `rate()` of the cpu counters (`lavinmq_cpu_user_time_total` and `lavinmq_cpu_system_time_total`) which produced huge spikes that went far above 100 % on some LavinMQ multi-node clusters. All of them happening a few seconds after a leader transition. 

**Fix:**

- New `src/lavinmq/process_start.cr` defines `LavinMQ::PROCESS_START = Time.instant`, captured once at static-init and immune to `Server.new`. `Server#uptime` now reads it instead of the instance var `@start`.
- `Server#initialize` seeds `@user_time` / `@sys_time` / `@blocks_in` / `@blocks_out` from `System.resource_usage`, so a fresh `Server` instance already reflects the OS process's accumulated rusage.
- The `METRICS` macro changed from `getter foo = 0_i64` to `getter foo : Int64` (no default). Crystal refuses to compile if a future change removes the seeding from `initialize` — the type system is the regression check.

### HOW can this pull request be tested?

**Spec** for the uptime fix:

```
make test SPEC=spec/api/prometheus_spec.cr
```

**Compile-time check** (regression for the cpu/blocks seeding):

Removing the seeding lines from `Server#initialize` produces:

```
Error: instance variable '@user_time' of LavinMQ::Server was not initialized directly in all of the 'initialize' methods, rendering it nilable.
```