### PR TITLE
Add bindings count to overview, CLI status and Prometheus metrics

### DIFF
--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -86,6 +86,25 @@ describe LavinMQ::HTTP::Server do
       end
     end
 
+    it "should return the number of bindings in object_totals" do
+      with_http_server do |http, s|
+        response = http.get("/api/overview")
+        before_count = JSON.parse(response.body).dig("object_totals", "bindings").as_i
+
+        with_channel(s) do |ch|
+          x = ch.fanout_exchange
+          q1 = ch.queue("bindings_q1", exclusive: true)
+          q2 = ch.queue("bindings_q2", exclusive: true)
+          ch.queue_bind(q1.name, x.name, "#")
+          ch.queue_bind(q2.name, x.name, "#")
+
+          response = http.get("/api/overview")
+          count = JSON.parse(response.body).dig("object_totals", "bindings").as_i
+          count.should eq(before_count + 2)
+        end
+      end
+    end
+
     it "should return the number of acked and delivered messages" do
       with_http_server do |http, s|
         response = http.get("/api/overview")

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -44,6 +44,20 @@ describe LavinMQ::HTTP::PrometheusController do
       end
     end
 
+    it "should expose the number of bindings" do
+      with_metrics_server do |http, s|
+        vhost = s.vhosts.create("pmthb")
+        vhost.declare_queue("bq", true, false)
+        vhost.bind_queue("bq", "amq.topic", "rk1")
+        vhost.bind_queue("bq", "amq.topic", "rk2")
+        raw = http.get("/metrics").body
+        parsed_metrics = PrometheusSpecHelper.parse_prometheus(raw)
+        bindings = parsed_metrics.find { |m| m[:key] == "lavinmq_bindings" }
+        bindings.should_not be_nil
+        bindings.try(&.[:value].should eq 2)
+      end
+    end
+
     it "should count all delivered messages (both get and deliver)" do
       with_metrics_server do |http, s|
         with_channel(s) do |ch|

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -89,6 +89,7 @@ describe "LavinMQCtl" do
         result[:stdout].should contain("Version")
         result[:stdout].should contain("Connections")
         result[:stdout].should contain("Queues")
+        result[:stdout].should contain("Bindings")
       end
     end
 
@@ -100,6 +101,7 @@ describe "LavinMQCtl" do
         json.as_h?.should_not be_nil
         json.as_h.has_key?("Version").should be_true
         json.as_h.has_key?("Queues").should be_true
+        json.as_h.has_key?("Bindings").should be_true
       end
     end
 

--- a/src/lavinmq/amqp/exchange/consistent_hash.cr
+++ b/src/lavinmq/amqp/exchange/consistent_hash.cr
@@ -48,6 +48,10 @@ module LavinMQ
         end
       end
 
+      def binding_count : Int32
+        @bindings.size
+      end
+
       def bind(destination : Destination, routing_key : String, arguments : AMQP::Table?)
         validate_delayed_binding!(destination)
         w = weight(routing_key)

--- a/src/lavinmq/amqp/exchange/default.cr
+++ b/src/lavinmq/amqp/exchange/default.cr
@@ -13,6 +13,10 @@ module LavinMQ
         [] of BindingDetails
       end
 
+      def binding_count : Int32
+        0
+      end
+
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
         if q = @vhost.queue?(routing_key)
           yield q

--- a/src/lavinmq/amqp/exchange/direct.cr
+++ b/src/lavinmq/amqp/exchange/direct.cr
@@ -19,6 +19,10 @@ module LavinMQ
         end
       end
 
+      def binding_count : Int32
+        @bindings.each_value.sum(&.size)
+      end
+
       def bind(destination : Destination, routing_key, arguments = nil) : Bool
         validate_delayed_binding!(destination)
         binding_key = BindingKey.new(routing_key, arguments)

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -199,6 +199,10 @@ module LavinMQ
       abstract def bindings_details : Array(BindingDetails)
       abstract def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
 
+      # Number of bindings on this exchange. Counted cheaply, without allocating
+      # the full `bindings_details` array.
+      abstract def binding_count : Int32
+
       # Result of routing a message through an exchange.
       # `Routed` is set if at least one queue accepted the message.
       # `Overflowed` is set if at least one matched queue rejected the message

--- a/src/lavinmq/amqp/exchange/fanout.cr
+++ b/src/lavinmq/amqp/exchange/fanout.cr
@@ -15,6 +15,10 @@ module LavinMQ
         end
       end
 
+      def binding_count : Int32
+        @bindings.size
+      end
+
       def bind(destination : Destination, routing_key, arguments = nil)
         validate_delayed_binding!(destination)
         binding_key = BindingKey.new(routing_key, arguments)

--- a/src/lavinmq/amqp/exchange/headers.cr
+++ b/src/lavinmq/amqp/exchange/headers.cr
@@ -26,6 +26,10 @@ module LavinMQ
         end
       end
 
+      def binding_count : Int32
+        @bindings.each_value.sum(&.size)
+      end
+
       def bind(destination : Destination, routing_key, arguments)
         validate_delayed_binding!(destination)
         validate!(arguments)

--- a/src/lavinmq/amqp/exchange/topic.cr
+++ b/src/lavinmq/amqp/exchange/topic.cr
@@ -121,6 +121,10 @@ module LavinMQ
         end
       end
 
+      def binding_count : Int32
+        @bindings.each_value.sum(&.size)
+      end
+
       def bind(destination : AMQP::Destination, routing_key, arguments = nil)
         validate_delayed_binding!(destination)
         binding_key = BindingKey.new(routing_key, arguments)

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -22,7 +22,7 @@ module LavinMQ
       private def register_routes
         get "/api/overview" do |context, _params|
           x_vhost = context.request.headers["x-vhost"]?
-          channels, connections, exchanges, queues, consumers, ready, unacked = 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32
+          channels, connections, exchanges, queues, bindings, consumers, ready, unacked = 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32, 0_u32
           recv_rate, send_rate = 0_f64, 0_f64
           ready_log = Deque(UInt32).new(LavinMQ::Config.instance.stats_log_size)
           unacked_log = Deque(UInt32).new(LavinMQ::Config.instance.stats_log_size)
@@ -47,6 +47,7 @@ module LavinMQ
             end
             exchanges += vhost.exchanges_size
             queues += vhost.queues_size
+            vhost.each_exchange { |e| bindings += e.binding_count }
             vhost.each_queue do |q|
               ready += q.message_count
               unacked += q.unacked_count
@@ -79,6 +80,7 @@ module LavinMQ
               consumers:   consumers,
               exchanges:   exchanges,
               queues:      queues,
+              bindings:    bindings,
             },
             queue_totals: {
               messages:                    ready + unacked,

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -356,7 +356,7 @@ module LavinMQ
       end
 
       private def overview_queue_metrics(vhosts, writer)
-        ready = unacked = connections = channels = consumers = queues = 0_u64
+        ready = unacked = connections = channels = consumers = queues = bindings = 0_u64
         vhosts.each do |vhost|
           d = vhost.message_details
           ready += d[:messages_ready]
@@ -369,6 +369,7 @@ module LavinMQ
             end
           end
           queues += vhost.queues_size
+          vhost.each_exchange { |e| bindings += e.binding_count }
         end
         writer.write({name:  "connections",
                       value: connections,
@@ -386,6 +387,10 @@ module LavinMQ
                       value: queues,
                       type:  "gauge",
                       help:  "Queues available"})
+        writer.write({name:  "bindings",
+                      value: bindings,
+                      type:  "gauge",
+                      help:  "Bindings currently configured"})
         writer.write({name:  "queue_messages_ready",
                       value: ready,
                       type:  "gauge",

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -75,6 +75,10 @@ module LavinMQ
         end
       end
 
+      def binding_count : Int32
+        @bindings.each_value.sum(&.size)
+      end
+
       # Only here to make superclass happy
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
       end

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -841,6 +841,7 @@ class LavinMQCtl
       Consumers:        body.dig("object_totals", "consumers"),
       Exchanges:        body.dig("object_totals", "exchanges"),
       Queues:           body.dig("object_totals", "queues"),
+      Bindings:         body.dig("object_totals", "bindings"),
       Messages:         body.dig("queue_totals", "messages"),
       Messages_ready:   body.dig("queue_totals", "messages_ready"),
       Messages_unacked: body.dig("queue_totals", "messages_unacknowledged"),

--- a/views/overview.shtml
+++ b/views/overview.shtml
@@ -37,6 +37,11 @@
           <div class="counter-header"><a href="queues">Queues</a></div>
         </div>
         <div class="overview-divider"></div>
+        <div>
+          <div class="counter" id="bindings">0</div>
+          <div class="counter-header">Bindings</div>
+        </div>
+        <div class="overview-divider"></div>
         <div class="flex-1">
           <div class="counter" id="uptime">0s</div>
           <div class="counter-header">Uptime</div>


### PR DESCRIPTION
## What

Surfaces the total number of **bindings** across the server in the three places the other object totals (queues, exchanges, …) already appear:

- **Web overview page** — a new *Bindings* gauge next to *Queues*
- **`lavinmqctl status`** — a `Bindings` field (plain and `--format=json` output)
- **Prometheus `/metrics`** — a `lavinmq_bindings` gauge next to `lavinmq_queues`

![Bindings gauge on the overview page](https://raw.githubusercontent.com/cloudamqp/lavinmq/screenshot-binding-count/overview-bindings.png)

## How

Adds `binding_count : Int32` to `AMQP::Exchange`. It's **abstract** (mirroring `bindings_details`), so every concrete exchange type provides a cheap count that avoids allocating the full `bindings_details` array:

- `fanout`, `consistent_hash` → `@bindings.size`
- `direct`, `topic`, `headers`, `mqtt` → `@bindings.each_value.sum(&.size)`
- `default` → `0`

The `/api/overview` handler sums `binding_count` per vhost and emits `object_totals.bindings`; the web UI's existing `render()` maps that key onto the new `#bindings` element automatically. The CLI and Prometheus controllers read/compute the same total.

## Tests

- `spec/api/http_api_spec.cr` — `object_totals.bindings` increments when queues are bound
- `spec/lavinmqctl_spec.cr` — `status` exposes `Bindings` (plain + JSON)
- `spec/api/prometheus_spec.cr` — `lavinmq_bindings` reports the expected count

`make test` (affected specs) and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)