### PR TITLE
Make the lavinmqctl control socket path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ More configuration options can be viewed with `-h`,
 and you can specify a configuration file too, see [extras/lavinmq.ini](extras/lavinmq.ini)
 for an example, or see the section on [config files in the documentation](https://lavinmq.com/documentation/configuration-files).
 
+To run multiple LavinMQ instances on the same host, give each one its own
+`--data-dir`, ports/binds and a unique `--control-unix-path` (the socket
+`lavinmqctl` connects to, default `/tmp/lavinmqctl.sock`). `lavinmqctl` accepts
+the same `--control-unix-path` flag (or the `LAVINMQCTL_CONTROL_UNIX_PATH`
+environment variable) to reach a specific instance.
+
 ### Client Libraries
 
 All AMQP client libraries work with LavinMQ, and there are AMQP client libraries for almost every platform. The LavinMQ website has guides for many common platforms:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Alternatively, set the `LAVINMQ_CONFIGURATION_DIRECTORY` environment variable (o
 | `log_level` | `-l`, `--log-level` | — | String | `info` | Log level: `trace`, `debug`, `info`, `notice`, `warn`, `error`, `fatal`, `none` |
 | `log_file` | — | — | String | (none) | Log file path |
 | `pidfile` | `--pidfile` | — | String | (empty) | PID file path |
+| `control_unix_path` | `--control-unix-path` | `LAVINMQ_CONTROL_UNIX_PATH` | String | `/tmp/lavinmqctl.sock` | UNIX socket that `lavinmqctl` connects to. Use a unique path per instance to run multiple servers on one host. |
 | `tls_cert` | `--cert` | `LAVINMQ_TLS_CERT_PATH` | String | (empty) | TLS certificate path (including chain) |
 | `tls_key` | `--key` | `LAVINMQ_TLS_KEY_PATH` | String | (empty) | TLS private key path |
 | `tls_ciphers` | `--ciphers` | `LAVINMQ_TLS_CIPHERS` | String | (empty) | Allowed TLS ciphers |

--- a/docs/lavinmqctl.md
+++ b/docs/lavinmqctl.md
@@ -12,6 +12,8 @@ lavinmqctl --uri http://host:port ...
 
 Or set the `LAVINMQCTL_HOST` environment variable.
 
+When no connection flag is given, `lavinmqctl` talks to the server over its local control socket (default `/tmp/lavinmqctl.sock`). If the server was started with a custom `--control-unix-path`, point `lavinmqctl` at it with `--control-unix-path` or the `LAVINMQCTL_CONTROL_UNIX_PATH` environment variable.
+
 Authentication uses `--user` and `--password` flags (default: `guest`/`guest`).
 
 ## Commands
@@ -109,6 +111,7 @@ Authentication uses `--user` and `--password` flags (default: `guest`/`guest`).
 | `--hostname=HOST` | Management API hostname |
 | `-P`, `--port=PORT` | Management API port |
 | `--scheme=SCHEME` | URI scheme (http/https) |
+| `--control-unix-path=PATH` | Control socket to use when not connecting via `--uri`/`--hostname` (default `/tmp/lavinmqctl.sock`, env `LAVINMQCTL_CONTROL_UNIX_PATH`) |
 | `-p`, `--vhost=VHOST` | Target vhost (default: `/`) |
 | `--user=USER` | API username |
 | `--password=PASS` | API password |

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -2,9 +2,6 @@
 data_dir = /var/lib/lavinmq
 log_level = info
 ;pidfile = /var/run/lavinmq.pid
-; Socket that lavinmqctl connects to. Set a unique path per instance when
-; running multiple LavinMQ servers on the same host.
-;control_unix_path = /tmp/lavinmqctl.sock
 ;default_user_only_loopback = true
 ;tls_cert = /etc/lavinmq/cert.pem
 ;tls_key = /etc/lavinmq/key.pem

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -2,6 +2,9 @@
 data_dir = /var/lib/lavinmq
 log_level = info
 ;pidfile = /var/run/lavinmq.pid
+; Socket that lavinmqctl connects to. Set a unique path per instance when
+; running multiple LavinMQ servers on the same host.
+;control_unix_path = /tmp/lavinmqctl.sock
 ;default_user_only_loopback = true
 ;tls_cert = /etc/lavinmq/cert.pem
 ;tls_key = /etc/lavinmq/key.pem

--- a/extras/start-cluster-in-tmux.sh
+++ b/extras/start-cluster-in-tmux.sh
@@ -13,7 +13,7 @@ NODES=${1:-3}
 
 node_cmd() {
   local n=$1
-  echo "bin/lavinmq --data-dir=/tmp/amqp$n --bind=127.$n --metrics-http-bind=127.$n --clustering --clustering-bind=127.$n --clustering-advertised-uri=tcp://127.$n:5679"
+  echo "bin/lavinmq --data-dir=/tmp/amqp$n --bind=127.$n --metrics-http-bind=127.$n --control-unix-path=/tmp/lavinmqctl$n.sock --clustering --clustering-bind=127.$n --clustering-advertised-uri=tcp://127.$n:5679"
 }
 
 # Create new window with first node

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -21,6 +21,10 @@ describe LavinMQ::Config do
     config.log_level.to_s.should eq "Fatal"
   end
 
+  it "defaults the control socket path to /tmp/lavinmqctl.sock" do
+    LavinMQ::Config.new.control_unix_path.should eq "/tmp/lavinmqctl.sock"
+  end
+
   it "should prioritize CLI arguments over other arguments" do
     config_file = File.tempfile do |file|
       file.print <<-CONFIG
@@ -119,6 +123,7 @@ describe LavinMQ::Config do
           tls_keylog_file = /tmp/keylog.txt
           metrics_http_bind = 0.0.0.0
           metrics_http_port = 9090
+          control_unix_path = /tmp/lavinmqctl-ini.sock
 
           [amqp]
           bind = 0.0.0.0
@@ -202,6 +207,7 @@ describe LavinMQ::Config do
       config.tls_keylog_file.should eq "/tmp/keylog.txt"
       config.metrics_http_bind.should eq "0.0.0.0"
       config.metrics_http_port.should eq 9090
+      config.control_unix_path.should eq "/tmp/lavinmqctl-ini.sock"
 
       # AMQP section
       config.amqp_bind.should eq "0.0.0.0"
@@ -266,6 +272,7 @@ describe LavinMQ::Config do
       "--http-bind=172.16.0.1",
       "--http-port=15673",
       "--http-unix-path=/tmp/http.sock",
+      "--control-unix-path=/tmp/lavinmqctl-cli.sock",
       "--mqtt-bind=10.0.0.2",
       "--mqtt-port=1884",
       "--mqtts-port=8884",
@@ -305,6 +312,7 @@ describe LavinMQ::Config do
     config.http_bind.should eq "172.16.0.1"
     config.http_port.should eq 15673
     config.http_unix_path.should eq "/tmp/http.sock"
+    config.control_unix_path.should eq "/tmp/lavinmqctl-cli.sock"
     config.mqtt_bind.should eq "10.0.0.2"
     config.mqtt_port.should eq 1884
     config.mqtts_port.should eq 8884
@@ -367,6 +375,7 @@ describe LavinMQ::Config do
       ENV["LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS"] = "2048"
       ENV["LAVINMQ_CLUSTERING_PORT"] = "5681"
       ENV["LAVINMQ_SYNC"] = "false"
+      ENV["LAVINMQ_CONTROL_UNIX_PATH"] = "/tmp/lavinmqctl-env.sock"
       config = LavinMQ::Config.new
       config.parse([] of String)
 
@@ -390,6 +399,7 @@ describe LavinMQ::Config do
       config.clustering_etcd_prefix.should eq "env-prefix"
       config.clustering_max_unsynced_actions.should eq 2048
       config.clustering_port.should eq 5681
+      config.control_unix_path.should eq "/tmp/lavinmqctl-env.sock"
     ensure
       ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
       ENV.delete("LAVINMQ_DATADIR")
@@ -412,6 +422,7 @@ describe LavinMQ::Config do
       ENV.delete("LAVINMQ_CLUSTERING_ETCD_PREFIX")
       ENV.delete("LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS")
       ENV.delete("LAVINMQ_CLUSTERING_PORT")
+      ENV.delete("LAVINMQ_CONTROL_UNIX_PATH")
     end
   end
 

--- a/spec/control_socket_spec.cr
+++ b/spec/control_socket_spec.cr
@@ -1,0 +1,32 @@
+require "./spec_helper"
+
+describe "control socket" do
+  # Regression test for running multiple instances on one host: the control
+  # socket path must be configurable, and both the bind and the no-auth bypass
+  # must follow the configured path rather than a hardcoded one.
+  it "authenticates connections over the configured control socket as the direct user" do
+    config = LavinMQ::Config.instance
+    original_path = config.control_unix_path
+    socket_path = File.tempname("lavinmqctl-spec", ".sock")
+    config.control_unix_path = socket_path
+    begin
+      with_amqp_server do |s|
+        h = LavinMQ::HTTP::Server.new(s)
+        h.bind_internal_unix
+        spawn(name: "control socket listen") { h.listen }
+        Fiber.yield
+        begin
+          client = HTTP::Client.new(UNIXSocket.new(socket_path))
+          response = client.get("/api/whoami")
+          response.status_code.should eq 200
+          response.body.should contain "__direct"
+        ensure
+          h.close
+        end
+      end
+    ensure
+      config.control_unix_path = original_path
+      File.delete?(socket_path)
+    end
+  end
+end

--- a/spec/control_socket_spec.cr
+++ b/spec/control_socket_spec.cr
@@ -29,4 +29,32 @@ describe "control socket" do
       File.delete?(socket_path)
     end
   end
+
+  it "uses the socket bound at startup even after the config is reloaded" do
+    config = LavinMQ::Config.instance
+    original_path = config.control_unix_path
+    socket_path = File.tempname("lavinmqctl-spec", ".sock")
+    config.control_unix_path = socket_path
+    begin
+      with_amqp_server do |s|
+        h = LavinMQ::HTTP::Server.new(s) # captures socket_path
+        h.bind_internal_unix
+        spawn(name: "control socket listen") { h.listen }
+        Fiber.yield
+        # Simulate a SIGHUP reload that changes the configured path
+        config.control_unix_path = File.tempname("lavinmqctl-reloaded", ".sock")
+        begin
+          client = HTTP::Client.new(UNIXSocket.new(socket_path))
+          response = client.get("/api/whoami")
+          response.status_code.should eq 200
+          response.body.should contain "__direct"
+        ensure
+          h.close
+        end
+      end
+    ensure
+      config.control_unix_path = original_path
+      File.delete?(socket_path)
+    end
+  end
 end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -2,6 +2,7 @@ require "log"
 require "../auth/password"
 require "../amqp/exchange/consistent_hash_algorithm"
 require "../ip_matcher"
+require "../http/constants"
 
 module LavinMQ
   class Config
@@ -94,6 +95,11 @@ module LavinMQ
       @[CliOpt("", "--http-unix-path=PATH", "HTTP UNIX path to listen to", section: "bindings")]
       @[IniOpt(ini_name: unix_path, section: "mgmt")]
       property http_unix_path = ""
+
+      @[CliOpt("", "--control-unix-path=PATH", "UNIX socket lavinmqctl connects to (default: /tmp/lavinmqctl.sock)", section: "bindings")]
+      @[IniOpt(section: "main")]
+      @[EnvOpt("LAVINMQ_CONTROL_UNIX_PATH")]
+      property control_unix_path : String = HTTP::DEFAULT_CONTROL_UNIX_PATH
 
       @[CliOpt("", "--https-port=PORT", "HTTPS port to listen on (default: -1)", section: "bindings")]
       @[IniOpt(ini_name: tls_port, section: "mgmt")]

--- a/src/lavinmq/http/constants.cr
+++ b/src/lavinmq/http/constants.cr
@@ -1,6 +1,6 @@
 module LavinMQ
   module HTTP
-    INTERNAL_UNIX_SOCKET = "/tmp/lavinmqctl.sock"
-    MAX_PAGE_SIZE        = 10_000
+    DEFAULT_CONTROL_UNIX_PATH = "/tmp/lavinmqctl.sock"
+    MAX_PAGE_SIZE             = 10_000
   end
 end

--- a/src/lavinmq/http/handler/auth_handler.cr
+++ b/src/lavinmq/http/handler/auth_handler.cr
@@ -64,7 +64,7 @@ module LavinMQ
 
       private def internal_unix_socket?(context) : Bool
         if addr = context.request.remote_address.as?(Socket::UNIXAddress)
-          return addr.to_s == HTTP::INTERNAL_UNIX_SOCKET
+          return addr.to_s == Config.instance.control_unix_path
         end
         false
       end

--- a/src/lavinmq/http/handler/auth_handler.cr
+++ b/src/lavinmq/http/handler/auth_handler.cr
@@ -6,7 +6,7 @@ module LavinMQ
     class AuthHandler
       include ::HTTP::Handler
 
-      def initialize(@authenticator : Auth::Authenticator, @direct_user : Auth::User)
+      def initialize(@authenticator : Auth::Authenticator, @direct_user : Auth::User, @internal_unix_socket_path : String)
       end
 
       def call(context)
@@ -64,7 +64,7 @@ module LavinMQ
 
       private def internal_unix_socket?(context) : Bool
         if addr = context.request.remote_address.as?(Socket::UNIXAddress)
-          return addr.to_s == Config.instance.control_unix_path
+          return addr.to_s == @internal_unix_socket_path
         end
         false
       end

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -70,9 +70,10 @@ module LavinMQ
       end
 
       def bind_internal_unix
-        File.delete?(INTERNAL_UNIX_SOCKET)
-        addr = @http.bind_unix(INTERNAL_UNIX_SOCKET)
-        File.chmod(INTERNAL_UNIX_SOCKET, 0o660)
+        path = Config.instance.control_unix_path
+        File.delete?(path)
+        addr = @http.bind_unix(path)
+        File.chmod(path, 0o660)
         Log.info { "Bound to #{addr}" }
         addr
       end
@@ -83,21 +84,22 @@ module LavinMQ
 
       def close
         @http.try &.close
-        File.delete?(INTERNAL_UNIX_SOCKET)
+        File.delete?(Config.instance.control_unix_path)
       end
 
       # Starts a HTTP server that binds to the internal UNIX socket used by lavinmqctl.
       # The server returns 503 to signal that the node is a follower and can not handle the request.
       def self.follower_internal_socket_http_server
+        path = Config.instance.control_unix_path
         http_server = ::HTTP::Server.new do |context|
           context.response.status_code = 503
           context.response.print "This node is a follower and does not handle lavinmqctl commands. \n" \
                                  "Please connect to the leader node by using the --host option."
         end
 
-        File.delete?(INTERNAL_UNIX_SOCKET)
-        addr = http_server.bind_unix(INTERNAL_UNIX_SOCKET)
-        File.chmod(INTERNAL_UNIX_SOCKET, 0o660)
+        File.delete?(path)
+        addr = http_server.bind_unix(path)
+        File.chmod(path, 0o660)
         Log.info { "Bound to #{addr}" }
 
         spawn(name: "HTTP listener") do

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -17,13 +17,18 @@ module LavinMQ
     class Server
       Log = LavinMQ::Log.for "http.server"
 
+      # Resolved once and reused for this server's lifetime so a later config
+      # reload (SIGHUP) can't make us delete or authenticate against a path
+      # different from the one we actually bound.
+      @internal_unix_socket_path : String = Config.instance.control_unix_path
+
       def initialize(@amqp_server : LavinMQ::Server)
         handlers = [
           StrictTransportSecurity.new,
           WebsocketProxy.new(@amqp_server),
           ViewsController.new,
           StaticController.new,
-          AuthHandler.new(@amqp_server.authenticator, @amqp_server.users.direct_user),
+          AuthHandler.new(@amqp_server.authenticator, @amqp_server.users.direct_user, @internal_unix_socket_path),
           ApiErrorHandler.new,
           RequireUserHandler.new,
           PrometheusController.new(@amqp_server, require_authentication: true),
@@ -70,10 +75,9 @@ module LavinMQ
       end
 
       def bind_internal_unix
-        path = Config.instance.control_unix_path
-        File.delete?(path)
-        addr = @http.bind_unix(path)
-        File.chmod(path, 0o660)
+        File.delete?(@internal_unix_socket_path)
+        addr = @http.bind_unix(@internal_unix_socket_path)
+        File.chmod(@internal_unix_socket_path, 0o660)
         Log.info { "Bound to #{addr}" }
         addr
       end
@@ -84,7 +88,7 @@ module LavinMQ
 
       def close
         @http.try &.close
-        File.delete?(Config.instance.control_unix_path)
+        File.delete?(@internal_unix_socket_path)
       end
 
       # Starts a HTTP server that binds to the internal UNIX socket used by lavinmqctl.

--- a/src/lavinmqctl/cli.cr
+++ b/src/lavinmqctl/cli.cr
@@ -86,6 +86,9 @@ class LavinMQCtl
     if host = ENV["LAVINMQCTL_HOST"]?
       @options["host"] = host
     end
+    if path = ENV["LAVINMQCTL_CONTROL_UNIX_PATH"]?
+      @options["control_unix_path"] = path
+    end
     global_options
     parse_cmd
   end
@@ -363,14 +366,15 @@ class LavinMQCtl
       uri = URI.new(scheme, hostname, port)
       client_from_uri(uri)
     else
+      path = @options["control_unix_path"]? || LavinMQ::HTTP::DEFAULT_CONTROL_UNIX_PATH
       begin
-        unless File.exists? LavinMQ::HTTP::INTERNAL_UNIX_SOCKET
-          abort "#{LavinMQ::HTTP::INTERNAL_UNIX_SOCKET} not found. Is LavinMQ running?"
+        unless File.exists? path
+          abort "#{path} not found. Is LavinMQ running?"
         end
-        unless File::Info.writable? LavinMQ::HTTP::INTERNAL_UNIX_SOCKET
+        unless File::Info.writable? path
           abort "Please run lavinmqctl as root or as the same user as LavinMQ."
         end
-        socket = UNIXSocket.new(LavinMQ::HTTP::INTERNAL_UNIX_SOCKET)
+        socket = UNIXSocket.new(path)
         HTTP::Client.new(socket)
       rescue ex : Socket::ConnectError
         abort "Can't connect to LavinMQ: #{ex.message}"
@@ -429,6 +433,9 @@ class LavinMQCtl
     end
     @parser.on("--scheme=scheme", "Specify scheme (http)") do |v|
       @options["scheme"] = v
+    end
+    @parser.on("--control-unix-path=PATH", "Path to the LavinMQ control socket (default: #{LavinMQ::HTTP::DEFAULT_CONTROL_UNIX_PATH})") do |v|
+      @options["control_unix_path"] = v
     end
     @parser.on("-n node", "--node=node", "Specify node") do |v|
       # Only used by tests in cloudamqp/rabbitmq-java-client


### PR DESCRIPTION
The control socket was hardcoded to `/tmp/lavinmqctl.sock`, so two LavinMQ instances on one host collided: each rebinds that path on startup (hijacking `lavinmqctl`) and deletes it on shutdown.

Add a `control_unix_path` option — CLI `--control-unix-path`, INI `[main] control_unix_path`, env `LAVINMQ_CONTROL_UNIX_PATH` — defaulting to `/tmp/lavinmqctl.sock` for backwards compatibility. The HTTP server bind, shutdown cleanup, clustering-follower socket and the auth bypass now all read the configured path. `lavinmqctl` gains a matching `--control-unix-path` flag and `LAVINMQCTL_CONTROL_UNIX_PATH` env var.

Run multiple instances by giving each a distinct `--control-unix-path` (demonstrated in `extras/start-cluster-in-tmux.sh`).