### PR TITLE
Enable sni hosts added on reload

### DIFF
--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -486,7 +486,7 @@ describe LavinMQ::Launcher do
     default_ctx.certificate_chain = "spec/resources/server_certificate.pem"
     default_ctx.private_key = "spec/resources/server_key.pem"
 
-    LavinMQ::Launcher.install_sni_callback(default_ctx, sni_manager, :amqp)
+    LavinMQ::Launcher.install_sni_callback(default_ctx, sni_manager, LavinMQ::Launcher::TLSProtocol::AMQP)
 
     foobar_host = LavinMQ::SNIHost.new("foobar.localhost")
     foobar_host.tls_cert = "spec/resources/foobar_localhost_certificate.pem"

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "../src/stdlib/openssl_on_server_name"
+require "../src/lavinmq/launcher"
 
 describe LavinMQ::SNIHost do
   it "creates TLS contexts with default settings" do
@@ -467,6 +468,55 @@ describe "SNI end-to-end" do
     begin
       ssl_client = OpenSSL::SSL::Socket::Client.new(tcp_client, client_ctx, hostname: "mtls.localhost")
       ssl_client.gets
+      ssl_client.close
+    ensure
+      tcp_client.close
+    end
+
+    tcp_server.close
+    server_done.receive
+  end
+end
+
+describe LavinMQ::Launcher do
+  it "serves a per-host certificate for an SNI host added after the callback was installed" do
+    sni_manager = LavinMQ::SNIManager.new
+    sni_manager.empty?.should be_true
+    default_ctx = OpenSSL::SSL::Context::Server.new
+    default_ctx.certificate_chain = "spec/resources/server_certificate.pem"
+    default_ctx.private_key = "spec/resources/server_key.pem"
+
+    LavinMQ::Launcher.install_sni_callback(default_ctx, sni_manager, :amqp)
+
+    foobar_host = LavinMQ::SNIHost.new("foobar.localhost")
+    foobar_host.tls_cert = "spec/resources/foobar_localhost_certificate.pem"
+    foobar_host.tls_key = "spec/resources/foobar_localhost_key.pem"
+    sni_manager.add_host(foobar_host)
+
+    tcp_server = TCPServer.new("127.0.0.1", 0)
+    port = tcp_server.local_address.port
+    server_done = Channel(Nil).new
+
+    spawn do
+      if client = tcp_server.accept?
+        begin
+          ssl_socket = OpenSSL::SSL::Socket::Server.new(client, default_ctx)
+          ssl_socket.close
+        rescue
+          # Ignore handshake errors in server
+        ensure
+          client.close
+        end
+      end
+      server_done.send(nil)
+    end
+
+    tcp_client = TCPSocket.new("127.0.0.1", port)
+    client_ctx = OpenSSL::SSL::Context::Client.new
+    client_ctx.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+    client_ctx.ca_certificates = "spec/resources/foobar_localhost_certificate.pem"
+    begin
+      ssl_client = OpenSSL::SSL::Socket::Client.new(tcp_client, client_ctx, hostname: "foobar.localhost")
       ssl_client.close
     ensure
       tcp_client.close

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -306,6 +306,7 @@ module LavinMQ
         configure_tls_context(ctx)
       end
       @config.sni_manager.reload
+      setup_sni_callbacks
     end
 
     private def configure_tls_context(ctx : OpenSSL::SSL::Context::Server)
@@ -348,47 +349,32 @@ module LavinMQ
     end
 
     private def setup_sni_callbacks
-      return if @config.sni_manager.empty?
-
-      # Set up SNI callback for AMQP TLS context
+      sni_manager = @config.sni_manager
       if amqp_tls = @amqp_tls_context
-        sni_manager = @config.sni_manager
-        amqp_tls.on_server_name do |hostname|
-          if sni_host = sni_manager.get_host(hostname)
-            Log.debug { "SNI (AMQP): Using certificate for hostname '#{hostname}'" }
-            sni_host.amqp_tls_context
-          else
-            Log.debug { "SNI (AMQP): No specific certificate for '#{hostname}', using default" }
-            nil
-          end
-        end
+        self.class.install_sni_callback(amqp_tls, sni_manager, :amqp)
       end
-
-      # Set up SNI callback for MQTT TLS context
       if mqtt_tls = @mqtt_tls_context
-        sni_manager = @config.sni_manager
-        mqtt_tls.on_server_name do |hostname|
-          if sni_host = sni_manager.get_host(hostname)
-            Log.debug { "SNI (MQTT): Using certificate for hostname '#{hostname}'" }
-            sni_host.mqtt_tls_context
-          else
-            Log.debug { "SNI (MQTT): No specific certificate for '#{hostname}', using default" }
-            nil
-          end
-        end
+        self.class.install_sni_callback(mqtt_tls, sni_manager, :mqtt)
       end
-
-      # Set up SNI callback for HTTP TLS context
       if http_tls = @http_tls_context
-        sni_manager = @config.sni_manager
-        http_tls.on_server_name do |hostname|
-          if sni_host = sni_manager.get_host(hostname)
-            Log.debug { "SNI (HTTP): Using certificate for hostname '#{hostname}'" }
-            sni_host.http_tls_context
-          else
-            Log.debug { "SNI (HTTP): No specific certificate for '#{hostname}', using default" }
-            nil
+        self.class.install_sni_callback(http_tls, sni_manager, :http)
+      end
+    end
+
+    def self.install_sni_callback(ctx : OpenSSL::SSL::Context::Server,
+                                  sni_manager : SNIManager,
+                                  protocol : Symbol)
+      ctx.on_server_name do |hostname|
+        if sni_host = sni_manager.get_host(hostname)
+          Log.debug { "SNI (#{protocol}): Using certificate for hostname '#{hostname}'" }
+          case protocol
+          when :amqp then sni_host.amqp_tls_context
+          when :mqtt then sni_host.mqtt_tls_context
+          else            sni_host.http_tls_context
           end
+        else
+          Log.debug { "SNI (#{protocol}): No specific certificate for '#{hostname}', using default" }
+          nil
         end
       end
     end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -17,6 +17,14 @@ require "../stdlib/openssl_on_server_name"
 module LavinMQ
   class Launcher
     Log = LavinMQ::Log.for "launcher"
+
+    # Protocols that have their own TLS context and SNI callback.
+    enum TLSProtocol
+      AMQP
+      MQTT
+      HTTP
+    end
+
     @amqp_tls_context : OpenSSL::SSL::Context::Server?
     @mqtt_tls_context : OpenSSL::SSL::Context::Server?
     @http_tls_context : OpenSSL::SSL::Context::Server?
@@ -351,26 +359,26 @@ module LavinMQ
     private def setup_sni_callbacks
       sni_manager = @config.sni_manager
       if amqp_tls = @amqp_tls_context
-        self.class.install_sni_callback(amqp_tls, sni_manager, :amqp)
+        self.class.install_sni_callback(amqp_tls, sni_manager, TLSProtocol::AMQP)
       end
       if mqtt_tls = @mqtt_tls_context
-        self.class.install_sni_callback(mqtt_tls, sni_manager, :mqtt)
+        self.class.install_sni_callback(mqtt_tls, sni_manager, TLSProtocol::MQTT)
       end
       if http_tls = @http_tls_context
-        self.class.install_sni_callback(http_tls, sni_manager, :http)
+        self.class.install_sni_callback(http_tls, sni_manager, TLSProtocol::HTTP)
       end
     end
 
     def self.install_sni_callback(ctx : OpenSSL::SSL::Context::Server,
                                   sni_manager : SNIManager,
-                                  protocol : Symbol)
+                                  protocol : TLSProtocol)
       ctx.on_server_name do |hostname|
         if sni_host = sni_manager.get_host(hostname)
           Log.debug { "SNI (#{protocol}): Using certificate for hostname '#{hostname}'" }
           case protocol
-          when :amqp then sni_host.amqp_tls_context
-          when :mqtt then sni_host.mqtt_tls_context
-          else            sni_host.http_tls_context
+          in .amqp? then sni_host.amqp_tls_context
+          in .mqtt? then sni_host.mqtt_tls_context
+          in .http? then sni_host.http_tls_context
           end
         else
           Log.debug { "SNI (#{protocol}): No specific certificate for '#{hostname}', using default" }


### PR DESCRIPTION
### WHAT is this pull request doing?

`setup_sni_callbacks` has an early return if the `sni_manager` is empty. This is the case when you bootstrap a lavinmq server with no sni-sections in the lavinmq.ini, which is fine. However, if a user wishes to add an sni-section, they have to restart lavinmq for that change to take effect.

On reload, `reload_tls_context` will reload the sni managers hosts and exist in memory, but since the callback is not installed for the listeners, they will still serve the default certificate.

### HOW can this pull request be tested?

I created a spec that installs the callback first, adds an SNI host afterwards and verifies a TLS client requesting that hostname is served the correct per-host certificate.

Manual steps is to create a certificate and key, boot lavinmq with no sni host section, send SIGHUP to the lavinmq process after adding an sni host section, for example this config

```
[main]
log_level = debug
data_dir = ./tmp/data
tls_cert = /tmp/default.pem
tls_key  = /tmp/default.key

[amqp]
tls_port = 5671

[mgmt]
tls_port = 15671

[sni:broker-a.local]
tls_cert = /tmp/a.pem
tls_key  = /tmp/a.key
```

and this should be the result of the openssl command:
`
echo | openssl s_client -connect localhost:15671 -servername broker-a.local 2>/dev/null | openssl x509 -noout -subject
subject=CN=broker-a.local
`

before this change it shows the default certificate.