### PR TITLE
Fix: sub-second stats_interval produced NaN/Inf rates

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -565,6 +565,35 @@ describe LavinMQ::Config do
     config.mqtt_bind.should eq "0.0.0.0"
   end
 
+  describe "stats_interval" do
+    it "accepts sub-second values" do
+      config_file = File.tempfile do |file|
+        file.print <<-CONFIG
+          [main]
+          stats_interval = 500
+        CONFIG
+      end
+      config = LavinMQ::Config.new
+      config.parse(["-c", config_file.path])
+      config.stats_interval.should eq 500
+    end
+
+    it "rejects non-positive values" do
+      [0, -5000].each do |ms|
+        config_file = File.tempfile do |file|
+          file.print <<-CONFIG
+            [main]
+            stats_interval = #{ms}
+          CONFIG
+        end
+        config = LavinMQ::Config.new
+        expect_raises(OptionParser::Exception, /stats_interval/) do
+          config.parse(["-c", config_file.path])
+        end
+      end
+    end
+  end
+
   describe "tcp_proxy_protocol" do
     {% for value, expected in {"1": true, "yes": true, "2": true, "-1": false, "no": false, "false": false, "0": false} %}
       it "sets tcp_proxy_protocol to {{expected}} when value is {{value}}" do

--- a/spec/stats_interval_spec.cr
+++ b/spec/stats_interval_spec.cr
@@ -25,6 +25,22 @@ module LavinMQ
     end
   end
 
+  describe Server do
+    describe "#update_system_metrics" do
+      it "yields finite rates with sub-second stats_interval" do
+        with_stats_interval(500) do
+          with_amqp_server do |s|
+            s.update_system_metrics(nil)
+            s.update_system_metrics(nil)
+            {s.user_time_log, s.sys_time_log, s.blocks_out_log, s.blocks_in_log}.each do |log|
+              log.each &.finite?.should be_true
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe Stats do
     describe "#update_rates" do
       [1, 50, 250, 500, 999, 1000, 5000, 30_000].each do |ms|

--- a/spec/stats_interval_spec.cr
+++ b/spec/stats_interval_spec.cr
@@ -1,0 +1,58 @@
+require "./spec_helper"
+
+private def with_stats_interval(ms : Int32, &)
+  cfg = LavinMQ::Config.instance
+  orig = cfg.stats_interval
+  begin
+    cfg.stats_interval = ms
+    yield
+  ensure
+    cfg.stats_interval = orig
+  end
+end
+
+module LavinMQ
+  private class IntervalProbe
+    include Stats
+    rate_stats({"x"})
+
+    def bump(n : UInt64)
+      @x_count.add(n)
+    end
+
+    def x_rate
+      @x_rate
+    end
+  end
+
+  describe Stats do
+    describe "#update_rates" do
+      [1, 50, 250, 500, 999, 1000, 5000, 30_000].each do |ms|
+        it "yields finite rates with stats_interval=#{ms}ms" do
+          with_stats_interval(ms) do
+            p = IntervalProbe.new
+            p.update_rates
+            p.x_rate.finite?.should be_true
+            p.x_rate.should eq 0.0
+            p.bump(1234_u64)
+            p.update_rates
+            p.x_rate.finite?.should be_true
+            p.x_rate.should be > 0.0
+          end
+        end
+      end
+
+      it "reports events-per-second independent of the sampling interval" do
+        {500 => 100.0, 1000 => 50.0, 5000 => 10.0}.each do |ms, expected|
+          with_stats_interval(ms) do
+            p = IntervalProbe.new
+            p.update_rates
+            p.bump(50_u64)
+            p.update_rates
+            p.x_rate.should eq expected
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -34,7 +34,14 @@ module LavinMQ
       parse_ini(@config_file)
       parse_env()
       parse_cli(argv)
+      validate!
       setup_logger
+    end
+
+    private def validate!
+      unless @stats_interval.positive?
+        raise OptionParser::Exception.new("stats_interval must be positive (got #{@stats_interval})")
+      end
     end
 
     private def parse_config_from_cli(argv)
@@ -273,6 +280,7 @@ module LavinMQ
     def reload
       @sni_manager.clear
       parse_ini(@config_file)
+      validate!
       setup_logger
     end
 

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -360,7 +360,7 @@ module LavinMQ
     end
 
     def update_system_metrics(statm)
-      interval = @config.stats_interval.milliseconds.to_i
+      interval = @config.stats_interval / 1000.0
       log_size = @config.stats_log_size
       rusage = System.resource_usage
 

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -38,7 +38,7 @@ module LavinMQ
       end
 
       def update_rates : Nil
-        interval = Config.instance.stats_interval // 1000
+        interval = Config.instance.stats_interval / 1000.0
         log_size = Config.instance.stats_log_size
         {% for name in stats_keys %}
           until @{{ name.id }}_log.size < log_size


### PR DESCRIPTION
`interval = Config.instance.stats_interval // 1000` truncates to 0 when stats_interval < 1000 ms, so the rate becomes delta / 0 = NaN/Inf, which breaks JSON serialization of the stats endpoints.

Compute interval as float seconds instead.