### PR TITLE
Add MQTT client_id validation tied to the username

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `max_packet_size` | — | — | UInt32 | `268435455` | Max MQTT packet size (bytes) |
 | `default_vhost` | — | — | String | `/` | Default vhost for MQTT connections |
 | `permission_check_enabled` | — | — | Bool | `false` | Enable MQTT permission checks |
+| `client_id_validation` | — | — | String | `none` | Validate client_id against the username: `none` or `username` |
 
 ## [mgmt] Section
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -93,6 +93,7 @@ Internally, MQTT is implemented on top of LavinMQ's AMQP infrastructure:
 | `max_packet_size` | `[mqtt]` | `268435455` | Max MQTT packet size in bytes |
 | `default_vhost` | `[mqtt]` | `/` | Default vhost for MQTT connections |
 | `permission_check_enabled` | `[mqtt]` | `false` | Enable ACL checks on MQTT publish/subscribe |
+| `client_id_validation` | `[mqtt]` | `none` | Validate client_id against the username: `none` or `username` |
 
 ## Permissions
 
@@ -108,6 +109,16 @@ When disabled, any authenticated MQTT client can publish and subscribe to any to
 MQTT clients authenticate using the CONNECT packet's username and password fields. These are validated against the same authentication chain as AMQP (local users, OAuth2). For OAuth2, the password field carries the JWT token.
 
 The username field can include a vhost using the format `vhost:username`. If no colon is present, `default_vhost` is used.
+
+### Client ID Validation
+
+By default any client_id is accepted. Since the client_id is chosen freely by the client, it cannot be trusted for identity purposes on its own. The `client_id_validation` setting ties it to the authenticated username:
+
+- `username`: the client_id must be equal to the username
+
+A CONNECT with a non-conforming client_id is rejected with return code 2 (identifier rejected) and the connection is closed. An empty client_id is automatically assigned a conforming one. When the username includes a vhost (`vhost:username`), the client_id is validated against the username part only.
+
+Note that connecting with a client_id already in use takes over that session, so `username` mode limits each user to one connection at a time.
 
 ## Limitations
 

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -157,6 +157,7 @@ describe LavinMQ::Config do
           max_packet_size = 536870910
           max_inflight_messages = 100
           default_vhost = /mqtt
+          client_id_validation = username
 
           [mgmt]
           bind = 0.0.0.0
@@ -241,6 +242,7 @@ describe LavinMQ::Config do
       config.mqtt_max_packet_size.should eq 536870910
       config.max_inflight_messages.should eq 100
       config.default_mqtt_vhost.should eq "/mqtt"
+      config.mqtt_client_id_validation.should eq LavinMQ::MQTT::ClientIdValidation::Username
 
       # MGMT section
       config.http_bind.should eq "0.0.0.0"

--- a/spec/mqtt/client_id_validation_spec.cr
+++ b/spec/mqtt/client_id_validation_spec.cr
@@ -1,0 +1,77 @@
+require "./spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  describe "MQTT client_id validation" do
+    after_each do
+      LavinMQ::Config.instance.mqtt_client_id_validation = LavinMQ::MQTT::ClientIdValidation::None
+    end
+
+    describe "username mode" do
+      before_each do
+        LavinMQ::Config.instance.mqtt_client_id_validation = LavinMQ::MQTT::ClientIdValidation::Username
+      end
+
+      it "accepts a client_id equal to the username" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connack = connect(io, client_id: "guest")
+            connack.should be_a(MQTT::Protocol::Connack)
+            connack.as(MQTT::Protocol::Connack).return_code.should eq MQTT::Protocol::Connack::ReturnCode::Accepted
+          end
+        end
+      end
+
+      it "rejects a client_id that differs from the username" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connack = connect(io, client_id: "not_guest")
+            connack.should be_a(MQTT::Protocol::Connack)
+            connack.as(MQTT::Protocol::Connack).return_code.should eq MQTT::Protocol::Connack::ReturnCode::IdentifierRejected
+            io.should be_closed
+          end
+        end
+      end
+
+      it "assigns the username as client_id when it is empty" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connack = connect(io, client_id: "", clean_session: true)
+            connack.should be_a(MQTT::Protocol::Connack)
+            connack.as(MQTT::Protocol::Connack).return_code.should eq MQTT::Protocol::Connack::ReturnCode::Accepted
+            # Proof the assigned id is the username: a second connection with
+            # client_id "guest" must take over this session [MQTT-3.1.4-2]
+            with_client_io(server) do |io2|
+              connect(io2, client_id: "guest")
+              io.should be_closed
+            end
+          end
+        end
+      end
+
+      it "validates against the username without the vhost prefix" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connack = connect(io, username: "/:guest", client_id: "guest")
+            connack.should be_a(MQTT::Protocol::Connack)
+            connack.as(MQTT::Protocol::Connack).return_code.should eq MQTT::Protocol::Connack::ReturnCode::Accepted
+          end
+        end
+      end
+    end
+
+    describe "none mode (default)" do
+      it "accepts any client_id" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connack = connect(io, client_id: "anything_goes")
+            connack.should be_a(MQTT::Protocol::Connack)
+            connack.as(MQTT::Protocol::Connack).return_code.should eq MQTT::Protocol::Connack::ReturnCode::Accepted
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -3,6 +3,7 @@ require "../auth/password"
 require "../amqp/exchange/consistent_hash_algorithm"
 require "../ip_matcher"
 require "../http/constants"
+require "../mqtt/client_id_validation"
 
 module LavinMQ
   class Config
@@ -240,6 +241,9 @@ module LavinMQ
 
       @[IniOpt(ini_name: permission_check_enabled, section: "mqtt")]
       property? mqtt_permission_check_enabled : Bool = false
+
+      @[IniOpt(ini_name: client_id_validation, section: "mqtt", transform: ->MQTT::ClientIdValidation.parse(String))]
+      property mqtt_client_id_validation : MQTT::ClientIdValidation = MQTT::ClientIdValidation::None
 
       @[IniOpt(ini_name: on_leader_elected, section: "clustering")]
       @[CliOpt("", "--clustering-on-leader-elected=COMMAND", "Shell command to execute when elected leader", section: "clustering")]

--- a/src/lavinmq/mqtt/client_id_validation.cr
+++ b/src/lavinmq/mqtt/client_id_validation.cr
@@ -1,0 +1,10 @@
+module LavinMQ
+  module MQTT
+    # Controls how the MQTT client_id is validated against the
+    # authenticated username at connect.
+    enum ClientIdValidation
+      None     # any client_id accepted
+      Username # client_id must equal the username
+    end
+  end
+end

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -23,16 +23,12 @@ module LavinMQ
           io = Protocol::IO.new(socket, @config.mqtt_max_packet_size)
           if packet = io.read_packet.as?(Protocol::Connect)
             logger.trace { "recv #{packet.inspect}" }
-            if user_and_broker = authenticate(io, packet)
-              user, broker = user_and_broker
-              packet = assign_client_id(packet) if packet.client_id.empty?
-              session_present = broker.session_present?(packet.client_id, packet.clean_session?)
-              connack io, session_present, Protocol::Connack::ReturnCode::Accepted
-              return broker.add_client(io, connection_info, user, packet)
-            else
-              logger.warn { "Authentication failure for user \"#{packet.username}\"" }
-              connack io, false, Protocol::Connack::ReturnCode::NotAuthorized
-            end
+            user, broker = authenticate(io, packet)
+            packet = assign_client_id(packet, user.name) if packet.client_id.empty?
+            validate_client_id!(packet.client_id, user.name)
+            session_present = broker.session_present?(packet.client_id, packet.clean_session?)
+            connack io, session_present, Protocol::Connack::ReturnCode::Accepted
+            return broker.add_client(io, connection_info, user, packet)
           end
         rescue ex : Protocol::Error::Connect
           logger.warn { "Connect error #{ex.inspect}" }
@@ -54,7 +50,9 @@ module LavinMQ
       end
 
       def authenticate(io : Protocol::IO, packet)
-        return unless (username = packet.username) && (password = packet.password)
+        username = packet.username
+        password = packet.password
+        raise Protocol::Error::NotAuthorized.new("missing credentials") unless username && password
 
         vhost = @config.default_mqtt_vhost
         if split_pos = username.index(':')
@@ -65,22 +63,35 @@ module LavinMQ
         context = Auth::Context.new(username, password, io.io)
 
         user = @authenticator.authenticate(context)
-        return unless user
-        return unless user.find_permission(vhost)
+        raise Protocol::Error::NotAuthorized.new("authentication failure for user \"#{username}\"") unless user
+        raise Protocol::Error::NotAuthorized.new("user \"#{username}\" lacks permission for vhost \"#{vhost}\"") unless user.find_permission(vhost)
         broker = @brokers[vhost]?
-        return unless broker
+        raise Protocol::Error::NotAuthorized.new("no broker for vhost \"#{vhost}\"") unless broker
 
         {user, broker}
       end
 
-      def assign_client_id(packet)
-        client_id = Random::Secure.base64(32)
+      def assign_client_id(packet, username : String)
+        client_id = case @config.mqtt_client_id_validation
+                    in .none?     then Random::Secure.base64(32)
+                    in .username? then username
+                    end
         Protocol::Connect.new(client_id,
           packet.clean_session?,
           packet.keepalive,
           packet.username,
           packet.password,
           packet.will)
+      end
+
+      private def validate_client_id!(client_id : String, username : String) : Nil
+        valid = case @config.mqtt_client_id_validation
+                in .none?     then true
+                in .username? then client_id == username
+                end
+        return if valid
+        raise Protocol::Error::IdentifierRejected.new(
+          "client_id \"#{client_id}\" rejected for user \"#{username}\" (client_id_validation=#{@config.mqtt_client_id_validation})")
       end
     end
   end

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -85,13 +85,14 @@ module LavinMQ
       end
 
       private def validate_client_id!(client_id : String, username : String) : Nil
-        valid = case @config.mqtt_client_id_validation
-                in .none?     then true
-                in .username? then client_id == username
-                end
-        return if valid
-        raise Protocol::Error::IdentifierRejected.new(
-          "client_id \"#{client_id}\" rejected for user \"#{username}\" (client_id_validation=#{@config.mqtt_client_id_validation})")
+        case @config.mqtt_client_id_validation
+        in .none?
+          return
+        in .username?
+          return if client_id == username
+          raise Protocol::Error::IdentifierRejected.new(
+            %(client_id "#{client_id}" rejected: it must be the same as the username "#{username}"))
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a new config option, client_id_validation in the [mqtt] section, with two modes: none (default, current behavior) and username (client_id must equal the authenticated username). Connections that violate the mode get CONNACK return code 2 (identifier rejected) and are closed. Empty client_ids are auto-assigned a conforming id. Validation uses the username after the optional vhost: prefix has been stripped.

This is groundwork for topic permissions (#1272): rules like devices/{client_id}/# only give real isolation when the client_id is as trustworthy as the login, since plain MQTT clients can claim any client_id.

Worth noting: username mode implies one connection per user, since a second connection with the same client_id takes over the session per MQTT 3.1.4-2.

A username_prefix mode for sharing one login across several devices was considered but dropped from this PR. A plain prefix match ties the namespace separator to a character that is legal in usernames, so a user whose name is a prefix of another (fleet1 vs fleet1-eu) can claim ids in that user's namespace. It needs a safer namespace design before shipping.

Connect rejections (auth failures and invalid client_ids) now raise MQTT::Error subclasses handled by the existing Connect rescue, so #start is a single happy path with all connack-on-error logic in one place.
