### PR TITLE
Add embedded Raft as an alternative to etcd for clustering

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,25 +1,57 @@
 # Clustering
 
-LavinMQ supports multi-node clustering with leader-based replication, using etcd for leader election and coordination.
+LavinMQ supports multi-node clustering with leader-based replication. Leader election, ISR tracking and shared state are handled by a coordination **backend**: either an external **etcd** cluster (default) or an **embedded Raft** group (no external dependency).
 
 ## Architecture
 
 - **Leader** — accepts all client connections and writes. Replicates data to followers.
 - **Followers** — receive replicated data from the leader. Can be promoted to leader on failover.
-- **etcd** — external coordination service for leader election, ISR tracking, and shared state.
+- **Coordination backend** — `etcd` (external) or `raft` (embedded); handles leader election, ISR tracking, and advertising the leader's URI.
 
 Only the leader handles client traffic. Followers maintain a synchronized copy of the data.
 
 ## Enabling Clustering
 
+### etcd backend (default)
+
 ```ini
 [clustering]
 enabled = true
+backend = etcd
 bind = 0.0.0.0
 port = 5679
 advertised_uri = tcp://node1.example.com:5679
 etcd_endpoints = etcd1:2379,etcd2:2379,etcd3:2379
 etcd_prefix = lavinmq
+```
+
+### Raft backend (embedded, no etcd)
+
+The Raft backend runs consensus inside LavinMQ itself, so no etcd is needed. It requires a few extra settings because, unlike etcd, it can't auto-discover the cluster:
+
+- **Static membership** — every node must be listed in `raft_peers` as `id@host:port`, where `id` is a small integer that is unique across the cluster and is used as both the Raft node id and the LavinMQ clustering id. Set `raft_node_id` to this node's own id.
+- **Replication secret** — the shared secret used to authenticate followers is **not** stored in the Raft log. Each node reads it from `<data_dir>/.replication_secret`. Generate a secret once and copy the same file to every node (like an Erlang cookie). LavinMQ refuses to start in Raft mode if the file is missing.
+
+```ini
+[clustering]
+enabled = true
+backend = raft
+bind = 0.0.0.0
+port = 5679
+advertised_uri = tcp://node1.example.com:5679
+; this node's id; must match its entry in raft_peers
+raft_node_id = 1
+; all nodes (including this one): id@host:port for the Raft transport
+raft_peers = 1@node1.example.com:5680,2@node2.example.com:5680,3@node3.example.com:5680
+raft_bind = 0.0.0.0
+raft_port = 5680
+```
+
+Create the shared secret on every node:
+
+```sh
+head -c 32 /dev/urandom | base64 > /var/lib/lavinmq/.replication_secret
+# copy the identical file to every node's data dir
 ```
 
 See [Configuration](configuration.md) for all clustering options.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,8 +106,13 @@ Alternatively, set the `LAVINMQ_CONFIGURATION_DIRECTORY` environment variable (o
 | `bind` | `--clustering-bind` | `LAVINMQ_CLUSTERING_BIND` | String | `127.0.0.1` | Clustering bind address |
 | `port` | `--clustering-port` | `LAVINMQ_CLUSTERING_PORT` | Int | `5679` | Clustering port |
 | `advertised_uri` | `--clustering-advertised-uri` | `LAVINMQ_CLUSTERING_ADVERTISED_URI` | String | (none) | Advertised URI for peers |
+| `backend` | `--clustering-backend` | `LAVINMQ_CLUSTERING_BACKEND` | `etcd`\|`raft` | `etcd` | Coordination backend |
 | `etcd_endpoints` | `--clustering-etcd-endpoints` | `LAVINMQ_CLUSTERING_ETCD_ENDPOINTS` | String | `localhost:2379` | etcd endpoints (comma-separated) |
 | `etcd_prefix` | `--clustering-etcd-prefix` | `LAVINMQ_CLUSTERING_ETCD_PREFIX` | String | `lavinmq` | etcd key prefix |
+| `raft_peers` | `--clustering-raft-peers` | `LAVINMQ_CLUSTERING_RAFT_PEERS` | String | (empty) | Raft backend: all nodes as `id@host:port` (comma-separated) |
+| `raft_node_id` | `--clustering-raft-node-id` | `LAVINMQ_CLUSTERING_RAFT_NODE_ID` | Int | `0` | Raft backend: this node's id (and clustering id) |
+| `raft_bind` | `--clustering-raft-bind` | `LAVINMQ_CLUSTERING_RAFT_BIND` | String | `127.0.0.1` | Raft backend: transport listen address |
+| `raft_port` | `--clustering-raft-port` | `LAVINMQ_CLUSTERING_RAFT_PORT` | Int | `5680` | Raft backend: transport listen port |
 | `max_unsynced_actions` | `--clustering-max-unsynced-actions` | `LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS` | Int | `8192` | **Deprecated:** still accepted but has no effect; how far a follower may lag is governed by the leader's ack deadline |
 | `on_leader_elected` | `--clustering-on-leader-elected` | — | String | (empty) | Shell command on leader election |
 | `on_leader_lost` | `--clustering-on-leader-lost` | — | String | (empty) | Shell command on losing leadership |

--- a/extras/lavinmq.ini
+++ b/extras/lavinmq.ini
@@ -29,4 +29,11 @@ enabled = false
 bind = ::
 ;port = 5679
 ;advertised_uri = tcp://hostname.local:5679
+; backend = etcd (default) or raft (embedded, no external etcd)
+;backend = etcd
 ;etcd_endpoints = localhost:2379
+; raft backend: every node as id@host:port, plus this node's id (see docs/clustering.md)
+;raft_node_id = 1
+;raft_peers = 1@node1:5680,2@node2:5680,3@node3:5680
+;raft_bind = ::
+;raft_port = 5680

--- a/shard.lock
+++ b/shard.lock
@@ -20,6 +20,10 @@ shards:
     git: https://github.com/84codes/mqtt-protocol.cr.git
     version: 0.3.0
 
+  raft:
+    git: https://github.com/84codes/raft.cr.git
+    version: 0.1.0+git.commit.df3e1c94b2a7a8ce95e4331582d701c4b0b1aa8c
+
   systemd:
     git: https://github.com/84codes/systemd.cr.git
     version: 3.0.1

--- a/shard.yml
+++ b/shard.yml
@@ -34,6 +34,8 @@ dependencies:
     github: 84codes/lz4.cr
   mqtt-protocol:
     github: 84codes/mqtt-protocol.cr
+  raft:
+    github: 84codes/raft.cr
 
 development_dependencies:
   ameba:

--- a/spec/clustering/raft_coordinator_spec.cr
+++ b/spec/clustering/raft_coordinator_spec.cr
@@ -152,6 +152,63 @@ describe LavinMQ::Clustering::RaftCoordinator do
     end
   end
 
+  describe "configuration" do
+    it "reads and strips the replication secret from disk" do
+      with_datadir do |dir|
+        File.write(File.join(dir, ".replication_secret"), "  s3cr3t\n")
+        config = raft_config(dir, 1, "")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        coord.password.should eq "s3cr3t"
+      end
+    end
+
+    it "rejects a peer entry without a port" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "1@host-without-port")
+        expect_raises(ArgumentError, /raft peer/) do
+          LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        end
+      end
+    end
+
+    it "rejects a non-numeric peer id" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "x@127.0.0.1:5680")
+        expect_raises(ArgumentError, /raft peer id/) do
+          LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        end
+      end
+    end
+
+    it "accepts bracketed IPv6 peers" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "1@[::1]:5681,2@[::1]:5682")
+        # parse_peers runs in the constructor; bracketed IPv6 must not raise.
+        LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+      end
+    end
+  end
+
+  describe "not leader" do
+    it "update_isr raises StaleLeadership when this node never wins" do
+      with_datadir do |dir|
+        # Two configured peers but a standalone transport that can't reach peer
+        # 2, so this node campaigns forever and never becomes leader.
+        config = raft_config(dir, 1, "1@127.0.0.1:5681,2@127.0.0.1:5682")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        begin
+          coord.start
+          became_leader?(coord, 1.second).should be_false
+          expect_raises(LavinMQ::Clustering::RaftCoordinator::StaleLeadership) do
+            coord.update_isr(Set{1})
+          end
+        ensure
+          coord.release
+        end
+      end
+    end
+  end
+
   describe "multi node" do
     it "elects exactly one leader and fails over on release", tags: "slow" do
       with_datadir do |dir1|

--- a/spec/clustering/raft_coordinator_spec.cr
+++ b/spec/clustering/raft_coordinator_spec.cr
@@ -1,0 +1,201 @@
+require "../spec_helper"
+require "raft"
+require "../../src/lavinmq/clustering/raft_coordinator"
+
+private def raft_config(data_dir : String, id : Int32, peers : String) : LavinMQ::Config
+  config = LavinMQ::Config.new
+  config.data_dir = data_dir
+  config.clustering = true
+  config.clustering_backend = LavinMQ::ClusteringBackend::Raft
+  config.clustering_raft_node_id = id
+  config.clustering_raft_peers = peers
+  config.clustering_raft_bind = "127.0.0.1"
+  config.clustering_raft_port = 5680 + id
+  config
+end
+
+# Run an election in a fiber and return whether leadership was acquired within
+# the timeout.
+private def became_leader?(coord, timeout : Time::Span = 3.seconds) : Bool
+  ch = Channel(Nil).new(1)
+  spawn { coord.await_leadership; ch.send(nil) }
+  select
+  when ch.receive
+    true
+  when timeout(timeout)
+    false
+  end
+end
+
+describe LavinMQ::Clustering::RaftCoordinator do
+  describe "single node" do
+    it "elects itself leader on bootstrap" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        begin
+          coord.start
+          became_leader?(coord).should be_true
+        ensure
+          coord.release
+        end
+      end
+    end
+
+    it "round-trips the ISR set" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        begin
+          coord.start
+          became_leader?(coord).should be_true
+          coord.isr.should be_nil # nothing recorded yet
+          coord.update_isr(Set{1})
+          coord.isr.should eq Set{1}
+          coord.update_isr(Set{1, 2})
+          coord.isr.should eq Set{1, 2}
+        ensure
+          coord.release
+        end
+      end
+    end
+
+    it "notifies watch_isr on change" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        begin
+          coord.start
+          became_leader?(coord).should be_true
+          seen = Channel(Set(Int32)?).new(4)
+          spawn do
+            coord.watch_isr do |members|
+              seen.send(members)
+              break if members == Set{7}
+            end
+          end
+          coord.update_isr(Set{7})
+          found = false
+          4.times do
+            select
+            when members = seen.receive
+              if members == Set{7}
+                found = true
+                break
+              end
+            when timeout(3.seconds)
+              break
+            end
+          end
+          found.should be_true
+        ensure
+          coord.release
+        end
+      end
+    end
+
+    it "publishes and observes the leader URI" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "")
+        uri = "tcp://localhost:6001"
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, uri, Raft::MemoryTransport.new(1u64))
+        begin
+          coord.start
+          became_leader?(coord).should be_true
+          coord.publish_leader_uri(uri)
+          observed = Channel(String?).new(4)
+          spawn do
+            coord.watch_leader_uri do |u|
+              observed.send(u)
+              break if u == uri
+            end
+          end
+          found = false
+          4.times do
+            select
+            when u = observed.receive
+              if u == uri
+                found = true
+                break
+              end
+            when timeout(3.seconds)
+              break
+            end
+          end
+          found.should be_true
+        ensure
+          coord.release
+        end
+      end
+    end
+
+    it "restores the ISR from disk after restart" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        coord.start
+        became_leader?(coord).should be_true
+        coord.update_isr(Set{1, 5, 9})
+        coord.release
+        Fiber.yield
+
+        # Re-open on the same data dir: the persisted Raft log replays and the
+        # state machine restores the ISR.
+        coord2 = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        begin
+          coord2.start
+          coord2.isr.should eq Set{1, 5, 9}
+        ensure
+          coord2.release
+        end
+      end
+    end
+  end
+
+  describe "multi node" do
+    it "elects exactly one leader and fails over on release", tags: "slow" do
+      with_datadir do |dir1|
+        with_datadir do |dir2|
+          with_datadir do |dir3|
+            peers = "1@127.0.0.1:5681,2@127.0.0.1:5682,3@127.0.0.1:5683"
+            transports = Raft::MemoryTransport.mesh([1u64, 2u64, 3u64])
+            dirs = {1 => dir1, 2 => dir2, 3 => dir3}
+            coords = {} of Int32 => LavinMQ::Clustering::RaftCoordinator
+            (1..3).each do |id|
+              config = raft_config(dirs[id], id, peers)
+              coords[id] = LavinMQ::Clustering::RaftCoordinator.new(
+                config, id, "tcp://localhost:600#{id}", transports[id.to_u64])
+            end
+            begin
+              coords.each_value &.start
+
+              leader = Channel(Int32).new(3)
+              coords.each do |id, c|
+                spawn { c.await_leadership; leader.send(id) }
+              end
+
+              first_leader =
+                select
+                when id = leader.receive
+                  id
+                when timeout(5.seconds)
+                  fail "no leader elected"
+                end
+
+              # Releasing the leader must let another node take over.
+              coords[first_leader].release
+              select
+              when id = leader.receive
+                id.should_not eq first_leader
+              when timeout(5.seconds)
+                fail "no failover after leader released"
+              end
+            ensure
+              coords.each_value &.release
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/clustering/raft_coordinator_spec.cr
+++ b/spec/clustering/raft_coordinator_spec.cr
@@ -209,6 +209,103 @@ describe LavinMQ::Clustering::RaftCoordinator do
     end
   end
 
+  describe "graceful stop" do
+    it "wakes await_leadership_lost on release" do
+      with_datadir do |dir|
+        config = raft_config(dir, 1, "")
+        coord = LavinMQ::Clustering::RaftCoordinator.new(config, 1, "tcp://localhost:6001", Raft::MemoryTransport.new(1u64))
+        coord.start
+        became_leader?(coord).should be_true
+        lost = Channel(Nil).new(1)
+        spawn { coord.await_leadership_lost; lost.send(nil) }
+        coord.release
+        select
+        when lost.receive
+          # released cleanly
+        when timeout(3.seconds)
+          fail "await_leadership_lost did not return after release"
+        end
+      end
+    end
+  end
+
+  describe "stale leader URI after restart" do
+    # A former leader that restarts in isolation (can't reach its peers, so it
+    # can't re-win) must not replay its own persisted URI as the live leader,
+    # or follow_leader would abort it as a duplicate.
+    it "suppresses its own persisted URI while not leading", tags: "slow" do
+      with_datadir do |dir1|
+        with_datadir do |dir2|
+          peers = "1@127.0.0.1:5691,2@127.0.0.1:5692"
+          transports = Raft::MemoryTransport.mesh([1u64, 2u64])
+          uris = {1 => "tcp://localhost:6001", 2 => "tcp://localhost:6002"}
+          dirs = {1 => dir1, 2 => dir2}
+          coords = {} of Int32 => LavinMQ::Clustering::RaftCoordinator
+          {1, 2}.each do |id|
+            coords[id] = LavinMQ::Clustering::RaftCoordinator.new(
+              raft_config(dirs[id], id, peers), id, uris[id], transports[id.to_u64])
+          end
+          leader_id = 0
+          begin
+            coords.each_value &.start
+            elected = Channel(Int32).new(2)
+            coords.each { |id, c| spawn { c.await_leadership; elected.send(id) } }
+            leader_id =
+              select
+              when id = elected.receive
+                id
+              when timeout(5.seconds)
+                fail "no leader elected"
+              end
+            # Wait until the leader's own URI is committed+applied (and thus
+            # persisted) by observing it through its own watch.
+            published = Channel(Nil).new(1)
+            spawn do
+              coords[leader_id].watch_leader_uri do |u|
+                if u == uris[leader_id]
+                  published.send(nil)
+                  break
+                end
+              end
+            end
+            select
+            when published.receive
+            when timeout(5.seconds)
+              fail "leader never published its URI"
+            end
+          ensure
+            coords.each_value &.release
+          end
+          Fiber.yield
+
+          # Restart the former leader alone: a standalone transport can't reach
+          # the peer, so it campaigns forever and never becomes leader.
+          restarted = LavinMQ::Clustering::RaftCoordinator.new(
+            raft_config(dirs[leader_id], leader_id, peers), leader_id, uris[leader_id], Raft::MemoryTransport.new(leader_id.to_u64))
+          begin
+            restarted.start
+            observed = Channel(String?).new(8)
+            spawn { restarted.watch_leader_uri { |u| observed.send(u) } }
+            # Over a short window, it must never report its own (stale) URI.
+            saw_self = false
+            done = false
+            until done
+              select
+              when u = observed.receive
+                saw_self = true if u == uris[leader_id]
+              when timeout(1.second)
+                done = true
+              end
+            end
+            saw_self.should be_false
+          ensure
+            restarted.release
+          end
+        end
+      end
+    end
+  end
+
   describe "multi node" do
     it "elects exactly one leader and fails over on release", tags: "slow" do
       with_datadir do |dir1|

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -379,9 +379,10 @@ describe LavinMQ::Clustering::Client, tags: %w[etcd slow] do
       config = LavinMQ::Config.new
       config.data_dir = data_dir
       config.clustering_advertised_uri = "tcp://localhost:5685"
-      etcd = SelfLeaderEtcd.new(config.clustering_advertised_uri.not_nil!)
-      coordinator = LavinMQ::Clustering::EtcdCoordinator.new(config, etcd)
-      controller = SelfLeaderController.new(config, etcd, coordinator)
+      uri = config.clustering_advertised_uri.not_nil!
+      etcd = SelfLeaderEtcd.new(uri)
+      coordinator = LavinMQ::Clustering::EtcdCoordinator.new(config, etcd, 1, uri)
+      controller = SelfLeaderController.new(config, coordinator, 1, uri)
       done = Channel(Exception?).new(1)
 
       spawn(name: "self leader follower monitor spec") do

--- a/src/lavinmq/clustering/backend.cr
+++ b/src/lavinmq/clustering/backend.cr
@@ -1,0 +1,11 @@
+module LavinMQ
+  # Which coordination backend clustering uses for leader election, storing the
+  # in-sync replica set and sharing the replication secret.
+  enum ClusteringBackend
+    # External etcd cluster (default, the original implementation).
+    Etcd
+    # Embedded Raft (the `raft` shard); no external dependency. The replication
+    # secret is read from `<data_dir>/.replication_secret`.
+    Raft
+  end
+end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -494,7 +494,7 @@ module LavinMQ
 
       private def authenticate(socket)
         socket.write Start
-        socket.write_bytes @password.bytesize.to_u8, IO::ByteFormat::LittleEndian
+        socket.write_byte @password.bytesize.to_u8
         socket.write @password.to_slice
         case socket.read_byte
         when 0 # ok

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -47,6 +47,9 @@ class LavinMQ::Clustering::Controller
   rescue Coordinator::IdConflict
     Log.fatal { "Cluster ID #{@id.to_s(36)} used by another node" }
     exit 3
+  rescue Etcd::LeaseNotFound
+    Log.fatal { "Lease not found, etcd may have been reset" }
+    exit 3
   end
 
   @stopped = false

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -1,23 +1,25 @@
-require "../etcd"
 require "./client"
+require "./coordinator"
 require "./etcd_coordinator"
+require "./raft_coordinator"
+require "../etcd"
 
 class LavinMQ::Clustering::Controller
   Log = LavinMQ::Log.for "clustering.controller"
 
   getter id : Int32
+  getter coordinator : Coordinator
 
   @repli_client : Client? = nil
 
   def self.new(config : Config)
-    etcd = Etcd.new(config.clustering_etcd_endpoints)
-    new(config, etcd, EtcdCoordinator.new(config, etcd))
+    id = clustering_id(config)
+    advertised_uri = advertised_uri(config)
+    coordinator = build_coordinator(config, id, advertised_uri)
+    new(config, coordinator, id, advertised_uri)
   end
 
-  def initialize(@config : Config, @etcd : Etcd, @coordinator : EtcdCoordinator)
-    @id = clustering_id
-    @advertised_uri = @config.clustering_advertised_uri ||
-                      "tcp://#{System.hostname}:#{@config.clustering_port}"
+  def initialize(@config : Config, @coordinator : Coordinator, @id : Int32, @advertised_uri : String)
     @elected_leader = BoolChannel.new(false)
   end
 
@@ -25,31 +27,25 @@ class LavinMQ::Clustering::Controller
   # The block will be yielded when the controller's prerequisites for a leader
   # to start are met, i.e when the current node has been elected leader.
   # The method is blocking.
-
   def run(&)
-    lease = @lease = @etcd.lease_grant(id: @id)
+    @coordinator.start
     spawn(follow_leader, name: "Follower monitor")
-    wait_to_be_insync(lease)
-    @coordinator.campaign(@advertised_uri, @id) # blocks until becoming leader, captures the fencing token
+    wait_to_be_insync
+    @coordinator.await_leadership # blocks until becoming leader
     @elected_leader.set(true)
     ensure_in_isr!
+    @coordinator.publish_leader_uri(@advertised_uri)
     execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
     @repli_client.try &.close
     yield
-    loop do
-      lease.wait(1.hour) # blocks until the lease expires (raises Expired)
-    end
-  rescue Etcd::Lease::Expired
+    @coordinator.await_leadership_lost # blocks until leadership is lost
     execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
     unless @stopped
-      Log.fatal { "Lease expired, lost leadership" }
+      Log.fatal { "Lost leadership" }
       exit 3
     end
-  rescue Etcd::LeaseAlreadyExists
+  rescue Coordinator::IdConflict
     Log.fatal { "Cluster ID #{@id.to_s(36)} used by another node" }
-    exit 3
-  rescue Etcd::LeaseNotFound
-    Log.fatal { "Lease not found, etcd may have been reset" }
     exit 3
   end
 
@@ -58,30 +54,47 @@ class LavinMQ::Clustering::Controller
   def stop
     @stopped = true
     @repli_client.try &.close
-    @lease.try &.release
+    @coordinator.release
   end
 
-  # Each node in a cluster has an unique id, for tracking ISR
-  private def clustering_id : Int32
-    id_file_path = File.join(@config.data_dir, ".clustering_id")
+  # Each node in a cluster has an unique id, for tracking ISR. With the raft
+  # backend the id is assigned in config; otherwise it's read from (or generated
+  # into) the data dir.
+  private def self.clustering_id(config : Config) : Int32
+    return config.clustering_raft_node_id if config.clustering_backend.raft?
+
+    id_file_path = File.join(config.data_dir, ".clustering_id")
     begin
-      id = File.read(id_file_path).to_i(36)
+      File.read(id_file_path).to_i(36)
     rescue File::NotFoundError
       id = rand(Int32::MAX)
-      Dir.mkdir_p @config.data_dir
+      Dir.mkdir_p config.data_dir
       File.write(id_file_path, id.to_s(36))
       Log.info { "Generated new clustering ID" }
+      id
     end
-    id
+  end
+
+  private def self.advertised_uri(config : Config) : String
+    config.clustering_advertised_uri ||
+      "tcp://#{System.hostname}:#{config.clustering_port}"
+  end
+
+  private def self.build_coordinator(config : Config, id : Int32, advertised_uri : String) : Coordinator
+    if config.clustering_backend.raft?
+      RaftCoordinator.new(config, id, advertised_uri)
+    else
+      EtcdCoordinator.new(config, Etcd.new(config.clustering_etcd_endpoints), id, advertised_uri)
+    end
   end
 
   # Replicate from the leader
   # Listens for leader change events
   private def follow_leader
-    @etcd.elect_listen("#{@config.clustering_etcd_prefix}/leader") do |uri|
+    @coordinator.watch_leader_uri do |uri|
       if repli_client = @repli_client # is currently following a leader
         if repli_client.follows? uri
-          next # if lost connection to etcd we continue follow the leader as is
+          next # if lost connection to the coordinator we continue follow the leader as is
         else
           repli_client.close
         end
@@ -101,15 +114,7 @@ class LavinMQ::Clustering::Controller
         end
       end
       Log.info { "Leader: #{uri}" }
-      key = "#{@config.clustering_etcd_prefix}/clustering_secret"
-      secret = @etcd.get(key)
-      until secret # the leader might not have had time to set the secret yet
-        Log.debug { "Clustering secret is missing, watching for it" }
-        @etcd.watch(key) do |value|
-          secret = value
-          break
-        end
-      end
+      secret = @coordinator.password
       @repli_client = r = Clustering::Client.new(@config, @id, secret)
       spawn r.follow(uri), name: "Clustering client #{uri}"
       SystemD.notify_ready
@@ -124,28 +129,27 @@ class LavinMQ::Clustering::Controller
 
   # A queued election candidacy can outlive ISR membership: this node may have
   # been dropped from the ISR (lagging or disconnected replication) after it
-  # campaigned, and etcd's election doesn't consult the ISR key. Serving as
-  # leader while missing confirmed messages would lose them cluster-wide — the
-  # in-sync nodes would full_sync from us and delete them. Exit instead: that
-  # releases the lease, withdraws the candidacy and lets an in-sync candidate
-  # win; on restart wait_to_be_insync blocks until this node is re-synced.
+  # campaigned, and the election doesn't consult the ISR. Serving as leader
+  # while missing confirmed messages would lose them cluster-wide — the in-sync
+  # nodes would full_sync from us and delete them. Exit instead: that releases
+  # leadership, withdraws the candidacy and lets an in-sync candidate win; on
+  # restart wait_to_be_insync blocks until this node is re-synced.
   private def ensure_in_isr! : Nil
     isr = @coordinator.isr
     return if isr.nil? # no ISR recorded yet (fresh cluster)
     return if isr.includes?(@id)
     Log.fatal { "Won the leader election but is not in the in-sync replica set (ISR: #{isr.to_a}), stepping down" }
-    # Release the lease explicitly: the election key is bound to it, so this
-    # revokes the just-won leadership at once instead of leaving the cluster
-    # leaderless until the lease TTL expires.
+    # Release leadership explicitly so the cluster isn't left leaderless until a
+    # timeout: revokes the just-won leadership at once.
     begin
-      @lease.try &.release
+      @coordinator.release
     rescue ex
-      Log.warn(exception: ex) { "Failed to release lease while stepping down, it will expire on its own" }
+      Log.warn(exception: ex) { "Failed to release leadership while stepping down" }
     end
     exit 3
   end
 
-  def wait_to_be_insync(lease)
+  def wait_to_be_insync
     if isr = @coordinator.isr
       unless isr.includes?(@id)
         Log.info { "ISR: #{isr.to_a}" }
@@ -160,12 +164,8 @@ class LavinMQ::Clustering::Controller
           end
         end
         select
-        when err = lease.expired.receive?
-          if err
-            Log.fatal { "Lease expired while waiting to be in sync: #{err.message}" }
-          else
-            Log.fatal { "Lease expired while waiting to be in sync" }
-          end
+        when @coordinator.membership_lost.receive?
+          Log.fatal { "Lost membership while waiting to be in sync" }
           exit 3
         when in_sync.receive?
           Log.info { "In sync with leader" }

--- a/src/lavinmq/clustering/coordinator.cr
+++ b/src/lavinmq/clustering/coordinator.cr
@@ -1,13 +1,80 @@
 module LavinMQ::Clustering
-  # What Clustering::Server uses to write ISR and read/write the shared
-  # replication secret.
+  # Abstracts away how a cluster elects a leader, stores the in-sync replica
+  # (ISR) set, advertises the leader's URI and shares the replication secret.
   #
-  # All methods are safe to call from any thread.
+  # `Clustering::Server` (the leader side) only needs `update_isr` and
+  # `password`, so those are the only abstract methods — that keeps the
+  # Server-only test doubles (NullCoordinator, SpyCoordinator) tiny. The
+  # lifecycle/election methods below are used solely by `Clustering::Controller`
+  # and have base implementations so a Server-only double doesn't have to
+  # implement them; the real backends (EtcdCoordinator, RaftCoordinator)
+  # override what they need.
+  #
+  # All methods are safe to call from any thread/fiber.
   abstract class Coordinator
-    # Replace the ISR set wholesale with the given node ids.
+    # Replace the ISR set wholesale with the given node ids. Must only succeed
+    # while this node is still the leader, and must be durable before it
+    # returns (Server treats a successful return as "the ISR write is
+    # committed"). Raises if leadership has been lost so Server#flush_isr
+    # retries.
     abstract def update_isr(synced_node_ids : Set(Int32)) : Nil
 
-    # Read the cluster's shared replication secret, generating one if missing.
+    # The cluster's shared replication secret, used to authenticate followers.
     abstract def password : String
+
+    # Join the cluster / acquire the membership handle. Must be called before
+    # any other lifecycle method. Raises `IdConflict` if this node's id is
+    # already taken by another live node.
+    def start : Nil
+    end
+
+    # Block until THIS node is the cluster leader.
+    def await_leadership : Nil
+      raise NotImplementedError.new("await_leadership")
+    end
+
+    # Block until this node's leadership is lost, then return. The caller
+    # (Controller) exits the process afterwards.
+    def await_leadership_lost : Nil
+      raise NotImplementedError.new("await_leadership_lost")
+    end
+
+    # A channel that is closed when this node's membership/leadership is lost,
+    # so a caller waiting for something else (e.g. to enter the ISR) can abort.
+    # The base implementation never closes.
+    def membership_lost : Channel(Nil)
+      Channel(Nil).new
+    end
+
+    # Voluntarily give up leadership/membership immediately (graceful shutdown
+    # or stepping down because not in the ISR). Idempotent, never raises.
+    def release : Nil
+    end
+
+    # The current in-sync replica set, or nil if none has been recorded yet (a
+    # fresh cluster).
+    def isr : Set(Int32)?
+      nil
+    end
+
+    # Yield the parsed ISR set on every change (nil when no ISR is recorded),
+    # until the block breaks. Blocks like a watch.
+    def watch_isr(& : Set(Int32)? -> Nil) : Nil
+    end
+
+    # Yield the current leader's advertised URI on every change (nil when there
+    # is no leader), until the block breaks. Used by the follower monitor to
+    # know where to replicate from.
+    def watch_leader_uri(& : String? -> Nil) : Nil
+    end
+
+    # Publish this node's advertised URI as the current leader's URI. Called by
+    # the Controller right after `await_leadership` returns.
+    def publish_leader_uri(advertised_uri : String) : Nil
+    end
+
+    # Raised by `start`/`await_leadership` when this node's id is already in use
+    # by another live node in the cluster.
+    class IdConflict < Exception; end
   end
 end

--- a/src/lavinmq/clustering/coordinator.cr
+++ b/src/lavinmq/clustering/coordinator.cr
@@ -5,10 +5,15 @@ module LavinMQ::Clustering
   # `Clustering::Server` (the leader side) only needs `update_isr` and
   # `password`, so those are the only abstract methods — that keeps the
   # Server-only test doubles (NullCoordinator, SpyCoordinator) tiny. The
-  # lifecycle/election methods below are used solely by `Clustering::Controller`
-  # and have base implementations so a Server-only double doesn't have to
-  # implement them; the real backends (EtcdCoordinator, RaftCoordinator)
-  # override what they need.
+  # lifecycle/election methods below are used solely by `Clustering::Controller`.
+  # They are *not* abstract (so the Server-only doubles don't have to implement
+  # them) but their base implementations raise `NotImplementedError` rather than
+  # silently no-op: a real backend that forgets to override one fails loudly the
+  # first time the Controller calls it, instead of, say, never discovering a
+  # leader and silently never replicating. The two genuinely-optional hooks
+  # (`start`, `release`) keep a no-op default; `membership_lost`/`isr` keep a
+  # safe-value default. The real backends (EtcdCoordinator, RaftCoordinator)
+  # override everything they use.
   #
   # All methods are safe to call from any thread/fiber.
   abstract class Coordinator
@@ -60,17 +65,20 @@ module LavinMQ::Clustering
     # Yield the parsed ISR set on every change (nil when no ISR is recorded),
     # until the block breaks. Blocks like a watch.
     def watch_isr(& : Set(Int32)? -> Nil) : Nil
+      raise NotImplementedError.new("watch_isr")
     end
 
     # Yield the current leader's advertised URI on every change (nil when there
     # is no leader), until the block breaks. Used by the follower monitor to
     # know where to replicate from.
     def watch_leader_uri(& : String? -> Nil) : Nil
+      raise NotImplementedError.new("watch_leader_uri")
     end
 
     # Publish this node's advertised URI as the current leader's URI. Called by
     # the Controller right after `await_leadership` returns.
     def publish_leader_uri(advertised_uri : String) : Nil
+      raise NotImplementedError.new("publish_leader_uri")
     end
 
     # Raised by `start`/`await_leadership` when this node's id is already in use

--- a/src/lavinmq/clustering/etcd_coordinator.cr
+++ b/src/lavinmq/clustering/etcd_coordinator.cr
@@ -14,8 +14,48 @@ module LavinMQ::Clustering
     # (Mutex) over Shared (RWLock). Keeps ElectionLeader a struct: the value is
     # an immutable record, so get returns a safe value-copy.
     @election_leader = Sync::Exclusive(Etcd::ElectionLeader?).new(nil)
+    @lease : Etcd::Lease?
+    @membership_lost = Channel(Nil).new
 
-    def initialize(@config : Config, @etcd : Etcd)
+    # `id` and `advertised_uri` are only needed for the Controller-driven
+    # lifecycle (start/await_leadership); they default so specs that only
+    # exercise campaign/update_isr can construct with just (config, etcd).
+    def initialize(@config : Config, @etcd : Etcd, @id : Int32 = 0, @advertised_uri : String = "")
+    end
+
+    def start : Nil
+      @lease = lease = @etcd.lease_grant(id: @id)
+      # Bridge lease expiry to the membership_lost channel so the Controller can
+      # abort while waiting to enter the ISR.
+      spawn(name: "etcd lease watcher") do
+        lease.expired.receive?
+        @membership_lost.close rescue nil
+      end
+    rescue Etcd::LeaseAlreadyExists
+      raise Coordinator::IdConflict.new("Cluster ID #{@id.to_s(36)} used by another node")
+    end
+
+    def membership_lost : Channel(Nil)
+      @membership_lost
+    end
+
+    def await_leadership : Nil
+      lease = @lease || raise "start must be called before await_leadership"
+      campaign(@advertised_uri, lease.id)
+    end
+
+    def await_leadership_lost : Nil
+      lease = @lease || raise "start must be called before await_leadership_lost"
+      loop do
+        lease.wait(1.hour) # blocks until the lease expires (raises Expired)
+      end
+    rescue Etcd::Lease::Expired
+    end
+
+    def release : Nil
+      @lease.try &.release
+    rescue ex
+      Log.warn(exception: ex) { "Failed to release lease, it will expire on its own" }
     end
 
     # Campaign for leadership and capture the won election as the fencing token
@@ -49,6 +89,19 @@ module LavinMQ::Clustering
       @etcd.watch(isr_key) do |value|
         yield value.try { |raw| parse_isr(raw) }
       end
+    end
+
+    # The leader's advertised URI is published as the election value during
+    # campaign, so observing the election yields the current leader's URI.
+    def watch_leader_uri(&)
+      @etcd.elect_listen(leader_key) do |uri|
+        yield uri
+      end
+    end
+
+    # No-op: the URI was already published as the election value in
+    # `campaign`.
+    def publish_leader_uri(advertised_uri : String) : Nil
     end
 
     private def parse_isr(raw : String) : Set(Int32)

--- a/src/lavinmq/clustering/raft_coordinator.cr
+++ b/src/lavinmq/clustering/raft_coordinator.cr
@@ -383,7 +383,7 @@ module LavinMQ::Clustering
       end
 
       def to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::LittleEndian)
-        io.write_bytes(@kind.value, format)
+        io.write_byte(@kind.value)
         case kind
         in .set_isr?
           io.write_bytes(@isr.size.to_u32, format)
@@ -404,9 +404,7 @@ module LavinMQ::Clustering
           for_isr(isr)
         in .set_leader?
           len = io.read_bytes(UInt16, format)
-          buf = Bytes.new(len)
-          io.read_fully(buf)
-          for_leader(String.new(buf))
+          for_leader(io.read_string(len))
         end
       end
     end
@@ -480,20 +478,18 @@ module LavinMQ::Clustering
           io.write_bytes(uri.bytesize.to_u16, IO::ByteFormat::LittleEndian)
           io.write(uri.to_slice)
           if isr = @isr
-            io.write_bytes(1u8, IO::ByteFormat::LittleEndian)
+            io.write_byte(1u8)
             io.write_bytes(isr.size.to_u32, IO::ByteFormat::LittleEndian)
             isr.each { |id| io.write_bytes(id, IO::ByteFormat::LittleEndian) }
           else
-            io.write_bytes(0u8, IO::ByteFormat::LittleEndian)
+            io.write_byte(0u8)
           end
         end
       end
 
       def restore(io : IO)
         len = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
-        buf = Bytes.new(len)
-        io.read_fully(buf)
-        uri = String.new(buf)
+        uri = io.read_string(len)
         has_isr = io.read_bytes(UInt8, IO::ByteFormat::LittleEndian)
         isr = nil
         if has_isr == 1

--- a/src/lavinmq/clustering/raft_coordinator.cr
+++ b/src/lavinmq/clustering/raft_coordinator.cr
@@ -1,0 +1,403 @@
+require "raft"
+require "./coordinator"
+require "../config"
+require "../bool_channel"
+
+module LavinMQ::Clustering
+  # A Coordinator backed by an embedded Raft group (the `raft` shard) instead of
+  # an external etcd. The replicated state machine stores the ISR set and the
+  # current leader's advertised URI; the replication secret is read from a local
+  # file (`<data_dir>/.replication_secret`), never the Raft log.
+  #
+  # Concurrency: raft.cr's `Raft::Node` is single-threaded — only the driver
+  # fiber may call step/tick/propose/take_messages. Every public method that
+  # needs the node marshals a closure onto that fiber through `@ops`. Reads of
+  # ISR/leader state bypass the node entirely and read the state machine's own
+  # mutex-guarded copy.
+  class RaftCoordinator < Coordinator
+    Log = LavinMQ::Log.for "clustering.raft_coordinator"
+
+    GROUP_ID = 0_u64
+
+    @node : Raft::Node(RaftCommand)
+    @transport : Raft::Transport
+    @ops = Channel(Proc(Raft::Node(RaftCommand), Nil)).new
+    @is_leader = BoolChannel.new(false)
+    @closing = Atomic(Bool).new(false)
+    @tick_interval : Time::Span
+    # Pending "wait until index N is committed+applied" requests. Only touched
+    # on the driver fiber (added by an op, resolved by the loop), so no lock.
+    @commit_waiters = [] of {UInt64, Channel(Symbol)}
+
+    def initialize(@config : Config, @id : Int32, @advertised_uri : String, transport : Raft::Transport? = nil)
+      raft_dir = File.join(@config.data_dir, "raft")
+      Dir.mkdir_p raft_dir
+
+      peers = parse_peers(@config.clustering_raft_peers)
+      peer_ids = peers.map(&.[0]).reject { |pid| pid == @id.to_u64 }
+
+      cfg = Raft::Config.new
+      cfg.data_dir = raft_dir
+
+      @sm = SM.new
+      @node = Raft::Node(RaftCommand).new(
+        id: @id.to_u64,
+        peers: peer_ids,
+        config: cfg,
+        state_machine: @sm,
+        group_id: GROUP_ID,
+        address: "#{@config.clustering_raft_bind}:#{@config.clustering_raft_port}",
+      )
+      @tick_interval = cfg.tick_interval
+
+      @transport = transport || Raft::TCPTransport.new(
+        listen_address: @config.clustering_raft_bind,
+        listen_port: @config.clustering_raft_port,
+        data_dir: raft_dir,
+      )
+      peers.each do |pid, host, port|
+        @transport.register_peer(pid, host, port) unless pid == @id.to_u64
+      end
+
+      # on_role_change runs on the driver fiber — keep it non-blocking.
+      @node.on_role_change do |_old, new_role|
+        @is_leader.set(new_role.leader?)
+      end
+    end
+
+    def start : Nil
+      @transport.register_channel(GROUP_ID, @node.inbox)
+      @transport.start
+      # A node with no configured peers can't hold an election — bootstrap it as
+      # a single-node cluster. On restart the persisted config makes bootstrap a
+      # no-op and the lone voter re-elects itself.
+      @node.bootstrap if @node.peers.empty?
+      spawn(run_loop, name: "raft-coordinator")
+    end
+
+    private def run_loop
+      node = @node
+      transport = @transport
+      loop do
+        select
+        when msg = node.inbox.receive
+          node.step(msg)
+        when op = @ops.receive
+          op.call(node)
+        when timeout(@tick_interval)
+          node.tick
+        end
+        drain_outbox(node, transport)
+        resolve_commit_waiters(node.last_applied)
+        if @closing.get
+          drain_outbox(node, transport) # flush a pending leadership transfer
+          break
+        end
+      rescue Channel::ClosedError
+        break
+      end
+      node.close
+      transport.stop
+    end
+
+    private def drain_outbox(node, transport) : Nil
+      node.take_messages.each do |target_id, msg|
+        transport.outbox.send({target_id, msg})
+      end
+    end
+
+    private def resolve_commit_waiters(applied : UInt64) : Nil
+      @commit_waiters.reject! do |index, ch|
+        if applied >= index
+          ch.send(:committed) rescue nil
+          true
+        else
+          false
+        end
+      end
+    end
+
+    def await_leadership : Nil
+      @is_leader.when_true.receive
+    end
+
+    def await_leadership_lost : Nil
+      @is_leader.when_false.receive
+    end
+
+    def release : Nil
+      return if @closing.swap(true)
+      # Best-effort fast failover: hand leadership to a caught-up voter before
+      # tearing down. The loop flushes the resulting TimeoutNow then exits.
+      @ops.send(->(node : Raft::Node(RaftCommand)) do
+        if node.role.leader?
+          if target = node.voters.find { |p| p.id != node.id }
+            node.transfer_leadership(to: target.id)
+          end
+        end
+        nil
+      end)
+    rescue Channel::ClosedError
+    end
+
+    def update_isr(synced_node_ids : Set(Int32)) : Nil
+      # The driver loop stops consuming @ops once closing, so don't enqueue (it
+      # would block forever). Server#flush_isr treats this like a lost-leadership
+      # and stops once the process exits.
+      raise StaleLeadership.new("Raft node closing") if @closing.get
+      result = Channel(Symbol).new(1)
+      begin
+        @ops.send(->(node : Raft::Node(RaftCommand)) do
+          if !node.role.leader? || !node.propose(RaftCommand.for_isr(synced_node_ids))
+            result.send(:not_leader)
+          else
+            index = node.log.last_index
+            if node.last_applied >= index
+              result.send(:committed)
+            else
+              @commit_waiters << {index, result}
+            end
+          end
+          nil
+        end)
+      rescue Channel::ClosedError
+        raise StaleLeadership.new("Raft node closed")
+      end
+
+      # Block until the ISR write is committed+applied (durable) before
+      # returning, since Server treats a successful return as durable. If
+      # leadership is lost first, raise so Server#flush_isr retries.
+      select
+      when r = result.receive
+        raise StaleLeadership.new("Not the Raft leader") if r == :not_leader
+      when @is_leader.when_false.receive
+        raise StaleLeadership.new("Lost Raft leadership before ISR committed")
+      end
+    end
+
+    def isr : Set(Int32)?
+      @sm.isr
+    end
+
+    def watch_isr(&) : Nil
+      bell = @sm.subscribe_isr
+      begin
+        loop do
+          bell.receive
+          yield @sm.isr
+        end
+      ensure
+        @sm.unsubscribe_isr(bell)
+      end
+    end
+
+    def watch_leader_uri(&) : Nil
+      bell = @sm.subscribe_leader_uri
+      begin
+        loop do
+          bell.receive
+          yield @sm.leader_uri
+        end
+      ensure
+        @sm.unsubscribe_leader_uri(bell)
+      end
+    end
+
+    def publish_leader_uri(advertised_uri : String) : Nil
+      return if @closing.get
+      @ops.send(->(node : Raft::Node(RaftCommand)) do
+        node.propose(RaftCommand.for_leader(@id, advertised_uri))
+        nil
+      end)
+    rescue Channel::ClosedError
+    end
+
+    def password : String
+      path = File.join(@config.data_dir, ".replication_secret")
+      File.read(path).strip
+    rescue File::NotFoundError
+      Log.fatal { "Replication secret file missing: #{path}. Create it (a shared secret) and copy it to every node." }
+      exit 3
+    end
+
+    # Parse "1@host1:5680,2@host2:5680" into [{1, "host1", 5680}, ...].
+    private def parse_peers(raw : String) : Array({UInt64, String, Int32})
+      peers = [] of {UInt64, String, Int32}
+      raw.split(',') do |entry|
+        entry = entry.strip
+        next if entry.empty?
+        id_part, _, addr = entry.partition('@')
+        host, _, port = addr.rpartition(':')
+        peers << {id_part.to_u64, host, port.to_i}
+      end
+      peers
+    end
+
+    # The replicated command: replace the ISR wholesale, or set the leader id +
+    # advertised URI. Both are idempotent full replacements.
+    struct RaftCommand
+      enum Kind : UInt8
+        SetISR    = 0
+        SetLeader = 1
+      end
+
+      getter kind : Kind
+      getter isr : Set(Int32)
+      getter leader_id : Int32
+      getter leader_uri : String
+
+      def initialize(@kind, @isr, @leader_id, @leader_uri)
+      end
+
+      def self.for_isr(isr : Set(Int32)) : self
+        new(Kind::SetISR, isr, 0, "")
+      end
+
+      def self.for_leader(leader_id : Int32, leader_uri : String) : self
+        new(Kind::SetLeader, Set(Int32).new, leader_id, leader_uri)
+      end
+
+      def bytesize : Int32
+        case kind
+        in .set_isr?    then 1 + 4 + 4 * @isr.size
+        in .set_leader? then 1 + 4 + 2 + @leader_uri.bytesize
+        end
+      end
+
+      def to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::LittleEndian)
+        io.write_bytes(@kind.value, format)
+        case kind
+        in .set_isr?
+          io.write_bytes(@isr.size.to_u32, format)
+          @isr.each { |id| io.write_bytes(id, format) }
+        in .set_leader?
+          io.write_bytes(@leader_id, format)
+          io.write_bytes(@leader_uri.bytesize.to_u16, format)
+          io.write(@leader_uri.to_slice)
+        end
+      end
+
+      def self.from_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::LittleEndian) : self
+        kind = Kind.new(io.read_bytes(UInt8, format))
+        case kind
+        in .set_isr?
+          count = io.read_bytes(UInt32, format)
+          isr = Set(Int32).new(count)
+          count.times { isr << io.read_bytes(Int32, format) }
+          for_isr(isr)
+        in .set_leader?
+          leader_id = io.read_bytes(Int32, format)
+          len = io.read_bytes(UInt16, format)
+          buf = Bytes.new(len)
+          io.read_fully(buf)
+          for_leader(leader_id, String.new(buf))
+        end
+      end
+    end
+
+    # The replicated state machine. apply runs on the Raft driver fiber and must
+    # not block; subscriber notification is a non-blocking doorbell ("something
+    # changed, go read the latest"), so updates can't be lost and a slow watcher
+    # can't stall the Raft loop.
+    class SM < Raft::StateMachine(RaftCommand)
+      @lock = Mutex.new
+      @isr : Set(Int32)? = nil # nil until the first SetISR (fresh cluster)
+      @leader_id = 0
+      @leader_uri : String? = nil
+      @isr_bells = [] of Channel(Nil)
+      @uri_bells = [] of Channel(Nil)
+
+      def apply(entry : RaftCommand)
+        case entry.kind
+        in .set_isr?
+          @lock.synchronize { @isr = entry.isr }
+          ring(@isr_bells)
+        in .set_leader?
+          @lock.synchronize { @leader_id = entry.leader_id; @leader_uri = entry.leader_uri }
+          ring(@uri_bells)
+        end
+      end
+
+      def isr : Set(Int32)?
+        @lock.synchronize { @isr.dup }
+      end
+
+      def leader_uri : String?
+        @lock.synchronize { @leader_uri }
+      end
+
+      def subscribe_isr : Channel(Nil)
+        bell = Channel(Nil).new(1)
+        @lock.synchronize { @isr_bells << bell }
+        bell.send(nil) rescue nil # deliver current value immediately
+        bell
+      end
+
+      def unsubscribe_isr(bell : Channel(Nil)) : Nil
+        @lock.synchronize { @isr_bells.delete(bell) }
+      end
+
+      def subscribe_leader_uri : Channel(Nil)
+        bell = Channel(Nil).new(1)
+        @lock.synchronize { @uri_bells << bell }
+        bell.send(nil) rescue nil
+        bell
+      end
+
+      def unsubscribe_leader_uri(bell : Channel(Nil)) : Nil
+        @lock.synchronize { @uri_bells.delete(bell) }
+      end
+
+      private def ring(bells : Array(Channel(Nil))) : Nil
+        @lock.synchronize do
+          bells.each do |bell|
+            select
+            when bell.send(nil)
+            else # already signalled; watcher will read the latest value
+            end
+          end
+        end
+      end
+
+      def snapshot(io : IO)
+        @lock.synchronize do
+          io.write_bytes(@leader_id, IO::ByteFormat::LittleEndian)
+          uri = @leader_uri || ""
+          io.write_bytes(uri.bytesize.to_u16, IO::ByteFormat::LittleEndian)
+          io.write(uri.to_slice)
+          if isr = @isr
+            io.write_bytes(1u8, IO::ByteFormat::LittleEndian)
+            io.write_bytes(isr.size.to_u32, IO::ByteFormat::LittleEndian)
+            isr.each { |id| io.write_bytes(id, IO::ByteFormat::LittleEndian) }
+          else
+            io.write_bytes(0u8, IO::ByteFormat::LittleEndian)
+          end
+        end
+      end
+
+      def restore(io : IO)
+        leader_id = io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
+        len = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
+        buf = Bytes.new(len)
+        io.read_fully(buf)
+        uri = String.new(buf)
+        has_isr = io.read_bytes(UInt8, IO::ByteFormat::LittleEndian)
+        isr = nil
+        if has_isr == 1
+          count = io.read_bytes(UInt32, IO::ByteFormat::LittleEndian)
+          isr = Set(Int32).new(count)
+          count.times { isr << io.read_bytes(Int32, IO::ByteFormat::LittleEndian) }
+        end
+        @lock.synchronize do
+          @leader_id = leader_id
+          @leader_uri = uri.empty? ? nil : uri
+          @isr = isr
+        end
+        ring(@isr_bells)
+        ring(@uri_bells)
+      end
+    end
+
+    class StaleLeadership < Exception; end
+  end
+end

--- a/src/lavinmq/clustering/raft_coordinator.cr
+++ b/src/lavinmq/clustering/raft_coordinator.cr
@@ -25,9 +25,20 @@ module LavinMQ::Clustering
     @is_leader = BoolChannel.new(false)
     @closing = Atomic(Bool).new(false)
     @tick_interval : Time::Span
-    # Pending "wait until index N is committed+applied" requests. Only touched
-    # on the driver fiber (added by an op, resolved by the loop), so no lock.
-    @commit_waiters = [] of {UInt64, Channel(Symbol)}
+    # How long await_leadership_lost rides out a momentary step-down before
+    # treating leadership as truly lost (≈ one election cycle).
+    @election_grace : Time::Span
+    # Closed when this node's coordinator is shutting down, so a follower parked
+    # in wait_to_be_insync can abort.
+    @membership_lost = Channel(Nil).new
+    # Set while this node should (re)publish its advertised URI as the leader's;
+    # the driver loop proposes it until accepted, and clears it. Re-armed on
+    # every leadership acquisition (on_role_change).
+    @want_publish_uri = Atomic(Bool).new(false)
+    # Pending "wait until index N (proposed at term T) is committed+applied"
+    # requests, as {index, term, channel}. Only touched on the driver fiber
+    # (added by an op, resolved/failed by the loop), so no lock.
+    @commit_waiters = [] of {UInt64, UInt64, Channel(Symbol)}
 
     def initialize(@config : Config, @id : Int32, @advertised_uri : String, transport : Raft::Transport? = nil)
       raft_dir = File.join(@config.data_dir, "raft")
@@ -49,6 +60,7 @@ module LavinMQ::Clustering
         address: "#{@config.clustering_raft_bind}:#{@config.clustering_raft_port}",
       )
       @tick_interval = cfg.tick_interval
+      @election_grace = cfg.tick_interval * (cfg.election_timeout_max_ticks + cfg.heartbeat_ticks)
 
       @transport = transport || Raft::TCPTransport.new(
         listen_address: @config.clustering_raft_bind,
@@ -59,9 +71,19 @@ module LavinMQ::Clustering
         @transport.register_peer(pid, host, port) unless pid == @id.to_u64
       end
 
-      # on_role_change runs on the driver fiber — keep it non-blocking.
+      # on_role_change runs on the driver fiber (or, for the bootstrap-leader
+      # transition, on the fiber calling start before the loop spawns) — keep it
+      # non-blocking and don't re-enter the node here.
       @node.on_role_change do |_old, new_role|
         @is_leader.set(new_role.leader?)
+        if new_role.leader?
+          @want_publish_uri.set(true) # (re)advertise our URI once we drive the loop
+        else
+          # We are no longer leader: any in-flight ISR write can't be guaranteed,
+          # so fail every pending waiter (driver fiber only, see @commit_waiters).
+          @want_publish_uri.set(false)
+          fail_commit_waiters
+        end
       end
     end
 
@@ -88,7 +110,8 @@ module LavinMQ::Clustering
           node.tick
         end
         drain_outbox(node, transport)
-        resolve_commit_waiters(node.last_applied)
+        resolve_commit_waiters(node)
+        maybe_publish_leader_uri(node)
         if @closing.get
           drain_outbox(node, transport) # flush a pending leadership transfer
           break
@@ -96,6 +119,14 @@ module LavinMQ::Clustering
       rescue Channel::ClosedError
         break
       end
+      # Stop receiving ops and unblock anything still waiting: closing @ops makes
+      # a sender blocked on the unbuffered rendezvous raise ClosedError (which
+      # every op-enqueuing method rescues) instead of hanging forever; failing
+      # the commit waiters releases any update_isr parked on its result; closing
+      # membership_lost aborts a follower parked in wait_to_be_insync.
+      @ops.close
+      fail_commit_waiters
+      @membership_lost.close rescue nil
       node.close
       transport.stop
     end
@@ -106,15 +137,37 @@ module LavinMQ::Clustering
       end
     end
 
-    private def resolve_commit_waiters(applied : UInt64) : Nil
-      @commit_waiters.reject! do |index, ch|
-        if applied >= index
-          ch.send(:committed) rescue nil
-          true
-        else
-          false
-        end
+    private def resolve_commit_waiters(node) : Nil
+      return if @commit_waiters.empty?
+      applied = node.last_applied
+      @commit_waiters.reject! do |index, term, ch|
+        next false if applied < index
+        # The entry at `index` has been applied; confirm it's still OUR entry. A
+        # new leader can overwrite an uncommitted index after we stepped down, so
+        # only a matching term proves the ISR write we proposed actually carried.
+        committed = node.log.term_at(index) == term
+        ch.send(committed ? :committed : :lost) rescue nil
+        true
       end
+    end
+
+    # Release every pending ISR waiter as lost (no longer leader / shutting
+    # down). Driver-fiber only.
+    private def fail_commit_waiters : Nil
+      return if @commit_waiters.empty?
+      @commit_waiters.each { |_index, _term, ch| ch.send(:lost) rescue nil }
+      @commit_waiters.clear
+    end
+
+    # Publish our advertised URI while we're leader, retrying each loop iteration
+    # until a proposal is accepted, then clear the flag. Coupling publication to
+    # leadership (re-armed by on_role_change) closes the window where a node
+    # serves as leader but no leader URI was ever committed.
+    private def maybe_publish_leader_uri(node) : Nil
+      return if @closing.get
+      return unless @want_publish_uri.get
+      return unless node.role.leader?
+      @want_publish_uri.set(false) if node.propose(RaftCommand.for_leader(@advertised_uri))
     end
 
     def await_leadership : Nil
@@ -122,7 +175,24 @@ module LavinMQ::Clustering
     end
 
     def await_leadership_lost : Nil
-      @is_leader.when_false.receive
+      # Raft can briefly step a leader down (e.g. a higher-term heartbeat) and
+      # then re-win; treat leadership as lost only if it isn't regained within a
+      # grace window, so a momentary flap doesn't kill the process. This is safe
+      # because update_isr independently gates durability on node.role.leader?,
+      # so nothing is acknowledged while we're transiently not the leader.
+      loop do
+        @is_leader.when_false.receive
+        select
+        when @is_leader.when_true.receive
+          next # regained leadership, keep serving
+        when timeout(@election_grace)
+          return # durably lost
+        end
+      end
+    end
+
+    def membership_lost : Channel(Nil)
+      @membership_lost
     end
 
     def release : Nil
@@ -152,10 +222,11 @@ module LavinMQ::Clustering
             result.send(:not_leader)
           else
             index = node.log.last_index
-            if node.last_applied >= index
+            term = node.current_term
+            if node.last_applied >= index && node.log.term_at(index) == term
               result.send(:committed)
             else
-              @commit_waiters << {index, result}
+              @commit_waiters << {index, term, result}
             end
           end
           nil
@@ -165,11 +236,12 @@ module LavinMQ::Clustering
       end
 
       # Block until the ISR write is committed+applied (durable) before
-      # returning, since Server treats a successful return as durable. If
-      # leadership is lost first, raise so Server#flush_isr retries.
+      # returning, since Server treats a successful return as durable. Anything
+      # other than :committed (not leader, or the entry was discarded after a
+      # leadership change) raises so Server#flush_isr retries.
       select
       when r = result.receive
-        raise StaleLeadership.new("Not the Raft leader") if r == :not_leader
+        raise StaleLeadership.new("ISR write not committed (#{r})") unless r == :committed
       when @is_leader.when_false.receive
         raise StaleLeadership.new("Lost Raft leadership before ISR committed")
       end
@@ -204,12 +276,12 @@ module LavinMQ::Clustering
     end
 
     def publish_leader_uri(advertised_uri : String) : Nil
-      return if @closing.get
-      @ops.send(->(node : Raft::Node(RaftCommand)) do
-        node.propose(RaftCommand.for_leader(@id, advertised_uri))
-        nil
-      end)
-    rescue Channel::ClosedError
+      # The advertised URI is fixed at construction (@advertised_uri), so just
+      # arm the flag; the driver loop publishes it while we're leader and retries
+      # until a proposal is accepted. on_role_change also arms it on every
+      # leadership acquisition, so the URI is published even without this call —
+      # there is no window where we lead but never advertise.
+      @want_publish_uri.set(true) unless @closing.get
     end
 
     def password : String
@@ -220,20 +292,40 @@ module LavinMQ::Clustering
       exit 3
     end
 
-    # Parse "1@host1:5680,2@host2:5680" into [{1, "host1", 5680}, ...].
+    # Parse "1@host1:5680,2@host2:5680" into [{1, "host1", 5680}, ...]. IPv6
+    # hosts must be bracketed: "3@[::1]:5680". Raises ArgumentError with the
+    # offending entry on malformed input rather than crashing with an opaque
+    # error deep in construction.
     private def parse_peers(raw : String) : Array({UInt64, String, Int32})
       peers = [] of {UInt64, String, Int32}
       raw.split(',') do |entry|
         entry = entry.strip
         next if entry.empty?
-        id_part, _, addr = entry.partition('@')
-        host, _, port = addr.rpartition(':')
-        peers << {id_part.to_u64, host, port.to_i}
+        id_part, sep, addr = entry.partition('@')
+        raise ArgumentError.new("Invalid raft peer #{entry.inspect}, expected id@host:port") if sep.empty? || addr.empty?
+        id = id_part.to_u64? || raise ArgumentError.new("Invalid raft peer id in #{entry.inspect}")
+        host, port = parse_host_port(addr, entry)
+        peers << {id, host, port}
       end
       peers
     end
 
-    # The replicated command: replace the ISR wholesale, or set the leader id +
+    private def parse_host_port(addr : String, entry : String) : {String, Int32}
+      if addr.starts_with?('[') # bracketed IPv6: [::1]:5680
+        close = addr.index(']') || raise ArgumentError.new("Unterminated IPv6 address in raft peer #{entry.inspect}")
+        host = addr[1...close]
+        rest = addr[(close + 1)..]
+        raise ArgumentError.new("Missing port in raft peer #{entry.inspect}") unless rest.starts_with?(':')
+        port_part = rest[1..]
+      else
+        host, sep, port_part = addr.rpartition(':')
+        raise ArgumentError.new("Missing port in raft peer #{entry.inspect}") if sep.empty? || host.empty?
+      end
+      port = port_part.to_i? || raise ArgumentError.new("Invalid port in raft peer #{entry.inspect}")
+      {host, port}
+    end
+
+    # The replicated command: replace the ISR wholesale, or set the leader's
     # advertised URI. Both are idempotent full replacements.
     struct RaftCommand
       enum Kind : UInt8
@@ -243,24 +335,23 @@ module LavinMQ::Clustering
 
       getter kind : Kind
       getter isr : Set(Int32)
-      getter leader_id : Int32
       getter leader_uri : String
 
-      def initialize(@kind, @isr, @leader_id, @leader_uri)
+      def initialize(@kind, @isr, @leader_uri)
       end
 
       def self.for_isr(isr : Set(Int32)) : self
-        new(Kind::SetISR, isr, 0, "")
+        new(Kind::SetISR, isr, "")
       end
 
-      def self.for_leader(leader_id : Int32, leader_uri : String) : self
-        new(Kind::SetLeader, Set(Int32).new, leader_id, leader_uri)
+      def self.for_leader(leader_uri : String) : self
+        new(Kind::SetLeader, Set(Int32).new, leader_uri)
       end
 
       def bytesize : Int32
         case kind
         in .set_isr?    then 1 + 4 + 4 * @isr.size
-        in .set_leader? then 1 + 4 + 2 + @leader_uri.bytesize
+        in .set_leader? then 1 + 2 + @leader_uri.bytesize
         end
       end
 
@@ -271,7 +362,6 @@ module LavinMQ::Clustering
           io.write_bytes(@isr.size.to_u32, format)
           @isr.each { |id| io.write_bytes(id, format) }
         in .set_leader?
-          io.write_bytes(@leader_id, format)
           io.write_bytes(@leader_uri.bytesize.to_u16, format)
           io.write(@leader_uri.to_slice)
         end
@@ -286,11 +376,10 @@ module LavinMQ::Clustering
           count.times { isr << io.read_bytes(Int32, format) }
           for_isr(isr)
         in .set_leader?
-          leader_id = io.read_bytes(Int32, format)
           len = io.read_bytes(UInt16, format)
           buf = Bytes.new(len)
           io.read_fully(buf)
-          for_leader(leader_id, String.new(buf))
+          for_leader(String.new(buf))
         end
       end
     end
@@ -302,7 +391,6 @@ module LavinMQ::Clustering
     class SM < Raft::StateMachine(RaftCommand)
       @lock = Mutex.new
       @isr : Set(Int32)? = nil # nil until the first SetISR (fresh cluster)
-      @leader_id = 0
       @leader_uri : String? = nil
       @isr_bells = [] of Channel(Nil)
       @uri_bells = [] of Channel(Nil)
@@ -313,7 +401,7 @@ module LavinMQ::Clustering
           @lock.synchronize { @isr = entry.isr }
           ring(@isr_bells)
         in .set_leader?
-          @lock.synchronize { @leader_id = entry.leader_id; @leader_uri = entry.leader_uri }
+          @lock.synchronize { @leader_uri = entry.leader_uri }
           ring(@uri_bells)
         end
       end
@@ -361,7 +449,6 @@ module LavinMQ::Clustering
 
       def snapshot(io : IO)
         @lock.synchronize do
-          io.write_bytes(@leader_id, IO::ByteFormat::LittleEndian)
           uri = @leader_uri || ""
           io.write_bytes(uri.bytesize.to_u16, IO::ByteFormat::LittleEndian)
           io.write(uri.to_slice)
@@ -376,7 +463,6 @@ module LavinMQ::Clustering
       end
 
       def restore(io : IO)
-        leader_id = io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
         len = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
         buf = Bytes.new(len)
         io.read_fully(buf)
@@ -389,7 +475,6 @@ module LavinMQ::Clustering
           count.times { isr << io.read_bytes(Int32, IO::ByteFormat::LittleEndian) }
         end
         @lock.synchronize do
-          @leader_id = leader_id
           @leader_uri = uri.empty? ? nil : uri
           @isr = isr
         end

--- a/src/lavinmq/clustering/raft_coordinator.cr
+++ b/src/lavinmq/clustering/raft_coordinator.cr
@@ -31,6 +31,10 @@ module LavinMQ::Clustering
     # Closed when this node's coordinator is shutting down, so a follower parked
     # in wait_to_be_insync can abort.
     @membership_lost = Channel(Nil).new
+    # Closed by release so a leader parked in await_leadership_lost wakes up and
+    # lets Controller#run finish its cleanup on a graceful/programmatic stop
+    # (raft has no lease whose expiry would otherwise wake it).
+    @released = Channel(Nil).new
     # Set while this node should (re)publish its advertised URI as the leader's;
     # the driver loop proposes it until accepted, and clears it. Re-armed on
     # every leadership acquisition (on_role_change).
@@ -180,11 +184,20 @@ module LavinMQ::Clustering
       # grace window, so a momentary flap doesn't kill the process. This is safe
       # because update_isr independently gates durability on node.role.leader?,
       # so nothing is acknowledged while we're transiently not the leader.
+      # `release` (graceful stop) closes @released to return immediately, since
+      # there's no lease expiry to wake us as in the etcd backend.
       loop do
-        @is_leader.when_false.receive
+        select
+        when @is_leader.when_false.receive
+          # leadership lost — possibly a transient flap, fall through to grace
+        when @released.receive?
+          return
+        end
         select
         when @is_leader.when_true.receive
           next # regained leadership, keep serving
+        when @released.receive?
+          return
         when timeout(@election_grace)
           return # durably lost
         end
@@ -197,6 +210,7 @@ module LavinMQ::Clustering
 
     def release : Nil
       return if @closing.swap(true)
+      @released.close rescue nil # wake await_leadership_lost so the stop completes
       # Best-effort fast failover: hand leadership to a caught-up voter before
       # tearing down. The loop flushes the resulting TimeoutNow then exits.
       @ops.send(->(node : Raft::Node(RaftCommand)) do
@@ -268,11 +282,24 @@ module LavinMQ::Clustering
       begin
         loop do
           bell.receive
-          yield @sm.leader_uri
+          yield current_leader_uri
         end
       ensure
         @sm.unsubscribe_leader_uri(bell)
       end
+    end
+
+    # The leader URI to report to watchers. A persisted SetLeader survives a
+    # restart, and subscribe delivers it immediately; if it still points at us
+    # but we're no longer the leader it's stale (we led before restarting), so
+    # report no leader until a fresh election publishes one. Otherwise
+    # follow_leader would see our own URI, fail the 1s self-URI check and abort
+    # as a duplicate. Mirrors etcd, whose lease-bound election value simply
+    # vanishes when the old leader dies.
+    private def current_leader_uri : String?
+      uri = @sm.leader_uri
+      return nil if uri == @advertised_uri && !@is_leader.value
+      uri
     end
 
     def publish_leader_uri(advertised_uri : String) : Nil

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -1,6 +1,7 @@
 require "log"
 require "../auth/password"
 require "../amqp/exchange/consistent_hash_algorithm"
+require "../clustering/backend"
 require "../ip_matcher"
 require "../http/constants"
 
@@ -291,6 +292,11 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_CLUSTERING")]
       property? clustering = false
 
+      @[CliOpt("", "--clustering-backend=BACKEND", "Coordination backend: etcd or raft (default: etcd)", ->ClusteringBackend.parse(String), section: "clustering")]
+      @[IniOpt(ini_name: backend, section: "clustering", transform: ->ClusteringBackend.parse(String))]
+      @[EnvOpt("LAVINMQ_CLUSTERING_BACKEND", ->ClusteringBackend.parse(String))]
+      property clustering_backend : ClusteringBackend = ClusteringBackend::Etcd
+
       @[CliOpt("", "--clustering-advertised-uri=URI", "Advertised URI for the clustering server", section: "clustering")]
       @[IniOpt(ini_name: advertised_uri, section: "clustering")]
       @[EnvOpt("LAVINMQ_CLUSTERING_ADVERTISED_URI")]
@@ -310,6 +316,31 @@ module LavinMQ
       @[IniOpt(ini_name: etcd_prefix, section: "clustering")]
       @[EnvOpt("LAVINMQ_CLUSTERING_ETCD_PREFIX")]
       property clustering_etcd_prefix = "lavinmq"
+
+      # Raft backend: comma-separated id@host:port for every node (including
+      # self), where id is a small, cluster-wide unique integer used as both the
+      # Raft node id and the LavinMQ clustering id.
+      @[CliOpt("", "--clustering-raft-peers=PEERS", "Raft backend: comma separated id@host:port for all nodes", section: "clustering")]
+      @[IniOpt(ini_name: raft_peers, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_RAFT_PEERS")]
+      property clustering_raft_peers = ""
+
+      # This node's Raft id (and clustering id). Must match its entry in
+      # clustering_raft_peers.
+      @[CliOpt("", "--clustering-raft-node-id=ID", "Raft backend: this node's id", section: "clustering")]
+      @[IniOpt(ini_name: raft_node_id, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_RAFT_NODE_ID")]
+      property clustering_raft_node_id = 0
+
+      @[CliOpt("", "--clustering-raft-bind=BIND", "Raft backend: transport listen address (default: 127.0.0.1)", section: "clustering")]
+      @[IniOpt(ini_name: raft_bind, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_RAFT_BIND")]
+      property clustering_raft_bind = "127.0.0.1"
+
+      @[CliOpt("", "--clustering-raft-port=PORT", "Raft backend: transport listen port (default: 5680)", section: "clustering")]
+      @[IniOpt(ini_name: raft_port, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_RAFT_PORT")]
+      property clustering_raft_port = 5680
 
       # Deprecated: still accepted (CLI/INI/ENV) so existing configs don't break,
       # but has no effect. The follower ack buffer is a fixed size now and how far

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -9,7 +9,6 @@ require "./data_dir_lock"
 require "./pidfile"
 require "./etcd"
 require "./clustering/controller"
-require "./clustering/etcd_coordinator"
 require "./standalone_runner"
 require "./definitions"
 require "../stdlib/openssl_on_server_name"
@@ -40,10 +39,8 @@ module LavinMQ
       end
 
       if @config.clustering?
-        etcd = Etcd.new(@config.clustering_etcd_endpoints)
-        coordinator = Clustering::EtcdCoordinator.new(@config, etcd)
-        @runner = controller = Clustering::Controller.new(@config, etcd, coordinator)
-        @replicator = Clustering::Server.new(@config, coordinator, controller.id)
+        @runner = controller = Clustering::Controller.new(@config)
+        @replicator = Clustering::Server.new(@config, controller.coordinator, controller.id)
       else
         @runner = StandaloneRunner.new
       end


### PR DESCRIPTION
Adds an embedded **Raft** coordination backend (the `raft.cr` shard) as an alternative to the external **etcd** cluster for leader election, ISR tracking and leader-URI advertisement. Selected via `clustering.backend = etcd|raft`. No external dependency in `raft` mode; the replication secret is read from `<data_dir>/.replication_secret` (Erlang-cookie style), never the Raft log.

## What's in here

- `Clustering::Coordinator` abstraction over etcd vs embedded Raft, wired through `Controller`/`Server`/`Launcher`.
- `RaftCoordinator`: single driver-fiber `Raft::Node`, replicated state machine storing the ISR set + leader URI, term-checked commit-wait for durable ISR writes, leader-URI publication coupled to leadership acquisition.
- New config: `backend`, `raft_peers` (`id@host:port`, IPv6 bracketed), `raft_node_id`, `raft_bind`, `raft_port`. Docs + `extras/lavinmq.ini` updated.

## Review hardening (commits 2–3)

Two review passes on the coordinator are folded in:

- Shutdown deadlock on the unbuffered `@ops` channel; term-less commit-wait that could report a discarded ISR write as durable; fire-and-forget leader-URI publish; `parse_peers` crashes / IPv6; unbounded `@commit_waiters` leak; exit-on-transient-flap; restored `Etcd::LeaseNotFound` handling; `membership_lost` never firing; dead `leader_id` wire field; silent no-op base-class defaults.
- **Graceful-stop hang** — `await_leadership_lost` never returned on `release` (no lease expiry to wake it), so `Controller#run` parked forever and launcher cleanup was skipped.
- **Stale leader URI on restart** — a former leader replayed its own persisted URI before re-election, tripping `follow_leader`'s self-URI duplicate check (`exit 36`).

## Testing

- New `spec/clustering/raft_coordinator_spec.cr` (single-node, multi-node failover, restart, config validation, not-leader, graceful-stop, stale-URI-after-restart — the last verified to fail without its fix).
- `spec/clustering_spec.cr` (21) and `spec/clustering/isr_spec.cr` (10) green; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)