### PR TITLE
Consistent and simpler depreciation handling in config

### DIFF
--- a/spec/deprecated_config_spec.cr
+++ b/spec/deprecated_config_spec.cr
@@ -45,26 +45,54 @@ module LavinMQ
       {% end %}
     end
 
-    # Returns names of all instance variables marked as deprecated (via CliOpt or IniOpt)
-    def self.deprecated_option_names : Set(String)
+    # Returns names of deprecated options (CliOpt or IniOpt) that forward to a
+    # replacement, i.e. that define a setter. Options deprecated without a
+    # replacement define no setter and are excluded. Uses the same `has_method?`
+    # predicate the parser uses to decide whether to forward.
+    def self.forwarded_deprecated_names : Set(String)
       {% begin %}
-        Set{
-          {% for ivar in @type.instance_vars %}
-            {% if (ivar.annotation(IniOpt) && ivar.annotation(IniOpt)[:deprecated]) ||
-                    (ivar.annotation(CliOpt) && ivar.annotation(CliOpt)[:deprecated]) %}
-              {{ivar.name.stringify}},
-            {% end %}
-          {% end %}
-        }
+        {%
+          vars = @type.instance_vars.select do |ivar|
+            ((ivar.annotation(IniOpt) && ivar.annotation(IniOpt)[:deprecated]) ||
+              (ivar.annotation(CliOpt) && ivar.annotation(CliOpt)[:deprecated])) &&
+              @type.has_method?("#{ivar.name}=")
+          end
+        %}
+        {% if vars.empty? %}
+          Set(String).new
+        {% else %}
+          Set{ {{ vars.map(&.name.stringify).splat }} }
+        {% end %}
+      {% end %}
+    end
+
+    # Returns names of deprecated options that expose a getter. Deprecated options
+    # must not have a getter (to avoid accidentally reading the stale value), so
+    # this should always be empty.
+    def self.deprecated_getters : Set(String)
+      {% begin %}
+        {%
+          vars = @type.instance_vars.select do |ivar|
+            ((ivar.annotation(IniOpt) && ivar.annotation(IniOpt)[:deprecated]) ||
+              (ivar.annotation(CliOpt) && ivar.annotation(CliOpt)[:deprecated])) &&
+              @type.has_method?(ivar.name.stringify)
+          end
+        %}
+        {% if vars.empty? %}
+          Set(String).new
+        {% else %}
+          Set{ {{ vars.map(&.name.stringify).splat }} }
+        {% end %}
       {% end %}
     end
   end
 end
 
 # Deprecated option forwarding map.
-# Each entry maps a deprecated ivar name to its forwarding target and a test value.
-# If a new deprecated annotation is added without an entry here, the
-# completeness check will fail.
+# Each entry maps a deprecated ivar name (one that forwards to a replacement via a
+# setter) to its forwarding target and a test value. Deprecated options with no
+# replacement (no setter) are intentionally excluded. If a new forwarding deprecated
+# annotation is added without an entry here, the completeness check will fail.
 DEPRECATED_FORWARDS = {
   "default_password"               => {target: "default_password_hash", value: "8Yw8kj5HkhfRxQ/3kbTAO/nmgqGpkvMsGDbUWXA6+jTF3JP3"},
   "guest_only_loopback"            => {target: "default_user_only_loopback", value: "false"},
@@ -78,8 +106,12 @@ DEPRECATED_FORWARDS = {
 }
 
 describe LavinMQ::Config, "deprecated options" do
-  it "has entries in DEPRECATED_FORWARDS for all deprecated options" do
-    LavinMQ::Config.deprecated_option_names.should eq DEPRECATED_FORWARDS.keys.to_set
+  it "has entries in DEPRECATED_FORWARDS for all forwarding deprecated options" do
+    LavinMQ::Config.forwarded_deprecated_names.should eq DEPRECATED_FORWARDS.keys.to_set
+  end
+
+  it "exposes no getter for deprecated options" do
+    LavinMQ::Config.deprecated_getters.should be_empty
   end
 
   it "forwards all deprecated INI options to their replacements" do
@@ -142,6 +174,36 @@ describe LavinMQ::Config, "deprecated options" do
       io = IO::Memory.new
       config = LavinMQ::Config.new(io)
       config.parse([clean_flag, value])
+      io.to_s.should match(/deprecated/i)
+    end
+  end
+
+  # Options that are deprecated without a replacement (no setter) must still be
+  # accepted and warned about, but their value is dropped rather than forwarded.
+  it "warns for deprecated INI options without a replacement without error" do
+    ini_info = LavinMQ::Config.deprecated_ini_info
+    ini_info.each do |deprecated, (section, key)|
+      next if DEPRECATED_FORWARDS[deprecated]?
+      config_file = File.tempfile do |file|
+        file.print "[#{section}]\n#{key} = 1"
+      end
+      io = IO::Memory.new
+      config = LavinMQ::Config.new(io)
+      config.parse(["-c", config_file.path])
+      io.to_s.should match(/deprecated/i)
+    ensure
+      config_file.try &.delete
+    end
+  end
+
+  it "warns for deprecated CLI options without a replacement without error" do
+    cli_info = LavinMQ::Config.deprecated_cli_info
+    cli_info.each do |deprecated, flag|
+      next if DEPRECATED_FORWARDS[deprecated]?
+      clean_flag = flag.split("=").first
+      io = IO::Memory.new
+      config = LavinMQ::Config.new(io)
+      config.parse([clean_flag, "1"])
       io.to_s.should match(/deprecated/i)
     end
   end

--- a/spec/deprecated_config_spec.cr
+++ b/spec/deprecated_config_spec.cr
@@ -49,40 +49,32 @@ module LavinMQ
     # replacement, i.e. that define a setter. Options deprecated without a
     # replacement define no setter and are excluded. Uses the same `has_method?`
     # predicate the parser uses to decide whether to forward.
-    def self.forwarded_deprecated_names : Set(String)
+    def self.forwarded_deprecated_names
       {% begin %}
         {%
           vars = @type.instance_vars.select do |ivar|
             ((ivar.annotation(IniOpt) && ivar.annotation(IniOpt)[:deprecated]) ||
               (ivar.annotation(CliOpt) && ivar.annotation(CliOpt)[:deprecated])) &&
               @type.has_method?("#{ivar.name}=")
-          end
+          end.uniq
         %}
-        {% if vars.empty? %}
-          Set(String).new
-        {% else %}
-          Set{ {{ vars.map(&.name.stringify).splat }} }
-        {% end %}
+        Tuple.new({{ vars.map(&.name.stringify).sort.splat }})
       {% end %}
     end
 
     # Returns names of deprecated options that expose a getter. Deprecated options
     # must not have a getter (to avoid accidentally reading the stale value), so
     # this should always be empty.
-    def self.deprecated_getters : Set(String)
+    def self.deprecated_getters
       {% begin %}
         {%
           vars = @type.instance_vars.select do |ivar|
             ((ivar.annotation(IniOpt) && ivar.annotation(IniOpt)[:deprecated]) ||
               (ivar.annotation(CliOpt) && ivar.annotation(CliOpt)[:deprecated])) &&
               @type.has_method?(ivar.name.stringify)
-          end
+          end.uniq
         %}
-        {% if vars.empty? %}
-          Set(String).new
-        {% else %}
-          Set{ {{ vars.map(&.name.stringify).splat }} }
-        {% end %}
+        Tuple.new({{ vars.map(&.name.stringify).sort.splat }})
       {% end %}
     end
   end
@@ -107,7 +99,10 @@ DEPRECATED_FORWARDS = {
 
 describe LavinMQ::Config, "deprecated options" do
   it "has entries in DEPRECATED_FORWARDS for all forwarding deprecated options" do
-    LavinMQ::Config.forwarded_deprecated_names.should eq DEPRECATED_FORWARDS.keys.to_set
+    {% begin %}
+      {% expected = DEPRECATED_FORWARDS.keys.sort.splat %}
+      LavinMQ::Config.forwarded_deprecated_names.should eq Tuple.new({{ expected }})
+    {% end %}
   end
 
   it "exposes no getter for deprecated options" do

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -82,6 +82,22 @@ module LavinMQ
       parser.parse(argv.dup)
     end
 
+    # Assigns a parsed option value to its property. When `message` is present the
+    # option is deprecated: the message is printed verbatim and the value is
+    # forwarded only if the (getter-less) deprecated property defines a setter.
+    # An option with no replacement defines no setter, so its value is dropped
+    # after the warning. Shared by `parse_cli` and `parse_section`.
+    private macro assign_option(var_name, value, transform, message)
+      {% if message %}
+        @io.puts "WARNING: {{message.id}}"
+        {% if @type.has_method?("#{var_name.id}=") %}
+          self.{{var_name.id}} = parse_value({{value}}, {{transform}})
+        {% end %}
+      {% else %}
+        self.{{var_name.id}} = parse_value({{value}}, {{transform}})
+      {% end %}
+    end
+
     private def parse_env
       {% for ivar in @type.instance_vars.select(&.annotation(EnvOpt)) %}
         {% for ann in ivar.annotations(EnvOpt) %}
@@ -120,10 +136,7 @@ module LavinMQ
           # Create Option object with CLI args and a block that parses and stores the value
           # when the option is encountered during command line parsing
           sections[:{{section_id}}][:options] << Option.new({{parser_arg.splat}}) do |value|
-            {% if cli_opt[:deprecated] %}
-              @io.puts "WARNING: {{cli_opt[:deprecated].id}}"
-            {% end %}
-            self.{{ivar.name.id}} = parse_value(value, {{value_parser}})
+            assign_option({{ivar.name}}, value, {{value_parser}}, {{cli_opt[:deprecated]}})
           end
         {% end %}
         sections.each do |_section_id, section|
@@ -235,17 +248,14 @@ module LavinMQ
         end
     %}
 
-    # Generate a case branch for each INI setting in this section.
-    # If a setting is marked as deprecated, look up the replacement instance variable
-    # and redirect the value assignment to it instead, logging a deprecation warning.
+    # Generate a case branch for each INI setting in this section. Deprecated
+    # settings carry a verbatim warning message and are handled by `assign_option`,
+    # which forwards the value to the replacement when a setter exists.
     settings.each do |name, v|
       case name
         {% for var in ivars_in_section %}
-         when "{{var[:ini_name]}}"
-         {% if (deprecated = var[:deprecated]) %}
-           @io.puts "WARNING: Config {{var[:ini_name]}} is deprecated, use {{deprecated.id}} instead"
-         {% end %}
-         self.{{var[:var_name]}} = parse_value(v, {{var[:transform]}})
+          when "{{var[:ini_name]}}"
+            assign_option({{var[:var_name]}}, v, {{var[:transform]}}, {{var[:deprecated]}})
         {% end %}
      else
        @io.puts "WARNING: Unknown setting '#{name}' in section [{{section.id}}]"

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -82,14 +82,17 @@ module LavinMQ
       parser.parse(argv.dup)
     end
 
-    # Assigns a parsed option value to its property. When `message` is present the
-    # option is deprecated: the message is printed verbatim and the value is
-    # forwarded only if the (getter-less) deprecated property defines a setter.
-    # An option with no replacement defines no setter, so its value is dropped
-    # after the warning. Shared by `parse_cli` and `parse_section`.
-    private macro assign_option(var_name, value, transform, message)
-      {% if message %}
-        @io.puts "WARNING: {{message.id}}"
+    # Assigns a parsed option value to its property. When `deprecation_message` is
+    # present the option is deprecated: the message is printed verbatim and the
+    # value is forwarded only if the (getter-less) deprecated property defines a
+    # setter. An option with no replacement defines no setter, so its value is
+    # dropped after the warning. Shared by `parse_cli` and `parse_section`.
+    private macro assign_option(var_name, value, transform, deprecation_message)
+      {% if deprecation_message %}
+        @io.puts "WARNING: {{deprecation_message.id}}"
+        # Since deprecation_message is set, the variable is deprecated. It may
+        # be forwarded to another variable using a setter, but it may also be
+        # completley removed, therefore we need to check for a setter.
         {% if @type.has_method?("#{var_name.id}=") %}
           self.{{var_name.id}} = parse_value({{value}}, {{transform}})
         {% end %}

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -6,8 +6,105 @@ require "../http/constants"
 
 module LavinMQ
   class Config
+    # Marks a config property as settable from a command-line argument.
+    #
+    # Positional arguments (in order):
+    # 1. short flag with optional value placeholder, e.g. `"-p PORT"`
+    #    (use `""` when the option has no short flag)
+    # 2. long flag with optional value placeholder, e.g. `"--amqp-port=PORT"`
+    # 3. description shown in `--help`
+    # 4. *optional* `Proc(String, T)` that converts the raw argument to the
+    #    property's type. When omitted, the property's own type is used and the
+    #    value is converted by the matching `Config#parse_value` overload.
+    #
+    # Named arguments:
+    # - `section:` groups the flag under a heading in `--help`, one of
+    #   `"options"`, `"bindings"`, `"tls"` or `"clustering"`. Defaults to `"options"`.
+    # - `deprecated:` a complete warning message, printed verbatim, when the flag
+    #   is used. To forward the old value to a replacement, define a setter (and no
+    #   getter) on the deprecated property; an option with no replacement defines no
+    #   setter and its value is dropped after the warning.
+    #
+    # Parsed by `Config#parse_cli`. CLI args take precedence over `EnvOpt` and `IniOpt`.
+    #
+    # ```
+    # @[CliOpt("-p PORT", "--amqp-port=PORT", "AMQP port to listen on (default: 5672)", section: "bindings")]
+    # property amqp_port = 5672
+    # ```
+    #
+    # A deprecated flag whose value is forwarded to a replacement: declare the
+    # instance variable (not a `property`) and define only the setter, which
+    # assigns to the new property.
+    #
+    # ```
+    # @[CliOpt("", "--default-password=HASH", "(Deprecated) Hashed password for default user",
+    #   section: "options", deprecated: "--default-password is deprecated, use --default-password-hash")]
+    # @default_password : Auth::Password::SHA256Password = DEFAULT_PASSWORD_HASH
+    #
+    # def default_password=(value)
+    #   @default_password_hash = value # forward to the replacement
+    # end
+    # ```
     annotation CliOpt; end
+
+    # Marks a config property as settable from a section in the INI config file.
+    #
+    # Named arguments:
+    # - `section:` the INI section the key belongs to, one of `INI_SECTIONS`
+    #   (e.g. `"main"`, `"amqp"`, `"mqtt"`, `"mgmt"`, `"clustering"`, `"oauth"`,
+    #   `"experimental"`). Used to select which properties belong to a section.
+    # - `ini_name:` the key name within the section, given as a bare identifier
+    #   (e.g. `ini_name: port`). Defaults to the property name.
+    # - `transform:` a `Proc(String, T)` that converts the raw value to the
+    #   property's type. When omitted, the property's own type is used and the
+    #   value is converted by the matching `Config#parse_value` overload.
+    # - `deprecated:` a complete warning message, printed verbatim, when the key
+    #   is used. To forward the old value to a replacement, define a setter (and no
+    #   getter) on the deprecated property; an option with no replacement defines no
+    #   setter and its value is dropped after the warning.
+    #
+    # Parsed by `Config#parse_section`.
+    #
+    # ```
+    # @[IniOpt(ini_name: port, section: "amqp")]
+    # property amqp_port = 5672
+    # ```
+    #
+    # A deprecated key whose value is forwarded to a replacement: declare the
+    # instance variable (not a `property`) and define only the setter, which
+    # assigns to the new property.
+    #
+    # ```
+    # @[IniOpt(ini_name: tls_cert, section: "amqp",
+    #   deprecated: "Ini config tls_cert in [amqp] is deprecated, use tls_cert in [main] instead")]
+    # @amqp_tls_cert = ""
+    #
+    # def amqp_tls_cert=(value)
+    #   @tls_cert_path = value # forward to the replacement
+    # end
+    # ```
     annotation IniOpt; end
+
+    # Marks a config property as settable from an environment variable.
+    #
+    # Positional arguments (in order):
+    # 1. the environment variable name, e.g. `"LAVINMQ_AMQP_PORT"`
+    # 2. *optional* `Proc(String, T)` that converts the raw value to the
+    #    property's type. When omitted, the property's own type is used and the
+    #    value is converted by the matching `Config#parse_value` overload.
+    #
+    # May be applied multiple times to accept several variable names for the same
+    # property. The value is assigned directly to the instance variable, bypassing
+    # any setter.
+    #
+    # Parsed by `Config#parse_env`. Env vars take precedence over `IniOpt` but are
+    # overridden by `CliOpt`.
+    #
+    # ```
+    # @[EnvOpt("STATE_DIRECTORY")]
+    # @[EnvOpt("LAVINMQ_DATADIR")]
+    # property data_dir : String = "/var/lib/lavinmq"
+    # ```
     annotation EnvOpt; end
     INI_SECTIONS = {"main", "amqp", "mqtt", "mgmt", "experimental", "clustering", "oauth"}
 
@@ -248,8 +345,9 @@ module LavinMQ
 
       @[CliOpt("", "--default-password=PASSWORD-HASH",
         "(Deprecated) Hashed password for default user (default: '+pHuxkR9fCyrrwXjOD4BP4XbzO3l8LJr8YkThMgJ0yVHFRE+' (guest))",
-        deprecated: "--default-password is deprecated, use --default-password-hash", section: "options")]
-      @[IniOpt(section: "main", deprecated: "default_password_hash")]
+        section: "options", deprecated: "--default-password is deprecated, use --default-password-hash")]
+      @[IniOpt(section: "main",
+        deprecated: "Ini config default_password is deprecated, use default_password_hash instead")]
       @default_password : Auth::Password::SHA256Password = DEFAULT_PASSWORD_HASH # Hashed password for default user
 
       def default_password=(value)
@@ -271,8 +369,10 @@ module LavinMQ
       @[IniOpt(section: "main")]
       property? default_user_only_loopback : Bool = true
 
-      @[CliOpt("", "--guest-only-loopback=BOOL", "Limit guest user to only connect from loopback address", deprecated: "Deprecated: Use --default-user-only-loopback instead.", section: "options")]
-      @[IniOpt(section: "main", deprecated: "default_user_only_loopback")]
+      @[CliOpt("", "--guest-only-loopback=BOOL", "(Deprecated) Limit guest user to only connect from loopback address",
+        section: "options", deprecated: "--guest-only-loopback is deprecated, use --default-user-only-loopback")]
+      @[IniOpt(section: "main",
+        deprecated: "Ini config guest_only_loopback is deprecated, use default_user_only_loopback instead")]
       @guest_only_loopback : Bool = true
 
       def guest_only_loopback=(value : Bool)
@@ -314,14 +414,12 @@ module LavinMQ
       # Deprecated: still accepted (CLI/INI/ENV) so existing configs don't break,
       # but has no effect. The follower ack buffer is a fixed size now and how far
       # a follower may lag is governed by the leader's ack deadline, not this.
-      @[CliOpt("", "--clustering-max-unsynced-actions=ACTIONS", "(Deprecated) No longer used", section: "clustering")]
-      @[IniOpt(ini_name: max_unsynced_actions, section: "clustering")]
+      @[CliOpt("", "--clustering-max-unsynced-actions=ACTIONS", "(Deprecated) No longer used",
+        section: "clustering", deprecated: "--clustering-max-unsynced-actions is deprecated and no longer used")]
+      @[IniOpt(ini_name: max_unsynced_actions, section: "clustering",
+        deprecated: "Ini config max_unsynced_actions is deprecated and no longer used")]
       @[EnvOpt("LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS")]
       @clustering_max_unsynced_actions = 8192 # deprecated, no longer used
-
-      def clustering_max_unsynced_actions=(_value)
-        @io.puts "WARNING: clustering_max_unsynced_actions is deprecated and has no effect"
-      end
 
       @[CliOpt("", "--clustering-port=PORT", "Listen for clustering followers on this port (default: 5679)", section: "clustering")]
       @[IniOpt(ini_name: port, section: "clustering")]
@@ -336,49 +434,56 @@ module LavinMQ
 
       # Deprecated options - these forward to the primary option in [main]
 
-      @[IniOpt(ini_name: tls_cert, section: "amqp", deprecated: "tls_cert in [main]")]
+      @[IniOpt(ini_name: tls_cert, section: "amqp",
+        deprecated: "Ini config tls_cert in [amqp] is deprecated, use tls_cert in [main] instead")]
       @amqp_tls_cert = ""
 
       def amqp_tls_cert=(value)
         @tls_cert_path = value
       end
 
-      @[IniOpt(ini_name: tls_key, section: "amqp", deprecated: "tls_key in [main]")]
+      @[IniOpt(ini_name: tls_key, section: "amqp",
+        deprecated: "Ini config tls_key in [amqp] is deprecated, use tls_key in [main] instead")]
       @amqp_tls_key = ""
 
       def amqp_tls_key=(value)
         @tls_key_path = value
       end
 
-      @[IniOpt(ini_name: tls_cert, section: "mgmt", deprecated: "tls_cert in [main]")]
+      @[IniOpt(ini_name: tls_cert, section: "mgmt",
+        deprecated: "Ini config tls_cert in [mgmt] is deprecated, use tls_cert in [main] instead")]
       @mgmt_tls_cert = ""
 
       def mgmt_tls_cert=(value)
         @tls_cert_path = value
       end
 
-      @[IniOpt(ini_name: tls_key, section: "mgmt", deprecated: "tls_key in [main]")]
+      @[IniOpt(ini_name: tls_key, section: "mgmt",
+        deprecated: "Ini config tls_key in [mgmt] is deprecated, use tls_key in [main] instead")]
       @mgmt_tls_key = ""
 
       def mgmt_tls_key=(value)
         @tls_key_path = value
       end
 
-      @[IniOpt(ini_name: set_timestamp, section: "amqp", deprecated: "set_timestamp in [main]")]
+      @[IniOpt(ini_name: set_timestamp, section: "amqp",
+        deprecated: "Ini config set_timestamp in [amqp] is deprecated, use set_timestamp in [main] instead")]
       @amqp_set_timestamp = false
 
       def amqp_set_timestamp=(value)
         @set_timestamp = value
       end
 
-      @[IniOpt(ini_name: consumer_timeout, section: "amqp", deprecated: "consumer_timeout in [main]")]
+      @[IniOpt(ini_name: consumer_timeout, section: "amqp",
+        deprecated: "Ini config consumer_timeout in [amqp] is deprecated, use consumer_timeout in [main] instead")]
       @amqp_consumer_timeout : UInt64? = nil
 
       def amqp_consumer_timeout=(value)
         @consumer_timeout = value
       end
 
-      @[IniOpt(ini_name: default_consumer_prefetch, section: "amqp", deprecated: "default_consumer_prefetch in [main]")]
+      @[IniOpt(ini_name: default_consumer_prefetch, section: "amqp",
+        deprecated: "Ini config default_consumer_prefetch in [amqp] is deprecated, use default_consumer_prefetch in [main] instead")]
       @amqp_default_consumer_prefetch = UInt16::MAX
 
       def amqp_default_consumer_prefetch=(value)


### PR DESCRIPTION
### WHAT is this pull request doing?
Before this `IniOpt` and `CliOpt` had different ways to handle deprecated options. This PR makes the handling consistent and explicit.

Now the `deprecated` argument to `IniOpt` and `CliOpt` should be a warning message that's printed when lavinmq starts.

### HOW can this pull request be tested?
Specs and manually
