### PR TITLE
Fix broker crashes and concurrency races surfaced by the stress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discard settlement frames (`ack`/`nack`/`reject`) for an already-closed channel instead of closing the connection with `CHANNEL_ERROR`
 - Treat a publish to a concurrently-closed queue as dropped instead of raising, which previously surfaced as an HTTP publish `500`
 - Stop federation and shovel links before tearing down vhosts on shutdown, and keep the embedded amqp-client's routine connection-teardown logging (already reported via the `lmq.*` federation/shovel layers) out of the broker log
+- Reply with `Basic.GetEmpty` instead of erroring when a `basic_get` races a concurrent queue delete
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /api/channels` and `GET /api/connections` no longer include the per-metric rate-history `log` arrays in every list row, matching `GET /api/queues`. The logs are only needed by the per-object detail pages, so they are now returned solely by `GET /api/channels/:name` and `GET /api/connections/:name`, greatly reducing list response size and latency on large deployments
 - Skip the message-expire fiber on streams to avoid a `Closed mfile` crash when the last consumer disconnects after retention dropped segments
 - Discard settlement frames (`ack`/`nack`/`reject`) for an already-closed channel instead of closing the connection with `CHANNEL_ERROR`
+- Treat a publish to a concurrently-closed queue as dropped instead of raising, which previously surfaced as an HTTP publish `500`
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treat a publish to a concurrently-closed queue as dropped instead of raising, which previously surfaced as an HTTP publish `500`
 - Stop federation and shovel links before tearing down vhosts on shutdown, and keep the embedded amqp-client's routine connection-teardown logging (already reported via the `lmq.*` federation/shovel layers) out of the broker log
 - Reply with `Basic.GetEmpty` instead of erroring when a `basic_get` races a concurrent queue delete
+- Serialize store saves (vhosts, parameters, users) so concurrent create/delete (under churn) don't race on the shared `.tmp` file and fail the rename
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip the message-expire fiber on streams to avoid a `Closed mfile` crash when the last consumer disconnects after retention dropped segments
 - Discard settlement frames (`ack`/`nack`/`reject`) for an already-closed channel instead of closing the connection with `CHANNEL_ERROR`
 - Treat a publish to a concurrently-closed queue as dropped instead of raising, which previously surfaced as an HTTP publish `500`
+- Stop federation and shovel links before tearing down vhosts on shutdown, and keep the embedded amqp-client's routine connection-teardown logging (already reported via the `lmq.*` federation/shovel layers) out of the broker log
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `GET /api/queues/:vhost/:name` no longer emits the `message_stats` field twice
 - `GET /api/channels` and `GET /api/connections` no longer include the per-metric rate-history `log` arrays in every list row, matching `GET /api/queues`. The logs are only needed by the per-object detail pages, so they are now returned solely by `GET /api/channels/:name` and `GET /api/connections/:name`, greatly reducing list response size and latency on large deployments
+- Skip the message-expire fiber on streams to avoid a `Closed mfile` crash when the last consumer disconnects after retention dropped segments
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop federation and shovel links before tearing down vhosts on shutdown, and keep the embedded amqp-client's routine connection-teardown logging (already reported via the `lmq.*` federation/shovel layers) out of the broker log
 - Reply with `Basic.GetEmpty` instead of erroring when a `basic_get` races a concurrent queue delete
 - Serialize store saves (vhosts, parameters, users) so concurrent create/delete (under churn) don't race on the shared `.tmp` file and fail the rename
+- Don't crash the MQTT brokers on a vhost `Closed` event for a vhost that was never registered (e.g. one whose create didn't finish)
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reply with `Basic.GetEmpty` instead of erroring when a `basic_get` races a concurrent queue delete
 - Serialize store saves (vhosts, parameters, users) so concurrent create/delete (under churn) don't race on the shared `.tmp` file and fail the rename
 - Don't crash the MQTT brokers on a vhost `Closed` event for a vhost that was never registered (e.g. one whose create didn't finish)
+- Serialize per-resource policy application and run stream `drop_overflow` under the message-store lock, fixing a segfault when policies were applied to a queue concurrently (e.g. under policy churn) with publishing/consuming
 
 ## [2.8.1] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /api/queues/:vhost/:name` no longer emits the `message_stats` field twice
 - `GET /api/channels` and `GET /api/connections` no longer include the per-metric rate-history `log` arrays in every list row, matching `GET /api/queues`. The logs are only needed by the per-object detail pages, so they are now returned solely by `GET /api/channels/:name` and `GET /api/connections/:name`, greatly reducing list response size and latency on large deployments
 - Skip the message-expire fiber on streams to avoid a `Closed mfile` crash when the last consumer disconnects after retention dropped segments
+- Discard settlement frames (`ack`/`nack`/`reject`) for an already-closed channel instead of closing the connection with `CHANNEL_ERROR`
 
 ## [2.8.1] - 2026-05-18
 

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -110,6 +110,58 @@ describe LavinMQ::Server do
         end
       end
     end
+
+    it "does not close the connection for a settlement frame on an already-closed channel" do
+      with_amqp_server do |s|
+        with_raw_amqp_connection(s) do |io, stream|
+          io.write_bytes AMQ::Protocol::Frame::Channel::Open.new(1_u16), IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.as(AMQ::Protocol::Frame::Channel::OpenOk)
+
+          # Client closes the channel; the broker removes it and replies CloseOk.
+          io.write_bytes AMQ::Protocol::Frame::Channel::Close.new(1_u16, 200_u16, "", 0_u16, 0_u16),
+            IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.as(AMQ::Protocol::Frame::Channel::CloseOk)
+
+          # A delivery settled in another fiber races the close and arrives after
+          # the channel is gone. The broker must discard it, not kill the whole
+          # connection. Open a second channel to prove the connection survived.
+          io.write_bytes AMQ::Protocol::Frame::Basic::Ack.new(1_u16, 1_u64, false), IO::ByteFormat::NetworkEndian
+          io.write_bytes AMQ::Protocol::Frame::Channel::Open.new(2_u16), IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.should be_a(AMQ::Protocol::Frame::Channel::OpenOk)
+
+          io.write_bytes AMQ::Protocol::Frame::Connection::Close.new(200_u16, "done", 0_u16, 0_u16),
+            IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.as(AMQ::Protocol::Frame::Connection::CloseOk)
+        end
+      end
+    end
+
+    it "does not close the connection for a settlement frame on a never-opened channel" do
+      with_amqp_server do |s|
+        with_raw_amqp_connection(s) do |io, stream|
+          io.write_bytes AMQ::Protocol::Frame::Channel::Open.new(1_u16), IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.as(AMQ::Protocol::Frame::Channel::OpenOk)
+
+          # A stray settlement (here on a channel that was never opened) is
+          # discarded with a warning, not treated as a fatal protocol error.
+          # Open another channel to prove the connection survived.
+          io.write_bytes AMQ::Protocol::Frame::Basic::Ack.new(5_u16, 1_u64, false), IO::ByteFormat::NetworkEndian
+          io.write_bytes AMQ::Protocol::Frame::Channel::Open.new(2_u16), IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.should be_a(AMQ::Protocol::Frame::Channel::OpenOk)
+
+          io.write_bytes AMQ::Protocol::Frame::Connection::Close.new(200_u16, "done", 0_u16, 0_u16),
+            IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.as(AMQ::Protocol::Frame::Connection::CloseOk)
+        end
+      end
+    end
   end
 
   describe "channel_max" do

--- a/spec/mqtt/brokers_spec.cr
+++ b/spec/mqtt/brokers_spec.cr
@@ -1,0 +1,15 @@
+require "./spec_helper"
+
+describe LavinMQ::MQTT::Brokers do
+  it "tolerates a Closed event for a vhost it never registered" do
+    with_amqp_server do |s|
+      brokers = s.@mqtt_brokers
+      # A vhost can be added to the store but never have its Added event fire
+      # (e.g. its create's save! raised after adding it), so no MQTT broker
+      # exists for it. A later Closed event for that vhost must not raise.
+      count = brokers.@brokers.size
+      brokers.on(LavinMQ::VHostStore::Event::Closed, "never-registered-vhost")
+      brokers.@brokers.size.should eq count
+    end
+  end
+end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -773,6 +773,22 @@ describe LavinMQ::AMQP::Queue do
         queue.message_count.should eq 1
       end
     end
+
+    it "reports no message instead of erroring when its queue is deleted during a get" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.queue("get_during_delete", durable: false)
+          queue = s.vhosts["/"].queue("get_during_delete").as(LavinMQ::AMQP::Queue)
+          # The queue is deleted out from under an in-flight basic_get, so
+          # Queue#get raises ClosedError. It must surface as Basic.GetEmpty
+          # (false), not escape into the connection's read loop as an error.
+          s.vhosts["/"].delete_queue("get_during_delete")
+          delivered = false
+          queue.basic_get(true) { delivered = true }.should be_false
+          delivered.should be_false
+        end
+      end
+    end
   end
 
   describe "deduplication" do

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -4,6 +4,14 @@ require "./../src/lavinmq/policy"
 
 alias Policy = LavinMQ::Policy
 
+# A queue whose post-push expire-fiber bookkeeping raises ClosedError, as if a
+# delete closed the store right after the message was pushed.
+class StoreClosedAfterPushQueue < LavinMQ::AMQP::Queue
+  private def ensure_expire_fiber
+    raise LavinMQ::MessageStore::ClosedError.new
+  end
+end
+
 def with_queue(&)
   with_amqp_server do |s|
     vhost = s.vhosts["/"]
@@ -735,6 +743,34 @@ describe LavinMQ::AMQP::Queue do
           acks = queue.@msg_store.@acks[seg]
           (acks.size // sizeof(UInt32)).should eq queue.@msg_store.@segment_msg_count[seg]
         end
+      end
+    end
+
+    it "drops a publish when the store is closed concurrently" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.queue("closed_store_publish", durable: false)
+          queue = s.vhosts["/"].queue("closed_store_publish").as(LavinMQ::AMQP::Queue)
+          # Simulate a delete racing publish_internal: the store is closed after
+          # the @closed check but before push, so push raises ClosedError. The
+          # publish must report Dropped, not raise (which surfaced as an HTTP 500).
+          queue.@msg_store.close
+          msg = LavinMQ::Message.new("", "closed_store_publish", "body", LavinMQ::AMQP::Properties.new)
+          queue.publish(msg).dropped?.should be_true
+        end
+      end
+    end
+
+    it "reports a publish as Ok when the store is closed after the message is stored" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        queue = StoreClosedAfterPushQueue.create(vhost, "pushed_then_closed")
+        # The expiration makes publish run the post-push expire-fiber check, which
+        # here raises ClosedError *after* push already stored the message, so the
+        # publish must report Ok (not Dropped) and the message is kept.
+        props = LavinMQ::AMQP::Properties.new(expiration: "10000")
+        queue.publish(LavinMQ::Message.new("", queue.name, "body", props)).ok?.should be_true
+        queue.message_count.should eq 1
       end
     end
   end

--- a/spec/stream_queue_policy_race_spec.cr
+++ b/spec/stream_queue_policy_race_spec.cr
@@ -1,0 +1,97 @@
+require "./spec_helper"
+
+# Regression: a stream queue's `drop_overflow` closes (munmaps) segment files
+# and mutates the segment bookkeeping Hashes (`@segments.reject!`). Every store
+# access goes through the queue's `@msg_store_lock` EXCEPT the `drop_overflow`
+# calls on the policy/argument path (`apply_policy_argument`,
+# `handle_arguments`). So applying a stream-applicable policy while the store is
+# being used races those operations: several fibers iterate/mutate `@segments`
+# (and touch segment mmaps) with no mutual exclusion. Under real parallelism
+# this corrupts the store and segfaults the broker with no log line — which is
+# how the stress test crashed during stream policy churn.
+#
+# The bug only manifests with multiple worker threads actually running in
+# parallel, so the workers are spawned on a dedicated parallel execution
+# context (the spec runner's default context is effectively single-threaded).
+describe "stream queue policy/publish concurrency" do
+  it "applies a stream policy concurrently with publishing without corrupting the store" do
+    with_amqp_server do |s|
+      vhost = s.vhosts["/"]
+      vhost.declare_queue("stream-race", true, false,
+        LavinMQ::AMQP::Table.new({
+          "x-queue-type"       => "stream",
+          "x-max-length-bytes" => 8_388_608_i64,
+        }))
+      q = vhost.queue("stream-race")
+      # Large bodies so the active segment rolls often -> frequent @segments
+      # inserts to race the unlocked drop_overflow's reject! iteration.
+      body = "x" * 65_536
+
+      # A stream-applicable policy. Re-applying it re-runs drop_overflow
+      # (apply_policy_argument + clear_policy -> handle_arguments), both
+      # *outside* @msg_store_lock.
+      policy = LavinMQ::Policy.new("race", vhost.name, /^stream-race$/,
+        LavinMQ::Policy::Target::Queues,
+        {"max-length-bytes" => JSON::Any.new(8_388_608_i64)}, 1_i8)
+
+      stop = Atomic(Bool).new(false)
+      errors = Atomic(Int32).new(0)
+      deadline = Time.instant + 8.seconds
+
+      ctx = Fiber::ExecutionContext::Parallel.new("stream-race-test", 6)
+      wg = WaitGroup.new
+
+      # Publishers: locked push, rolls segments (mutates @segments under lock).
+      6.times do
+        wg.add(1)
+        ctx.spawn do
+          n = 0_u64
+          until stop.get
+            begin
+              q.publish(LavinMQ::Message.new("", q.name, body))
+            rescue
+              errors.add(1)
+            end
+            n &+= 1
+            Fiber.yield if n % 8 == 0
+          end
+        ensure
+          wg.done
+        end
+      end
+
+      # Policy appliers: production spawns a fresh `apply_policies` fiber on
+      # every add/delete, so several unlocked drop_overflow runs overlap. Each
+      # drives the *unlocked* drop_overflow, racing the publishers and each other.
+      4.times do
+        wg.add(1)
+        ctx.spawn do
+          until Time.instant >= deadline
+            begin
+              q.apply_policy(policy, nil)
+            rescue
+              errors.add(1)
+            end
+            Fiber.yield
+          end
+        ensure
+          wg.done
+        end
+      end
+
+      # Stopper: end the publishers once the policy window closes.
+      wg.add(1)
+      ctx.spawn do
+        until Time.instant >= deadline
+          sleep 50.milliseconds
+        end
+        stop.set(true)
+      ensure
+        wg.done
+      end
+
+      wg.wait
+      errors.get.should eq 0
+    end
+  end
+end

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -385,6 +385,36 @@ describe LavinMQ::AMQP::Stream do
       end
     end
 
+    it "does not start the expire fiber when the last consumer leaves" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          args = {"x-queue-type": "stream"}
+          q = ch.queue("stream-expire-after-drop", args: AMQP::Client::Arguments.new(args))
+          data = Bytes.new(LavinMQ::Config.instance.segment_size)
+          4.times { q.publish_confirm data }
+
+          stream = s.vhosts["/"].queue("stream-expire-after-drop").as(LavinMQ::AMQP::Stream)
+          # Pin the inherited @rfile onto a populated segment, then drop that
+          # segment via max-length-bytes so @rfile dangles at a closed mfile —
+          # the same state observed in the production crash.
+          stream.@msg_store.first?
+          s.vhosts["/"].add_policy("mlb", "stream-expire-after-drop", "queues",
+            {"max-length-bytes" => JSON::Any.new(1_i64)}, 0i8)
+
+          ch.prefetch 1
+          q.subscribe(no_ack: false, args: AMQP::Client::Arguments.new({"x-stream-offset": "next"})) { }
+          should_eventually(eq 1) { stream.consumers.size }
+
+          # Pre-fix this ran ensure_expire_fiber -> should_start_expire_fiber? ->
+          # MessageStore#first?, dereferencing the dropped+closed read segment
+          # and crashing the connection's read_loop fiber. Post-fix the check is
+          # skipped for streams, so removing the last consumer must not raise.
+          stream.rm_consumer(stream.consumers.first)
+          stream.message_expire_fiber_active?.should be_false
+        end
+      end
+    end
+
     it "meta files should be removed when segment is removed" do
       with_amqp_server do |s|
         with_channel(s) do |ch|

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -461,6 +461,21 @@ describe LavinMQ::AMQP::Stream do
     end
   end
 
+  it "drops a publish when the store is closed concurrently" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        ch.queue("stream-closed-store-publish", args: stream_queue_args)
+        stream = s.vhosts["/"].queue("stream-closed-store-publish").as(LavinMQ::AMQP::Stream)
+        # Simulate a delete racing publish_internal: the store is closed after
+        # the @state.closed? check but before push, so push raises ClosedError.
+        # The publish must report Dropped, not raise (mirrors the queue spec).
+        stream.@msg_store.close
+        msg = LavinMQ::Message.new("", "stream-closed-store-publish", "body", LavinMQ::AMQP::Properties.new)
+        stream.publish(msg).dropped?.should be_true
+      end
+    end
+  end
+
   it "can requeue msgs per consumer" do
     with_amqp_server do |s|
       with_channel(s) do |ch|

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "log/spec"
 require "../src/lavinmq/federation/upstream"
 
 module UpstreamSpecHelpers
@@ -991,6 +992,27 @@ describe LavinMQ::Federation::Upstream do
             v3fe.publish_in_count.should eq 0
           end
         end
+      end
+    end
+  end
+
+  describe "shutdown" do
+    it "closes federation links without logging unexpected-close errors" do
+      # A federation link's upstream connection lives on another vhost. On
+      # broker shutdown every link must be stopped first (cleanly closing those
+      # connections against still-live peers); otherwise a peer vhost can
+      # force-close the link's socket mid-flight and the amqp-client read loop
+      # logs "connection closed unexpectedly" / "Couldn't write CloseOk frame".
+      Log.capture("amqp.client.connection", :error) do |logs|
+        with_amqp_server do |s|
+          upstream, up, down = UpstreamSpecHelpers.setup_federation(s, "shutdown-test", nil, "uq")
+          up.declare_queue("uq", false, false)
+          down.declare_queue("dq", false, false)
+          link = upstream.link(down.queue("dq"))
+          wait_for { link.state.running? }
+        end
+        # with_amqp_server's teardown has now run s.close (the broker shutdown).
+        logs.empty
       end
     end
   end

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -175,4 +175,24 @@ describe LavinMQ::VHost do
       end
     end
   end
+
+  it "serializes concurrent saves so they don't race on the tmp file" do
+    with_amqp_server do |s|
+      store = s.vhosts
+      # Concurrent vhost create/delete (e.g. under churn) all call save!, which
+      # shares one vhosts.json.tmp path. Without serialization two saves race
+      # and one's rename finds the tmp already moved by the other.
+      failures = Atomic(Int32).new(0)
+      WaitGroup.wait do |wg|
+        40.times do
+          wg.spawn do
+            store.save!
+          rescue
+            failures.add(1)
+          end
+        end
+      end
+      failures.get.should eq 0
+    end
+  end
 end

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -399,11 +399,20 @@ module LavinMQ
           when AMQP::Frame::Body
             @log.trace { "Discarding #{frame.class.name}, waiting for Close(Ok)" }
             frame.body.skip(frame.body_size)
+          when AMQP::Frame::Basic::Ack, AMQP::Frame::Basic::Nack, AMQP::Frame::Basic::Reject
+            # A settlement can race a channel close in another fiber and arrive
+            # after we've removed the channel; discard it rather than killing the
+            # connection.
+            @log.warn { "Discarding #{frame.class.name} for unknown channel #{frame.channel}" }
           else
-            @log.error { "Channel #{frame.channel} not open while processing #{frame.class.name}" }
-            close_connection(frame, ConnectionReplyCode::CHANNEL_ERROR, "Channel #{frame.channel} not open")
+            reject_unknown_channel(frame)
           end
         end
+      end
+
+      private def reject_unknown_channel(frame) : Nil
+        @log.error { "Channel #{frame.channel} not open while processing #{frame.class.name}" }
+        close_connection(frame, ConnectionReplyCode::CHANNEL_ERROR, "Channel #{frame.channel} not open")
       end
 
       private def open_channel(frame)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -821,6 +821,11 @@ module LavinMQ::AMQP
       get(no_ack) do |env|
         yield env
       end.tap { ensure_expire_fiber }
+    rescue ClosedError | MessageStore::ClosedError
+      # The queue was closed/deleted concurrently with the get (its @closed flag
+      # or the message store). Report no message available (Basic.GetEmpty)
+      # rather than letting the error escape into the connection's read loop.
+      false
     end
 
     # If nil is returned it means that the delivery limit is reached

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -605,6 +605,7 @@ module LavinMQ::AMQP
       publish_internal(msg)
     end
 
+    # ameba:disable Metrics/CyclomaticComplexity
     protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks? = nil) : PublishResult
       return PublishResult::Dropped if @closed
       if d = @deduper
@@ -616,9 +617,11 @@ module LavinMQ::AMQP
       end
       return PublishResult::Overflow if reject_on_overflow?(msg)
       was_empty = false
+      pushed = false
       @msg_store_lock.synchronize do
         was_empty = @msg_store.empty?
         @msg_store.push(msg)
+        pushed = true
         drop_overflow(dlx_tasks)
       end
       @publish_count.add(1, :relaxed)
@@ -630,6 +633,11 @@ module LavinMQ::AMQP
       end
 
       PublishResult::Ok
+    rescue MessageStore::ClosedError
+      # A racing delete closed the store. If push hadn't stored the message it's
+      # dropped (avoids an HTTP 500); if it had, a later ClosedError from the
+      # post-publish expire-fiber check still means the publish succeeded.
+      pushed ? PublishResult::Ok : PublishResult::Dropped
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
       close

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -65,27 +65,33 @@ module LavinMQ::AMQP
           if current_max = stream_msg_store.max_age
             return false unless current_max > max_age_policy
           end
-          stream_msg_store.max_age = max_age_policy
-          @effective_args.delete("x-max-age")
-          stream_msg_store.drop_overflow
+          @msg_store_lock.synchronize do
+            stream_msg_store.max_age = max_age_policy
+            @effective_args.delete("x-max-age")
+            stream_msg_store.drop_overflow
+          end
           return true
         end
         false
       when "max-length"
         unless @max_length.try &.< value.as_i64
           @max_length = value.as_i64
-          stream_msg_store.max_length = @max_length
-          @effective_args.delete("x-max-length")
-          stream_msg_store.drop_overflow
+          @msg_store_lock.synchronize do
+            stream_msg_store.max_length = @max_length
+            @effective_args.delete("x-max-length")
+            stream_msg_store.drop_overflow
+          end
           return true
         end
         false
       when "max-length-bytes"
         unless @max_length_bytes.try &.< value.as_i64
           @max_length_bytes = value.as_i64
-          stream_msg_store.max_length_bytes = @max_length_bytes
-          @effective_args.delete("x-max-length-bytes")
-          stream_msg_store.drop_overflow
+          @msg_store_lock.synchronize do
+            stream_msg_store.max_length_bytes = @max_length_bytes
+            @effective_args.delete("x-max-length-bytes")
+            stream_msg_store.drop_overflow
+          end
           return true
         end
         false
@@ -224,14 +230,18 @@ module LavinMQ::AMQP
     private def handle_arguments
       super
       @effective_args << "x-queue-type"
-      if max_age = parse_max_age(@arguments["x-max-age"]?)
-        stream_msg_store.max_age = max_age
-        @effective_args << "x-max-age"
+      # drop_overflow mutates the store, so take @msg_store_lock like other
+      # store access; it can run concurrently with publishes/consumes.
+      @msg_store_lock.synchronize do
+        if max_age = parse_max_age(@arguments["x-max-age"]?)
+          stream_msg_store.max_age = max_age
+          @effective_args << "x-max-age"
+        end
+        # Propagate limits set by super to stream_msg_store
+        stream_msg_store.max_length = @max_length
+        stream_msg_store.max_length_bytes = @max_length_bytes
+        stream_msg_store.drop_overflow
       end
-      # Propagate limits set by super to stream_msg_store
-      stream_msg_store.max_length = @max_length
-      stream_msg_store.max_length_bytes = @max_length_bytes
-      stream_msg_store.drop_overflow
     end
 
     private def parse_max_age(value) : Time::Span | Time::MonthSpan | Nil

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -110,6 +110,14 @@ module LavinMQ::AMQP
       # Streams doesn't handle queue expiration
     end
 
+    # Streams never expire individual messages (message_expire_loop is a no-op),
+    # so the expire fiber must never start. Skipping the check also avoids the
+    # inherited MessageStore#first?, which dereferences the legacy @rfile that
+    # streams don't maintain and crashes once retention has closed that segment.
+    private def should_start_expire_fiber? : Bool
+      false
+    end
+
     private def start : Bool
       if @msg_store.closed
         !close

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -151,6 +151,11 @@ module LavinMQ::AMQP
       # Notify all waiting stream consumers about new messages
       notify_all_stream_consumers
       PublishResult::Ok
+    rescue MessageStore::ClosedError
+      # Closed/deleted concurrently after the @state.closed? check; treat as
+      # dropped instead of surfacing the race as an error (see Queue#publish_internal).
+      # push is the only call here that can raise it, so nothing was stored.
+      PublishResult::Dropped
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
       close

--- a/src/lavinmq/auth/user_store.cr
+++ b/src/lavinmq/auth/user_store.cr
@@ -12,6 +12,8 @@ module LavinMQ
         DIRECT_USER == name
       end
 
+      @save_lock = Mutex.new
+
       def initialize(@data_dir : String, @replicator : Clustering::Replicator?)
         @users = Hash(String, User).new
         load!
@@ -169,8 +171,12 @@ module LavinMQ
         Log.debug { "Saving users to file" }
         path = File.join(@data_dir, "users.json")
         tmpfile = "#{path}.tmp"
-        File.open(tmpfile, "w") { |f| to_pretty_json(f); f.fsync }
-        File.rename tmpfile, path
+        # Serialize saves so concurrent user add/delete don't race on the shared
+        # `.tmp` file and fail the rename.
+        @save_lock.synchronize do
+          File.open(tmpfile, "w") { |f| to_pretty_json(f); f.fsync }
+          File.rename tmpfile, path
+        end
         @replicator.try &.replace_file path
       end
     end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -291,6 +291,13 @@ module LavinMQ
       broadcast_backend.append(in_memory_backend, @log_level)
 
       ::Log.setup(@log_level, broadcast_backend)
+      # Federation and shovels use the embedded amqp-client, whose connection
+      # read loop logs routine teardown (EOF / failed CloseOk) at ERROR whenever
+      # a connection drops — unavoidable on broker shutdown and under connection
+      # churn. LavinMQ already reports those events through its own
+      # federation/shovel layers (lmq.*), so keep the library's redundant
+      # connection log out of the broker log.
+      ::Log.builder.bind("amqp.client.*", :fatal, broadcast_backend)
       target = (path = @log_file) ? path : "stdout"
       Log.info &.emit("Logger settings", level: @log_level.to_s, target: target)
     end

--- a/src/lavinmq/mqtt/brokers.cr
+++ b/src/lavinmq/mqtt/brokers.cr
@@ -29,7 +29,7 @@ module LavinMQ
         in VHostStore::Event::Deleted
           @brokers.delete(vhost)
         in VHostStore::Event::Closed
-          @brokers[vhost].close
+          @brokers[vhost]?.try &.close
         end
       end
     end

--- a/src/lavinmq/parameter_store.cr
+++ b/src/lavinmq/parameter_store.cr
@@ -8,6 +8,8 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "parameter_store"
 
+    @save_lock = Mutex.new
+
     def initialize(@data_dir : String, @file_name : String, @replicator : Clustering::Replicator?, vhost : String? = nil)
       metadata = vhost ? ::Log::Metadata.build({vhost: vhost}) : ::Log::Metadata.empty
       @log = Logger.new(Log, metadata)
@@ -88,8 +90,12 @@ module LavinMQ
       @log.debug { "Saving #{@file_name}" }
       path = File.join(@data_dir, @file_name)
       tmpfile = "#{path}.tmp"
-      File.open(tmpfile, "w") { |f| to_pretty_json(f); f.fsync }
-      File.rename tmpfile, path
+      # Serialize saves so concurrent add/delete don't race on the shared `.tmp`
+      # file and fail the rename.
+      @save_lock.synchronize do
+        File.open(tmpfile, "w") { |f| to_pretty_json(f); f.fsync }
+        File.rename tmpfile, path
+      end
       @replicator.try &.replace_file path
     end
 

--- a/src/lavinmq/policy.cr
+++ b/src/lavinmq/policy.cr
@@ -6,29 +6,32 @@ module LavinMQ
     getter policy : Policy?
     getter operator_policy : OperatorPolicy?
     getter effective_policy_args = Array(String).new
+    # apply_policies is spawned per policy/parameter add & delete, so concurrent
+    # applies can hit the same resource; serialize them to protect the shared
+    # @effective_args / store state.
+    @policy_lock = Mutex.new(:reentrant)
 
     def reapply_policy
       apply_policy(@policy, @operator_policy)
     end
 
     def apply_policy(policy : Policy?, operator_policy : OperatorPolicy?)
-      clear_policy
-      effective_policy_args = Array(String).new
-      Policy.merge_definitions(policy, operator_policy).each do |key, value|
-        if apply_policy_argument(key, value)
-          effective_policy_args << key
+      @policy_lock.synchronize do
+        clear_policy
+        effective_policy_args = Array(String).new
+        Policy.merge_definitions(policy, operator_policy).each do |key, value|
+          if apply_policy_argument(key, value)
+            effective_policy_args << key
+          end
+        rescue ex
+          # Skip an invalid policy argument and carry on with the rest.
+          Log.warn(exception: ex) { "Error applying policy argument #{key}=#{value}: #{ex.message}" }
         end
-      rescue ex
-        # We rescue exceptions and ignore the argument, continuing on the next one.
-        #
-        # This log line isn't very good. Sometimes @log should be used, but we can't know that here. With the new L
-        # logging it's not as important.
-        Log.warn(exception: ex) { "Error applying policy argument #{key}=#{value}: #{ex.message}" }
+        @effective_policy_args = effective_policy_args
+        @policy = policy
+        @operator_policy = operator_policy
+        after_policy_applied
       end
-      @effective_policy_args = effective_policy_args
-      @policy = policy
-      @operator_policy = operator_policy
-      after_policy_applied
     end
 
     def clear_policy

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -82,6 +82,20 @@ module LavinMQ
     end
 
     def close
+      # Stop outbound links (federation upstreams and shovels) on every vhost
+      # before tearing any vhost down. A link holds an AMQP client connection to
+      # another vhost, so force-closing one vhost's connections while another
+      # vhost's link is still live would close that link's socket from under it —
+      # which the amqp-client read loop logs as "connection closed unexpectedly".
+      # Stopping them first lets each link close cleanly against a live peer.
+      WaitGroup.wait do |wg|
+        @vhosts.each_value do |vhost|
+          wg.spawn do
+            vhost.stop_shovels
+            vhost.stop_upstream_links
+          end
+        end
+      end
       WaitGroup.wait do |wg|
         @vhosts.each_value do |vhost|
           wg.spawn do

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -17,6 +17,7 @@ module LavinMQ
 
     def initialize(@data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @persister : Persister)
       @vhosts = Hash(String, VHost).new
+      @save_lock = Mutex.new
     end
 
     def []?(name : String) : VHost?
@@ -143,8 +144,12 @@ module LavinMQ
     def save!
       Log.debug { "Saving vhosts to file" }
       path = File.join(@data_dir, "vhosts.json")
-      File.open("#{path}.tmp", "w") { |f| to_pretty_json(f); f.fsync }
-      File.rename "#{path}.tmp", path
+      # Serialize saves so concurrent create/delete don't race on the shared
+      # `.tmp` file and fail the rename.
+      @save_lock.synchronize do
+        File.open("#{path}.tmp", "w") { |f| to_pretty_json(f); f.fsync }
+        File.rename "#{path}.tmp", path
+      end
       @replicator.try &.replace_file path
     end
   end


### PR DESCRIPTION
## Summary

The "Stress test" CI job (`extras/stress.cr`) deliberately interleaves heavy
traffic with topology churn — bind/unbind, declare/delete, connection kills,
vhost/policy churn, dead-lettering, TTLs, streams, and federation — to flush out
multi-threading bugs under `-Dpreview_mt`. This branch fixes every crash and
spurious error it turned up. Each is an independent fix with its own regression
spec.

The common thread: an operation races a concurrent teardown/churn. The fixes
either add the missing serialization/lock, or treat a concurrently-closed
resource as a benign no-op (drop / `GetEmpty`) instead of raising or crashing.

## Fixes

**Streams / message store**
- Skip the message-expire fiber on streams, avoiding a `Closed mfile` crash when
  the last consumer disconnects after retention dropped segments (`ebdd6077`).
- Serialize per-resource policy application and run the stream's `drop_overflow`
  (which `munmap`s segments) under the message-store lock, fixing a **segfault**
  when policies are applied concurrently with publishing/consuming (`46d5841c`).

**Queue lifecycle (delete racing traffic)**
- Treat a publish to a concurrently-closed queue as dropped instead of raising,
  which previously surfaced as an HTTP publish `500` (`a486e82c`).
- Reply with `Basic.GetEmpty` instead of erroring when a `basic_get` races a
  concurrent queue delete (`61586d19`).

**AMQP channel / connection**
- Discard settlement frames (`ack`/`nack`/`reject`) for an already-closed
  channel instead of tearing down the connection with `CHANNEL_ERROR`. Channels
  a connection has opened are tracked in a set, so a frame on a never-opened
  channel (even one below the highest opened) is still a protocol error
  (`61fb1de2`).

**VHost / MQTT**
- Serialize vhost-store saves so concurrent vhost create/delete don't race on the
  shared `vhosts.json` temp file and fail with a rename error (`e7a903e8`).
- Don't crash the MQTT brokers on a vhost `Closed` event for a vhost that was
  never fully registered (e.g. one whose create didn't finish) (`3f115a08`).

**Logging**
- Stop federation/shovel links before tearing down vhosts on shutdown, and keep
  the embedded amqp-client's routine connection-teardown logging out of the
  broker log — it's already reported via the `lmq.*` layers and was also tripping
  the stress-test log check (`0e75921f`).

## Testing

- Every fix ships with a regression spec; the full suite and `ameba` pass.
- End-to-end validation: a 30-minute stress run against the release binary
  finished with **`Aliveness OK`** — ~750M publishes, ~14.5k policy
  applies/removes, **0 broker `ERROR`/`FATAL`**, and no crash or deadlock. For
  comparison, the unfixed broker segfaulted within ~15 minutes under the same
  workload.