### PR TITLE
Replace periodic GC.collect with on-demand GC

### DIFF
--- a/spec/api/node_spec.cr
+++ b/spec/api/node_spec.cr
@@ -16,5 +16,54 @@ describe LavinMQ::HTTP::NodesController do
         end
       end
     end
+
+    it "should not include GC stats" do
+      with_http_server do |http, _|
+        response = http.get("/api/nodes")
+        response.status_code.should eq 200
+        JSON.parse(response.body).as_a.first.as_h.has_key?("gc_stats").should be_false
+      end
+    end
+  end
+
+  describe "GET /api/nodes/gc_stats" do
+    it "returns GC profiling stats" do
+      with_http_server do |http, _|
+        response = http.get("/api/nodes/gc_stats")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body).as_h
+        body.has_key?("gc_no").should be_true
+        body.has_key?("heap_size").should be_true
+      end
+    end
+  end
+
+  describe "POST /api/nodes/gc_collect" do
+    it "triggers garbage collection" do
+      with_http_server do |http, _|
+        before = GC.prof_stats.gc_no
+        response = http.post("/api/nodes/gc_collect")
+        response.status_code.should eq 204
+        GC.prof_stats.gc_no.should be > before
+      end
+    end
+  end
+
+  describe "POST /api/nodes/:name/gc_collect" do
+    it "triggers garbage collection for the current node" do
+      with_http_server do |http, _|
+        before = GC.prof_stats.gc_no
+        response = http.post("/api/nodes/#{System.hostname}/gc_collect")
+        response.status_code.should eq 204
+        GC.prof_stats.gc_no.should be > before
+      end
+    end
+
+    it "returns 404 for an unknown node" do
+      with_http_server do |http, _|
+        response = http.post("/api/nodes/unknown-node/gc_collect")
+        response.status_code.should eq 404
+      end
+    end
   end
 end

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -103,6 +103,16 @@ describe "LavinMQCtl" do
       end
     end
 
+    it "should trigger garbage collection and print stats" do
+      with_http_server do |(http, s)|
+        before = GC.prof_stats.gc_no
+        result = run_lavinmqctl(http.addr.to_s, ["gc_collect"])
+        result[:exit].should eq(0)
+        GC.prof_stats.gc_no.should be > before
+        result[:stdout].should contain("gc_no")
+      end
+    end
+
     it "should create and delete queue" do
       with_http_server do |(http, s)|
         result = run_lavinmqctl(http.addr.to_s, ["create_queue", "new_queue"])

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -36,8 +36,7 @@ class LavinMQ::Clustering::Controller
     # TODO: make sure we still are in the ISR set
     yield
     loop do
-      lease.wait(30.seconds)
-      GC.collect
+      lease.wait(1.hour) # blocks until the lease expires (raises Expired)
     end
   rescue Etcd::Lease::Expired
     execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -83,6 +83,24 @@ module LavinMQ
         }
       end
 
+      private def gc_stats
+        ps = GC.prof_stats
+        {
+          gc_no:                     ps.gc_no,
+          heap_size:                 ps.heap_size,
+          free_bytes:                ps.free_bytes,
+          unmapped_bytes:            ps.unmapped_bytes,
+          bytes_since_gc:            ps.bytes_since_gc,
+          bytes_before_gc:           ps.bytes_before_gc,
+          non_gc_bytes:              ps.non_gc_bytes,
+          markers_m1:                ps.markers_m1,
+          bytes_reclaimed_since_gc:  ps.bytes_reclaimed_since_gc,
+          reclaimed_bytes_before_gc: ps.reclaimed_bytes_before_gc,
+          expl_freed_bytes_since_gc: ps.expl_freed_bytes_since_gc,
+          obtained_from_os_bytes:    ps.obtained_from_os_bytes,
+        }
+      end
+
       private def stats(context)
         current_user = user(context)
         my_vhosts = vhosts(current_user)
@@ -101,9 +119,36 @@ module LavinMQ
           context
         end
 
+        # Garbage collector profiling stats for the current node.
+        # Registered before the :name route so it isn't matched as a node name.
+        get "/api/nodes/gc_stats" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          gc_stats.to_json(context.response)
+          context
+        end
+
         get "/api/nodes/:name" do |context, params|
           if params["name"] == System.hostname
             stats(context).to_json(context.response)
+          else
+            context.response.status_code = 404
+          end
+          context
+        end
+
+        # Run GC on the current node, without having to know its name
+        post "/api/nodes/gc_collect" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          GC.collect
+          context.response.status_code = 204
+          context
+        end
+
+        post "/api/nodes/:name/gc_collect" do |context, params|
+          refuse_unless_administrator(context, user(context))
+          if params["name"] == System.hostname
+            GC.collect
+            context.response.status_code = 204
           else
             context.response.status_code = 404
           end

--- a/src/lavinmq/standalone_runner.cr
+++ b/src/lavinmq/standalone_runner.cr
@@ -3,14 +3,7 @@ module LavinMQ
     # Yields to the block immediately, then blocks until stop is called.
     def run(&)
       yield
-      loop do
-        select
-        when @stop_channel.receive?
-          break
-        when timeout(30.seconds)
-          GC.collect
-        end
-      end
+      @stop_channel.receive?
     end
 
     def stop

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -78,6 +78,7 @@ class LavinMQCtl
   SERVER_CMDS = {
     {"stop_app", "Stop the AMQP broker", ""},
     {"start_app", "Starts the AMQP broker", ""},
+    {"gc_collect", "Trigger a garbage collection cycle and print GC stats", ""},
   }
 
   def initialize(@io : IO = STDOUT, @err_io : IO = STDERR)
@@ -324,6 +325,7 @@ class LavinMQCtl
     when "delete_exchange"       then delete_exchange
     when "status"                then status
     when "cluster_status"        then cluster_status
+    when "gc_collect"            then gc_collect
     when "set_vhost_limits"      then set_vhost_limits
     when "set_permissions"       then set_permissions
     when "definitions"           then definitions
@@ -860,6 +862,14 @@ class LavinMQCtl
       }
       output cluster_status_obj
     end
+  end
+
+  private def gc_collect
+    resp = http.post "/api/nodes/gc_collect", @headers
+    handle_response(resp, 204)
+    resp = http.get "/api/nodes/gc_stats"
+    handle_response(resp, 200)
+    output JSON.parse(resp.body).as_h
   end
 
   private def set_vhost_limits

--- a/static/docs/openapi.yaml
+++ b/static/docs/openapi.yaml
@@ -85,6 +85,8 @@ components:
       "$ref": "./schemas/nodes.yaml#/node"
     nodes:
       "$ref": "./schemas/nodes.yaml#/nodes"
+    gc_stats:
+      "$ref": "./schemas/nodes.yaml#/gc_stats"
     parameter:
       "$ref": "./schemas/parameters.yaml#/parameter"
     parameters:
@@ -228,8 +230,14 @@ paths:
     "$ref": "./paths/main.yaml#/~1extensions"
   "/nodes":
     "$ref": "./paths/nodes.yaml#/~1nodes"
+  "/nodes/gc_stats":
+    "$ref": "./paths/nodes.yaml#/~1nodes~1gc_stats"
+  "/nodes/gc_collect":
+    "$ref": "./paths/nodes.yaml#/~1nodes~1gc_collect"
   "/nodes/{name}":
     "$ref": "./paths/nodes.yaml#/~1nodes~1{name}"
+  "/nodes/{name}/gc_collect":
+    "$ref": "./paths/nodes.yaml#/~1nodes~1{name}~1gc_collect"
   "/parameters":
     "$ref": "./paths/parameters.yaml#/~1parameters"
   "/parameters/{component}":

--- a/static/docs/paths/nodes.yaml
+++ b/static/docs/paths/nodes.yaml
@@ -58,3 +58,83 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/nodes/gc_stats":
+  get:
+    tags:
+    - nodes
+    description: Get garbage collector profiling statistics for the current node.
+      Requires administrator access.
+    summary: Garbage collector statistics
+    operationId: GetGCStats
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/gc_stats"
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/nodes/gc_collect":
+  post:
+    tags:
+    - nodes
+    description: Trigger a garbage collection cycle on the current node. Requires
+      administrator access.
+    summary: Run garbage collection on the current node
+    operationId: RunGCCollect
+    responses:
+      '204':
+        description: No Content
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+"/nodes/{name}/gc_collect":
+  parameters:
+  - in: path
+    name: name
+    required: true
+    schema:
+      type: string
+      description: Name of node.
+  post:
+    tags:
+    - nodes
+    description: Trigger a garbage collection cycle on the specified node. Requires
+      administrator access.
+    summary: Run garbage collection
+    operationId: RunNodeGCCollect
+    responses:
+      '204':
+        description: No Content
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"

--- a/static/docs/schemas/nodes.yaml
+++ b/static/docs/schemas/nodes.yaml
@@ -169,3 +169,43 @@ node:
     uptime:
       type: integer
       description: Uptime in milliseconds.
+gc_stats:
+  type: object
+  description: Garbage collector profiling statistics (admin only).
+  properties:
+    gc_no:
+      type: integer
+      description: Garbage collection cycle number. The value may wrap.
+    heap_size:
+      type: integer
+      description: Heap size in bytes (including the area unmapped to OS).
+    free_bytes:
+      type: integer
+      description: Total bytes contained in free and unmapped blocks.
+    unmapped_bytes:
+      type: integer
+      description: Amount of memory unmapped to the OS.
+    bytes_since_gc:
+      type: integer
+      description: Number of bytes allocated since the recent collection.
+    bytes_before_gc:
+      type: integer
+      description: Number of bytes allocated before the recent garbage collection. The value may wrap.
+    non_gc_bytes:
+      type: integer
+      description: Number of bytes not considered candidates for garbage collection.
+    markers_m1:
+      type: integer
+      description: Number of marker threads (excluding the initiating one), or 0 if single-threaded.
+    bytes_reclaimed_since_gc:
+      type: integer
+      description: Approximate number of reclaimed bytes after the recent garbage collection.
+    reclaimed_bytes_before_gc:
+      type: integer
+      description: Approximate number of bytes reclaimed before the recent garbage collection. The value may wrap.
+    expl_freed_bytes_since_gc:
+      type: integer
+      description: Number of bytes freed explicitly since the recent garbage collection.
+    obtained_from_os_bytes:
+      type: integer
+      description: Total amount of memory obtained from the OS, in bytes.

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -2,6 +2,7 @@ import * as HTTP from './http.js'
 import * as Chart from './chart.js'
 import * as Helpers from './helpers.js'
 import * as Table from './table.js'
+import * as DOM from './dom.js'
 import { DataSource } from './datasource.js'
 
 const numFormatter = new Intl.NumberFormat()
@@ -31,6 +32,76 @@ function render (data) {
 function start (cb) {
   update(cb)
   setInterval(update, 5000, cb)
+}
+
+const gcStatsFields = [
+  { heading: 'GC cycles', key: 'gc_no', info: 'Garbage collection cycle number. The value may wrap.' },
+  { heading: 'Heap size', key: 'heap_size', bytes: true, info: 'Heap size in bytes (including the area unmapped to OS).' },
+  { heading: 'Free bytes', key: 'free_bytes', bytes: true, info: 'Total bytes contained in free and unmapped blocks.' },
+  { heading: 'Unmapped bytes', key: 'unmapped_bytes', bytes: true, info: 'Amount of memory unmapped to the OS.' },
+  { heading: 'Allocated since last GC', key: 'bytes_since_gc', bytes: true, info: 'Number of bytes allocated since the recent collection.' },
+  { heading: 'Allocated before last GC', key: 'bytes_before_gc', bytes: true, info: 'Number of bytes allocated before the recent garbage collection. The value may wrap.' },
+  { heading: 'Non GC bytes', key: 'non_gc_bytes', bytes: true, info: 'Number of bytes not considered candidates for garbage collection.' },
+  { heading: 'Marker threads', key: 'markers_m1', info: 'Number of marker threads (excluding the initiating one), or 0 if single-threaded.' },
+  { heading: 'Reclaimed since last GC', key: 'bytes_reclaimed_since_gc', bytes: true, info: 'Approximate number of reclaimed bytes after the recent garbage collection.' },
+  { heading: 'Reclaimed before last GC', key: 'reclaimed_bytes_before_gc', bytes: true, info: 'Approximate number of bytes reclaimed before the recent garbage collection. The value may wrap.' },
+  { heading: 'Explicitly freed since last GC', key: 'expl_freed_bytes_since_gc', bytes: true, info: 'Number of bytes freed explicitly since the recent garbage collection.' },
+  { heading: 'Obtained from OS', key: 'obtained_from_os_bytes', bytes: true, info: 'Total amount of memory obtained from the OS, in bytes.' }
+]
+
+const renderGCStats = (gc) => {
+  const table = document.getElementById('gc-stats-table')
+  if (!table || gc === undefined) return
+  while (table.firstChild) {
+    table.firstChild.remove()
+  }
+  for (const field of gcStatsFields) {
+    const value = gc[field.key]
+    if (value === undefined) continue
+    const row = document.createElement('tr')
+    const th = document.createElement('th')
+    const tooltip = document.createElement('a')
+    tooltip.className = 'prop-tooltip'
+    tooltip.append(document.createTextNode(field.heading))
+    const icon = document.createElement('span')
+    icon.className = 'tooltip-icon'
+    icon.textContent = '?'
+    const text = document.createElement('span')
+    text.className = 'prop-tooltiptext'
+    text.textContent = field.info
+    tooltip.append(icon, text)
+    th.append(tooltip)
+    const td = document.createElement('td')
+    td.textContent = field.bytes ? humanizeBytes(value) : numFormatter.format(value)
+    row.append(th, td)
+    table.append(row)
+  }
+}
+
+const refreshGCStats = () => {
+  return HTTP.request('GET', 'api/nodes/gc_stats').then(renderGCStats)
+}
+
+const gcRefreshBtn = document.getElementById('gc-refresh-btn')
+if (gcRefreshBtn) {
+  gcRefreshBtn.addEventListener('click', () => {
+    gcRefreshBtn.disabled = true
+    refreshGCStats().finally(() => { gcRefreshBtn.disabled = false })
+  })
+}
+
+const gcBtn = document.getElementById('gc-btn')
+if (gcBtn) {
+  gcBtn.addEventListener('click', () => {
+    gcBtn.disabled = true
+    HTTP.request('POST', 'api/nodes/gc_collect')
+      .then(() => {
+        DOM.toast('Garbage collection triggered')
+        return refreshGCStats()
+      })
+      .finally(() => { gcBtn.disabled = false })
+  })
+  refreshGCStats() // initial load; afterwards only on demand
 }
 
 const updateDetails = (nodeStats) => {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -3,7 +3,6 @@ import * as Chart from './chart.js'
 import * as Helpers from './helpers.js'
 import * as Table from './table.js'
 import * as DOM from './dom.js'
-import * as Auth from './auth.js'
 import { DataSource } from './datasource.js'
 
 const numFormatter = new Intl.NumberFormat()
@@ -105,10 +104,11 @@ if (gcBtn) {
   // Only admins may read GC stats; the gc-btn element is in the DOM for all
   // users (require-administrator only hides it via CSS), so fetching here
   // unconditionally would 403 for non-admins and pop up an error. Gate the
-  // initial load on the resolved user tags; afterwards fetch only on demand.
-  Auth.whoAmI()
-    .then(u => { if (u?.tags?.split(/,\s*/).includes('administrator')) refreshGCStats() })
-    .catch(() => {})
+  // initial load on the (persisted, synchronously applied) admin role class;
+  // afterwards fetch only on demand.
+  if (Helpers.stateClasses.has('user-is-administrator')) {
+    refreshGCStats()
+  }
 }
 
 const updateDetails = (nodeStats) => {

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -3,6 +3,7 @@ import * as Chart from './chart.js'
 import * as Helpers from './helpers.js'
 import * as Table from './table.js'
 import * as DOM from './dom.js'
+import * as Auth from './auth.js'
 import { DataSource } from './datasource.js'
 
 const numFormatter = new Intl.NumberFormat()
@@ -101,7 +102,13 @@ if (gcBtn) {
       })
       .finally(() => { gcBtn.disabled = false })
   })
-  refreshGCStats() // initial load; afterwards only on demand
+  // Only admins may read GC stats; the gc-btn element is in the DOM for all
+  // users (require-administrator only hides it via CSS), so fetching here
+  // unconditionally would 403 for non-admins and pop up an error. Gate the
+  // initial load on the resolved user tags; afterwards fetch only on demand.
+  Auth.whoAmI()
+    .then(u => { if (u?.tags?.split(/,\s*/).includes('administrator')) refreshGCStats() })
+    .catch(() => {})
 }
 
 const updateDetails = (nodeStats) => {

--- a/static/main.css
+++ b/static/main.css
@@ -474,6 +474,11 @@ button {
   }
 }
 
+.btn-icon-svg {
+  min-width: 0;
+  padding: 0.5rem;
+}
+
 .btn-green {
   background: var(--color-success);
   border: 1px solid transparent;
@@ -2297,6 +2302,10 @@ pre.arguments .inactive-argument:before {
 
 .justify-center {
   justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
 }
 
 .items-center {

--- a/views/nodes.shtml
+++ b/views/nodes.shtml
@@ -100,6 +100,17 @@
           </table>
         </div>
       </section>
+      <section class="card cols-6 require-administrator">
+        <div class="flex flex-row items-center justify-between gap-2">
+          <h3>Garbage collection</h3>
+          <div class="flex flex-row gap-2">
+            <button type="button" id="gc-refresh-btn" class="btn btn-outlined btn-icon-svg" title="Refresh" aria-label="Refresh GC stats"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg></button>
+            <button type="button" id="gc-btn" class="btn btn-outlined">Collect</button>
+          </div>
+        </div>
+        <table id="gc-stats-table" class="details-table">
+        </table>
+      </section>
     </main>
     <!--#include file="partials/footer.shtml" -->
   </body>


### PR DESCRIPTION
## Why

The 30-second periodic `GC.collect` (in `StandaloneRunner` and `Clustering::Controller`) caused high CPU spikes on servers using a lot of memory — e.g. hundreds of thousands of bindings or queues. This removes the timers and makes garbage collection an explicit, on-demand operation instead.

## Changes

**Removed periodic GC**
- `StandaloneRunner#run` now just blocks on the stop channel.
- `Clustering::Controller` post-leadership loop just waits on lease expiry.
- (Left the event-driven `SystemD::MemoryPressure` collection and the `USR2` signal trap in `launcher.cr` untouched — those aren't periodic.)

**HTTP API** (`NodesController`, admin only)
- `GET /api/nodes/gc_stats` — returns `GC.prof_stats` as JSON.
- `POST /api/nodes/gc_collect` and `POST /api/nodes/:name/gc_collect` — trigger a collection, return `204 No Content`.
- GC stats are *not* part of the regular `/api/nodes` payload.

**UI** (nodes page)
- A **Garbage collection** card at the bottom (admin only) showing the prof_stats, each field labelled with its Boehm `GC_prof_stats_s` description via tooltip.
- A **Collect** button and a refresh icon button on the title row. GC stats are fetched once on load and then only on demand (Refresh / after Collect) — they do *not* join the 5s auto-poll.

**lavinmqctl**
- New `gc_collect` command: triggers a collection then prints the resulting GC stats.

## Tests
- `spec/api/node_spec.cr` — `gc_stats` (200), `gc_collect` (204 + `gc_no` increments), `:name` variant (204 / 404), and that `/api/nodes` no longer carries `gc_stats`.
- `spec/lavinmqctl_spec.cr` — `gc_collect` increments `gc_no` and prints stats.
- OpenAPI docs updated for the new paths and the `gc_stats` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)