### PR TITLE
stats: Store object stats as packed column buffers

### DIFF
--- a/spec/stat_log_compact_race_spec.cr
+++ b/spec/stat_log_compact_race_spec.cr
@@ -1,0 +1,91 @@
+require "./spec_helper"
+
+# Memory-safety stress for the compact path: a writer repeatedly materializes
+# then compacts an object's stats buffer (compact nulls the buffer; GC.collect +
+# GC_UNMAP_THRESHOLD=1 can unmap it) while reader fibers iterate StatLogViews to
+# JSON (the HTTP read path). If a view did not pin the buffer via its BASE
+# pointer, a compacted+unmapped buffer would be dereferenced -> SIGSEGV.
+#
+# Uses 3 rate columns so columns 1 and 2 sit at INTERIOR offsets (base + i*cap),
+# the exact case the base-pointer storage protects. Run the adversarial control
+# to prove no dependence on interior-pointer recognition:
+#   GC_UNMAP_THRESHOLD=1 GC_FREE_SPACE_DIVISOR=1 crystal spec ... (must pass)
+#   GC_UNMAP_THRESHOLD=1 GC_ALL_INTERIOR_POINTERS=0 crystal spec ... (must also pass)
+module LavinMQ
+  class RaceProbe
+    include Stats
+    rate_stats({"a", "b", "c"}, {"d"})
+
+    @d = 0_u32
+
+    def d
+      @d
+    end
+
+    def bump(n : UInt64)
+      @a_count.add(n)
+      @b_count.add(n)
+      @c_count.add(n)
+      @d &+= 1
+    end
+
+    def constant?
+      @_stats_rate_buffer.null?
+    end
+  end
+end
+
+describe "StatLogView compact/read race" do
+  it "never frees a buffer out from under a concurrent reader" do
+    cap = LavinMQ::Config.instance.stats_log_size
+    probe = LavinMQ::RaceProbe.new
+    stop = Atomic(Int32).new(0)
+    errors = Atomic(Int32).new(0)
+    done = Channel(Nil).new
+    readers = 8
+
+    readers.times do
+      spawn do
+        until stop.get(:relaxed) == 1
+          begin
+            io = IO::Memory.new
+            jb = JSON::Builder.new(io)
+            jb.document do
+              jb.array do
+                probe.a_log.to_json(jb) # column 0 (base)
+                probe.b_log.to_json(jb) # column 1 (interior)
+                probe.c_log.to_json(jb) # column 2 (interior)
+                probe.d_log.to_json(jb) # count column
+              end
+            end
+            probe.b_log.to_a
+            probe.c_log.each { |v| v }
+          rescue
+            errors.add(1)
+          end
+          Fiber.yield
+        end
+        done.send(nil)
+      end
+    end
+
+    materializes = 0
+    compacts = 0
+    300.times do |c|
+      probe.bump(c.odd? ? 7_u64 : 131_u64) # changing delta -> rate diverges -> materialize
+      probe.update_rates
+      materializes += 1 unless probe.constant?
+      (cap + 1).times { probe.update_rates } # constant (no bump) -> rate holds -> compact
+      compacts += 1 if probe.constant?
+      GC.collect # with GC_UNMAP_THRESHOLD=1 may unmap a just-freed buffer
+      Fiber.yield
+    end
+
+    stop.set(1, :relaxed)
+    readers.times { done.receive }
+
+    errors.get(:relaxed).should eq 0
+    (materializes > 100).should be_true # really exercised buffered logs
+    (compacts > 100).should be_true     # ...and really compacted them
+  end
+end

--- a/spec/stat_log_differential_spec.cr
+++ b/spec/stat_log_differential_spec.cr
@@ -1,0 +1,135 @@
+require "./spec_helper"
+
+module LavinMQ
+  # 3 rate + 2 count keys: exercises non-zero column offsets (i*cap) and the
+  # path where one key diverging materializes all columns (others back-fill).
+  class MultiProbe
+    include Stats
+    rate_stats({"a", "b", "c"}, {"m", "n"})
+
+    @m = 0_u32
+    @n = 0_u32
+
+    def m
+      @m
+    end
+
+    def n
+      @n
+    end
+
+    def bump(da : UInt64, db : UInt64, dc : UInt64, mv : UInt32, nv : UInt32)
+      @a_count.add(da)
+      @b_count.add(db)
+      @c_count.add(dc)
+      @m = mv
+      @n = nv
+    end
+
+    def constant?
+      @_stats_rate_buffer.null?
+    end
+  end
+end
+
+# Inline PRNG (not stdlib Random) so the sequence and coverage are identical on
+# every machine and Crystal version.
+private class Xorshift
+  def initialize(seed : UInt32)
+    @s = seed.zero? ? 0x9e3779b9_u32 : seed
+  end
+
+  def u32 : UInt32
+    x = @s
+    x ^= x << 13
+    x ^= x >> 17
+    x ^= x << 5
+    @s = x
+    x
+  end
+
+  def below(n : Int32) : Int32
+    (u32 % n.to_u32).to_i
+  end
+end
+
+private def rate_for(dx : UInt64, interval : Float64) : Float64
+  dx.zero? ? 0.0 : (dx / interval).round(1)
+end
+
+private def check(view, oracle, do_json) : Bool
+  return false if view.size != oracle.size
+  view.size.times do |i|
+    return false if view[i] != oracle[i]
+  end
+  return false if do_json && view.to_json != oracle.to_a.to_json
+  true
+end
+
+describe "constant-encoding differential vs Deque oracle (deterministic, multi-column)" do
+  it "matches per-column Deque logs over a deterministic sequence (wrap + materialize + compact)" do
+    orig_cap = LavinMQ::Config.instance.stats_log_size
+    orig_int = LavinMQ::Config.instance.stats_interval
+    begin
+      LavinMQ::Config.instance.stats_interval = 5000
+      interval = 5.0
+
+      [1, 2, 3, 6, 120].each do |cap|
+        LavinMQ::Config.instance.stats_log_size = cap
+        saw_buffered = 0
+        compactions = 0
+        steps_total = 0
+
+        (1_u32..24_u32).each do |stream|
+          rng = Xorshift.new(stream)
+          p = LavinMQ::MultiProbe.new
+          orates = Array.new(3) { Deque(Float64).new }
+          ocounts = Array.new(2) { Deque(UInt32).new }
+          da = db = dc = 0_u64
+          mv = nv = 0_u32
+          was_constant = true
+
+          250.times do |step|
+            da = (rng.below(3).zero? ? 0_u64 : rng.below(200).to_u64 + 1) if rng.below(10).zero?
+            db = (rng.below(3).zero? ? 0_u64 : rng.below(200).to_u64 + 1) if rng.below(10).zero?
+            dc = (rng.below(3).zero? ? 0_u64 : rng.below(200).to_u64 + 1) if rng.below(10).zero?
+            mv = rng.below(50).to_u32 if rng.below(10).zero?
+            nv = rng.below(50).to_u32 if rng.below(10).zero?
+
+            p.bump(da, db, dc, mv, nv)
+            p.update_rates
+
+            orates[0].push rate_for(da, interval); orates[0].shift if orates[0].size > cap
+            orates[1].push rate_for(db, interval); orates[1].shift if orates[1].size > cap
+            orates[2].push rate_for(dc, interval); orates[2].shift if orates[2].size > cap
+            ocounts[0].push mv; ocounts[0].shift if ocounts[0].size > cap
+            ocounts[1].push nv; ocounts[1].shift if ocounts[1].size > cap
+
+            do_json = step % 16 == 0
+            ok = check(p.a_log, orates[0], do_json) && check(p.b_log, orates[1], do_json) &&
+                 check(p.c_log, orates[2], do_json) && check(p.m_log, ocounts[0], do_json) &&
+                 check(p.n_log, ocounts[1], do_json)
+            unless ok
+              fail "cap=#{cap} stream=#{stream} step=#{step} constant?=#{p.constant?}\n" \
+                   "  a got=#{p.a_log.to_a} exp=#{orates[0].to_a}\n  b got=#{p.b_log.to_a} exp=#{orates[1].to_a}\n" \
+                   "  c got=#{p.c_log.to_a} exp=#{orates[2].to_a}\n  m got=#{p.m_log.to_a} exp=#{ocounts[0].to_a}\n" \
+                   "  n got=#{p.n_log.to_a} exp=#{ocounts[1].to_a}"
+            end
+
+            saw_buffered += 1 unless p.constant?
+            compactions += 1 if p.constant? && !was_constant
+            was_constant = p.constant?
+            steps_total += 1
+          end
+        end
+
+        STDERR.puts "cap=#{cap}: steps=#{steps_total} buffered=#{saw_buffered} compactions=#{compactions}"
+        saw_buffered.should be > 0
+        compactions.should be > 0 if cap <= 6
+      end
+    ensure
+      LavinMQ::Config.instance.stats_log_size = orig_cap
+      LavinMQ::Config.instance.stats_interval = orig_int
+    end
+  end
+end

--- a/spec/stat_log_spec.cr
+++ b/spec/stat_log_spec.cr
@@ -1,0 +1,158 @@
+require "./spec_helper"
+
+# Build a single buffered column and a StatLogView over it, mirroring how the
+# rate_stats macro writes a column.
+private def view(values : Array(Float64), cap = 4) : LavinMQ::StatLogView(Float64)
+  col = Pointer(Float64).malloc(cap)
+  head = 0
+  size = 0
+  values.each do |v|
+    tail = head + size
+    tail -= cap if tail >= cap
+    col[tail] = v
+    if size < cap
+      size += 1
+    else
+      head += 1
+      head -= cap if head >= cap
+    end
+  end
+  LavinMQ::StatLogView(Float64).new(col, 0, head, size, cap, 0.0)
+end
+
+describe LavinMQ::StatLogView do
+  it "reads in order before wrapping" do
+    view([1.0, 2.0, 3.0]).to_a.should eq [1.0, 2.0, 3.0]
+  end
+
+  it "overwrites oldest when full (wraps)" do
+    view([1.0, 2.0, 3.0, 4.0, 5.0]).to_a.should eq [2.0, 3.0, 4.0, 5.0] # cap 4
+  end
+
+  it "wraps multiple times" do
+    view((1..10).map(&.to_f64)).to_a.should eq [7.0, 8.0, 9.0, 10.0]
+  end
+
+  it "indexes by position" do
+    v = view([1.0, 2.0, 3.0, 4.0, 5.0])
+    v[0].should eq 2.0
+    v[3].should eq 5.0
+  end
+
+  it "raises IndexError out of range" do
+    expect_raises(IndexError) { view([1.0])[-1] }
+    expect_raises(IndexError) { view([1.0])[1] }
+    expect_raises(IndexError) { view([] of Float64)[0] }
+  end
+
+  it "serializes to a JSON array" do
+    view([1.0, 2.0, 3.0, 4.0, 5.0]).to_json.should eq "[2.0,3.0,4.0,5.0]"
+    view([] of Float64).to_json.should eq "[]"
+  end
+
+  it "is Enumerable" do
+    view([1.0, 2.0, 3.0, 4.0]).sum.should eq 10.0
+  end
+
+  describe "constant mode (null base)" do
+    it "yields the constant `size` times with no buffer" do
+      v = LavinMQ::StatLogView(Float64).new(Pointer(Float64).null, 0, 0, 5, 120, 3.5)
+      v.size.should eq 5
+      v.to_a.should eq [3.5, 3.5, 3.5, 3.5, 3.5]
+      v[0].should eq 3.5
+      v[4].should eq 3.5
+      v.to_json.should eq "[3.5,3.5,3.5,3.5,3.5]"
+    end
+
+    it "is empty when size is zero" do
+      v = LavinMQ::StatLogView(Float64).new(Pointer(Float64).null, 0, 0, 0, 120, 0.0)
+      v.to_a.should eq [] of Float64
+      v.to_json.should eq "[]"
+      expect_raises(IndexError) { v[0] }
+    end
+  end
+end
+
+module LavinMQ
+  class StatsProbe
+    include Stats
+    rate_stats({"x"}, {"y"})
+
+    @y = 0_u32
+
+    def y
+      @y
+    end
+
+    def bump(dx : UInt64, yv : UInt32)
+      @x_count.add(dx)
+      @y = yv
+    end
+
+    def constant?
+      @_stats_rate_buffer.null?
+    end
+  end
+end
+
+describe LavinMQ::Stats do
+  it "stays constant (no buffer) while idle, serving zeros" do
+    p = LavinMQ::StatsProbe.new
+    10.times { p.bump(0_u64, 0_u32); p.update_rates }
+    p.constant?.should be_true
+    p.x_log.size.should eq 10
+    p.x_log.to_a.should eq Array.new(10, 0.0)
+    p.y_log.to_a.should eq Array.new(10, 0_u32)
+  end
+
+  it "stays constant for a steady rate" do
+    p = LavinMQ::StatsProbe.new
+    5.times { p.bump(25_u64, 7_u32); p.update_rates } # steady rate 5.0, y constant 7
+    p.constant?.should be_true
+    p.x_log.to_a.should eq Array.new(5, 5.0)
+    p.y_log.to_a.should eq Array.new(5, 7_u32)
+  end
+
+  it "materializes on divergence, replaying the constant history losslessly" do
+    p = LavinMQ::StatsProbe.new
+    3.times { p.bump(25_u64, 5_u32); p.update_rates } # constant: rate 5.0 x3, y 5 x3
+    p.constant?.should be_true
+    p.bump(0_u64, 5_u32); p.update_rates # rate -> 0.0 diverges, y stays 5
+    p.constant?.should be_false
+    p.x_log.to_a.should eq [5.0, 5.0, 5.0, 0.0]
+    p.y_log.to_a.should eq [5_u32, 5_u32, 5_u32, 5_u32]
+  end
+
+  it "compacts buffered -> constant after a full constant window" do
+    p = LavinMQ::StatsProbe.new
+    cap = LavinMQ::Config.instance.stats_log_size
+    p.bump(5_u64, 1_u32); p.update_rates  # rate 1.0
+    p.bump(50_u64, 9_u32); p.update_rates # rate 10.0, y 9 -> materialize
+    p.constant?.should be_false
+    (cap + 2).times { p.bump(50_u64, 9_u32); p.update_rates } # steady -> compact
+    p.constant?.should be_true
+    p.x_log.to_a.should eq Array.new(cap, 10.0)
+    p.y_log.to_a.should eq Array.new(cap, 9_u32)
+  end
+end
+
+private class AggProbe
+  include LavinMQ::HTTP::StatsHelpers
+end
+
+describe "add_logs! with a StatLogView source" do
+  it "sums a buffered view element-wise into a Deque" do
+    a = Deque(Float64).new
+    a.concat([1.0, 2.0, 3.0, 4.0])
+    AggProbe.new.add_logs!(a, view([10.0, 20.0, 30.0, 40.0, 50.0])) # holds [20,30,40,50]
+    a.to_a.should eq [21.0, 32.0, 43.0, 54.0]
+  end
+
+  it "sums a constant view element-wise into a Deque" do
+    a = Deque(Float64).new
+    a.concat([1.0, 2.0, 3.0])
+    b = LavinMQ::StatLogView(Float64).new(Pointer(Float64).null, 0, 0, 3, 120, 10.0)
+    AggProbe.new.add_logs!(a, b)
+    a.to_a.should eq [11.0, 12.0, 13.0]
+  end
+end

--- a/src/lavinmq/http/stats_helper.cr
+++ b/src/lavinmq/http/stats_helper.cr
@@ -1,15 +1,14 @@
 module LavinMQ
   module HTTP
     module StatsHelpers
+      # logs_b is a read-only view, so pad only logs_a and right-align the sum.
       def add_logs!(logs_a, logs_b)
         until logs_a.size >= logs_b.size
           logs_a.unshift 0
         end
-        until logs_b.size >= logs_a.size
-          logs_b.unshift 0
-        end
-        logs_a.size.times do |i|
-          logs_a[i] += logs_b[i]
+        offset = logs_a.size - logs_b.size
+        logs_b.size.times do |i|
+          logs_a[offset + i] += logs_b[i]
         end
         logs_a
       end

--- a/src/lavinmq/stat_log.cr
+++ b/src/lavinmq/stat_log.cr
@@ -1,0 +1,52 @@
+require "json"
+
+module LavinMQ
+  # Read-only value-type view over one column of a per-object stats buffer
+  # (or, when `base` is null, a constant repeated `size` times).
+  #
+  # Stores the buffer BASE pointer + column offset, never an interior base+offset
+  # pointer: update_rates may free the buffer mid-read, and holding the base keeps
+  # a conservative GC from collecting it even with interior pointers off.
+  struct StatLogView(T)
+    include Enumerable(T)
+
+    def initialize(@base : Pointer(T), @offset : Int32, @head : Int32, @size : Int32, @capacity : Int32, @const : T)
+    end
+
+    def size : Int32
+      @size
+    end
+
+    def [](index : Int32) : T
+      raise IndexError.new if index >= @size || index < 0
+      return @const if @base.null?
+      j = @head + index
+      j -= @capacity if j >= @capacity
+      @base[@offset + j]
+    end
+
+    def each(& : T ->) : Nil
+      if @base.null?
+        @size.times { yield @const }
+      else
+        @size.times do |i|
+          j = @head + i
+          j -= @capacity if j >= @capacity
+          yield @base[@offset + j]
+        end
+      end
+    end
+
+    def to_json(json : JSON::Builder) : Nil
+      json.array do
+        each(&.to_json(json))
+      end
+    end
+
+    def to_a : Array(T)
+      arr = Array(T).new(@size)
+      each { |v| arr << v }
+      arr
+    end
+  end
+end

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -72,7 +72,8 @@ module LavinMQ
 
         {% for name, i in stats_keys %}
           new_count_{{ i }} = @{{ name.id }}_count.get(:relaxed)
-          new_rate_{{ i }} = ((new_count_{{ i }} - @{{ name.id }}_count_prev) / interval).round(1)
+          delta_{{ i }} = new_count_{{ i }} - @{{ name.id }}_count_prev
+          new_rate_{{ i }} = delta_{{ i }}.zero? ? 0.0 : (delta_{{ i }} / interval).round(1)
         {% end %}
         {% for name, j in log_keys %}
           new_log_{{ j }} = {{ name.id }}

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -1,18 +1,45 @@
+require "./config"
+require "./stat_log"
+
 module LavinMQ
   module Stats
     macro rate_stats(stats_keys, log_keys = %w[])
-      {% for name in stats_keys %}
+      @_stats_log_capacity : Int32 = Config.instance.stats_log_size
+      @_stats_log_head : Int32 = 0
+      @_stats_log_size : Int32 = 0
+      @_stats_const_run : Int32 = 0
+      @_stats_rate_buffer : Pointer(Float64) = Pointer(Float64).null # null while constant
+      {% if log_keys.size > 0 %}
+        @_stats_count_buffer : Pointer(UInt32) = Pointer(UInt32).null
+      {% end %}
+
+      {% for name, i in stats_keys %}
         @{{ name.id }}_count = Atomic(UInt64).new(0_u64)
         @{{ name.id }}_count_prev = 0_u64
         @{{ name.id }}_rate = 0_f64
-        @{{ name.id }}_log = Deque(Float64).new(Config.instance.stats_log_size)
         def {{ name.id }}_count
           @{{ name.id }}_count.get(:relaxed)
         end
+
+        def {{ name.id }}_log : StatLogView(Float64)
+          if @_stats_rate_buffer.null?
+            StatLogView(Float64).new(Pointer(Float64).null, 0, 0, @_stats_log_size, @_stats_log_capacity, @{{ name.id }}_rate)
+          else
+            StatLogView(Float64).new(@_stats_rate_buffer, {{ i }} * @_stats_log_capacity,
+              @_stats_log_head, @_stats_log_size, @_stats_log_capacity, 0_f64)
+          end
+        end
       {% end %}
-      {% for name in log_keys %}
-        @{{ name.id }}_log = Deque(UInt32).new(Config.instance.stats_log_size)
-        getter {{ name.id }}_log
+      {% for name, j in log_keys %}
+        @{{ name.id }}_log_last = 0_u32
+        def {{ name.id }}_log : StatLogView(UInt32)
+          if @_stats_rate_buffer.null?
+            StatLogView(UInt32).new(Pointer(UInt32).null, 0, 0, @_stats_log_size, @_stats_log_capacity, @{{ name.id }}_log_last)
+          else
+            StatLogView(UInt32).new(@_stats_count_buffer, {{ j }} * @_stats_log_capacity,
+              @_stats_log_head, @_stats_log_size, @_stats_log_capacity, 0_u32)
+          end
+        end
       {% end %}
 
       def stats_details
@@ -21,7 +48,7 @@ module LavinMQ
             {{ name.id }}: {{ name.id }}_count,
             {{ name.id }}_details: {
               rate: @{{ name.id }}_rate,
-              log: @{{ name.id }}_log
+              log:  {{ name.id }}_log,
             },
           {% end %}
         }
@@ -38,23 +65,99 @@ module LavinMQ
       end
 
       def update_rates : Nil
-        interval = Config.instance.stats_interval // 1000
-        log_size = Config.instance.stats_log_size
-        {% for name in stats_keys %}
-          until @{{ name.id }}_log.size < log_size
-            @{{ name.id }}_log.shift
-          end
-          {{ name.id }}_count = @{{ name.id }}_count.get(:relaxed)
-          @{{ name.id }}_rate = (({{ name.id }}_count - @{{ name.id }}_count_prev) / interval).round(1)
-          @{{ name.id }}_log.push @{{ name.id }}_rate
-          @{{ name.id }}_count_prev = {{ name.id }}_count
+        # Float seconds so a sub-second stats_interval does not truncate to 0
+        # and produce NaN/Inf rates.
+        interval = Config.instance.stats_interval / 1000.0
+        cap = @_stats_log_capacity
+
+        {% for name, i in stats_keys %}
+          new_count_{{ i }} = @{{ name.id }}_count.get(:relaxed)
+          new_rate_{{ i }} = ((new_count_{{ i }} - @{{ name.id }}_count_prev) / interval).round(1)
         {% end %}
-        {% for name in log_keys %}
-          until @{{ name.id }}_log.size < log_size
-            @{{ name.id }}_log.shift
-          end
-          @{{ name.id }}_log.push {{ name.id }}
+        {% for name, j in log_keys %}
+          new_log_{{ j }} = {{ name.id }}
         {% end %}
+
+        if @_stats_rate_buffer.null?
+          diverged = false
+          if @_stats_log_size > 0 # size 0: first sample just establishes the constant
+            {% for name, i in stats_keys %}
+              diverged = true if new_rate_{{ i }} != @{{ name.id }}_rate
+            {% end %}
+            {% for name, j in log_keys %}
+              diverged = true if new_log_{{ j }} != @{{ name.id }}_log_last
+            {% end %}
+          end
+
+          unless diverged
+            {% for name, i in stats_keys %}
+              @{{ name.id }}_rate = new_rate_{{ i }}
+              @{{ name.id }}_count_prev = new_count_{{ i }}
+            {% end %}
+            {% for name, j in log_keys %}
+              @{{ name.id }}_log_last = new_log_{{ j }}
+            {% end %}
+            @_stats_log_size += 1 if @_stats_log_size < cap
+            return
+          end
+
+          filled = @_stats_log_size
+          @_stats_rate_buffer = GC.malloc_atomic({{ stats_keys.size }} * cap * sizeof(Float64)).as(Pointer(Float64))
+          {% if log_keys.size > 0 %}
+            @_stats_count_buffer = GC.malloc_atomic({{ log_keys.size }} * cap * sizeof(UInt32)).as(Pointer(UInt32))
+          {% end %}
+          {% for name, i in stats_keys %}
+            f = 0
+            while f < filled
+              @_stats_rate_buffer[{{ i }} * cap + f] = @{{ name.id }}_rate
+              f += 1
+            end
+          {% end %}
+          {% for name, j in log_keys %}
+            f = 0
+            while f < filled
+              @_stats_count_buffer[{{ j }} * cap + f] = @{{ name.id }}_log_last
+              f += 1
+            end
+          {% end %}
+          @_stats_log_head = 0
+        end
+
+        tail = @_stats_log_head + @_stats_log_size
+        tail -= cap if tail >= cap
+        constant = true
+        {% for name, i in stats_keys %}
+          constant = false if new_rate_{{ i }} != @{{ name.id }}_rate
+          @{{ name.id }}_rate = new_rate_{{ i }}
+          @_stats_rate_buffer[{{ i }} * cap + tail] = new_rate_{{ i }}
+          @{{ name.id }}_count_prev = new_count_{{ i }}
+        {% end %}
+        {% for name, j in log_keys %}
+          constant = false if new_log_{{ j }} != @{{ name.id }}_log_last
+          @_stats_count_buffer[{{ j }} * cap + tail] = new_log_{{ j }}
+          @{{ name.id }}_log_last = new_log_{{ j }}
+        {% end %}
+        if @_stats_log_size < cap
+          @_stats_log_size += 1
+        else
+          @_stats_log_head += 1
+          @_stats_log_head -= cap if @_stats_log_head >= cap
+        end
+
+        if constant
+          @_stats_const_run += 1
+          if @_stats_const_run >= cap
+            @_stats_rate_buffer = Pointer(Float64).null
+            {% if log_keys.size > 0 %}
+              @_stats_count_buffer = Pointer(UInt32).null
+            {% end %}
+            @_stats_log_head = 0
+            @_stats_log_size = cap
+            @_stats_const_run = 0
+          end
+        else
+          @_stats_const_run = 1
+        end
       end
     end
   end


### PR DESCRIPTION
TL;DR: Overall efficient, huge improvements on idle exchanges/channels,
i.e. no problem handling a 100k channel leak now.

Complete rewrite of metrics storage, it's API compatible[1] with no
reduction in precision. There's a steady overall improvement in
memory efficiency but a dramatic improvement for idle objects mostly
made up of stats buffers (channels, exchanges).

This replaces a previous optimisation attempt by replacing `Deque` with
`RingBuffer` PR #1353. This is much more focused on memory efficiency
but also has an overall reduction in CPU time spent handling stats.

Instead of objects (Channel, Queue etc) each having N rolling Deques
(12-14 per queue/channel) each object has one buffer that stores all
logs with a shared head/size index.

By using a single `GC.malloc_atomic` buffer (Float64 rates + UInt32
counts) there's not only less memory overhead there's also reduced GC
work as the whole region is marked as "no pointers" and the GC never scans it.

To further optimize the case with "idle" objects, i.e. objects without
any activity with the set stats log interval (default 10 minutes) we can
completely remove this buffer (0 allocations). This gives very
impressive numbers on a large number of idle channels and exchanges
which use most of the memory to handle stats. (86% less memory)

For an active object, we push the allocation to the stats loop fiber
as all objects are "idle by default". Channel churn benchmark shows a
20% improvement.

Reads are handled via `StatLogView`, which manages the buffer base pointer and
column offset. Designed for a concurrent use and keeps whole buffer
alive while any reader iterates even though a concurrent `update_rates`
may compact and free it (no interior pointers).

This does not touch the "hot path" for message handling, nonetheless
benchmarked to ensure no regressions.

Benchmark results:

Idle RSS, 100k objects (MiB, peak-base)

    object                       before   after  reduction
    --------------------------- ------- ------- ----------
    exchanges                       507      72       -86%
    channels                       1416     200       -86%
    queues                         1878     393       -79%
    streams                        2425     944       -61%
    priority queues (P=5, 30k)      887     455       -49%
    connections (AMQP)             3364    3097        -8%
    MQTT connect                   3294    3017        -8%
    MQTT subscribe (100k)          6434    4622       -28%

Active RSS, 100k objects (MiB, peak-base)

    object                       before   after  reduction
    --------------------------- ------- ------- ----------
    exchanges                       535     523        -2%
    channels                       1510    1477        -2%
    queues                         1917    1716       -10%
    streams                        2486    2325        -6%
    priority queues (P=5, 30k)      908     843        -7%
    connections (AMQP)             5984    5552        -7%
    MQTT connect                   3744    3646        -3%
    MQTT subscribe (100k)          6399    5197       -19%

Idle means there's no activity the last 10 minutes, active has some sort
of activity that needs a buffer allocated.

Benchmarks ran on a Ubuntu 26.04 Linux 7.0
Crystal 1.20.2 `-Dpreview_mt -Dexecution_context` and `GC_UNMAP_THRESHOLD=1`

Specs for the stats API already existed, but added specs that should
cover this implementation. Existing specs should reduce risk of a
regression.

[1]: add_logs! no longer mutates its second argument, so slight change