### PR TITLE
Resync upstream exchange bindings on federation link reconnect 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ benchmark: extras/benchmark.sh bin/lavinmqperf bin/lavinmqctl
 lib: shard.yml shard.lock
 	shards install --production
 
+# Development dependencies (used by specs), not installed by `lib`
+lib/time_control: shard.yml shard.lock
+	shards install
+
 bin static/js/lib man1 static/js/lib/chunks:
 	mkdir -p $@
 
@@ -114,7 +118,7 @@ lint-openapi:
 	npx --yes --package=@stoplight/spectral-cli --package=@stoplight/spectral-rulesets@1.22.2 spectral --ruleset openapi/.spectral.json lint static/docs/openapi.yaml
 
 .PHONY: test
-test: lib views
+test: lib/time_control views
 	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(if $(TAGS),--tag '$(TAGS)') $(SPEC)
 
 .PHONY: format

--- a/shard.lock
+++ b/shard.lock
@@ -24,3 +24,7 @@ shards:
     git: https://github.com/84codes/systemd.cr.git
     version: 3.0.1
 
+  time_control:
+    git: https://github.com/84codes/time_control.cr.git
+    version: 0.1.0+git.commit.f45b50811f1e9230ae9a3031d59d746f50bcc971
+

--- a/shard.yml
+++ b/shard.yml
@@ -38,6 +38,9 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+  time_control:
+    github: 84codes/time_control.cr
+    branch: fiber-name-filter
 
 crystal: 1.20.1
 

--- a/spec/upstream_reconnect_spec.cr
+++ b/spec/upstream_reconnect_spec.cr
@@ -1,0 +1,67 @@
+require "./spec_helper"
+require "../src/lavinmq/federation/upstream"
+require "time_control"
+
+# Busy-wait without sleeping: inside TimeControl.control all non-zero sleeps
+# are virtualized, so wait_for (which sleeps) would deadlock the controlling
+# fiber. Bounded by iterations since the clock stands still too.
+private def spin_until(max_yields = 10_000_000, file = __FILE__, line = __LINE__, &)
+  max_yields.times do
+    return if yield
+    Fiber.yield
+  end
+  fail "spin_until expired", file: file, line: line
+end
+
+describe LavinMQ::Federation::Upstream do
+  it "should resync upstream exchange bindings on reconnect" do
+    with_amqp_server do |s|
+      upstream_vhost = s.vhosts.create("upstream")
+      downstream_vhost = s.vhosts.create("downstream")
+      upstream = LavinMQ::Federation::Upstream.new(
+        downstream_vhost, "ef reconnect resync",
+        "#{s.amqp_url}/upstream", "upstream_ex", nil,
+        LavinMQ::Federation::AckMode::OnConfirm, expires: nil, max_hops: 1_i64,
+        msg_ttl: nil, prefetch: 1000_u16, reconnect_delay: 1.second)
+      downstream_vhost.upstreams.not_nil!.add(upstream)
+
+      with_channel(s, vhost: "downstream") do |downstream_ch|
+        downstream_ch.exchange("downstream_ex", "topic")
+        downstream_q = downstream_ch.queue("downstream_q")
+        downstream_q.bind("downstream_ex", "keep")
+        downstream_q.bind("downstream_ex", "remove")
+
+        definitions = {"federation-upstream" => JSON::Any.new(upstream.name)} of String => JSON::Any
+        downstream_vhost.add_policy("FE", "downstream_ex", "exchanges", definitions, 12_i8)
+
+        link = wait_for { upstream.links.first? }
+        wait_for { link.state.running? }
+        upstream_ex = wait_for { upstream_vhost.exchange?("upstream_ex") }
+        upstream_ex = upstream_ex.as(LavinMQ::AMQP::Exchange)
+        wait_for { upstream_ex.bindings_details.size == 2 }
+
+        # Only control the link's fiber; the broker's housekeeping fibers
+        # (RoughTime, stats loop, ...) keep re-arming periodic sleeps, which
+        # would freeze and leak as pending timers.
+        TimeControl.control(only: /^Federation link /) do |controller|
+          # Kill the link's upstream connection; the link parks in
+          # wait_before_reconnect on a now-virtual reconnect_delay timeout.
+          upstream_vhost.each_connection do |conn|
+            conn.close if conn.client_name.starts_with?("Federation link")
+          end
+          spin_until { link.state.stopped? }
+          # Mutate downstream bindings while the link is disconnected
+          downstream_q.unbind("downstream_ex", "remove")
+          downstream_q.bind("downstream_ex", "added")
+          # Margin over reconnect_delay: the timeout may register while the
+          # advance is already in progress.
+          controller.advance(2.seconds)
+        end
+
+        # The resync happens during link setup, before the state is Running
+        wait_for { link.state.running? }
+        upstream_ex.bindings_details.map(&.routing_key).sort!.should eq ["added", "keep"]
+      end
+    end
+  end
+end

--- a/spec/upstream_reconnect_spec.cr
+++ b/spec/upstream_reconnect_spec.cr
@@ -40,10 +40,12 @@ describe LavinMQ::Federation::Upstream do
         upstream_ex = upstream_ex.as(LavinMQ::AMQP::Exchange)
         wait_for { upstream_ex.bindings_details.size == 2 }
 
-        # Only control the link's fiber; the broker's housekeeping fibers
-        # (RoughTime, stats loop, ...) keep re-arming periodic sleeps, which
-        # would freeze and leak as pending timers.
-        TimeControl.control(only: /^Federation link /) do |controller|
+        # Only control this spec's link fiber, matched by its full name: any
+        # other fiber re-arming a timer during the block — the broker's
+        # housekeeping fibers (RoughTime, stats loop, ...), but also leftover
+        # federation links from earlier specs — would freeze and leak as a
+        # pending timer.
+        TimeControl.control(only: /^Federation link downstream\/downstream_ex$/) do |controller|
           # Kill the link's upstream connection; the link parks in
           # wait_before_reconnect on a now-virtual reconnect_delay timeout.
           upstream_vhost.each_connection do |conn|

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -723,6 +723,42 @@ describe LavinMQ::Federation::Upstream do
       end
     end
 
+    it "should not recreate bindings removed while link is starting" do
+      with_amqp_server do |s|
+        upstream, upstream_vhost, downstream_vhost =
+          UpstreamSpecHelpers.setup_federation(s, "ef test unbindings during start", "upstream_ex")
+        with_channel(s, vhost: "downstream") do |downstream_ch|
+          downstream_ch.exchange("downstream_ex", "topic")
+          downstream_q = downstream_ch.queue("downstream_q")
+          # Pre-existing bindings stretch the binding replay the link does
+          # during startup, so that the unbinds below land mid-replay.
+          before = 200
+          before.times { |i| downstream_q.bind("downstream_ex", "before.link.#{i}") }
+
+          UpstreamSpecHelpers.start_link(upstream)
+          link = wait_for { upstream.links.first? }
+          downstream_ex = downstream_vhost.exchange("downstream_ex").as(LavinMQ::AMQP::Exchange)
+          # The link starts observing the downstream exchange while it is
+          # still replaying the bindings above to the upstream exchange.
+          wait_for { downstream_ex.@__lavinmq_exchangeevent_observers.includes?(link) }
+          # Unbind bindings the replay has not reached yet. (Regression: the
+          # unbind was a no-op upstream because the binding did not exist
+          # there yet, and the replay then recreated it from its stale
+          # snapshot, leaving an upstream binding that no longer exists
+          # downstream.)
+          removed = 10
+          removed.times { |i| downstream_q.unbind("downstream_ex", "before.link.#{before - 1 - i}") }
+
+          # Only check the upstream bindings once the replay is done, the
+          # binding count passes through the expected value while it runs.
+          wait_for { link.state.running? }
+          upstream_ex = upstream_vhost.exchange("upstream_ex").as(LavinMQ::AMQP::Exchange)
+          wait_for { upstream_ex.bindings_details.size == before - removed }
+          upstream_ex.bindings_details.map(&.routing_key).should_not contain "before.link.#{before - 1}"
+        end
+      end
+    end
+
     it "set x-received-from" do
       with_amqp_server do |s|
         vhost1 = s.vhosts.create("one")

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -569,9 +569,16 @@ describe LavinMQ::Federation::Upstream do
           vhost.declare_exchange("ex1", "topic", true, false)
 
           upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", {{v}})
-          link1 = upstream.link(vhost.exchange("ex1"))
+          begin
+            link1 = upstream.link(vhost.exchange("ex1"))
 
-          link1.@upstream_exchange.should eq "ex1"
+            link1.@upstream_exchange.should eq "ex1"
+          ensure
+            # The upstream is not registered in the vhost's upstream store, so
+            # nothing else stops the link; without this the link fiber keeps
+            # reconnecting for the rest of the spec process.
+            upstream.close
+          end
         end
       end
     end

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -342,6 +342,13 @@ module LavinMQ
         @replay_queue = Deque({ExchangeEvent, BindingDetails}).new
         @replay_lock = Mutex.new
         @replaying = false
+        # The upstream bindings this link has created, keyed by the downstream
+        # binding's properties_key, holding the routing key and transformed
+        # arguments needed to unbind upstream. Bindings removed downstream
+        # while the link is disconnected are never observed as events, so this
+        # is what lets a reconnect unbind them upstream. Guarded by
+        # @replay_lock.
+        @upstream_bindings = Hash(String, {String, ::AMQP::Client::Arguments}).new
 
         def initialize(@upstream : Upstream, @federated_ex : Exchange, @upstream_q : String,
                        @upstream_exchange : String)
@@ -380,9 +387,14 @@ module LavinMQ
         private def apply_binding_event(ex, event : ExchangeEvent, b : BindingDetails)
           updated, args = update_bound_from?(b.arguments)
           return unless updated
+          key = b.binding_key.properties_key
           case event
-          when .bind?   then ex.bind(@upstream_exchange, b.routing_key, args: args)
-          when .unbind? then ex.unbind(@upstream_exchange, b.routing_key, args: args)
+          when .bind?
+            ex.bind(@upstream_exchange, b.routing_key, args: args)
+            @replay_lock.synchronize { @upstream_bindings[key] = {b.routing_key, args} }
+          when .unbind?
+            ex.unbind(@upstream_exchange, b.routing_key, args: args)
+            @replay_lock.synchronize { @upstream_bindings.delete(key) }
           end
         end
 
@@ -483,7 +495,9 @@ module LavinMQ
           # a direct RPC here would race the replay below on the same channel.
           @consumer_ex = consumer_ex
           @federated_ex.register_observer(self)
-          @federated_ex.bindings_details.each do |binding|
+          snapshot = @federated_ex.bindings_details
+          unbind_removed_bindings(consumer_ex, snapshot)
+          snapshot.each do |binding|
             apply_binding_event(consumer_ex, ExchangeEvent::Bind, binding)
           end
           loop do
@@ -506,6 +520,22 @@ module LavinMQ
           @replay_lock.synchronize do
             @replaying = false
             @replay_queue.clear
+          end
+        end
+
+        # Unbind upstream bindings this link created that are no longer in the
+        # downstream snapshot: their unbinds happened while the link was
+        # disconnected, so they were never seen as events and would otherwise
+        # stay bound upstream forever, forwarding messages the downstream no
+        # longer wants.
+        private def unbind_removed_bindings(consumer_ex, snapshot)
+          desired = snapshot.map(&.binding_key.properties_key).to_set
+          removed = @replay_lock.synchronize do
+            @upstream_bindings.reject { |key, _| desired.includes?(key) }
+          end
+          removed.each do |key, (routing_key, args)|
+            consumer_ex.unbind(@upstream_exchange, routing_key, args: args)
+            @replay_lock.synchronize { @upstream_bindings.delete(key) }
           end
         end
 

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -1,4 +1,5 @@
 require "amqp-client"
+require "../binding_details"
 require "../observable"
 require "../logger"
 require "../sortable_json"

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -461,10 +461,6 @@ module LavinMQ
             uch.queue_bind(@upstream_q, @upstream_q, routing_key: "")
             ex
           end
-          # @consumer_ex must be set before the observer is registered:
-          # bind/unbind events are dropped while it's nil, and a binding made
-          # in that window would never be propagated to the upstream exchange.
-          @consumer_ex = consumer_ex
           replay_bindings(consumer_ex)
           upstream_q = ch.queue(@upstream_q, args: q_args, passive: true)
           {ch, upstream_q}
@@ -482,6 +478,10 @@ module LavinMQ
             @replay_queue.clear
             @replaying = true
           end
+          # On reconnect the observer is still registered, so expose the
+          # upstream exchange to the event handler only after queueing is on —
+          # a direct RPC here would race the replay below on the same channel.
+          @consumer_ex = consumer_ex
           @federated_ex.register_observer(self)
           @federated_ex.bindings_details.each do |binding|
             apply_binding_event(consumer_ex, ExchangeEvent::Bind, binding)

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -338,6 +338,9 @@ module LavinMQ
       class ExchangeLink < Link
         include Observer(ExchangeEvent)
         @consumer_ex : ::AMQP::Client::Exchange?
+        @replay_queue = Deque({ExchangeEvent, BindingDetails}).new
+        @replay_lock = Mutex.new
+        @replaying = false
 
         def initialize(@upstream : Upstream, @federated_ex : Exchange, @upstream_q : String,
                        @upstream_exchange : String)
@@ -362,25 +365,31 @@ module LavinMQ
           case event
           in .deleted?
             @upstream.stop_link(@federated_ex)
-          in .bind?
+          in .bind?, .unbind?
             b = data_as_binding_details(data)
-            updated, args = update_bound_from?(b.arguments)
-            if updated
-              with_consumer_ex do |ex|
-                ex.bind(@upstream_exchange, b.routing_key, args: args)
-              end
-            end
-          in .unbind?
-            b = data_as_binding_details(data)
-            updated, args = update_bound_from?(b.arguments)
-            if updated
-              with_consumer_ex do |ex|
-                ex.unbind(@upstream_exchange, b.routing_key, args: args)
-              end
+            return if queued_during_replay?(event, b)
+            with_consumer_ex do |ex|
+              apply_binding_event(ex, event, b)
             end
           end
         rescue e
           @log.error { "Could not process event=#{event} data=#{data} error=#{e.inspect_with_backtrace}" }
+        end
+
+        private def apply_binding_event(ex, event : ExchangeEvent, b : BindingDetails)
+          updated, args = update_bound_from?(b.arguments)
+          return unless updated
+          case event
+          when .bind?   then ex.bind(@upstream_exchange, b.routing_key, args: args)
+          when .unbind? then ex.unbind(@upstream_exchange, b.routing_key, args: args)
+          end
+        end
+
+        private def queued_during_replay?(event : ExchangeEvent, b : BindingDetails) : Bool
+          @replay_lock.synchronize do
+            @replay_queue.push({event, b}) if @replaying
+            @replaying
+          end
         end
 
         private def data_as_binding_details(data) : BindingDetails
@@ -454,18 +463,49 @@ module LavinMQ
           # @consumer_ex must be set before the observer is registered:
           # bind/unbind events are dropped while it's nil, and a binding made
           # in that window would never be propagated to the upstream exchange.
-          # Bindings made before registration are covered by the snapshot
-          # below (exchanges store bindings before notifying observers).
           @consumer_ex = consumer_ex
-          @federated_ex.register_observer(self)
-          @federated_ex.bindings_details.each do |binding|
-            updated, args = update_bound_from?(binding.arguments)
-            if updated
-              consumer_ex.bind(@upstream_exchange, binding.routing_key, args: args)
-            end
-          end
+          replay_bindings(consumer_ex)
           upstream_q = ch.queue(@upstream_q, args: q_args, passive: true)
           {ch, upstream_q}
+        end
+
+        # Replay the downstream exchange's bindings to the upstream exchange.
+        # The observer must be registered before the snapshot is taken so that
+        # no event is missed, but events that arrive while the replay is
+        # running are queued and applied in order afterwards: applied
+        # concurrently, an unbind for a binding the replay has not reached yet
+        # is a no-op upstream, and the replay then recreates the binding from
+        # its stale snapshot.
+        private def replay_bindings(consumer_ex)
+          @replay_lock.synchronize do
+            @replay_queue.clear
+            @replaying = true
+          end
+          @federated_ex.register_observer(self)
+          @federated_ex.bindings_details.each do |binding|
+            apply_binding_event(consumer_ex, ExchangeEvent::Bind, binding)
+          end
+          loop do
+            event = @replay_lock.synchronize do
+              if e = @replay_queue.shift?
+                e
+              else
+                # Stop queueing atomically with observing an empty queue, so
+                # that no event is left behind in it.
+                @replaying = false
+                nil
+              end
+            end
+            break unless event
+            apply_binding_event(consumer_ex, *event)
+          end
+        ensure
+          # If the replay failed, stop queueing; the queued events are
+          # dropped, but the next setup resyncs from a fresh snapshot.
+          @replay_lock.synchronize do
+            @replaying = false
+            @replay_queue.clear
+          end
         end
 
         private def start_link


### PR DESCRIPTION
Stacked on https://github.com/cloudamqp/lavinmq/pull/2040, uses https://github.com/84codes/time_control.cr/pull/1

A binding removed downstream while an exchange federation link was
disconnected was never propagated: unbind events are dropped without
an upstream connection, and the reconnect replay only recreated the
bindings in the downstream snapshot, additively. The stale binding
stayed on the upstream exchange forever, forwarding messages the
downstream no longer wanted.

The link now remembers the upstream bindings it has created, keyed by
the downstream binding's `properties_key`, and the reconnect replay
starts by unbinding every remembered binding that is no longer in the
downstream snapshot. Bindings from before a broker restart are still
unknowable (the map is in-memory), as before.

The spec drives the reconnect deterministically with the time_control
shard: `TimeControl.control(only: /^Federation link /)` virtualizes
only the link fiber's reconnect-delay timeout, so the spec can park
the link, mutate bindings while it is disconnected, and release the
reconnect by advancing virtual time — no real-time racing. Requires
the `fiber-name-filter` branch of time_control (the `only:` filter and
the named `PendingTimersError` were added for this), so `shards
install` will fail until that branch is pushed.