### PR TITLE
Pause UI polling when the browser tab is hidden

### DIFF
--- a/spec/frontend/helpers.js
+++ b/spec/frontend/helpers.js
@@ -53,4 +53,14 @@ async function trackCspViolations (page) {
   return () => page.evaluate(() => window.__cspViolations || [])
 }
 
-export { waitForPathRequest, trackCspViolations }
+// Simulate the Page Visibility API by overriding document.hidden /
+// document.visibilityState and dispatching a visibilitychange event.
+async function setPageVisibility (page, state) {
+  await page.evaluate((state) => {
+    Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+    Object.defineProperty(document, 'hidden', { value: state === 'hidden', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+  }, state)
+}
+
+export { waitForPathRequest, trackCspViolations, setPageVisibility }

--- a/spec/frontend/overview.spec.js
+++ b/spec/frontend/overview.spec.js
@@ -1,26 +1,50 @@
 import * as helpers from './helpers.js'
-import { test, expect } from './fixtures.js';
+import { test, expect } from './fixtures.js'
 
-test.describe("overview", _ => {
+test.describe('overview', _ => {
   test('is loaded', async ({ page }) => {
     const apiOverviewRequest = helpers.waitForPathRequest(page, '/api/overview')
     await page.goto('/')
     await expect(apiOverviewRequest).toBeRequested()
   })
 
-  test('is refreshed automatically', async({ page }) => {
+  test('is refreshed automatically', async ({ page }) => {
     await page.clock.install()
-    await page.goto(`/`)
+    await page.goto('/')
     // Verify that at least 3 requests are made
-    for (let i=0; i<3; i++) {
-      const apiOverviewRequest = helpers.waitForPathRequest(page, `/api/overview`)
+    for (let i = 0; i < 3; i++) {
+      const apiOverviewRequest = helpers.waitForPathRequest(page, '/api/overview')
       await page.clock.runFor(10000) // advance time by 10 seconds
       await expect(apiOverviewRequest).toBeRequested()
     }
   })
 
+  test('stops polling while hidden and polls immediately when visible again', async ({ page }) => {
+    await page.clock.install()
+    let count = 0
+    await page.route(/\/api\/overview/, route => {
+      count++
+      route.fulfill({ json: {} })
+    })
+    await page.goto('/')
+    await expect.poll(() => count).toBeGreaterThanOrEqual(1)
+    const whenHidden = count
+
+    // Hidden: advancing the clock must not trigger any new requests
+    await helpers.setPageVisibility(page, 'hidden')
+    await page.clock.runFor(20000)
+    expect(count).toBe(whenHidden)
+
+    // Visible again: poll immediately, then resume the interval
+    await helpers.setPageVisibility(page, 'visible')
+    await expect.poll(() => count).toBe(whenHidden + 1)
+    const apiOverviewRequest = helpers.waitForPathRequest(page, '/api/overview')
+    await page.clock.runFor(10000)
+    await expect(apiOverviewRequest).toBeRequested()
+  })
+
   test('definitions export trigger GET to /api/definitions for all vhosts', async ({ page }) => {
-    const definitionsRequest  = helpers.waitForPathRequest(page, '/api/definitions')
+    const definitionsRequest = helpers.waitForPathRequest(page, '/api/definitions')
     await page.goto('/')
     await page.locator('#exportDefinitions').getByRole('button', { name: /download/i }).click()
     await expect(definitionsRequest).toBeRequested()
@@ -29,23 +53,21 @@ test.describe("overview", _ => {
   test('definitions export trigger GET to /api/definitions/<selected vhost>', async ({ page, vhostsLoaded }) => {
     await page.goto('/')
     const vhosts = await vhostsLoaded
-    const definitionsRequest  = helpers.waitForPathRequest(page, `/api/definitions/${vhosts[0]}`)
+    const definitionsRequest = helpers.waitForPathRequest(page, `/api/definitions/${vhosts[0]}`)
     await page.locator('#exportDefinitions').getByRole('combobox').selectOption(vhosts[0])
     await page.locator('#exportDefinitions').getByRole('button', { name: /download/i }).click()
     await expect(definitionsRequest).toBeRequested()
   })
-
-
 
   test('definitions import trigger POST to /api/definitions/upload', async ({ page }) => {
     const definitionsRequest = helpers.waitForPathRequest(page, '/api/definitions/upload', { method: 'POST' })
     await page.goto('/')
 
     const importDefs = page.locator('#importDefinitions')
-    const fileChooserPromise = page.waitForEvent('filechooser');
-    await importDefs.getByLabel('File').click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles({'name': 'definitions.json', buffer: Buffer.from('{}')});
+    const fileChooserPromise = page.waitForEvent('filechooser')
+    await importDefs.getByLabel('File').click()
+    const fileChooser = await fileChooserPromise
+    await fileChooser.setFiles({ name: 'definitions.json', buffer: Buffer.from('{}') })
     await importDefs.getByRole('button', { name: /upload/i }).click()
 
     await expect(definitionsRequest).toBeRequested()

--- a/spec/frontend/queues.spec.js
+++ b/spec/frontend/queues.spec.js
@@ -1,28 +1,51 @@
 import * as helpers from './helpers.js'
 import * as qHelpers from './queues_helpers.js'
-import { test, expect } from './fixtures.js';
+import { test, expect } from './fixtures.js'
 
-test.describe("queues", _ => {
-    const queues = Array.from(Array(10), (_, i) => qHelpers.queue(`queue-${i}`))
-    const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })
+test.describe('queues', _ => {
+  const queues = Array.from(Array(10), (_, i) => qHelpers.queue(`queue-${i}`))
+  const queues_response = qHelpers.response(queues, { total_count: 100, page: 1, page_count: 10, page_size: 10 })
 
-    test.beforeEach(async ({ apimap, page }) => {
-      const queuesLoaded = apimap.get('/api/queues', queues_response)
-      page.goto('/queues')
-      await queuesLoaded
-    })
+  test.beforeEach(async ({ apimap, page }) => {
+    const queuesLoaded = apimap.get('/api/queues', queues_response)
+    page.goto('/queues')
+    await queuesLoaded
+  })
 
-  test('are refreshed automatically', async({ page }) => {
+  test('are refreshed automatically', async ({ page }) => {
     await page.clock.install()
     await page.goto('/queues')
     // Verify that at least 3 requests are made
-    for (let i=0; i<3; i++) {
+    for (let i = 0; i < 3; i++) {
       const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
       await page.clock.runFor(10000) // advance time by 10 seconds
       await expect(apiQueuesRequest).toBeRequested()
     }
   })
 
+  test('stop refreshing while hidden and refresh immediately when visible again', async ({ page }) => {
+    await page.clock.install()
+    let count = 0
+    await page.route(/\/api\/queues/, route => {
+      count++
+      route.fulfill({ json: qHelpers.response([], { total_count: 0, page: 1, page_count: 1, page_size: 100 }) })
+    })
+    await page.goto('/queues')
+    await expect.poll(() => count).toBeGreaterThanOrEqual(1)
+    const whenHidden = count
+
+    // Hidden: advancing the clock must not trigger any new requests
+    await helpers.setPageVisibility(page, 'hidden')
+    await page.clock.runFor(20000)
+    expect(count).toBe(whenHidden)
+
+    // Visible again: reload immediately, then resume auto-reloading
+    await helpers.setPageVisibility(page, 'visible')
+    await expect.poll(() => count).toBe(whenHidden + 1)
+    const apiQueuesRequest = helpers.waitForPathRequest(page, '/api/queues')
+    await page.clock.runFor(10000)
+    await expect(apiQueuesRequest).toBeRequested()
+  })
 
   // Test that different combination of hash params are sent in the request
   test.describe('are loaded with params when hash params', _ => {
@@ -104,9 +127,9 @@ test.describe("queues", _ => {
       const checkboxes = page.locator('#table tbody').getByRole('checkbox')
       await expect(checkboxes).toHaveCount(10)
 
-      const count = await checkboxes.count();
+      const count = await checkboxes.count()
       for (let i = 0; i < count; i++) {
-        await expect(checkboxes.nth(i)).toBeChecked();
+        await expect(checkboxes.nth(i)).toBeChecked()
       }
     })
 

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -121,4 +121,4 @@ function updateChannel () {
   })
 }
 updateChannel()
-setInterval(updateChannel, 5000)
+Helpers.pollWhileVisible(updateChannel, 5000)

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -74,7 +74,7 @@ function updateConnection (all) {
   })
 }
 updateConnection(true)
-setInterval(updateConnection, 5000)
+Helpers.pollWhileVisible(updateConnection, 5000)
 const channelsDataSource = new UrlDataSource(connectionUrl + '/channels', { useQueryState: false })
 const tableOptions = {
   dataSource: channelsDataSource,

--- a/static/js/datasource.js
+++ b/static/js/datasource.js
@@ -82,6 +82,15 @@ class DataSource {
         this.reload({ updateState: false })
       })
     }
+    // Pause auto-reloading while the page is hidden (Page Visibility API) and
+    // reload immediately when it becomes visible again.
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        clearTimeout(this._reloadTimer)
+      } else {
+        this.reload()
+      }
+    })
   }
 
   _setStateFromHash () {
@@ -164,7 +173,9 @@ class DataSource {
   }
 
   _enqueueReload () {
-    if (this._opts.autoReloadTimeout > 0) {
+    // Don't schedule another reload while the page is hidden; the
+    // visibilitychange handler reloads as soon as it becomes visible again.
+    if (this._opts.autoReloadTimeout > 0 && !document.hidden) {
       clearTimeout(this._reloadTimer)
       this._reloadTimer = setTimeout(this.reload.bind(this), this._opts.autoReloadTimeout)
     }

--- a/static/js/exchange.js
+++ b/static/js/exchange.js
@@ -54,7 +54,7 @@ function updateExchange (all) {
   })
 }
 updateExchange(true)
-setInterval(updateExchange, 5000)
+Helpers.pollWhileVisible(updateExchange, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(exchangeUrl + '/bindings/source', { useQueryState: false }),

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -172,6 +172,44 @@ function addVhostOptions (formId, options) {
   })
 }
 
+// Call `fn` every `interval` ms, but only while the page is visible.
+// When the page is hidden (e.g. the tab is in the background) polling is
+// paused; when it becomes visible again `fn` is called immediately and
+// periodic polling resumes. Uses the Page Visibility API.
+// Returns a handle with a `stop()` method to cancel polling entirely.
+function pollWhileVisible (fn, interval) {
+  let timer = null
+  const start = () => {
+    if (timer === null) {
+      timer = setInterval(fn, interval)
+    }
+  }
+  const stop = () => {
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+  const onVisibilityChange = () => {
+    if (document.hidden) {
+      stop()
+    } else {
+      fn()
+      start()
+    }
+  }
+  document.addEventListener('visibilitychange', onVisibilityChange)
+  if (!document.hidden) {
+    start()
+  }
+  return {
+    stop () {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      stop()
+    }
+  }
+}
+
 function disableUserMenuVhost () {
   const vhostMenu = document.getElementById('userMenuVhost')
   vhostMenu.disabled = true
@@ -250,5 +288,6 @@ export {
   autoCompleteDatalist,
   formatTimestamp,
   disableUserMenuVhost,
+  pollWhileVisible,
   stateClasses
 }

--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -30,7 +30,7 @@ function render (data) {
 
 function start (cb) {
   update(cb)
-  setInterval(update, 5000, cb)
+  Helpers.pollWhileVisible(() => update(cb), 5000)
 }
 
 const updateDetails = (nodeStats) => {

--- a/static/js/overview.js
+++ b/static/js/overview.js
@@ -111,5 +111,5 @@ function render (data) {
 
 function start (cb) {
   update(cb)
-  setInterval(update, 5000, cb)
+  Helpers.pollWhileVisible(() => update(cb), 5000)
 }

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -157,7 +157,7 @@ function updateQueue (all) {
     })
 }
 updateQueue(true)
-setInterval(updateQueue, 5000)
+Helpers.pollWhileVisible(updateQueue, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(queueUrl + '/bindings', { useQueryState: false }),

--- a/static/js/stream.js
+++ b/static/js/stream.js
@@ -135,7 +135,7 @@ function updateQueue (all) {
     })
 }
 updateQueue(true)
-setInterval(updateQueue, 5000)
+Helpers.pollWhileVisible(updateQueue, 5000)
 
 const tableOptions = {
   dataSource: new UrlDataSource(queueUrl + '/bindings', { useQueryState: false }),


### PR DESCRIPTION
## Motivation

The management UI polls the API every 5s on every open page (overview, queues/connections/exchanges lists, and the queue/exchange/connection/channel/stream/node detail pages). A browser tab left open in the background keeps generating this load indefinitely — for a user with several idle tabs, or many users who never close the dashboard, this is pure waste on the backend.

This PR uses the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) to **stop polling while the page is hidden** and **poll immediately when it becomes visible again** (so a returning user sees fresh data without waiting for the next interval).

## What changed

Two distinct polling mechanisms existed, so there are two fixes:

1. **`setInterval`-based polling** (detail pages + overview/nodes). New reusable helper `Helpers.pollWhileVisible(fn, interval)`:
   - runs the interval only while visible
   - on hide → `clearInterval`
   - on show → calls `fn()` immediately, then restarts the interval

   Applied in `channel.js`, `exchange.js`, `connection.js`, `stream.js`, `queue.js`, `overview.js`, `nodes.js`.

2. **`setTimeout`-chain auto-reload** in the table `DataSource` (`datasource.js`, used by all list pages). `_enqueueReload()` now skips scheduling while hidden, and a `visibilitychange` listener clears the pending timer on hide / reloads immediately on show.

## Tests

Playwright frontend specs (`overview.spec.js` for the `pollWhileVisible` path, `queues.spec.js` for the `DataSource` path) assert that:
- advancing the virtual clock while hidden fires **no** requests, and
- becoming visible triggers an immediate request and resumes the interval.

A `setPageVisibility` helper was added to `spec/frontend/helpers.js`.

> Note: I verified locally by running a debug server + Chromium. The `overview.spec.js` tests (and a throwaway DataSource spec) pass. The full `queues.spec.js` suite needs Node 24 locally (the shared `apimap` fixture uses `RegExp.escape`); CI runs Node 24 so it should be fine there.

## 🗣️ Discussion points

The current behavior is **stop completely as soon as the tab is hidden**. Two open questions before marking ready:

1. **Hard stop vs. throttle.** Should we stop entirely on hide (current), or instead **throttle** — keep polling but at a slower cadence (e.g. every 60s) after the tab has been hidden for a while? Trade-offs:
   - *Hard stop:* maximum backend savings; data can be arbitrarily stale, but we force an immediate refresh on return so the user never *sees* stale data.
   - *Throttle:* charts/rates keep a rough continuity while backgrounded (useful if someone glances back and forth between tabs), at the cost of continued — if reduced — load.

2. **Grace period?** Should hide take effect immediately, or only after the tab has been hidden for N seconds — to avoid churn from quick tab flicks (alt-tab away and back)? With the current immediate-refresh-on-show this is mostly cosmetic, but it affects how aggressively we tear down/restart timers.

My instinct is the hard stop here is the right default (simplest, biggest win, and immediate refresh on return hides the staleness), but happy to switch to a throttle or add a grace period if we think background continuity matters for the rate charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)