### PR TITLE
Fix HTTP Queue detail endpoint emitting message_stats twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `unix_proxy_protocol` config option; Unix sockets always auto-detect PROXY protocol headers [#1601](https://github.com/cloudamqp/lavinmq/pull/1601)
 
+### Fixed
+
+- `GET /api/queues/:vhost/:name` no longer emits the `message_stats` field twice
+
 ## [2.8.1] - 2026-05-18
 
 ### Changed

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -92,6 +92,14 @@ describe LavinMQ::HTTP::QueuesController do
       end
     end
 
+    it "writes message_stats only once" do
+      with_http_server do |http, s|
+        s.vhosts["/"].declare_queue("stats_q", false, false)
+        response = http.get("/api/queues/%2f/stats_q")
+        response.body.scan(/"message_stats"/).size.should eq 1
+      end
+    end
+
     it "should return no persistent message count" do
       with_http_server do |http, s|
         with_channel(s) do |ch|

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -1050,6 +1050,7 @@ module LavinMQ::AMQP
     def to_json(json : JSON::Builder, consumer_limit : Int32 = -1)
       json.object do
         details_tuple.each do |k, v|
+          next if k == :message_stats # rewritten below with the rate-history log
           json.field(k, v) unless v.nil?
         end
         json.field("message_stats") do


### PR DESCRIPTION
details_tuple already carries message_stats (current stats, no log) for list endpoints, and to_json then wrote a second message_stats with the full rate-history log. Skip the duplicate from details_tuple so the detail response carries message_stats once, with the log.