### PR TITLE
Log kTLS=off instead of kTLS= when offload is inactive

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -1,7 +1,21 @@
 require "./spec_helper"
 require "benchmark"
+require "log/spec"
 
 describe LavinMQ::Server do
+  it "logs kTLS=off for TLS connections without kernel offload" do
+    with_amqp_server(tls: true) do |s|
+      uri = URI.parse(s.amqp_url)
+      Log.capture("lmq.server", :info) do |logs|
+        client_ctx = OpenSSL::SSL::Context::Client.new
+        client_ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+        conn = AMQP::Client.new(host: uri.hostname.not_nil!, port: uri.port.not_nil!, tls: client_ctx).connect
+        conn.close
+        logs.check(:info, /connected with .* kTLS=off/)
+      end
+    end
+  end
+
   it "accepts connections" do
     with_amqp_server do |s|
       with_channel(s) do |ch|

--- a/spec/stdlib/openssl_ktls_spec.cr
+++ b/spec/stdlib/openssl_ktls_spec.cr
@@ -42,7 +42,7 @@ describe OpenSSL::SSL::Socket do
       ktls_handshake(ctx) do |ssl|
         ssl.ktls_send?.should be_false
         ssl.ktls_recv?.should be_false
-        ssl.ktls_status.should be_nil
+        ssl.ktls_status.should eq "off"
       end
     end
 
@@ -57,7 +57,7 @@ describe OpenSSL::SSL::Socket do
 
         ktls_handshake(ctx) do |ssl|
           ssl.ktls_send?.should be_true
-          ssl.ktls_status.should_not be_nil
+          ssl.ktls_status.should_not eq "off"
         end
       end
     {% end %}

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -237,7 +237,7 @@ module LavinMQ
         remote_addr = client.remote_address
         set_socket_options(client)
         ssl_client = OpenSSL::SSL::Socket::Server.new(client, context, sync_close: true)
-        Log.info { "#{remote_addr} connected with #{ssl_client.tls_version} #{ssl_client.cipher} kTLS=#{ssl_client.ktls_status || "off"}" }
+        Log.info { "#{remote_addr} connected with #{ssl_client.tls_version} #{ssl_client.cipher} kTLS=#{ssl_client.ktls_status}" }
         handle_tls_connection(ssl_client, client.local_address, remote_addr, protocol)
       rescue ex
         Log.warn(exception: ex) { "Error accepting TLS connection from #{remote_addr}" }

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -237,7 +237,7 @@ module LavinMQ
         remote_addr = client.remote_address
         set_socket_options(client)
         ssl_client = OpenSSL::SSL::Socket::Server.new(client, context, sync_close: true)
-        Log.info { "#{remote_addr} connected with #{ssl_client.tls_version} #{ssl_client.cipher} kTLS=#{ssl_client.ktls_status}" }
+        Log.info { "#{remote_addr} connected with #{ssl_client.tls_version} #{ssl_client.cipher} kTLS=#{ssl_client.ktls_status || "off"}" }
         handle_tls_connection(ssl_client, client.local_address, remote_addr, protocol)
       rescue ex
         Log.warn(exception: ex) { "Error accepting TLS connection from #{remote_addr}" }

--- a/src/stdlib/openssl_ktls.cr
+++ b/src/stdlib/openssl_ktls.cr
@@ -17,12 +17,13 @@ abstract class OpenSSL::SSL::Socket < IO
     bio.ktls_recv?
   end
 
-  # Returns a string describing the kTLS status: "send+recv", "send", "recv", or nil.
-  def ktls_status : String?
+  # Returns a string describing the kTLS status: "send+recv", "send", "recv", or "off".
+  def ktls_status : String
     case {ktls_send?, ktls_recv?}
-    when {true, true}  then "send+recv"
-    when {true, false} then "send"
-    when {false, true} then "recv"
+    in {true, true}   then "send+recv"
+    in {true, false}  then "send"
+    in {false, true}  then "recv"
+    in {false, false} then "off"
     end
   end
 end


### PR DESCRIPTION
TLS connections without kernel TLS offload logged "kTLS=" with an empty value, which reads like a missing field. Fall back to "off" in the log line so the value is always explicit.