### PR TITLE
Support per-queue-type policy apply-to values

### DIFF
--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -65,6 +65,43 @@ describe LavinMQ::VHost do
     end
   end
 
+  it "should apply classic_queues policy only to non-stream queues" do
+    PoliciesSpec.with_vhost do |vhost|
+      defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "classic"))
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "stream",
+        arguments: LavinMQ::AMQP::Table.new({"x-queue-type" => "stream"})))
+      vhost.add_policy("cq", "^.*$", "classic_queues", defs, 11_i8)
+      sleep 10.milliseconds
+      vhost.queue("classic").policy.try(&.name).should eq "cq"
+      vhost.queue("stream").policy.should be_nil
+    end
+  end
+
+  it "should apply streams policy only to stream queues" do
+    PoliciesSpec.with_vhost do |vhost|
+      defs = {"max-age" => JSON::Any.new("1D")} of String => JSON::Any
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "classic"))
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "stream",
+        arguments: LavinMQ::AMQP::Table.new({"x-queue-type" => "stream"})))
+      vhost.add_policy("sp", "^.*$", "streams", defs, 11_i8)
+      sleep 10.milliseconds
+      vhost.queue("stream").policy.try(&.name).should eq "sp"
+      vhost.queue("classic").policy.should be_nil
+    end
+  end
+
+  it "should accept quorum_queues apply-to without applying to any queue" do
+    PoliciesSpec.with_vhost do |vhost|
+      defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "classic"))
+      vhost.add_policy("qq", "^.*$", "quorum_queues", defs, 11_i8)
+      sleep 10.milliseconds
+      vhost.policies["qq"].apply_to.should eq LavinMQ::Policy::Target::QuorumQueues
+      vhost.queue("classic").policy.should be_nil
+    end
+  end
+
   it "should respect priority" do
     PoliciesSpec.with_vhost do |vhost|
       defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any

--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -91,14 +91,17 @@ describe LavinMQ::VHost do
     end
   end
 
-  it "should accept quorum_queues apply-to without applying to any queue" do
+  it "should apply quorum_queues policy to non-stream queues" do
     PoliciesSpec.with_vhost do |vhost|
-      defs = {"max-length" => JSON::Any.new(1_i64)} of String => JSON::Any
+      defs = {"delivery-limit" => JSON::Any.new(3_i64)} of String => JSON::Any
       vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "classic"))
+      vhost.register_queue(LavinMQ::QueueFactory.make(vhost, "stream",
+        arguments: LavinMQ::AMQP::Table.new({"x-queue-type" => "stream"})))
       vhost.add_policy("qq", "^.*$", "quorum_queues", defs, 11_i8)
       sleep 10.milliseconds
       vhost.policies["qq"].apply_to.should eq LavinMQ::Policy::Target::QuorumQueues
-      vhost.queue("classic").policy.should be_nil
+      vhost.queue("classic").policy.try(&.name).should eq "qq"
+      vhost.queue("stream").policy.should be_nil
     end
   end
 

--- a/src/lavinmq/policy.cr
+++ b/src/lavinmq/policy.cr
@@ -57,9 +57,12 @@ module LavinMQ
       All
       Queues
       Exchanges
+      ClassicQueues
+      QuorumQueues
+      Streams
 
       def to_json(json : JSON::Builder)
-        to_s.downcase.to_json(json)
+        to_s.underscore.to_json(json)
       end
     end
 
@@ -79,12 +82,24 @@ module LavinMQ
     end
 
     def match?(resource : Queue)
-      return false if @apply_to.exchanges?
-      @pattern.matches?(resource.name)
+      case @apply_to
+      in .all?, .queues?
+        @pattern.matches?(resource.name)
+      in .classic_queues?
+        return false if resource.is_a?(AMQP::Stream)
+        @pattern.matches?(resource.name)
+      in .streams?
+        return false unless resource.is_a?(AMQP::Stream)
+        @pattern.matches?(resource.name)
+      in .quorum_queues? # LavinMQ has no quorum queues
+        false
+      in .exchanges?
+        false
+      end
     end
 
     def match?(resource : Exchange)
-      return false if @apply_to.queues?
+      return false unless @apply_to.all? || @apply_to.exchanges?
       @pattern.matches?(resource.name)
     end
 

--- a/src/lavinmq/policy.cr
+++ b/src/lavinmq/policy.cr
@@ -85,14 +85,15 @@ module LavinMQ
       case @apply_to
       in .all?, .queues?
         @pattern.matches?(resource.name)
-      in .classic_queues?
+      in .classic_queues?, .quorum_queues?
+        # LavinMQ has no quorum queues; its regular queues support the same
+        # policies RabbitMQ allows for quorum queues (delivery-limit), so
+        # both targets apply to non-stream queues.
         return false if resource.is_a?(AMQP::Stream)
         @pattern.matches?(resource.name)
       in .streams?
         return false unless resource.is_a?(AMQP::Stream)
         @pattern.matches?(resource.name)
-      in .quorum_queues? # LavinMQ has no quorum queues
-        false
       in .exchanges?
         false
       end


### PR DESCRIPTION
## Problem

Importing RabbitMQ definitions that use per-queue-type `apply-to` targets failed with a 400:

```
method=POST path=/api/definitions status=400 error="Unknown enum LavinMQ::Policy::Target value: quorum_queues"
```

`Policy::Target` only knew `all`, `queues` and `exchanges`, so `Target.parse` raised on `classic_queues`, `quorum_queues` and `streams`.

## Change

- Add `ClassicQueues`, `QuorumQueues`, `Streams` to `Policy::Target`.
- `match?` now honors them:
  - `classic_queues` and `quorum_queues` → non-stream queues. LavinMQ has no quorum queues, but RabbitMQ only allows `delivery-limit`/`dead-letter-strategy` in QQ policies and LavinMQ supports `delivery-limit` on its regular queues, so those policies apply to non-stream queues.
  - `streams` → `AMQP::Stream` queues only
  - tightened the `Exchange` overload to match only `all`/`exchanges`
- `to_json` uses `underscore` casing so the multi-word members round-trip (`classic_queues`, not `classicqueues`); existing values unchanged.

## Tests

Added specs in `spec/policies_spec.cr` for `classic_queues`, `streams`, and `quorum_queues` matching. `make test SPEC=spec/policies_spec.cr`, `make test SPEC=spec/api/definitions_spec.cr`, and `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)