### PR TITLE
Fix lost exchange federation bindings during link startup

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -692,6 +692,37 @@ describe LavinMQ::Federation::Upstream do
       end
     end
 
+    it "should reflect bindings made while link is starting" do
+      with_amqp_server do |s|
+        upstream, upstream_vhost, downstream_vhost =
+          UpstreamSpecHelpers.setup_federation(s, "ef test bindings during start", "upstream_ex")
+        with_channel(s, vhost: "downstream") do |downstream_ch|
+          downstream_ch.exchange("downstream_ex", "topic")
+          downstream_q = downstream_ch.queue("downstream_q")
+          # Pre-existing bindings stretch the binding replay the link does
+          # during startup, so that the binds below land mid-replay.
+          before = 200
+          before.times { |i| downstream_q.bind("downstream_ex", "before.link.#{i}") }
+
+          UpstreamSpecHelpers.start_link(upstream)
+          link = wait_for { upstream.links.first? }
+          downstream_ex = downstream_vhost.exchange("downstream_ex").as(LavinMQ::AMQP::Exchange)
+          # The link starts observing the downstream exchange while it is
+          # still replaying the bindings above to the upstream exchange.
+          wait_for { downstream_ex.@__lavinmq_exchangeevent_observers.includes?(link) }
+          # Binds observed during startup must also be reflected upstream.
+          # (Regression: they were dropped if observed before the link had
+          # an upstream channel.)
+          during = 10
+          during.times { |i| downstream_q.bind("downstream_ex", "during.link.#{i}") }
+
+          upstream_ex = wait_for { upstream_vhost.exchange?("upstream_ex") }
+          upstream_ex = upstream_ex.as(LavinMQ::AMQP::Exchange)
+          wait_for { upstream_ex.bindings_details.size == before + during }
+        end
+      end
+    end
+
     it "set x-received-from" do
       with_amqp_server do |s|
         vhost1 = s.vhosts.create("one")

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -451,6 +451,12 @@ module LavinMQ
             uch.queue_bind(@upstream_q, @upstream_q, routing_key: "")
             ex
           end
+          # @consumer_ex must be set before the observer is registered:
+          # bind/unbind events are dropped while it's nil, and a binding made
+          # in that window would never be propagated to the upstream exchange.
+          # Bindings made before registration are covered by the snapshot
+          # below (exchanges store bindings before notifying observers).
+          @consumer_ex = consumer_ex
           @federated_ex.register_observer(self)
           @federated_ex.bindings_details.each do |binding|
             updated, args = update_bound_from?(binding.arguments)
@@ -459,12 +465,12 @@ module LavinMQ
             end
           end
           upstream_q = ch.queue(@upstream_q, args: q_args, passive: true)
-          {ch, consumer_ex, upstream_q}
+          {ch, upstream_q}
         end
 
         private def start_link
           setup_connection do |upstream_connection|
-            upstream_channel, @consumer_ex, upstream_q = setup(upstream_connection)
+            upstream_channel, upstream_q = setup(upstream_connection)
             upstream_channel.prefetch(count: @upstream.prefetch)
             no_ack = @upstream.ack_mode.no_ack?
             state(State::Running)


### PR DESCRIPTION
I noticed this in CI: https://github.com/cloudamqp/lavinmq/actions/runs/27281857240/job/80578254772#step:5:4300

--

`ExchangeLink#setup` registered the link as a bind/unbind observer on the downstream exchange, but `@consumer_ex` was only assigned after `setup` returned, one network round-trip later. Bind events are delivered synchronously and `with_consumer_ex` silently drops them while `@consumer_ex` is nil, so a binding created in that window was never propagated to the upstream exchange and stayed missing until the link reconnected.

This made the spec "should continue after upstream restart" flaky on slow runners (macOS CI): `downstream_q.bind` raced into the window, the `#` binding never reached the upstream exchange and `msg1` was unroutable, timing out the spec.

Fix by assigning `@consumer_ex` before registering the observer. Bindings made before registration are still covered by the snapshot replay, which runs after registration (exchanges store bindings before notifying observers), so every binding now takes at least one of the two paths.

The regression spec stretches the snapshot replay with pre-existing bindings, waits for the link to register its observer and then binds mid-startup; every binding must be reflected upstream. It fails 5/5 without this fix.