### PR TITLE
Rework connection lifecycle registration

### DIFF
--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -17,25 +17,28 @@ module MqttSpecs
         end
       end
 
-      it "keeps the reconnected client registered when a stale client is removed" do
+      it "keeps the replacement client registered after the old client cleanup runs" do
         with_server do |server|
-          broker = server.mqtt_server.brokers["/"]?.not_nil!
+          client_id = "reconnect-race"
+          broker = server.mqtt_server.broker("/")
+          vhost = server.vhosts["/"]
+
           with_client_io(server) do |io|
-            connect(io)
-            old_client = broker.@clients["client_id"]
+            connect(io, client_id: client_id)
+            old_client = broker.@clients[client_id]
+
             with_client_io(server) do |io2|
-              connect(io2)
-              # add_client runs after the CONNACK is sent, so wait until the
-              # reconnecting client has replaced the old one in @clients.
+              connect(io2, client_id: client_id)
               new_client = wait_for do
-                c = broker.@clients["client_id"]?
+                c = broker.@clients[client_id]?
                 c if c && !c.same?(old_client)
               end.not_nil!
-              # A stale read loop for the replaced client may call
-              # remove_client after the new client is already registered;
-              # removing by client_id alone would evict the live client.
-              broker.remove_client(old_client)
-              broker.@clients["client_id"]?.should eq(new_client)
+
+              io.should be_closed
+              wait_for { vhost.connections.none?(&.same?(old_client)) }
+
+              broker.@clients[client_id]?.try(&.same?(new_client)).should be_true
+              pingpong(io2).should be_a(MQTT::Protocol::PingResp)
             end
           end
         end

--- a/spec/mqtt/oauth_expiration_spec.cr
+++ b/spec/mqtt/oauth_expiration_spec.cr
@@ -27,7 +27,8 @@ module MqttSpecs
           will: nil,
         )
 
-        broker.add_client(mqtt_io, conn_info, user, packet)
+        spawn { broker.run_client(mqtt_io, conn_info, user, packet) }
+        Fiber.yield
 
         # Client should be connected
         reader.closed?.should be_false
@@ -59,7 +60,7 @@ module MqttSpecs
           will: nil,
         )
 
-        broker.add_client(mqtt_io, conn_info, user, packet)
+        spawn { broker.run_client(mqtt_io, conn_info, user, packet) }
 
         sleep 50.milliseconds
 

--- a/spec/mqtt/oauth_spec.cr
+++ b/spec/mqtt/oauth_spec.cr
@@ -26,7 +26,7 @@ module MqttSpecs
           will: nil,
         )
 
-        broker.add_client(mqtt_io, conn_info, user, packet)
+        spawn { broker.run_client(mqtt_io, conn_info, user, packet) }
 
         sleep 100.milliseconds
 
@@ -57,7 +57,7 @@ module MqttSpecs
           will: nil,
         )
 
-        broker.add_client(mqtt_io, conn_info, user, packet)
+        spawn { broker.run_client(mqtt_io, conn_info, user, packet) }
 
         sleep 100.milliseconds
 
@@ -87,7 +87,7 @@ module MqttSpecs
           will: nil,
         )
 
-        broker.add_client(mqtt_io, conn_info, user, packet)
+        spawn { broker.run_client(mqtt_io, conn_info, user, packet) }
 
         # Close the socket to trigger disconnect and cleanup
         reader.close

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -20,22 +20,23 @@ module LavinMQ
       getter id, name
       property? running = true
       getter? flow = true
-      @consumers = Array(Consumer).new
+      @consumers = Array(AMQP::Consumer).new
 
-      def consumers : Array(Consumer)
-        @consumers.dup
+      def consumers : Array(LavinMQ::Client::Channel::Consumer)
+        @consumers.map &.as(LavinMQ::Client::Channel::Consumer)
       end
 
       def consumers_size : Int32
         @consumers.size
       end
 
-      def find_consumer(& : Consumer -> Bool) : Consumer?
+      def find_consumer(& : AMQP::Consumer -> Bool) : AMQP::Consumer?
         @consumers.find { |c| yield c }
       end
 
-      def delete_consumer(consumer : Consumer) : Consumer?
-        @consumers.delete(consumer)
+      def cancel_consumer(consumer : AMQP::Consumer) : Nil
+        send AMQP::Frame::Basic::Cancel.new(@id, consumer.tag, no_wait: true)
+        delete_and_close_consumer(consumer)
       end
 
       getter prefetch_count : UInt16 = Config.instance.default_consumer_prefetch
@@ -73,7 +74,7 @@ module LavinMQ
         tag : UInt64,
         queue : Queue,
         sp : SegmentPosition,
-        consumer : Consumer?,
+        consumer : AMQP::Consumer?,
         delivered_at : Time::Instant
 
       def details_tuple
@@ -442,8 +443,7 @@ module LavinMQ
               else
                 AMQP::Consumer.new(self, q, frame)
               end
-          @consumers.push(c)
-          q.add_consumer(c)
+          add_consumer(c)
           unless frame.no_wait
             send AMQP::Frame::Basic::ConsumeOk.new(frame.channel, frame.consumer_tag)
           end
@@ -451,6 +451,11 @@ module LavinMQ
           @client.send_not_found(frame, "Queue '#{frame.queue}' not declared")
         end
         Fiber.yield # Notify :add_consumer observers
+      end
+
+      private def add_consumer(consumer : AMQP::Consumer) : Nil
+        @consumers.push(consumer)
+        consumer.queue.add_consumer(consumer)
       end
 
       def basic_get(frame)
@@ -709,12 +714,12 @@ module LavinMQ
         end
       end
 
-      def close
-        return unless @running
+      def close : Bool
+        return false unless @running
         @running = false
         @confirm_ack_mailbox.try &.close
         @consumers.each_with_index(1) do |consumer, i|
-          consumer.close
+          close_consumer(consumer)
           Fiber.yield if (i % 128) == 0
         end
         @consumers.clear
@@ -731,8 +736,19 @@ module LavinMQ
         end
         @has_capacity.close
         @next_msg_body_file.try &.close
-        @client.vhost.event_tick(EventType::ChannelClosed)
         @log.debug { "Closed" }
+        true
+      end
+
+      private def close_consumer(consumer : AMQP::Consumer) : Nil
+        consumer.close
+        consumer.queue.rm_consumer(consumer)
+      end
+
+      private def delete_and_close_consumer(consumer : AMQP::Consumer) : Nil
+        if @consumers.delete(consumer)
+          close_consumer(consumer)
+        end
       end
 
       protected def next_delivery_tag(queue : Queue, sp, no_ack, consumer) : UInt64
@@ -787,9 +803,8 @@ module LavinMQ
 
       def cancel_consumer(frame)
         @log.debug { "Cancelling consumer '#{frame.consumer_tag}'" }
-        if idx = @consumers.index { |cons| cons.tag == frame.consumer_tag }
-          c = @consumers.delete_at idx
-          c.close
+        if consumer = @consumers.find { |cons| cons.tag == frame.consumer_tag }
+          delete_and_close_consumer(consumer)
         elsif @direct_reply_consumer == frame.consumer_tag
           @direct_reply_consumer = nil
           @client.vhost.direct_reply_consumer_delete(frame.consumer_tag)

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -22,8 +22,8 @@ module LavinMQ
       getter? flow = true
       @consumers = Array(AMQP::Consumer).new
 
-      def consumers : Array(LavinMQ::Client::Channel::Consumer)
-        @consumers.map &.as(LavinMQ::Client::Channel::Consumer)
+      def consumers : Array(AMQP::Consumer)
+        @consumers.dup
       end
 
       def consumers_size : Int32
@@ -36,7 +36,10 @@ module LavinMQ
 
       def cancel_consumer(consumer : AMQP::Consumer) : Nil
         send AMQP::Frame::Basic::Cancel.new(@id, consumer.tag, no_wait: true)
-        delete_and_close_consumer(consumer)
+        if @consumers.delete(consumer)
+          consumer.close
+          consumer.queue.rm_consumer(consumer)
+        end
       end
 
       getter prefetch_count : UInt16 = Config.instance.default_consumer_prefetch
@@ -443,7 +446,8 @@ module LavinMQ
               else
                 AMQP::Consumer.new(self, q, frame)
               end
-          add_consumer(c)
+          @consumers.push(c)
+          q.add_consumer(c)
           unless frame.no_wait
             send AMQP::Frame::Basic::ConsumeOk.new(frame.channel, frame.consumer_tag)
           end
@@ -451,11 +455,6 @@ module LavinMQ
           @client.send_not_found(frame, "Queue '#{frame.queue}' not declared")
         end
         Fiber.yield # Notify :add_consumer observers
-      end
-
-      private def add_consumer(consumer : AMQP::Consumer) : Nil
-        @consumers.push(consumer)
-        consumer.queue.add_consumer(consumer)
       end
 
       def basic_get(frame)
@@ -719,7 +718,8 @@ module LavinMQ
         @running = false
         @confirm_ack_mailbox.try &.close
         @consumers.each_with_index(1) do |consumer, i|
-          close_consumer(consumer)
+          consumer.close
+          consumer.queue.rm_consumer(consumer)
           Fiber.yield if (i % 128) == 0
         end
         @consumers.clear
@@ -738,17 +738,6 @@ module LavinMQ
         @next_msg_body_file.try &.close
         @log.debug { "Closed" }
         true
-      end
-
-      private def close_consumer(consumer : AMQP::Consumer) : Nil
-        consumer.close
-        consumer.queue.rm_consumer(consumer)
-      end
-
-      private def delete_and_close_consumer(consumer : AMQP::Consumer) : Nil
-        if @consumers.delete(consumer)
-          close_consumer(consumer)
-        end
       end
 
       protected def next_delivery_tag(queue : Queue, sp, no_ack, consumer) : UInt64
@@ -804,7 +793,9 @@ module LavinMQ
       def cancel_consumer(frame)
         @log.debug { "Cancelling consumer '#{frame.consumer_tag}'" }
         if consumer = @consumers.find { |cons| cons.tag == frame.consumer_tag }
-          delete_and_close_consumer(consumer)
+          @consumers.delete(consumer)
+          consumer.close
+          consumer.queue.rm_consumer(consumer)
         elsif @direct_reply_consumer == frame.consumer_tag
           @direct_reply_consumer = nil
           @client.vhost.direct_reply_consumer_delete(frame.consumer_tag)

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -89,15 +89,17 @@ module LavinMQ
             ::Log::Metadata.new(nil, {vhost: @vhost.name, address: @connection_info.remote_address.to_s})
           end
         @log = Logger.new(Log, @metadata)
-        @vhost.add_connection(self)
+      end
+
+      def run : Nil
         @log.info { "Connection established for user=#{@user.name}" }
-        spawn read_loop, name: "Client#read_loop #{@connection_info.remote_address}"
         case user = @user
         when Auth::OAuthUser
           user.on_expiration do
             close_connection(nil, ConnectionReplyCode::CONNECTION_FORCED, "token expired")
           end
         end
+        read_loop
       end
 
       # Returns client provided connection name if set, else server generated name
@@ -423,10 +425,20 @@ module LavinMQ
                        " has reached the negotiated channel_max (#{@actual_channel_max})"
           close_connection(frame, ConnectionReplyCode::NOT_ALLOWED, reply_text)
         else
-          @channels[frame.channel] = AMQP::Channel.new(self, frame.channel)
-          @vhost.event_tick(EventType::ChannelCreated)
+          add_channel(frame.channel)
           send AMQP::Frame::Channel::OpenOk.new(frame.channel)
         end
+      end
+
+      private def add_channel(id : UInt16) : Client::Channel
+        AMQP::Channel.new(self, id).tap do |channel|
+          @channels[id] = channel
+          @vhost.event_tick(EventType::ChannelCreated)
+        end
+      end
+
+      private def close_channel(channel : Client::Channel?) : Nil
+        @vhost.event_tick(EventType::ChannelClosed) if channel.try &.close
       end
 
       # ameba:disable Metrics/CyclomaticComplexity
@@ -438,10 +450,10 @@ module LavinMQ
         when AMQP::Frame::Channel::Open
           open_channel(frame)
         when AMQP::Frame::Channel::Close
-          @channels.delete(frame.channel).try &.close
+          close_channel(@channels.delete(frame.channel))
           send AMQP::Frame::Channel::CloseOk.new(frame.channel), true
         when AMQP::Frame::Channel::CloseOk
-          @channels.delete(frame.channel).try &.close
+          close_channel(@channels.delete(frame.channel))
         when AMQP::Frame::Channel::Flow
           with_channel frame, &.flow(frame.active)
         when AMQP::Frame::Channel::FlowOk
@@ -516,7 +528,7 @@ module LavinMQ
         @running = false
         i = 0u32
         @channels.each_value do |ch|
-          ch.close
+          close_channel(ch)
           Fiber.yield if (i &+= 1) % 512 == 0
         end
         @channels.clear
@@ -524,7 +536,6 @@ module LavinMQ
         # whose observer mutates @exclusive_queues.
         @exclusive_queues.dup.each(&.close)
         @exclusive_queues.clear
-        @vhost.rm_connection(self)
         case user = @user
         when Auth::OAuthUser
           user.cleanup
@@ -572,7 +583,7 @@ module LavinMQ
         else
           send AMQP::Frame::Channel::Close.new(frame.channel, code.value, text, 0, 0)
         end
-        @channels[frame.channel]?.try &.close
+        close_channel(@channels[frame.channel]?)
       end
 
       def close_connection(frame : AMQ::Protocol::Frame?, code : ConnectionReplyCode, text)
@@ -626,7 +637,7 @@ module LavinMQ
           @running = false
         else
           send AMQP::Frame::Channel::Close.new(ex.channel, code.value, code.to_s, ex.class_id, ex.method_id)
-          @channels[ex.channel]?.try &.close
+          close_channel(@channels[ex.channel]?)
         end
       end
 

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -96,7 +96,7 @@ module LavinMQ
         case user = @user
         when Auth::OAuthUser
           user.on_expiration do
-            close_connection(nil, ConnectionReplyCode::CONNECTION_FORCED, "token expired")
+            send_connection_close(nil, ConnectionReplyCode::CONNECTION_FORCED, "token expired")
           end
         end
         read_loop
@@ -250,13 +250,13 @@ module LavinMQ
           user.refresh(frame.secret)
           send AMQP::Frame::Connection::UpdateSecretOk.new
         else
-          close_connection(frame, ConnectionReplyCode::ACCESS_REFUSED, "update-secret not supported for current authentication mechanism")
+          send_connection_close(frame, ConnectionReplyCode::ACCESS_REFUSED, "update-secret not supported for current authentication mechanism")
         end
       rescue ex : Auth::JWT::Error
-        close_connection(frame, ConnectionReplyCode::ACCESS_REFUSED, ex.message)
+        send_connection_close(frame, ConnectionReplyCode::ACCESS_REFUSED, ex.message)
       rescue ex : Exception
         @log.error(exception: ex) { "UpdateSecret failed for user '#{@user.name}': #{ex.message}" }
-        close_connection(frame, ConnectionReplyCode::INTERNAL_ERROR, "Failed to update secret: #{ex.message}")
+        send_connection_close(frame, ConnectionReplyCode::INTERNAL_ERROR, "Failed to update secret: #{ex.message}")
       end
 
       def send(frame : AMQP::Frame, channel_is_open : Bool? = nil) : Bool
@@ -414,16 +414,16 @@ module LavinMQ
 
       private def reject_unknown_channel(frame) : Nil
         @log.error { "Channel #{frame.channel} not open while processing #{frame.class.name}" }
-        close_connection(frame, ConnectionReplyCode::CHANNEL_ERROR, "Channel #{frame.channel} not open")
+        send_connection_close(frame, ConnectionReplyCode::CHANNEL_ERROR, "Channel #{frame.channel} not open")
       end
 
       private def open_channel(frame)
         if @channels.has_key? frame.channel
-          close_connection(frame, ConnectionReplyCode::CHANNEL_ERROR, "second 'channel.open' seen")
+          send_connection_close(frame, ConnectionReplyCode::CHANNEL_ERROR, "second 'channel.open' seen")
         elsif @channels.size >= @actual_channel_max
           reply_text = "number of channels opened (#{@channels.size})" \
                        " has reached the negotiated channel_max (#{@actual_channel_max})"
-          close_connection(frame, ConnectionReplyCode::NOT_ALLOWED, reply_text)
+          send_connection_close(frame, ConnectionReplyCode::NOT_ALLOWED, reply_text)
         else
           add_channel(frame.channel)
           send AMQP::Frame::Channel::OpenOk.new(frame.channel)
@@ -431,14 +431,16 @@ module LavinMQ
       end
 
       private def add_channel(id : UInt16) : Client::Channel
-        AMQP::Channel.new(self, id).tap do |channel|
-          @channels[id] = channel
-          @vhost.event_tick(EventType::ChannelCreated)
-        end
+        channel = AMQP::Channel.new(self, id)
+        @channels[id] = channel
+        @vhost.event_tick(EventType::ChannelCreated)
+        channel
       end
 
       private def close_channel(channel : Client::Channel?) : Nil
-        @vhost.event_tick(EventType::ChannelClosed) if channel.try &.close
+        if channel.try &.close
+          @vhost.event_tick(EventType::ChannelClosed)
+        end
       end
 
       # ameba:disable Metrics/CyclomaticComplexity
@@ -508,7 +510,7 @@ module LavinMQ
           with_channel frame, &.tx_rollback(frame)
         when AMQP::Frame::Heartbeat
           unless frame.channel.zero?
-            close_connection(frame, ConnectionReplyCode::UNEXPECTED_FRAME, "Heartbeat frame must be on channel 0")
+            send_connection_close(frame, ConnectionReplyCode::UNEXPECTED_FRAME, "Heartbeat frame must be on channel 0")
             return
           end
         else
@@ -521,7 +523,7 @@ module LavinMQ
         end
       rescue ex : LavinMQ::Error::UnexpectedFrame
         @log.error { ex.inspect }
-        close_channel(ex.frame, ChannelReplyCode::UNEXPECTED_FRAME, ex.frame.class.name)
+        send_channel_close(ex.frame, ChannelReplyCode::UNEXPECTED_FRAME, ex.frame.class.name)
       end
 
       private def cleanup
@@ -561,6 +563,7 @@ module LavinMQ
 
         code = ConnectionReplyCode::CONNECTION_FORCED
         send AMQP::Frame::Connection::Close.new(code.value, "#{code} - #{reason}", 0_u16, 0_u16)
+      ensure
         @running = false
       end
 
@@ -572,9 +575,9 @@ module LavinMQ
         !@running
       end
 
-      def close_channel(frame : AMQ::Protocol::Frame, code : ChannelReplyCode, text)
+      private def send_channel_close(frame : AMQ::Protocol::Frame, code : ChannelReplyCode, text)
         if frame.channel.zero?
-          return close_connection(frame, ConnectionReplyCode::UNEXPECTED_FRAME, text)
+          return send_connection_close(frame, ConnectionReplyCode::UNEXPECTED_FRAME, text)
         end
         text = "#{code} - #{text}"
         case frame
@@ -586,7 +589,7 @@ module LavinMQ
         close_channel(@channels[frame.channel]?)
       end
 
-      def close_connection(frame : AMQ::Protocol::Frame?, code : ConnectionReplyCode, text)
+      private def send_connection_close(frame : AMQ::Protocol::Frame?, code : ConnectionReplyCode, text)
         text = "#{code} - #{text}"
         @log.info { "Closing, #{text}" }
         case frame
@@ -602,32 +605,32 @@ module LavinMQ
 
       def send_access_refused(frame, text)
         @log.warn { "Access refused channel=#{frame.channel} reason=\"#{text}\"" }
-        close_channel(frame, ChannelReplyCode::ACCESS_REFUSED, text)
+        send_channel_close(frame, ChannelReplyCode::ACCESS_REFUSED, text)
       end
 
       def send_not_found(frame, text = "")
         @log.warn { "Not found channel=#{frame.channel} reason=\"#{text}\"" }
-        close_channel(frame, ChannelReplyCode::NOT_FOUND, text)
+        send_channel_close(frame, ChannelReplyCode::NOT_FOUND, text)
       end
 
       def send_passive_not_found(frame, text = "")
         @log.info { "Not found channel=#{frame.channel} reason=\"#{text}\"" }
-        close_channel(frame, ChannelReplyCode::NOT_FOUND, text)
+        send_channel_close(frame, ChannelReplyCode::NOT_FOUND, text)
       end
 
       def send_resource_locked(frame, text)
         @log.warn { "Resource locked channel=#{frame.channel} reason=\"#{text}\"" }
-        close_channel(frame, ChannelReplyCode::RESOURCE_LOCKED, text)
+        send_channel_close(frame, ChannelReplyCode::RESOURCE_LOCKED, text)
       end
 
       def send_precondition_failed(frame, text)
         @log.warn { "Precondition failed channel=#{frame.channel} reason=\"#{text}\"" }
-        close_channel(frame, ChannelReplyCode::PRECONDITION_FAILED, text)
+        send_channel_close(frame, ChannelReplyCode::PRECONDITION_FAILED, text)
       end
 
       def send_not_implemented(frame, text = nil)
         @log.error { "#{frame.inspect}, not implemented reason=\"#{text}\"" }
-        close_channel(frame, ChannelReplyCode::NOT_IMPLEMENTED, text)
+        send_channel_close(frame, ChannelReplyCode::NOT_IMPLEMENTED, text)
       end
 
       def send_not_implemented(ex : AMQ::Protocol::Error::NotImplemented)
@@ -642,16 +645,16 @@ module LavinMQ
       end
 
       def send_internal_error(message)
-        close_connection(nil, ConnectionReplyCode::INTERNAL_ERROR, "Unexpected error, please report")
+        send_connection_close(nil, ConnectionReplyCode::INTERNAL_ERROR, "Unexpected error, please report")
       end
 
       def send_resource_error(frame, message)
         @log.warn { "Resource error channel=#{frame.channel} reason=\"#{message}\"" }
-        close_channel(frame, ChannelReplyCode::RESOURCE_ERROR, message)
+        send_channel_close(frame, ChannelReplyCode::RESOURCE_ERROR, message)
       end
 
       def send_frame_error(message = nil)
-        close_connection(nil, ConnectionReplyCode::FRAME_ERROR, message)
+        send_connection_close(nil, ConnectionReplyCode::FRAME_ERROR, message)
       end
 
       private def declare_exchange(frame)

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -15,7 +15,7 @@ module LavinMQ
       def initialize(@authenticator : Auth::Authenticator, @vhosts : VHostStore)
       end
 
-      def start(socket, connection_info) : Client?
+      def create(socket, connection_info) : Client?
         socket.read_timeout = 15.seconds
         metadata = ::Log::Metadata.build({address: connection_info.remote_address.to_s})
         logger = Logger.new(Log, metadata)

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -37,11 +37,11 @@ module LavinMQ
       end
 
       def close
+        return if @closed
         @closed = true
         @notify_closed.close
         @has_capacity.close
         @flow_change.close
-        @queue.rm_consumer(self)
       end
 
       def ensure_deliver_loop
@@ -249,9 +249,7 @@ module LavinMQ
       end
 
       def cancel
-        @channel.send AMQP::Frame::Basic::Cancel.new(@channel.id, @tag, no_wait: true)
-        @channel.delete_consumer(self)
-        close
+        @channel.cancel_consumer(self)
       end
 
       private def consumer_priority(frame) : Int32

--- a/src/lavinmq/amqp/server.cr
+++ b/src/lavinmq/amqp/server.cr
@@ -24,8 +24,17 @@ module LavinMQ
       end
 
       def handle_connection(socket, connection_info)
-        client = @connection_factory.start(socket, connection_info)
-        socket.close if client.nil?
+        if client = @connection_factory.create(socket, connection_info)
+          vhost = client.vhost
+          vhost.add_connection(client)
+          begin
+            client.run
+          ensure
+            vhost.rm_connection(client)
+          end
+        else
+          socket.close
+        end
       end
     end
   end

--- a/src/lavinmq/amqp/stream/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream/stream_consumer.cr
@@ -156,6 +156,7 @@ module LavinMQ
       end
 
       def close
+        return if closed?
         @new_message_available.close
         super
       end

--- a/src/lavinmq/http/controller/consumers.cr
+++ b/src/lavinmq/http/controller/consumers.cr
@@ -16,11 +16,7 @@ module LavinMQ
           with_vhost(context, params) do |vhost|
             user = user(context)
             refuse_unless_management(context, user, vhost)
-            arr = connections(user).select(&.vhost.==(vhost))
-              .flat_map do |conn|
-                conn.channels.flat_map &.consumers
-              end
-            page(context, arr)
+            page(context, all_consumers(user, vhost))
           end
         end
 
@@ -53,8 +49,17 @@ module LavinMQ
         end
       end
 
-      private def all_consumers(user) : Array(Client::Channel::Consumer)
-        connections(user).flat_map { |c| c.channels.flat_map &.consumers }
+      private def all_consumers(user, vhost = nil) : Array(Client::Channel::Consumer)
+        consumers = Array(Client::Channel::Consumer).new
+        connections(user).each do |connection|
+          next if vhost && connection.vhost != vhost
+          connection.channels.each do |channel|
+            channel.consumers.each do |consumer|
+              consumers << consumer
+            end
+          end
+        end
+        consumers
       end
     end
   end

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -37,7 +37,7 @@ module LavinMQ
         true
       end
 
-      def add_client(io, connection_info, user, packet)
+      def add_client(io, connection_info, user, packet) : Client
         if prev_client = @clients[packet.client_id]?
           prev_client.close(
             "New client #{connection_info.remote_address} " \
@@ -61,6 +61,17 @@ module LavinMQ
         end
         @clients[packet.client_id] = client
         @vhost.add_connection client
+        client
+      end
+
+      def run_client(io, connection_info, user, packet) : Client
+        client = add_client(io, connection_info, user, packet)
+        begin
+          client.run
+        ensure
+          remove_client(client)
+        end
+        client
       end
 
       def remove_client(client)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -57,14 +57,17 @@ module LavinMQ
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
         metadata = ::Log::Metadata.new(nil, {vhost: @broker.vhost.name, address: @connection_info.remote_address.to_s, client_id: client_id})
         @log = Logger.new(Log, metadata)
+      end
+
+      def run : Nil
         @log.info { "Connection established for user=#{@user.name}" }
-        spawn read_loop, name: "MQTT read_loop #{@connection_info.remote_address}"
         case user = @user
         when Auth::OAuthUser
           user.on_expiration do
             close("token expired")
           end
         end
+        read_loop
       end
 
       def client_name
@@ -105,7 +108,6 @@ module LavinMQ
         @log.error(exception: ex) { "Read Loop error" }
         publish_will
       ensure
-        @broker.remove_client(self)
         case user = @user
         when Auth::OAuthUser
           user.cleanup

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -28,7 +28,7 @@ module LavinMQ
             validate_client_id!(packet.client_id, user.name)
             session_present = broker.session_present?(packet.client_id, packet.clean_session?)
             connack io, session_present, Protocol::Connack::ReturnCode::Accepted
-            return broker.add_client(io, connection_info, user, packet)
+            return broker.run_client(io, connection_info, user, packet)
           end
         rescue ex : Protocol::Error::Connect
           logger.warn { "Connect error #{ex.inspect}" }


### PR DESCRIPTION
## Summary
- move AMQP connection registration/unregistration out of client read-loop cleanup and into the AMQP server lifecycle
- keep MQTT client lifecycle owned by the MQTT broker
- make AMQP client own channel registration/close stats
- make AMQP channel own consumer registration and unregistering

## Testing
- make test TAGS='~slow'\n- make lint