### PR TITLE
Don't recreate removed bindings during federation link startup

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -723,6 +723,42 @@ describe LavinMQ::Federation::Upstream do
       end
     end
 
+    it "should not recreate bindings removed while link is starting" do
+      with_amqp_server do |s|
+        upstream, upstream_vhost, downstream_vhost =
+          UpstreamSpecHelpers.setup_federation(s, "ef test unbindings during start", "upstream_ex")
+        with_channel(s, vhost: "downstream") do |downstream_ch|
+          downstream_ch.exchange("downstream_ex", "topic")
+          downstream_q = downstream_ch.queue("downstream_q")
+          # Pre-existing bindings stretch the binding replay the link does
+          # during startup, so that the unbinds below land mid-replay.
+          before = 200
+          before.times { |i| downstream_q.bind("downstream_ex", "before.link.#{i}") }
+
+          UpstreamSpecHelpers.start_link(upstream)
+          link = wait_for { upstream.links.first? }
+          downstream_ex = downstream_vhost.exchange("downstream_ex").as(LavinMQ::AMQP::Exchange)
+          # The link starts observing the downstream exchange while it is
+          # still replaying the bindings above to the upstream exchange.
+          wait_for { downstream_ex.@__lavinmq_exchangeevent_observers.includes?(link) }
+          # Unbind bindings the replay has not reached yet. (Regression: the
+          # unbind was a no-op upstream because the binding did not exist
+          # there yet, and the replay then recreated it from its stale
+          # snapshot, leaving an upstream binding that no longer exists
+          # downstream.)
+          removed = 10
+          removed.times { |i| downstream_q.unbind("downstream_ex", "before.link.#{before - 1 - i}") }
+
+          # Only check the upstream bindings once the replay is done, the
+          # binding count passes through the expected value while it runs.
+          wait_for { link.state.running? }
+          upstream_ex = upstream_vhost.exchange("upstream_ex").as(LavinMQ::AMQP::Exchange)
+          wait_for { upstream_ex.bindings_details.size == before - removed }
+          upstream_ex.bindings_details.map(&.routing_key).should_not contain "before.link.#{before - 1}"
+        end
+      end
+    end
+
     it "set x-received-from" do
       with_amqp_server do |s|
         vhost1 = s.vhosts.create("one")

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -1,4 +1,5 @@
 require "amqp-client"
+require "../binding_details"
 require "../observable"
 require "../logger"
 require "../sortable_json"

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -338,6 +338,9 @@ module LavinMQ
       class ExchangeLink < Link
         include Observer(ExchangeEvent)
         @consumer_ex : ::AMQP::Client::Exchange?
+        @replay_queue = Deque({ExchangeEvent, BindingDetails}).new
+        @replay_lock = Mutex.new
+        @replaying = false
 
         def initialize(@upstream : Upstream, @federated_ex : Exchange, @upstream_q : String,
                        @upstream_exchange : String)
@@ -362,25 +365,31 @@ module LavinMQ
           case event
           in .deleted?
             @upstream.stop_link(@federated_ex)
-          in .bind?
+          in .bind?, .unbind?
             b = data_as_binding_details(data)
-            updated, args = update_bound_from?(b.arguments)
-            if updated
-              with_consumer_ex do |ex|
-                ex.bind(@upstream_exchange, b.routing_key, args: args)
-              end
-            end
-          in .unbind?
-            b = data_as_binding_details(data)
-            updated, args = update_bound_from?(b.arguments)
-            if updated
-              with_consumer_ex do |ex|
-                ex.unbind(@upstream_exchange, b.routing_key, args: args)
-              end
+            return if queued_during_replay?(event, b)
+            with_consumer_ex do |ex|
+              apply_binding_event(ex, event, b)
             end
           end
         rescue e
           @log.error { "Could not process event=#{event} data=#{data} error=#{e.inspect_with_backtrace}" }
+        end
+
+        private def apply_binding_event(ex, event : ExchangeEvent, b : BindingDetails)
+          updated, args = update_bound_from?(b.arguments)
+          return unless updated
+          case event
+          when .bind?   then ex.bind(@upstream_exchange, b.routing_key, args: args)
+          when .unbind? then ex.unbind(@upstream_exchange, b.routing_key, args: args)
+          end
+        end
+
+        private def queued_during_replay?(event : ExchangeEvent, b : BindingDetails) : Bool
+          @replay_lock.synchronize do
+            @replay_queue.push({event, b}) if @replaying
+            @replaying
+          end
         end
 
         private def data_as_binding_details(data) : BindingDetails
@@ -454,18 +463,49 @@ module LavinMQ
           # @consumer_ex must be set before the observer is registered:
           # bind/unbind events are dropped while it's nil, and a binding made
           # in that window would never be propagated to the upstream exchange.
-          # Bindings made before registration are covered by the snapshot
-          # below (exchanges store bindings before notifying observers).
           @consumer_ex = consumer_ex
-          @federated_ex.register_observer(self)
-          @federated_ex.bindings_details.each do |binding|
-            updated, args = update_bound_from?(binding.arguments)
-            if updated
-              consumer_ex.bind(@upstream_exchange, binding.routing_key, args: args)
-            end
-          end
+          replay_bindings(consumer_ex)
           upstream_q = ch.queue(@upstream_q, args: q_args, passive: true)
           {ch, upstream_q}
+        end
+
+        # Replay the downstream exchange's bindings to the upstream exchange.
+        # The observer must be registered before the snapshot is taken so that
+        # no event is missed, but events that arrive while the replay is
+        # running are queued and applied in order afterwards: applied
+        # concurrently, an unbind for a binding the replay has not reached yet
+        # is a no-op upstream, and the replay then recreates the binding from
+        # its stale snapshot.
+        private def replay_bindings(consumer_ex)
+          @replay_lock.synchronize do
+            @replay_queue.clear
+            @replaying = true
+          end
+          @federated_ex.register_observer(self)
+          @federated_ex.bindings_details.each do |binding|
+            apply_binding_event(consumer_ex, ExchangeEvent::Bind, binding)
+          end
+          loop do
+            event = @replay_lock.synchronize do
+              if e = @replay_queue.shift?
+                e
+              else
+                # Stop queueing atomically with observing an empty queue, so
+                # that no event is left behind in it.
+                @replaying = false
+                nil
+              end
+            end
+            break unless event
+            apply_binding_event(consumer_ex, *event)
+          end
+        ensure
+          # If the replay failed, stop queueing; the queued events are
+          # dropped, but the next setup resyncs from a fresh snapshot.
+          @replay_lock.synchronize do
+            @replaying = false
+            @replay_queue.clear
+          end
         end
 
         private def start_link


### PR DESCRIPTION
At startup an exchange federation link registers itself as a bind/unbind observer on the downstream exchange, then replays a snapshot of its current bindings to the upstream exchange, one round-trip per binding. An unbind observed mid-replay was sent upstream immediately, where it was a no-op because the replay had not created that binding yet — and the replay then recreated it from its stale snapshot. The result was an upstream binding with no downstream counterpart, so the upstream kept forwarding messages the downstream no longer wanted, until the link reconnected.

Fixed by queueing bind/unbind events observed while the replay is running and applying them in order once it finishes. The handoff back to direct handling happens atomically with observing an empty queue, so no event is lost; if the replay fails, the queue is discarded and the next setup resyncs from a fresh snapshot. Queueing also stops concurrent RPCs on the consumer channel during startup, which could mix up replies (`BindOk`/`UnbindOk` share one reply queue per channel).

The regression spec stretches the replay with 200 pre-existing bindings, unbinds tail-end snapshot bindings mid-replay, and requires the upstream exchange to settle on exactly the remaining bindings once the link is running. It fails 5/5 without this fix.
