### PR TITLE
Fix: HTTP API drop rate-history log from channel/connection lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `unix_proxy_protocol` config option; Unix sockets always auto-detect PROXY protocol headers [#1601](https://github.com/cloudamqp/lavinmq/pull/1601)
 
+### Fixed
+
+- `GET /api/channels` and `GET /api/connections` no longer include the per-metric rate-history `log` arrays in every list row, matching `GET /api/queues`. The logs are only needed by the per-object detail pages, so they are now returned solely by `GET /api/channels/:name` and `GET /api/connections/:name`, greatly reducing list response size and latency on large deployments
+
 ## [2.8.1] - 2026-05-18
 
 ### Changed

--- a/spec/api/stats_log_visibility_spec.cr
+++ b/spec/api/stats_log_visibility_spec.cr
@@ -1,0 +1,52 @@
+require "../spec_helper"
+require "uri"
+
+describe "rate-history log visibility" do
+  describe "GET /api/channels" do
+    it "omits the rate log, keeps the current rate" do
+      with_http_server do |http, s|
+        with_channel(s) do
+          ms = JSON.parse(http.get("/api/channels").body).as_a.first["message_stats"]
+          ms["publish_details"]["rate"]?.should_not be_nil
+          ms["publish_details"]["log"]?.should be_nil
+        end
+      end
+    end
+  end
+
+  describe "GET /api/channels/:name" do
+    it "includes the rate log (detail page renders the chart)" do
+      with_http_server do |http, s|
+        with_channel(s) do
+          name = URI.encode_path(JSON.parse(http.get("/api/channels").body).as_a.first["name"].as_s)
+          ms = JSON.parse(http.get("/api/channels/#{name}").body)["message_stats"]
+          ms["publish_details"]["log"]?.should_not be_nil
+        end
+      end
+    end
+  end
+
+  describe "GET /api/connections" do
+    it "omits the rate log, keeps the current rate" do
+      with_http_server do |http, s|
+        with_channel(s) do
+          c = JSON.parse(http.get("/api/connections").body).as_a.last
+          c["recv_oct_details"]["rate"]?.should_not be_nil
+          c["recv_oct_details"]["log"]?.should be_nil
+        end
+      end
+    end
+  end
+
+  describe "GET /api/connections/:name" do
+    it "includes the rate log" do
+      with_http_server do |http, s|
+        with_channel(s) do
+          name = URI.encode_path(JSON.parse(http.get("/api/connections").body).as_a.last["name"].as_s)
+          c = JSON.parse(http.get("/api/connections/#{name}").body)
+          c["recv_oct_details"]["log"]?.should_not be_nil
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -90,8 +90,15 @@ module LavinMQ
           messages_unacknowledged: @unacked.size,
           connection_details:      @client.connection_details,
           state:                   state,
-          message_stats:           stats_details,
+          message_stats:           current_stats_details,
         }
+      end
+
+      def to_json(json : JSON::Builder)
+        details_tuple.merge({
+          message_stats:    stats_details,
+          consumer_details: consumers,
+        }).to_json(json)
       end
 
       def flow(active : Bool)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -132,7 +132,11 @@ module LavinMQ
           tls_version:       @connection_info.ssl_version,
           cipher:            @connection_info.ssl_cipher,
           state:             state,
-        }.merge(stats_details)
+        }.merge(current_stats_details)
+      end
+
+      def to_json(json : JSON::Builder)
+        details_tuple.merge(stats_details).to_json(json)
       end
 
       def search_match?(value : String) : Bool

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -22,9 +22,7 @@ module LavinMQ
 
         get "/api/channels/:name" do |context, params|
           with_channel(context, params) do |channel|
-            channel.details_tuple.merge({
-              consumer_details: channel.consumers,
-            }).to_json(context.response)
+            channel.to_json(context.response)
           end
         end
 

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -212,7 +212,11 @@ module LavinMQ
           tls_version:       @connection_info.ssl_version,
           cipher:            @connection_info.ssl_cipher,
           client_properties: NamedTuple.new,
-        }.merge(stats_details)
+        }.merge(current_stats_details)
+      end
+
+      def to_json(json : JSON::Builder)
+        details_tuple.merge(stats_details).to_json(json)
       end
 
       def search_match?(value : String) : Bool


### PR DESCRIPTION
Bugfix, drop the log from the list representation; the detail endpoints (/api/channels/:name, /api/connections/:name) still return the full log.

We only show the current rate, never any history, huge resources used to serve these lists, follow the convention we have for queues etc.

GET /api/channels, 20k channels (warm logs), before vs after:

    response   59 MB  -> 8 MB    (7x smaller)
    latency    758 ms -> 120 ms  (6x faster)
    cpu/req    765 ms -> 86 ms   (9x less)

