### PR TITLE
Use f_frsize for disk sizes on Linux

### DIFF
--- a/spec/filesystem_spec.cr
+++ b/spec/filesystem_spec.cr
@@ -1,0 +1,45 @@
+require "spec"
+require "../src/stdlib/filesystem"
+
+describe FilesystemInfo do
+  # Real statfs64 against the OS; only diverges from the bug on virtiofs/NFS
+  # mounts. The deterministic specs below guard the regression everywhere.
+  it "matches df for the current filesystem" do
+    path = Dir.current
+    df = `df -P -k #{path}`.lines.last.split
+    df_total = df[1].to_u64 * 1024
+    df_available = df[3].to_u64 * 1024
+
+    info = Filesystem.info(path)
+    info.total.should eq df_total
+    # free space can change between the two measurements
+    info.available.should be_close(df_available, df_total // 100)
+  end
+
+  {% if flag?(:linux) %}
+    # Block counts are in f_frsize units; bsize is the (larger) transfer size.
+    it "scales block counts by f_frsize, not f_bsize" do
+      statfs = uninitialized LibC::Statfs
+      statfs.blocks = 1000_u64
+      statfs.bavail = 400_u64
+      statfs.frsize = 4096_i64
+      statfs.bsize = 1048576_i64
+
+      info = FilesystemInfo.new(statfs)
+      info.total.should eq 1000_u64 * 4096
+      info.available.should eq 400_u64 * 4096
+    end
+
+    it "falls back to f_bsize when f_frsize is zero" do
+      statfs = uninitialized LibC::Statfs
+      statfs.blocks = 1000_u64
+      statfs.bavail = 400_u64
+      statfs.frsize = 0_i64
+      statfs.bsize = 4096_i64
+
+      info = FilesystemInfo.new(statfs)
+      info.total.should eq 1000_u64 * 4096
+      info.available.should eq 400_u64 * 4096
+    end
+  {% end %}
+end

--- a/src/stdlib/filesystem.cr
+++ b/src/stdlib/filesystem.cr
@@ -78,8 +78,19 @@ end
 
 struct FilesystemInfo
   def initialize(statfs : LibC::Statfs)
-    @available = statfs.bavail.to_u64 * statfs.bsize
-    @total = statfs.blocks.to_u64 * statfs.bsize
+    block_size = block_size(statfs)
+    @available = statfs.bavail.to_u64 * block_size
+    @total = statfs.blocks.to_u64 * block_size
+  end
+
+  # Linux counts blocks in f_frsize units; bsize is the transfer size,
+  # 1 MiB on virtiofs/NFS, which would inflate sizes 256x.
+  private def block_size(statfs : LibC::Statfs)
+    {% if flag?(:linux) %}
+      statfs.frsize.zero? ? statfs.bsize : statfs.frsize
+    {% else %}
+      statfs.bsize
+    {% end %}
   end
 
   # Bytes available to non-privileged on disk


### PR DESCRIPTION
statfs(2) on Linux counts blocks in f_frsize units; f_bsize is only the optimal transfer size. They are equal on local filesystems, but virtiofs (Docker bind mounts) and NFS report a 1 MiB transfer size with 4 KiB fragments, inflating disk_total/disk_free 256x in the dashboard. Darwin is unaffected, its f_bsize is the fundamental block size.

Fixes #2054