### PR TITLE
Batch persistence during definitions import

### DIFF
--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -62,18 +62,18 @@ module LavinMQ
         user
       end
 
-      def add_permission(user : User, vhost, config, read, write)
-        add_permission(user.name, vhost, config, read, write)
+      def add_permission(user : User, vhost, config, read, write, save = true)
+        add_permission(user.name, vhost, config, read, write, save)
       end
 
-      def add_permission(user, vhost, config, read, write)
+      def add_permission(user, vhost, config, read, write, save = true)
         perm = {config: config, read: read, write: write}
         if @users[user].permissions[vhost]? && @users[user].permissions[vhost] == perm
           return perm
         end
         @users[user].permissions[vhost] = perm
         @users[user].clear_permissions_cache
-        save!
+        save! if save
         perm
       end
 

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -199,6 +199,11 @@ module LavinMQ
 
     private def import_parameters(body, skip_existing = false)
       if parameters = body["parameters"]?
+        # add with save: false and save each touched store once at the end, so a
+        # large import doesn't rewrite the whole parameters/operator_policies
+        # JSON file per entry.
+        touched_parameters = Set(VHost).new
+        touched_operator_policies = Set(VHost).new
         parameters.as_a.each do |p|
           if v = fetch_vhost?(p)
             name = p["name"].as_s
@@ -208,13 +213,16 @@ module LavinMQ
             when "vhost-limits"
               import_vhost_limits(v, value, skip_existing)
             when "operator_policy"
-              import_operator_policy(v, name, value, skip_existing)
+              touched_operator_policies << v if import_operator_policy(v, name, value, skip_existing)
             else
               next if skip_existing && v.parameters[{component, name}]?
-              v.add_parameter(Parameter.new(component, name, p["value"]))
+              v.add_parameter(Parameter.new(component, name, p["value"]), save: false)
+              touched_parameters << v
             end
           end
         end
+        touched_parameters.each(&.save_parameters!)
+        touched_operator_policies.each(&.save_operator_policies!)
       end
     end
 
@@ -228,28 +236,35 @@ module LavinMQ
       end
     end
 
-    private def import_operator_policy(v, name, value, skip_existing)
-      return if skip_existing && v.operator_policies[name]?
+    # Returns true if the operator policy was added (false when skipped).
+    private def import_operator_policy(v, name, value, skip_existing) : Bool
+      return false if skip_existing && v.operator_policies[name]?
       v.add_operator_policy(name,
         value["pattern"].as_s,
         value["apply-to"].as_s,
         value["definition"].as_h,
-        value["priority"].as_i.to_i8)
+        value["priority"].as_i.to_i8,
+        save: false)
+      true
     end
 
     private def import_global_parameters(body, skip_existing = false)
       if parameters = body["global_parameters"]?
+        added = false
         parameters.as_a.each do |p|
           name = p["name"].as_s
           next if skip_existing && @amqp_server.parameters[{nil, name}]?
           param = Parameter.new(nil, name, p["value"])
-          @amqp_server.add_parameter(param)
+          @amqp_server.add_parameter(param, save: false)
+          added = true
         end
+        @amqp_server.save_parameters! if added
       end
     end
 
     private def import_policies(body, skip_existing = false)
       if policies = body["policies"]?
+        touched = Set(VHost).new
         policies.as_a.each do |p|
           if v = fetch_vhost?(p)
             name = p["name"].as_s
@@ -259,9 +274,12 @@ module LavinMQ
               p["pattern"].as_s,
               p["apply-to"].as_s,
               p["definition"].as_h,
-              p["priority"].as_i.to_i8)
+              p["priority"].as_i.to_i8,
+              save: false)
+            touched << v
           end
         end
+        touched.each(&.save_policies!)
       end
     end
 

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -12,6 +12,13 @@ module LavinMQ
     abstract def fetch_vhost?(json)
     abstract def vhosts
 
+    # The queue/exchange/binding imports store definitions with fsync: false to
+    # avoid an fsync per object; this flushes each vhost's definitions file once
+    # at the end instead.
+    private def fsync_definition_files
+      vhosts.each_value(&.fsync_definitions)
+    end
+
     private def export_vhost_parameters(json)
       json.array do
         vhosts.each_value do |vhost|
@@ -75,7 +82,7 @@ module LavinMQ
             durable = q["durable"].as_bool
             auto_delete = q["auto_delete"].as_bool
             arguments = AMQP::Table.new(q["arguments"].as_h)
-            v.declare_queue(name, durable, auto_delete, arguments)
+            v.declare_queue(name, durable, auto_delete, arguments, fsync: false)
           end
         end
       end
@@ -91,7 +98,7 @@ module LavinMQ
             internal = e["internal"].as_bool
             auto_delete = e["auto_delete"].as_bool
             arguments = AMQP::Table.new(e["arguments"].as_h)
-            v.declare_exchange(name, type, durable, auto_delete, internal, arguments)
+            v.declare_exchange(name, type, durable, auto_delete, internal, arguments, fsync: false)
           end
         end
       end
@@ -108,9 +115,9 @@ module LavinMQ
             arguments = AMQP::Table.new(b["arguments"].as_h?)
             case destination_type
             when "queue"
-              v.bind_queue(destination, source, routing_key, arguments)
+              v.bind_queue(destination, source, routing_key, arguments, fsync: false)
             when "exchange"
-              v.bind_exchange(destination, source, routing_key, arguments)
+              v.bind_exchange(destination, source, routing_key, arguments, fsync: false)
             end
           end
         end
@@ -351,6 +358,7 @@ module LavinMQ
       import_queues(body)
       import_exchanges(body)
       import_bindings(body)
+      fsync_definition_files
       import_policies(body, skip_existing)
       import_parameters(body, skip_existing)
     end
@@ -388,6 +396,7 @@ module LavinMQ
       import_queues(body)
       import_exchanges(body)
       import_bindings(body)
+      fsync_definition_files
       import_policies(body, skip_existing)
       import_parameters(body, skip_existing)
       import_global_parameters(body, skip_existing)

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -67,10 +67,14 @@ module LavinMQ
 
     private def import_vhosts(body)
       if vhosts = body["vhosts"]?
+        # Create with save: false so each vhost doesn't rewrite+fsync vhosts.json
+        # (and users.json, via the permissions create adds); save both once at the end.
         vhosts.as_a.each do |v|
           name = v["name"].as_s
-          @amqp_server.vhosts.create name
+          @amqp_server.vhosts.create name, save: false
         end
+        @amqp_server.vhosts.save!
+        @amqp_server.users.save!
       end
     end
 

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -216,13 +216,14 @@ module LavinMQ
               touched_operator_policies << v if import_operator_policy(v, name, value, skip_existing)
             else
               next if skip_existing && v.parameters[{component, name}]?
-              v.add_parameter(Parameter.new(component, name, p["value"]), save: false)
+              v.add_parameter(Parameter.new(component, name, p["value"]), save: false, apply: false)
               touched_parameters << v
             end
           end
         end
         touched_parameters.each(&.save_parameters!)
         touched_operator_policies.each(&.save_operator_policies!)
+        apply_policies(touched_parameters | touched_operator_policies)
       end
     end
 
@@ -244,7 +245,8 @@ module LavinMQ
         value["apply-to"].as_s,
         value["definition"].as_h,
         value["priority"].as_i.to_i8,
-        save: false)
+        save: false,
+        apply: false)
       true
     end
 
@@ -275,11 +277,20 @@ module LavinMQ
               p["apply-to"].as_s,
               p["definition"].as_h,
               p["priority"].as_i.to_i8,
-              save: false)
+              save: false,
+              apply: false)
             touched << v
           end
         end
         touched.each(&.save_policies!)
+        apply_policies(touched)
+      end
+    end
+
+    # Apply policies once per vhost after a bulk import, instead of per entry.
+    private def apply_policies(vhosts : Set(VHost))
+      vhosts.each do |v|
+        spawn v.apply_policies, name: "ApplyPolicies (import) #{v.name}"
       end
     end
 

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -19,6 +19,14 @@ module LavinMQ
       @definitions_deletes = 0
     end
 
+    # Flush buffered definition writes to disk. Used after a bulk operation
+    # (e.g. import) that stored its definitions with fsync: false.
+    def fsync
+      @definitions_lock.synchronize do
+        @definitions_file.fsync
+      end
+    end
+
     # Exchange accessors
 
     def exchange?(name : String) : Exchange?
@@ -101,7 +109,7 @@ module LavinMQ
     end
 
     # ameba:disable Metrics/CyclomaticComplexity
-    def apply(f, loading = false) : Bool
+    def apply(f, loading = false, fsync = true) : Bool
       @definitions_lock.synchronize do
         case f
         when AMQP::Frame::Exchange::Declare
@@ -109,7 +117,7 @@ module LavinMQ
           e = @exchanges[f.exchange_name] =
             make_exchange(@vhost, f.exchange_name, f.exchange_type, f.durable, f.auto_delete, f.internal, f.arguments)
           @vhost.apply_policies([e] of Exchange) unless loading
-          store_definition(f) if !loading && f.durable
+          store_definition(f, fsync: fsync) if !loading && f.durable
         when AMQP::Frame::Exchange::Delete
           if x = @exchanges.delete f.exchange_name
             unless @vhost.closed?
@@ -129,7 +137,7 @@ module LavinMQ
           src = @exchanges[f.source]? || return false
           dst = @exchanges[f.destination]? || return false
           return false unless src.bind(dst, f.routing_key, f.arguments)
-          store_definition(f) if !loading && src.durable? && dst.durable?
+          store_definition(f, fsync: fsync) if !loading && src.durable? && dst.durable?
         when AMQP::Frame::Exchange::Unbind
           src = @exchanges[f.source]? || return false
           dst = @exchanges[f.destination]? || return false
@@ -139,7 +147,7 @@ module LavinMQ
           return false if @queues.has_key? f.queue_name
           q = @queues[f.queue_name] = QueueFactory.make(@vhost, f)
           @vhost.apply_policies([q] of Queue) unless loading
-          store_definition(f) if !loading && f.durable && !f.exclusive
+          store_definition(f, fsync: fsync) if !loading && f.durable && !f.exclusive
           @vhost.event_tick(EventType::QueueDeclared) unless loading
         when AMQP::Frame::Queue::Delete
           if q = @queues.delete(f.queue_name)
@@ -161,7 +169,7 @@ module LavinMQ
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || return false
           return false unless x.bind(q, f.routing_key, f.arguments)
-          store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
+          store_definition(f, fsync: fsync) if !loading && x.durable? && q.durable? && !q.exclusive?
         when AMQP::Frame::Queue::Unbind
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || return false
@@ -315,12 +323,12 @@ module LavinMQ
       end
     end
 
-    private def store_definition(frame, dirty = false)
+    private def store_definition(frame, dirty = false, fsync = true)
       @log.debug { "Storing definition: #{frame.inspect}" }
       bytes = frame.to_slice
       @definitions_file.write bytes
       @replicator.try &.append @definitions_file_path, bytes
-      @definitions_file.fsync
+      @definitions_file.fsync if fsync
       if dirty
         if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions
           compact!

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -88,7 +88,7 @@ module LavinMQ
       @log.debug { "Saving #{@file_name}" }
       path = File.join(@data_dir, @file_name)
       tmpfile = "#{path}.tmp"
-      File.open(tmpfile, "w") { |f| to_pretty_json(f) }
+      File.open(tmpfile, "w") { |f| to_pretty_json(f); f.fsync }
       File.rename tmpfile, path
       @replicator.try &.replace_file path
     end

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -84,7 +84,7 @@ module LavinMQ
       end
     end
 
-    private def save!
+    def save!
       @log.debug { "Saving #{@file_name}" }
       path = File.join(@data_dir, @file_name)
       tmpfile = "#{path}.tmp"

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -280,9 +280,15 @@ module LavinMQ
       @vhosts.close
     end
 
-    def add_parameter(parameter : Parameter)
-      @parameters.create parameter
+    def add_parameter(parameter : Parameter, save = true)
+      @parameters.create parameter, save: save
       apply_parameter(parameter)
+    end
+
+    # Persist the global parameter store; used to flush after a bulk import that
+    # created parameters with save: false.
+    def save_parameters!
+      @parameters.save!
     end
 
     def delete_parameter(component_name, parameter_name)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -367,21 +367,21 @@ module LavinMQ
     end
 
     def add_operator_policy(name : String, pattern : String, apply_to : String,
-                            definition : Hash(String, JSON::Any), priority : Int8, save = true) : OperatorPolicy
+                            definition : Hash(String, JSON::Any), priority : Int8, save = true, apply = true) : OperatorPolicy
       op = OperatorPolicy.new(name, @name, Regex.new(pattern),
         Policy::Target.parse(apply_to), definition, priority)
       @operator_policies.create(op, save: save)
-      spawn apply_policies, name: "ApplyPolicies (after add) OperatingPolicy #{@name}"
+      spawn apply_policies, name: "ApplyPolicies (after add) OperatingPolicy #{@name}" if apply
       @log.info { "OperatorPolicy=#{name} Created" }
       op
     end
 
     def add_policy(name : String, pattern : String, apply_to : String,
-                   definition : Hash(String, JSON::Any), priority : Int8, save = true) : Policy
+                   definition : Hash(String, JSON::Any), priority : Int8, save = true, apply = true) : Policy
       p = Policy.new(name, @name, Regex.new(pattern), Policy::Target.parse(apply_to),
         definition, priority)
       @policies.create(p, save: save)
-      spawn apply_policies, name: "ApplyPolicies (after add) #{@name}"
+      spawn apply_policies, name: "ApplyPolicies (after add) #{@name}" if apply
       @log.info { "Policy=#{name} Created" }
       p
     end
@@ -416,11 +416,11 @@ module LavinMQ
     FEDERATION_UPSTREAM     = "federation-upstream"
     FEDERATION_UPSTREAM_SET = "federation-upstream-set"
 
-    def add_parameter(p : Parameter, save = true)
+    def add_parameter(p : Parameter, save = true, apply = true)
       @log.debug { "Add parameter #{p.name}" }
       @parameters.create(p, save: save)
       apply_parameters(p)
-      spawn apply_policies, name: "ApplyPolicies (add parameter) #{@name}"
+      spawn apply_policies, name: "ApplyPolicies (add parameter) #{@name}" if apply
     end
 
     def delete_parameter(component_name, parameter_name)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -367,23 +367,37 @@ module LavinMQ
     end
 
     def add_operator_policy(name : String, pattern : String, apply_to : String,
-                            definition : Hash(String, JSON::Any), priority : Int8) : OperatorPolicy
+                            definition : Hash(String, JSON::Any), priority : Int8, save = true) : OperatorPolicy
       op = OperatorPolicy.new(name, @name, Regex.new(pattern),
         Policy::Target.parse(apply_to), definition, priority)
-      @operator_policies.create(op)
+      @operator_policies.create(op, save: save)
       spawn apply_policies, name: "ApplyPolicies (after add) OperatingPolicy #{@name}"
       @log.info { "OperatorPolicy=#{name} Created" }
       op
     end
 
     def add_policy(name : String, pattern : String, apply_to : String,
-                   definition : Hash(String, JSON::Any), priority : Int8) : Policy
+                   definition : Hash(String, JSON::Any), priority : Int8, save = true) : Policy
       p = Policy.new(name, @name, Regex.new(pattern), Policy::Target.parse(apply_to),
         definition, priority)
-      @policies.create(p)
+      @policies.create(p, save: save)
       spawn apply_policies, name: "ApplyPolicies (after add) #{@name}"
       @log.info { "Policy=#{name} Created" }
       p
+    end
+
+    # Persist the policy/operator-policy/parameter stores; used to flush after a
+    # bulk import that created entries with save: false.
+    def save_policies!
+      @policies.save!
+    end
+
+    def save_operator_policies!
+      @operator_policies.save!
+    end
+
+    def save_parameters!
+      @parameters.save!
     end
 
     def delete_operator_policy(name)
@@ -402,9 +416,9 @@ module LavinMQ
     FEDERATION_UPSTREAM     = "federation-upstream"
     FEDERATION_UPSTREAM_SET = "federation-upstream-set"
 
-    def add_parameter(p : Parameter)
+    def add_parameter(p : Parameter, save = true)
       @log.debug { "Add parameter #{p.name}" }
-      @parameters.create(p)
+      @parameters.create(p, save: save)
       apply_parameters(p)
       spawn apply_policies, name: "ApplyPolicies (add parameter) #{@name}"
     end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -310,9 +310,9 @@ module LavinMQ
       }
     end
 
-    def declare_queue(name, durable, auto_delete, arguments = AMQP::Table.new)
+    def declare_queue(name, durable, auto_delete, arguments = AMQP::Table.new, fsync = true)
       apply AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, name, false, durable, false,
-        auto_delete, false, arguments)
+        auto_delete, false, arguments), fsync: fsync
       @log.info { "Created queue: #{name} (durable=#{durable} auto_delete=#{auto_delete} arguments=#{arguments})" }
     end
 
@@ -322,9 +322,9 @@ module LavinMQ
     end
 
     def declare_exchange(name, type, durable, auto_delete, internal = false,
-                         arguments = AMQP::Table.new)
+                         arguments = AMQP::Table.new, fsync = true)
       apply AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, name, type, false, durable,
-        auto_delete, internal, false, arguments)
+        auto_delete, internal, false, arguments), fsync: fsync
       @log.info { "Created exchange: #{name} (type=#{type} durable=#{durable} auto_delete=#{auto_delete} arguments=#{arguments})" }
     end
 
@@ -333,14 +333,14 @@ module LavinMQ
       @log.info { "Deleted exchange: #{name}" }
     end
 
-    def bind_queue(destination, source, routing_key, arguments = AMQP::Table.new)
+    def bind_queue(destination, source, routing_key, arguments = AMQP::Table.new, fsync = true)
       apply AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, destination, source,
-        routing_key, false, arguments)
+        routing_key, false, arguments), fsync: fsync
     end
 
-    def bind_exchange(destination, source, routing_key, arguments = AMQP::Table.new)
+    def bind_exchange(destination, source, routing_key, arguments = AMQP::Table.new, fsync = true)
       apply AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, destination, source,
-        routing_key, false, arguments)
+        routing_key, false, arguments), fsync: fsync
     end
 
     def unbind_queue(destination, source, routing_key, arguments = AMQP::Table.new)
@@ -353,8 +353,13 @@ module LavinMQ
         routing_key, false, arguments)
     end
 
-    def apply(f, loading = false) : Bool
-      definitions.apply(f, loading)
+    def apply(f, loading = false, fsync = true) : Bool
+      definitions.apply(f, loading, fsync)
+    end
+
+    # Flush definitions written with fsync: false (e.g. during bulk import).
+    def fsync_definitions
+      definitions.fsync
     end
 
     def queue_bindings(queue : Queue) : Array(BindingDetails)

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -60,9 +60,9 @@ module LavinMQ
       vhost = VHost.new(name, @data_dir, @users, @replicator, @persister, description, tags)
       Log.info { "Created vhost #{name}" }
       unless @users[user.name]?.try &.permissions[name]?
-        @users.add_permission(user.name, name, /.*/, /.*/, /.*/)
+        @users.add_permission(user.name, name, /.*/, /.*/, /.*/, save: save)
       end
-      @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/)
+      @users.add_permission(@users.direct_user, name, /.*/, /.*/, /.*/, save: save)
       @vhosts[name] = vhost
       save! if save
       notify_observers(Event::Added, name)
@@ -126,7 +126,7 @@ module LavinMQ
       raise ex
     end
 
-    private def save!
+    def save!
       Log.debug { "Saving vhosts to file" }
       path = File.join(@data_dir, "vhosts.json")
       File.open("#{path}.tmp", "w") { |f| to_pretty_json(f); f.fsync }


### PR DESCRIPTION
Importing definitions persisted **per object**, so a large import did a disk write/fsync (or a full-file JSON rewrite) for every queue, exchange, binding, vhost, policy and parameter — plus a full policy re-application per policy/parameter. This batches all of it so each store is written/fsynced once and policies are applied once per vhost.

Commits, by concern:

### 1. Queues / exchanges / bindings — fsync per object
Every durable declare/bind called `fsync` on the definitions file. Made the fsync optional per call (`store_definition`/`apply` take an `fsync` flag, exposed through `VHost#declare_queue`/`declare_exchange`/`bind_queue`/`bind_exchange`); the importer declares everything with `fsync: false` and flushes each vhost's definitions file once at the end via `VHost#fsync_definitions`.

A per-call argument (not a store-wide "defer" flag) means a durable declare from a *live connection* during an import still fsyncs normally — only the import's own writes are batched.

### 2. Vhosts — rewrite + fsync per vhost
`import_vhosts` created each vhost with the default `save: true`, so every vhost rewrote+fsynced `vhosts.json`, plus the two permissions added per vhost (default + direct user) each rewrote+fsynced `users.json` — ~3 rewrites/fsyncs per vhost. Threaded a `save` flag through `UserStore#add_permission` and `VHostStore#create`; the importer creates all vhosts with `save: false` and saves `vhosts.json` + `users.json` once.

### 3. Policies / operator policies / parameters — full rewrite per entry
The `add_*` methods used `save: true`, re-serializing the entire `policies.json`/`operator_policies.json`/`parameters.json` per entry (O(n²) write amplification). Threaded a `save` flag through `VHost#add_policy`/`add_operator_policy`/`add_parameter` and `Server#add_parameter`; the importer adds with `save: false` and saves each touched store once.

### 4. Apply policies once per vhost, not per entry
Each `add_policy`/`add_operator_policy`/`add_parameter` spawned `apply_policies` (a full scan of every queue + exchange) per entry. Added an `apply` flag (default true) so the importer adds with `apply: false` and applies once per touched vhost at the end.

### 5. fsync the parameter/policy store files
`ParameterStore#save!` didn't fsync (unlike `VHostStore`/`UserStore`). Added `f.fsync` so `policies.json`/`operator_policies.json`/`parameters.json` are durable on write — cheap now that import saves each store once.

Already-batched and left as-is: `import_users` (`save: false` + one `users.save!`) and `import_permissions` (one `save!`).

### Tests
No new specs: writes land in the page cache regardless, so fsync *timing* isn't observable in a unit test, and import correctness/persistence is already covered by `spec/api/definitions_spec.cr`, `spec/api/parameters_spec.cr`, `spec/policies_spec.cr`, `spec/vhost_spec.cr`, `spec/users_spec.cr` — all green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)