### PR TITLE
MQTT: O(1) session binding lookup (fix O(n^2) subscribe/disconnect)

### DIFF
--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -131,5 +131,32 @@ module MqttSpecs
         end
       end
     end
+
+    it "keeps multiple subscriptions independent across resubscribe/unsubscribe" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"m/1", 0}, {"m/2", 0}, {"m/3", 0}))
+          # resubscribe only m/2 at qos1, and unsubscribe m/1
+          subscribe(io, topic_filters: mk_topic_filters({"m/2", 1}))
+          unsubscribe(io, topics: ["m/1"])
+
+          # m/1 is gone: publishing to it delivers nothing
+          publish(io, topic: "m/1", payload: "x".to_slice, qos: 1u8)
+          # m/2 still bound, now at qos1
+          publish(io, topic: "m/2", payload: "x".to_slice, qos: 1u8)
+          p2 = read_packet(io).as(MQTT::Protocol::Publish)
+          p2.topic.should eq("m/2")
+          p2.qos.should eq(1u8)
+          # m/3 untouched, still qos0
+          publish(io, topic: "m/3", payload: "x".to_slice, qos: 1u8)
+          p3 = read_packet(io).as(MQTT::Protocol::Publish)
+          p3.topic.should eq("m/3")
+          p3.qos.should eq(0u8)
+
+          io.should be_drained
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -158,5 +158,23 @@ module MqttSpecs
         end
       end
     end
+
+    it "Exchange#bindings_details_for matches a full scan (used by delete unbinding)" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "bdf", clean_session: false)
+          subscribe(io, topic_filters: mk_topic_filters({"bdf/a", 0}, {"bdf/b", 1}))
+
+          vhost = server.vhosts["/"]
+          ex = vhost.exchange?(LavinMQ::MQTT::EXCHANGE).not_nil!
+          session = vhost.queue?("mqtt.bdf").not_nil!
+
+          optimized = ex.bindings_details_for(session).map(&.routing_key).sort!
+          full_scan = ex.bindings_details.select { |b| b.destination == session }.map(&.routing_key).sort!
+          optimized.should eq(["bdf/a", "bdf/b"])
+          optimized.should eq(full_scan)
+        end
+      end
+    end
   end
 end

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -197,6 +197,11 @@ module LavinMQ
       abstract def bind(destination : AMQP::Destination, routing_key : String, arguments : AMQP::Table?)
       abstract def unbind(destination : AMQP::Destination, routing_key : String, arguments : AMQP::Table?)
       abstract def bindings_details : Array(BindingDetails)
+
+      def bindings_details_for(destination) : Array(BindingDetails)
+        bindings_details.select { |b| b.destination == destination }
+      end
+
       abstract def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
 
       # Result of routing a message through an exchange.

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -114,8 +114,7 @@ module LavinMQ
           if x = @exchanges.delete f.exchange_name
             unless @vhost.closed?
               @exchanges.each_value do |ex|
-                ex.bindings_details.each do |binding|
-                  next unless binding.destination == x
+                ex.bindings_details_for(x).each do |binding|
                   ex.unbind(x, binding.routing_key, binding.arguments)
                 end
               end
@@ -145,8 +144,7 @@ module LavinMQ
           if q = @queues.delete(f.queue_name)
             unless @vhost.closed?
               @exchanges.each_value do |ex|
-                ex.bindings_details.each do |binding|
-                  next unless binding.destination == q
+                ex.bindings_details_for(q).each do |binding|
                   ex.unbind(q, binding.routing_key, binding.arguments)
                 end
               end

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -87,6 +87,16 @@ module LavinMQ
         {false, nil}
       end
 
+      def bindings_details_for(destination) : Array(BindingDetails)
+        session = destination.as?(MQTT::Session)
+        return [] of BindingDetails unless session
+        rks = @session_bindings[session]?
+        return [] of BindingDetails unless rks
+        rks.map do |rk, args|
+          BindingDetails.new(name, vhost.name, BindingKey.new(rk, args).inner, session)
+        end
+      end
+
       # Only here to make superclass happy
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
       end

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -8,28 +8,10 @@ require "./retain_store"
 module LavinMQ
   module MQTT
     class Exchange < AMQP::Exchange
-      # In MQTT only topic/routing key is used in routing, but arguments is used to
-      # store QoS level for each subscription. To make @bingings treat the same subscription
-      # with different QoS as the same subscription this "custom" BindingKey is used which
-      # only includes the routing key in the hash.
-      struct BindingKey
-        def initialize(routing_key : String, arguments : AMQP::Table? = nil)
-          @binding_key = LavinMQ::BindingKey.new(routing_key, arguments)
-        end
-
-        def inner
-          @binding_key
-        end
-
-        def hash
-          @binding_key.routing_key.hash
-        end
-      end
-
-      @bindings = Hash(BindingKey, Set(MQTT::Session)).new do |h, k|
-        h[k] = Set(MQTT::Session).new
-      end
       @tree = MQTT::SubscriptionTree(MQTT::Session).new
+      # session => {routing_key => binding arguments}, reverse index so a session's
+      # subscriptions can be looked up and listed without scanning every binding.
+      # In MQTT only the routing key identifies a subscription; arguments only carry QoS.
       @session_bindings = Hash(MQTT::Session, Hash(String, AMQP::Table?)).new do |h, k|
         h[k] = Hash(String, AMQP::Table?).new
       end
@@ -71,9 +53,9 @@ module LavinMQ
       end
 
       def bindings_details : Array(BindingDetails)
-        @bindings.flat_map do |binding_key, ds|
-          ds.map do |d|
-            BindingDetails.new(name, vhost.name, binding_key.inner, d)
+        @session_bindings.flat_map do |session, rks|
+          rks.map do |rk, args|
+            BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(rk, args), session)
           end
         end
       end
@@ -93,7 +75,7 @@ module LavinMQ
         rks = @session_bindings[session]?
         return [] of BindingDetails unless rks
         rks.map do |rk, args|
-          BindingDetails.new(name, vhost.name, BindingKey.new(rk, args).inner, session)
+          BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(rk, args), session)
         end
       end
 
@@ -103,22 +85,15 @@ module LavinMQ
 
       def bind(destination : MQTT::Session, routing_key : String, arguments = nil) : Bool
         qos = arguments.try { |h| h[QOS_HEADER]?.try(&.as(UInt8)) } || 0u8
-        binding_key = BindingKey.new(routing_key, arguments)
-        @bindings[binding_key].add destination
         @tree.subscribe(routing_key, destination, qos)
         @session_bindings[destination][routing_key] = arguments
 
-        data = BindingDetails.new(name, vhost.name, binding_key.inner, destination)
+        data = BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(routing_key, arguments), destination)
         notify_observers(ExchangeEvent::Bind, data)
         true
       end
 
       def unbind(destination : MQTT::Session, routing_key, arguments = nil) : Bool
-        binding_key = BindingKey.new(routing_key, arguments)
-        rk_bindings = @bindings[binding_key]
-        rk_bindings.delete destination
-        @bindings.delete binding_key if rk_bindings.empty?
-
         if rks = @session_bindings[destination]?
           rks.delete routing_key
           @session_bindings.delete destination if rks.empty?
@@ -126,10 +101,10 @@ module LavinMQ
 
         @tree.unsubscribe(routing_key, destination)
 
-        data = BindingDetails.new(name, vhost.name, binding_key.inner, destination)
+        data = BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(routing_key, arguments), destination)
         notify_observers(ExchangeEvent::Unbind, data)
 
-        delete if @auto_delete && @bindings.each_value.all?(&.empty?)
+        delete if @auto_delete && @session_bindings.empty?
         true
       end
 

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -30,6 +30,9 @@ module LavinMQ
         h[k] = Set(MQTT::Session).new
       end
       @tree = MQTT::SubscriptionTree(MQTT::Session).new
+      @session_bindings = Hash(MQTT::Session, Hash(String, AMQP::Table?)).new do |h, k|
+        h[k] = Hash(String, AMQP::Table?).new
+      end
 
       def type : String
         "mqtt"
@@ -75,6 +78,15 @@ module LavinMQ
         end
       end
 
+      def subscription(session : MQTT::Session, routing_key : String) : {Bool, AMQP::Table?}
+        if rks = @session_bindings[session]?
+          if rks.has_key?(routing_key)
+            return {true, rks[routing_key]}
+          end
+        end
+        {false, nil}
+      end
+
       # Only here to make superclass happy
       protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
       end
@@ -84,6 +96,7 @@ module LavinMQ
         binding_key = BindingKey.new(routing_key, arguments)
         @bindings[binding_key].add destination
         @tree.subscribe(routing_key, destination, qos)
+        @session_bindings[destination][routing_key] = arguments
 
         data = BindingDetails.new(name, vhost.name, binding_key.inner, destination)
         notify_observers(ExchangeEvent::Bind, data)
@@ -95,6 +108,11 @@ module LavinMQ
         rk_bindings = @bindings[binding_key]
         rk_bindings.delete destination
         @bindings.delete binding_key if rk_bindings.empty?
+
+        if rks = @session_bindings[destination]?
+          rks.delete routing_key
+          @session_bindings.delete destination if rks.empty?
+        end
 
         @tree.unsubscribe(routing_key, destination)
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -11,6 +11,7 @@ module LavinMQ
       Log = ::LavinMQ::Log.for "mqtt.session"
 
       @client : MQTT::Client? = nil
+      @mqtt_exchange : MQTT::Exchange? = nil
 
       protected def initialize(@vhost : VHost,
                                @name : String,
@@ -93,17 +94,17 @@ module LavinMQ
       def subscribe(tf, qos)
         arguments = AMQP::Table.new
         arguments[QOS_HEADER] = qos
-        if binding = find_binding(tf)
-          return if binding.binding_key.arguments == arguments
-          unbind(tf, binding.binding_key.arguments)
+        bound, existing = mqtt_exchange.subscription(self, tf)
+        if bound
+          return if existing == arguments
+          unbind(tf, existing)
         end
         @vhost.bind_queue(@name, EXCHANGE, tf, arguments)
       end
 
       def unsubscribe(tf)
-        if binding = find_binding(tf)
-          unbind(tf, binding.binding_key.arguments)
-        end
+        bound, existing = mqtt_exchange.subscription(self, tf)
+        unbind(tf, existing) if bound
       end
 
       def publish(msg : Message) : PublishResult
@@ -112,8 +113,8 @@ module LavinMQ
         super
       end
 
-      private def find_binding(rk)
-        bindings.find { |b| b.binding_key.routing_key == rk }
+      private def mqtt_exchange : MQTT::Exchange
+        @mqtt_exchange ||= @vhost.exchange?(EXCHANGE).as(MQTT::Exchange)
       end
 
       private def unbind(rk, arguments)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -3,6 +3,7 @@ require "../error"
 require "../sortable_json"
 require "./client"
 require "./consts"
+require "./exchange"
 
 module LavinMQ
   module MQTT


### PR DESCRIPTION
`Session#subscribe`/`#unsubscribe` called `find_binding`, which `flat_mapped` ALL
exchange bindings into a fresh `Array(BindingDetails)` and scanned it: O(n) CPU +
O(n) alloc per call, O(n^2) total (~55% GC + ~18% bindings_details at 15k
sessions).

Add a reverse index (`session` -> `{routing_key -> arguments}`) updated in
`#bind`/`#unbind`, so the lookup is O(1) via `Exchange#subscription`. `#bind`/`#unbind`
also run on definition load, so restored persistent sessions are populated.

I was working on benchmarking connections/sessions, but couldn't reach my goal of 100k durable sessions due to CPU starvation. For 20k sessions this is 3.7x faster at least.

See per commit message for subscribe and cleanup improvements, plus a refactoring to avoid having a redundant `@bindings` now.