### PR TITLE
fix: guard empty destination in Move messages UI

### DIFF
--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -288,6 +288,10 @@ moveMessagesForm.addEventListener('submit', function (evt) {
   const password = Auth.getPassword()
   const uri = HTTP.url`amqp://${username}:${password}@localhost/${vhost}`
   const dest = document.querySelector('[name=shovel-destination]').value.trim()
+  if (dest === '') {
+    DOM.toast.error('Please select a destination queue')
+    return
+  }
   const name = 'Move ' + queue + ' to ' + dest
   const url = HTTP.url`api/parameters/shovel/${vhost}/${name}`
   const body = {

--- a/views/queue.shtml
+++ b/views/queue.shtml
@@ -245,7 +245,7 @@
         <h3>Move messages</h3>
         <label>
           <span>Destination queue</span>
-          <input type="text" name="shovel-destination" list="queue-list">
+          <input type="text" name="shovel-destination" required list="queue-list">
           <datalist id="queue-list">
           </datalist>
         </label>


### PR DESCRIPTION
## Summary

The Move messages form accepted an empty destination, which published to the default exchange with no routing key - silently dropping the messages. Added a guard in both the HTML (`required`) and JS (trim check + toast).

## Test plan

- Open a queue, click `Move messages`, leave the destination empty and submit -> form now blocks submission and shows an error toast instead of silently dropping messages.

## Follow-up

While investigating this, we found related issues in shovel destination routing and `validate_config!` (destination required when RabbitMQ treats it as optional, contradictory dest-queue/dest-exchange combos, default-exchange permission handling). Those are out of scope here and tracked in #2058.

Closes #2041