### PR TITLE
Add VR clustering backend

### DIFF
--- a/extras/start-cluster-in-tmux.sh
+++ b/extras/start-cluster-in-tmux.sh
@@ -3,18 +3,71 @@ set -e
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   echo "Usage: $0 [NODES]"
-  echo "Start a LavinMQ cluster in tmux panes"
+  echo "Start a LavinMQ VR cluster in tmux panes"
   echo ""
-  echo "  NODES  Number of nodes to start (default: 3)"
+  echo "  NODES  Number of nodes to start (default: 3, max: 254)"
+  echo ""
+  echo "Environment:"
+  echo "  LAVINMQ_CLUSTERING_SECRET     Shared VR secret (default: lavinmq-vr-local-cluster)"
+  echo "  LAVINMQ_CLUSTER_REUSE_DATA=1  Reuse existing /tmp/amqpN data dirs (default: reset)"
   exit 0
 fi
 
 NODES=${1:-3}
+SECRET=${LAVINMQ_CLUSTERING_SECRET:-lavinmq-vr-local-cluster}
+REUSE_DATA=${LAVINMQ_CLUSTER_REUSE_DATA:-0}
+
+if ! [[ "$NODES" =~ ^[1-9][0-9]*$ ]] || ((NODES > 254)); then
+  echo "NODES must be a number between 1 and 254" >&2
+  exit 1
+fi
+
+node_host() {
+  local n=$1
+  echo "127.0.0.$n"
+}
+
+members() {
+  local entries=()
+  local i
+  for ((i=1; i<=NODES; i++)); do
+    entries+=("$i=tcp://$(node_host "$i"):5679")
+  done
+  local IFS=,
+  echo "${entries[*]}"
+}
+
+MEMBERS=$(members)
+
+prepare_data_dirs() {
+  local i
+  local data_dir
+
+  if [[ "$REUSE_DATA" == "1" ]]; then
+    return
+  fi
+
+  echo "Resetting /tmp/amqp1..$NODES for a clean local VR cluster"
+  echo "Set LAVINMQ_CLUSTER_REUSE_DATA=1 to reuse existing data dirs"
+  for ((i=1; i<=NODES; i++)); do
+    data_dir="/tmp/amqp$i"
+    if [[ -e "$data_dir/.lock" ]] && command -v flock >/dev/null && ! flock -n "$data_dir/.lock" true; then
+      echo "$data_dir is locked by a running LavinMQ node; stop it before resetting the local cluster" >&2
+      exit 1
+    fi
+    rm -rf "$data_dir"
+    mkdir -p "$data_dir"
+  done
+}
 
 node_cmd() {
   local n=$1
-  echo "bin/lavinmq --data-dir=/tmp/amqp$n --bind=127.$n --metrics-http-bind=127.$n --clustering --clustering-bind=127.$n --clustering-advertised-uri=tcp://127.$n:5679"
+  local host
+  host=$(node_host "$n")
+  echo "bin/lavinmq --data-dir=/tmp/amqp$n --bind=$host --metrics-http-bind=$host --control-unix-path=/tmp/lavinmqctl$n.sock --clustering --clustering-backend=vr --clustering-members=$MEMBERS --clustering-node-id=$n --clustering-secret=$SECRET --clustering-bind=$host --clustering-advertised-uri=tcp://$host:5679"
 }
+
+prepare_data_dirs
 
 # Create new window with first node
 tmux new-window -n lavinmq-cluster "$(node_cmd 1); read"

--- a/spec/api/node_spec.cr
+++ b/spec/api/node_spec.cr
@@ -38,6 +38,18 @@ describe LavinMQ::HTTP::NodesController do
     end
   end
 
+  describe "GET /api/clustering/status" do
+    it "returns clustering status data" do
+      with_http_server do |http, _|
+        response = http.get("/api/clustering/status")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body).as_h
+        body["backend"].as_s.should eq "standalone"
+        body["role"].as_s.should eq "primary"
+      end
+    end
+  end
+
   describe "POST /api/nodes/gc_collect" do
     it "triggers garbage collection" do
       with_http_server do |http, _|

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -65,6 +65,38 @@ module ClientSyncSpec
   end
 
   describe LavinMQ::Clustering::Client do
+    describe "#connected?" do
+      it "stays false for a bare TCP connection until sync completes" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          tcp_server = TCPServer.new("localhost", 0)
+          leader_socket = nil.as(TCPSocket?)
+          accepted = Channel(TCPSocket).new(1)
+
+          spawn(name: "bare clustering server") do
+            socket = tcp_server.accept
+            leader_socket = socket
+            accepted.send socket
+            sleep 5.seconds
+          rescue IO::Error
+          end
+
+          spawn(name: "client bare follow") do
+            client.follow("localhost", tcp_server.local_address.port)
+          rescue
+          end
+
+          accepted.receive
+          sleep 100.milliseconds
+          client.connected?.should be_false
+        ensure
+          client.try &.close
+          leader_socket.try &.close
+          tcp_server.try &.close
+        end
+      end
+    end
+
     describe "stream_changes" do
       # Regression: a single large action must be acked incrementally as its
       # payload is written, not just once when the whole action completes.

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -497,7 +497,7 @@ module ClientSyncSpec
           # pending throughout the shutdown.
           spawn(name: "ack feeder") do
             20.times do
-              client.@acks.send(1i64)
+              client.@acks.send(LavinMQ::Clustering::Client::StreamAck.new(1i64))
               sleep 10.milliseconds
             end
           rescue Channel::ClosedError

--- a/spec/clustering/join_race_spec.cr
+++ b/spec/clustering/join_race_spec.cr
@@ -47,7 +47,10 @@ describe "clustering join-during-publish race", tags: "etcd" do
       end
 
       # Follower joins WHILE publishing is in flight.
-      follower_config = config.dup.tap &.data_dir = follower_dir
+      follower_config = config.dup.tap do |c|
+        c.data_dir = follower_dir
+        c.metrics_http_port = -1
+      end
       repli = LavinMQ::Clustering::Client.new(follower_config, 1, replicator.password, proxy: false)
       follower_done = WaitGroup.new(1)
       spawn(name: "follower spec") do
@@ -101,7 +104,10 @@ describe "clustering join-during-publish race", tags: "etcd" do
     leader_hashes = Hash(String, String).new
     leader_sizes = Hash(String, Int64).new
     with_amqp_server(replicator: replicator) do |s|
-      follower_config = config.dup.tap &.data_dir = follower_dir
+      follower_config = config.dup.tap do |c|
+        c.data_dir = follower_dir
+        c.metrics_http_port = -1
+      end
       repli = LavinMQ::Clustering::Client.new(follower_config, 1, replicator.password, proxy: false)
       follower_done = WaitGroup.new(1)
       spawn(name: "follower spec") do

--- a/spec/clustering/vr_spec.cr
+++ b/spec/clustering/vr_spec.cr
@@ -1,0 +1,151 @@
+require "../spec_helper"
+require "../../src/lavinmq/clustering/server"
+require "../../src/lavinmq/clustering/static_members"
+require "../../src/lavinmq/clustering/password_store"
+require "../../src/lavinmq/clustering/vr_state"
+require "lz4"
+
+private def sync_vr_follower(server, port, id : Int32) : TCPSocket
+  io = TCPSocket.new("localhost", port)
+  io.write LavinMQ::Clustering::Start
+  io.write_bytes server.password.bytesize.to_u8, IO::ByteFormat::LittleEndian
+  io.write server.password.to_slice
+  io.read_byte.should eq 0
+  io.write_bytes id, IO::ByteFormat::LittleEndian
+  io.flush
+  lz4 = Compress::LZ4::Reader.new(io)
+  sha1_size = Digest::SHA1.new.digest_size
+  2.times do
+    loop do
+      len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
+      break if len.zero?
+      lz4.skip len
+      lz4.skip sha1_size
+    end
+    io.write_bytes 0i32
+    io.flush
+  end
+  io
+end
+
+describe LavinMQ::Clustering::StaticMembers do
+  it "parses static members and picks primaries by view" do
+    members = LavinMQ::Clustering::StaticMembers.parse("2=tcp://b:5679,1=tcp://a:5679,3=tcp://c:5679")
+    members.ids.should eq [1, 2, 3]
+    members.quorum_size.should eq 2
+    members.primary_id(0).should eq 1
+    members.primary_id(1).should eq 2
+    members.primary_id(3).should eq 1
+  end
+
+  it "derives node id from advertised uri" do
+    members = LavinMQ::Clustering::StaticMembers.parse("1=tcp://a:5679,2=tcp://b:5679")
+    members.derive_node_id("tcp://b:5679").should eq 2
+  end
+end
+
+describe LavinMQ::Clustering::PasswordStore do
+  it "creates the clustering password with mode 0600" do
+    with_datadir do |data_dir|
+      store = LavinMQ::Clustering::PasswordStore.new(data_dir)
+      store.password("seed").should eq "seed"
+      path = File.join(data_dir, ".clustering_password")
+      mode = File.info(path).permissions.value & 0o777
+      mode.should eq 0o600
+    end
+  end
+
+  it "fails fast when an existing password differs from the configured seed" do
+    with_datadir do |data_dir|
+      path = File.join(data_dir, ".clustering_password")
+      File.write(path, "existing")
+      File.chmod(path, 0o600)
+      store = LavinMQ::Clustering::PasswordStore.new(data_dir)
+      expect_raises(LavinMQ::Clustering::PasswordStore::Error, /does not match/) do
+        store.password("different")
+      end
+    end
+  end
+end
+
+describe LavinMQ::Clustering do
+  it "marks local clustering metadata as non-replicated" do
+    LavinMQ::Clustering.metadata_file?(".lock").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_id").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_password").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_vr_state").should be_true
+    LavinMQ::Clustering.metadata_file?("definitions.amqp").should be_false
+  end
+end
+
+describe LavinMQ::Clustering::Server do
+  describe "VR quorum commit" do
+    it "commits once a quorum including the primary has acked" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      members = LavinMQ::Clustering::StaticMembers.parse("0=tcp://localhost:1,1=tcp://localhost:2,2=tcp://localhost:3")
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.role = "primary"
+      server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, NullCoordinator.new, 0, members, state)
+      tcp_server = TCPServer.new("localhost", 0)
+      spawn(server.listen(tcp_server), name: "vr quorum server spec")
+
+      follower_a = sync_vr_follower(server, tcp_server.local_address.port, 1)
+      follower_b = sync_vr_follower(server, tcp_server.local_address.port, 2)
+      wait_for { server.followers.size == 2 }
+
+      server.append_bytes(File.join(data_dir, "vr-quorum"), "x".to_slice, 0i64)
+      state.op_number.should eq 1
+
+      committed = Channel(Nil).new(1)
+      spawn(name: "vr quorum wait spec") do
+        server.wait_for_followers
+        committed.send nil
+      end
+
+      select
+      when committed.receive
+        fail "committed before any follower acked"
+      when timeout(300.milliseconds)
+      end
+
+      follower = server.followers.find!(&.id.== 1)
+      follower_a.write_bytes follower.lag_in_bytes, IO::ByteFormat::LittleEndian
+
+      select
+      when committed.receive
+      when timeout(5.seconds)
+        fail "VR quorum commit did not complete after one follower ack"
+      end
+      state.commit_number.should eq 1
+    ensure
+      follower_a.try &.close
+      follower_b.try &.close
+      server.try &.close
+      tcp_server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+
+    it "exposes VR status fields" do
+      with_datadir do |data_dir|
+        members = LavinMQ::Clustering::StaticMembers.parse("1=tcp://a:5679,2=tcp://b:5679,3=tcp://c:5679")
+        state = LavinMQ::Clustering::VRState.new(data_dir)
+        state.role = "primary"
+        state.next_op!
+        state.commit!(1)
+        server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, NullCoordinator.new, 1, members, state)
+
+        json = JSON.parse(server.status.to_json).as_h
+        json["backend"].as_s.should eq "vr"
+        json["node_id"].as_i.should eq 1
+        json["role"].as_s.should eq "primary"
+        json["view"].as_i.should eq 0
+        json["primary_id"].as_i.should eq 1
+        json["primary_uri"].as_s.should eq "tcp://a:5679"
+        json["op_number"].as_i.should eq 1
+        json["commit_number"].as_i.should eq 1
+        json["quorum_size"].as_i.should eq 2
+      end
+    end
+  end
+end

--- a/spec/clustering/vr_spec.cr
+++ b/spec/clustering/vr_spec.cr
@@ -143,21 +143,41 @@ describe LavinMQ::Clustering::PasswordStore do
   end
 end
 
+private def vr_state_path(data_dir : String) : String
+  File.join(data_dir, ".clustering_vr_state")
+end
+
+private def vr_counter_path(data_dir : String, name : String) : String
+  File.join(data_dir, ".clustering_vr_state.#{name}")
+end
+
+private def read_vr_counter(path : String) : Int64
+  File.open(path) do |file|
+    file.seek(File.size(path) - 8)
+    file.read_bytes(Int64, IO::ByteFormat::LittleEndian)
+  end
+end
+
 describe LavinMQ::Clustering::VRState do
-  it "stores a complete JSON state file with private permissions" do
+  it "stores cold state separately from append-only counter files" do
     with_datadir do |data_dir|
       state = LavinMQ::Clustering::VRState.new(data_dir)
       state.role = "primary"
       state.next_op!.should eq 1
       state.commit!(1)
 
-      path = File.join(data_dir, ".clustering_vr_state")
+      path = vr_state_path(data_dir)
       json = JSON.parse(File.read(path))
       json["role"].as_s.should eq "primary"
-      json["op_number"].as_i.should eq 1
-      json["commit_number"].as_i.should eq 1
-      mode = File.info(path).permissions.value & 0o777
-      mode.should eq 0o600
+      json["op_number"]?.should be_nil
+      json["commit_number"]?.should be_nil
+
+      op_path = vr_counter_path(data_dir, "op_number")
+      commit_path = vr_counter_path(data_dir, "commit_number")
+      read_vr_counter(op_path).should eq 1
+      read_vr_counter(commit_path).should eq 1
+      File.size(op_path).should eq 8
+      File.size(commit_path).should eq 8
     end
   end
 
@@ -184,6 +204,42 @@ describe LavinMQ::Clustering::VRState do
 
       restored = LavinMQ::Clustering::VRState.new(data_dir)
       restored.op_number.should eq 3
+    end
+  end
+
+  it "restores the last complete record and compacts interrupted trailing writes" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.apply_op!(3)
+
+      path = vr_counter_path(data_dir, "op_number")
+      File.open(path, "a", &.write_byte(1_u8))
+
+      restored = LavinMQ::Clustering::VRState.new(data_dir)
+      restored.op_number.should eq 3
+      restored.apply_op!(4)
+
+      File.size(path).should eq 8
+      read_vr_counter(path).should eq 4
+    end
+  end
+
+  it "compacts appended counter records when they reach the configured size" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir, 1_i64)
+      state.apply_op!(1)
+      state.apply_op!(2)
+      state.commit!(1)
+      state.commit!(2)
+
+      op_path = vr_counter_path(data_dir, "op_number")
+      commit_path = vr_counter_path(data_dir, "commit_number")
+      File.size(op_path).should eq 8
+      File.size(commit_path).should eq 8
+      read_vr_counter(op_path).should eq 2
+      read_vr_counter(commit_path).should eq 2
+      File.exists?("#{op_path}.tmp").should be_false
+      File.exists?("#{commit_path}.tmp").should be_false
     end
   end
 
@@ -218,6 +274,8 @@ describe LavinMQ::Clustering do
     LavinMQ::Clustering.metadata_file?(".clustering_password").should be_true
     LavinMQ::Clustering.metadata_file?(".clustering_password.abcd.tmp").should be_true
     LavinMQ::Clustering.metadata_file?(".clustering_vr_state").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_vr_state.op_number").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_vr_state.commit_number.tmp").should be_true
     LavinMQ::Clustering.metadata_file?(".clustering_vr_state.abcd.tmp").should be_true
     LavinMQ::Clustering.metadata_file?("definitions.amqp").should be_false
   end

--- a/spec/clustering/vr_spec.cr
+++ b/spec/clustering/vr_spec.cr
@@ -2,6 +2,7 @@ require "../spec_helper"
 require "../../src/lavinmq/clustering/server"
 require "../../src/lavinmq/clustering/static_members"
 require "../../src/lavinmq/clustering/password_store"
+require "../../src/lavinmq/clustering/vr_controller"
 require "../../src/lavinmq/clustering/vr_state"
 require "lz4"
 
@@ -42,6 +43,18 @@ describe LavinMQ::Clustering::StaticMembers do
     members = LavinMQ::Clustering::StaticMembers.parse("1=tcp://a:5679,2=tcp://b:5679")
     members.derive_node_id("tcp://b:5679").should eq 2
   end
+
+  it "derives node id with case-insensitive hostnames and default tcp port" do
+    members = LavinMQ::Clustering::StaticMembers.parse("1=tcp://node-a,2=tcp://node-b:5679")
+    members.derive_node_id("tcp://NODE-A:5679").should eq 1
+  end
+
+  it "does not match unknown schemes when both ports are omitted" do
+    members = LavinMQ::Clustering::StaticMembers.parse("1=custom://a")
+    expect_raises(LavinMQ::Clustering::StaticMembers::Error, /does not match/) do
+      members.derive_node_id("custom://a")
+    end
+  end
 end
 
 describe LavinMQ::Clustering::PasswordStore do
@@ -68,13 +81,84 @@ describe LavinMQ::Clustering::PasswordStore do
   end
 end
 
+describe LavinMQ::Clustering::VRState do
+  it "stores a complete JSON state file with private permissions" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.role = "primary"
+      state.next_op!.should eq 1
+      state.commit!(1)
+
+      path = File.join(data_dir, ".clustering_vr_state")
+      json = JSON.parse(File.read(path))
+      json["role"].as_s.should eq "primary"
+      json["op_number"].as_i.should eq 1
+      json["commit_number"].as_i.should eq 1
+      mode = File.info(path).permissions.value & 0o777
+      mode.should eq 0o600
+    end
+  end
+
+  it "ignores leftover temp state files from interrupted durable writes" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.role = "primary"
+      state.next_op!
+      state.commit!(1)
+      File.write(File.join(data_dir, ".clustering_vr_state.interrupted.tmp"), "{")
+
+      restored = LavinMQ::Clustering::VRState.new(data_dir)
+      restored.role.should eq "primary"
+      restored.op_number.should eq 1
+      restored.commit_number.should eq 1
+    end
+  end
+end
+
 describe LavinMQ::Clustering do
   it "marks local clustering metadata as non-replicated" do
     LavinMQ::Clustering.metadata_file?(".lock").should be_true
     LavinMQ::Clustering.metadata_file?(".clustering_id").should be_true
     LavinMQ::Clustering.metadata_file?(".clustering_password").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_password.abcd.tmp").should be_true
     LavinMQ::Clustering.metadata_file?(".clustering_vr_state").should be_true
+    LavinMQ::Clustering.metadata_file?(".clustering_vr_state.abcd.tmp").should be_true
     LavinMQ::Clustering.metadata_file?("definitions.amqp").should be_false
+  end
+end
+
+describe LavinMQ::Clustering::VRController do
+  it "fires leader-elected after start and leader-lost when stopped" do
+    with_datadir do |data_dir|
+      events_path = File.join(data_dir, "events")
+      config = LavinMQ::Config.instance.dup
+      config.data_dir = data_dir
+      config.clustering_members = "1=tcp://localhost:5679"
+      config.clustering_node_id = 1
+      config.clustering_on_leader_elected = "printf elected >> #{events_path}"
+      config.clustering_on_leader_lost = "printf lost >> #{events_path}"
+      controller = LavinMQ::Clustering::VRController.new(config)
+      started = Channel(Nil).new(1)
+      done = Channel(Nil).new(1)
+
+      spawn(name: "vr controller hook spec") do
+        controller.run do
+          File.write(events_path, "start\n")
+          started.send nil
+        end
+        done.send nil
+      end
+
+      started.receive
+      wait_for { File.exists?(events_path) && File.read(events_path) == "start\nelected" }
+      controller.stop
+      wait_for { File.read(events_path) == "start\nelectedlost" }
+      select
+      when done.receive
+      when timeout(2.seconds)
+        fail "VR controller did not stop"
+      end
+    end
   end
 end
 
@@ -121,6 +205,49 @@ describe LavinMQ::Clustering::Server do
     ensure
       follower_a.try &.close
       follower_b.try &.close
+      server.try &.close
+      tcp_server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+
+    it "does not wait behind a slow follower before counting a healthy quorum follower" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      members = LavinMQ::Clustering::StaticMembers.parse("0=tcp://localhost:1,1=tcp://localhost:2,2=tcp://localhost:3")
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.role = "primary"
+      server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, NullCoordinator.new, 0, members, state)
+      tcp_server = TCPServer.new("localhost", 0)
+      spawn(server.listen(tcp_server), name: "vr quorum nonsequential spec")
+
+      slow_follower = sync_vr_follower(server, tcp_server.local_address.port, 1)
+      fast_follower = sync_vr_follower(server, tcp_server.local_address.port, 2)
+      wait_for { server.followers.size == 2 }
+
+      server.append_bytes(File.join(data_dir, "vr-quorum-nonsequential"), "x".to_slice, 0i64)
+      wait_for { server.followers.all? { |f| f.lag_in_bytes > 0 } }
+
+      committed = Channel(Time::Span).new(1)
+      started_at = Time.instant
+      spawn(name: "vr quorum nonsequential wait spec") do
+        server.wait_for_followers
+        committed.send(Time.instant - started_at)
+      end
+
+      sleep 100.milliseconds
+      follower = server.followers.find!(&.id.== 2)
+      fast_follower.write_bytes follower.lag_in_bytes, IO::ByteFormat::LittleEndian
+
+      select
+      when elapsed = committed.receive
+        elapsed.should be < 1.second
+      when timeout(1.second)
+        fail "VR quorum waited behind the slow follower"
+      end
+      state.commit_number.should eq 1
+    ensure
+      slow_follower.try &.close
+      fast_follower.try &.close
       server.try &.close
       tcp_server.try &.close
       FileUtils.rm_rf LavinMQ::Config.instance.data_dir

--- a/spec/clustering/vr_spec.cr
+++ b/spec/clustering/vr_spec.cr
@@ -6,13 +6,14 @@ require "../../src/lavinmq/clustering/vr_controller"
 require "../../src/lavinmq/clustering/vr_state"
 require "lz4"
 
-private def sync_vr_follower(server, port, id : Int32) : TCPSocket
+private def sync_vr_follower(server, port, id : Int32, v2 = true) : TCPSocket
   io = TCPSocket.new("localhost", port)
-  io.write LavinMQ::Clustering::Start
+  io.write(v2 ? LavinMQ::Clustering::StartV2 : LavinMQ::Clustering::Start)
   io.write_bytes server.password.bytesize.to_u8, IO::ByteFormat::LittleEndian
   io.write server.password.to_slice
   io.read_byte.should eq 0
   io.write_bytes id, IO::ByteFormat::LittleEndian
+  io.write_byte LavinMQ::Clustering::ConnectionKind::Replication.value if v2
   io.flush
   lz4 = Compress::LZ4::Reader.new(io)
   sha1_size = Digest::SHA1.new.digest_size
@@ -26,7 +27,68 @@ private def sync_vr_follower(server, port, id : Int32) : TCPSocket
     io.write_bytes 0i32
     io.flush
   end
+  lz4.read_bytes(Int64, IO::ByteFormat::LittleEndian) if v2
   io
+end
+
+private def vr_config(data_dir : String, node_id : Int32, members : String, secret = "vr-spec-secret")
+  LavinMQ::Config.instance.dup.tap do |config|
+    config.data_dir = data_dir
+    config.clustering_members = members
+    config.clustering_node_id = node_id
+    config.clustering_secret = secret
+    config.metrics_http_port = -1
+  end
+end
+
+private def unused_local_port : Int32
+  server = TCPServer.new("localhost", 0)
+  server.local_address.port
+ensure
+  server.try &.close
+end
+
+private def start_vr_server(config, members, state, id : Int32, tcp_server)
+  server = LavinMQ::Clustering::Server.new(
+    config,
+    LavinMQ::Clustering::VRCoordinator.new(config),
+    id,
+    members,
+    state)
+  spawn(server.listen(tcp_server), name: "vr spec server #{id}")
+  server
+end
+
+private def vr_control_vote(server, port, requester_id : Int32, view : Int64, op_number : Int64)
+  io = TCPSocket.new("localhost", port)
+  io.write LavinMQ::Clustering::StartV2
+  io.write_bytes server.password.bytesize.to_u8, IO::ByteFormat::LittleEndian
+  io.write server.password.to_slice
+  io.read_byte.should eq 0
+  io.write_bytes requester_id, IO::ByteFormat::LittleEndian
+  io.write_byte LavinMQ::Clustering::ConnectionKind::Control.value
+  io.write_byte LavinMQ::Clustering::ControlRequest::Vote.value
+  io.write_bytes view, IO::ByteFormat::LittleEndian
+  io.write_bytes requester_id, IO::ByteFormat::LittleEndian
+  io.write_bytes op_number, IO::ByteFormat::LittleEndian
+  io.flush
+  {
+    granted:   io.read_byte == 1,
+    view:      io.read_bytes(Int64, IO::ByteFormat::LittleEndian),
+    op_number: io.read_bytes(Int64, IO::ByteFormat::LittleEndian),
+  }
+ensure
+  io.try &.close
+end
+
+class LavinMQ::Clustering::VRController
+  def win_election_for_spec : Bool
+    win_election?
+  end
+
+  def authority_status_for_spec(view : Int64) : {Bool, Int64}
+    authority_status(view)
+  end
 end
 
 describe LavinMQ::Clustering::StaticMembers do
@@ -113,6 +175,40 @@ describe LavinMQ::Clustering::VRState do
       restored.commit_number.should eq 1
     end
   end
+
+  it "applies operation numbers monotonically and persists them" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.apply_op!(3)
+      state.apply_op!(2)
+
+      restored = LavinMQ::Clustering::VRState.new(data_dir)
+      restored.op_number.should eq 3
+    end
+  end
+
+  it "persists one vote per view" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.grant_vote?(1, 5, 0, 1).should be_true
+
+      restored = LavinMQ::Clustering::VRState.new(data_dir)
+      restored.voted_view.should eq 5
+      restored.voted_for.should eq 1
+      restored.grant_vote?(1, 5, 0, 1).should be_true
+      restored.grant_vote?(2, 5, 0, 2).should be_false
+    end
+  end
+
+  it "denies stale candidates behind the local operation number" do
+    with_datadir do |data_dir|
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.apply_op!(7)
+
+      state.grant_vote?(1, 0, 6, 1).should be_false
+      state.grant_vote?(1, 0, 7, 1).should be_true
+    end
+  end
 end
 
 describe LavinMQ::Clustering do
@@ -164,6 +260,83 @@ end
 
 describe LavinMQ::Clustering::Server do
   describe "VR quorum commit" do
+    it "routes v2 replication connections to the stream path" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      members = LavinMQ::Clustering::StaticMembers.parse("0=tcp://localhost:1,1=tcp://localhost:2")
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.role = "primary"
+      server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, NullCoordinator.new, 0, members, state)
+      tcp_server = TCPServer.new("localhost", 0)
+      spawn(server.listen(tcp_server), name: "vr v2 route spec")
+
+      follower = sync_vr_follower(server, tcp_server.local_address.port, 1)
+      wait_for { server.followers.size == 1 }
+      server.followers.first.v2?.should be_true
+    ensure
+      follower.try &.close
+      server.try &.close
+      tcp_server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+
+    it "routes v2 control RPCs to the vote handler" do
+      with_datadir do |data_dir|
+        members = LavinMQ::Clustering::StaticMembers.parse("1=tcp://localhost:1,2=tcp://localhost:2")
+        config = vr_config(data_dir, 2, "1=tcp://localhost:1,2=tcp://localhost:2")
+        state = LavinMQ::Clustering::VRState.new(data_dir)
+        state.apply_op!(4)
+        tcp_server = TCPServer.new("localhost", 0)
+        server = start_vr_server(config, members, state, 2, tcp_server)
+
+        response = vr_control_vote(server, tcp_server.local_address.port, 1, 0_i64, 4_i64)
+        response[:granted].should be_true
+        response[:view].should eq 0
+        response[:op_number].should eq 4
+        state.voted_for.should eq 1
+      ensure
+        server.try &.close
+        tcp_server.try &.close
+      end
+    end
+
+    it "excludes v1 replication peers from VR quorum" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      members = LavinMQ::Clustering::StaticMembers.parse("0=tcp://localhost:1,1=tcp://localhost:2,2=tcp://localhost:3")
+      state = LavinMQ::Clustering::VRState.new(data_dir)
+      state.role = "primary"
+      server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, NullCoordinator.new, 0, members, state)
+      tcp_server = TCPServer.new("localhost", 0)
+      spawn(server.listen(tcp_server), name: "vr v1 quorum exclusion spec")
+
+      follower_io = sync_vr_follower(server, tcp_server.local_address.port, 1, v2: false)
+      wait_for { server.followers.size == 1 }
+      server.followers.first.v2?.should be_false
+
+      server.append_bytes(File.join(data_dir, "vr-v1-excluded"), "x".to_slice, 0i64)
+      follower = server.followers.first
+      follower_io.write_bytes follower.lag_in_bytes, IO::ByteFormat::LittleEndian
+
+      committed = Channel(Nil).new(1)
+      spawn(name: "vr v1 excluded wait spec") do
+        server.wait_for_followers
+        committed.send nil
+      end
+
+      select
+      when committed.receive
+        fail "v1 follower satisfied VR quorum"
+      when timeout(300.milliseconds)
+      end
+      state.commit_number.should eq 0
+    ensure
+      follower_io.try &.close
+      server.try &.close
+      tcp_server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+
     it "commits once a quorum including the primary has acked" do
       data_dir = LavinMQ::Config.instance.data_dir
       Dir.mkdir_p(data_dir)
@@ -272,6 +445,86 @@ describe LavinMQ::Clustering::Server do
         json["op_number"].as_i.should eq 1
         json["commit_number"].as_i.should eq 1
         json["quorum_size"].as_i.should eq 2
+      end
+    end
+  end
+end
+
+describe "VR election safety" do
+  it "prevents a stale deterministic candidate from winning without an up-to-date quorum" do
+    with_datadir do |candidate_dir|
+      with_datadir do |peer_dir|
+        peer2_tcp = TCPServer.new("localhost", 0)
+        peer3_port = unused_local_port
+        members_raw = "1=tcp://localhost:#{unused_local_port},2=tcp://localhost:#{peer2_tcp.local_address.port},3=tcp://localhost:#{peer3_port}"
+        members = LavinMQ::Clustering::StaticMembers.parse(members_raw)
+
+        peer_config = vr_config(peer_dir, 2, members_raw)
+        peer_state = LavinMQ::Clustering::VRState.new(peer_dir)
+        peer_state.apply_op!(2)
+        peer_server = start_vr_server(peer_config, members, peer_state, 2, peer2_tcp)
+
+        candidate_config = vr_config(candidate_dir, 1, members_raw)
+        candidate = LavinMQ::Clustering::VRController.new(candidate_config)
+        candidate.state.apply_op!(1)
+
+        candidate.win_election_for_spec.should be_false
+      ensure
+        peer_server.try &.close
+        peer2_tcp.try &.close
+      end
+    end
+  end
+
+  it "allows the next up-to-date deterministic candidate to win" do
+    with_datadir do |peer_dir|
+      with_datadir do |candidate_dir|
+        peer1_tcp = TCPServer.new("localhost", 0)
+        peer3_port = unused_local_port
+        members_raw = "1=tcp://localhost:#{peer1_tcp.local_address.port},2=tcp://localhost:#{unused_local_port},3=tcp://localhost:#{peer3_port}"
+        members = LavinMQ::Clustering::StaticMembers.parse(members_raw)
+
+        peer_config = vr_config(peer_dir, 1, members_raw)
+        peer_state = LavinMQ::Clustering::VRState.new(peer_dir)
+        peer_state.observe_view!(1)
+        peer_state.apply_op!(1)
+        peer_server = start_vr_server(peer_config, members, peer_state, 1, peer1_tcp)
+
+        candidate_config = vr_config(candidate_dir, 2, members_raw)
+        candidate = LavinMQ::Clustering::VRController.new(candidate_config)
+        candidate.state.observe_view!(1)
+        candidate.state.apply_op!(2)
+
+        candidate.win_election_for_spec.should be_true
+      ensure
+        peer_server.try &.close
+        peer1_tcp.try &.close
+      end
+    end
+  end
+
+  it "detects loss of authority after a peer votes in a higher view" do
+    with_datadir do |primary_dir|
+      with_datadir do |peer_dir|
+        peer2_tcp = TCPServer.new("localhost", 0)
+        peer3_port = unused_local_port
+        members_raw = "1=tcp://localhost:#{unused_local_port},2=tcp://localhost:#{peer2_tcp.local_address.port},3=tcp://localhost:#{peer3_port}"
+        members = LavinMQ::Clustering::StaticMembers.parse(members_raw)
+
+        peer_config = vr_config(peer_dir, 2, members_raw)
+        peer_state = LavinMQ::Clustering::VRState.new(peer_dir)
+        peer_state.grant_vote?(2, 1, 0, 2).should be_true
+        peer_server = start_vr_server(peer_config, members, peer_state, 2, peer2_tcp)
+
+        primary_config = vr_config(primary_dir, 1, members_raw)
+        primary = LavinMQ::Clustering::VRController.new(primary_config)
+
+        authorized, highest_view = primary.authority_status_for_spec(0)
+        authorized.should be_false
+        highest_view.should eq 1
+      ensure
+        peer_server.try &.close
+        peer2_tcp.try &.close
       end
     end
   end

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -349,6 +349,23 @@ describe LavinMQ::Config do
     config2.log_level.should eq ::Log::Severity::Debug
   end
 
+  it "can parse VR clustering options" do
+    config = LavinMQ::Config.new
+    config.parse([
+      "--clustering",
+      "--clustering-backend=vr",
+      "--clustering-members=1=tcp://a:5679,2=tcp://b:5679",
+      "--clustering-node-id=2",
+      "--clustering-secret=shared",
+    ])
+
+    config.clustering?.should be_true
+    config.clustering_backend.should eq "vr"
+    config.clustering_members.should eq "1=tcp://a:5679,2=tcp://b:5679"
+    config.clustering_node_id.should eq 2
+    config.clustering_secret.should eq "shared"
+  end
+
   it "can parse all ENV arguments" do
     begin
       ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = "/etc/custom"

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -85,6 +85,10 @@ class DiskVisibilitySpyReplicator
   def password : String
     ""
   end
+
+  def status
+    {backend: "spy"}
+  end
 end
 
 describe LavinMQ::DefinitionsStore do

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -74,6 +74,10 @@ class SpyReplicator
   def password : String
     ""
   end
+
+  def status
+    {backend: "spy"}
+  end
 end
 
 def mktmpdir(&)

--- a/src/lavinmq/clustering.cr
+++ b/src/lavinmq/clustering.cr
@@ -4,7 +4,18 @@ require "digest/sha1"
 
 module LavinMQ
   module Clustering
-    Start = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 1, 0, 0]
+    Start   = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 1, 0, 0]
+    StartV2 = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 2, 0, 0]
+
+    enum ConnectionKind : UInt8
+      Replication = 0
+      Control     = 1
+    end
+
+    enum ControlRequest : UInt8
+      Vote      = 1
+      Authority = 2
+    end
 
     class Error < Exception; end
 

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -485,9 +485,9 @@ module LavinMQ
       # Concatenate as many acks as possible to generate few TCP packets.
       # Data is synced to disk before each ack is sent unless sync is disabled:
       # the leader holds publish confirms until in-sync followers have acked,
-      # so an acked byte must be durable here in normal operation. Syncing once
-      # per coalesced batch makes batching emerge naturally — acks accumulate
-      # while the blocking syncfs runs.
+      # so an acked byte must be durable here in normal operation. In v2 the VR
+      # op state is appended before the sync so the same syncfs covers both the
+      # replicated data and the local election freshness marker.
       private def send_ack_loop(acks, socket)
         socket.tcp_nodelay = true
         while ack = acks.receive?
@@ -503,10 +503,10 @@ module LavinMQ
               end
             end
           end
-          sync_to_disk
           if op = op_number
             @vr_state.try &.apply_op!(op)
           end
+          sync_to_disk
           socket.write_bytes ack_bytes, IO::ByteFormat::LittleEndian # ack
         end
       rescue Channel::ClosedError

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -4,6 +4,7 @@ require "../rate_limiter"
 require "./checksums"
 require "./metadata"
 require "./proxy"
+require "./vr_state"
 require "lz4"
 require "http/server"
 require "wait_group"
@@ -23,6 +24,14 @@ module LavinMQ
       # leader's ack deadline, not this, governs how far a follower may lag.
       ACK_BUFFER_CAPACITY = 8192
 
+      struct StreamAck
+        getter bytes : Int64
+        getter op_number : Int64?
+
+        def initialize(@bytes : Int64, @op_number : Int64? = nil)
+        end
+      end
+
       @data_dir_lock : DataDirLock
       @closed = false
       @amqp_proxy : Proxy?
@@ -37,15 +46,16 @@ module LavinMQ
       @file_digests = Hash(String, Digest::SHA1).new
       @follower_done = Channel(Nil).new
       @connected = Atomic(Int32).new(0)
+      @protocol_version = 1
       # Buffers acks from the stream-reading fiber to the ack-sending fiber.
       # Replaced with a fresh channel on each (re)connect in #stream_changes.
-      @acks = Channel(Int64).new
+      @acks = Channel(StreamAck).new
       # Tracks the ack-sending fiber: #close must wait for it to finish before
       # closing @data_dir_fd, since it may sync (syncfs on that fd) before acks
       # it sends — even acks still buffered in @acks after the stream ends.
       @ack_loops = WaitGroup.new
 
-      def initialize(@config : Config, @id : Int32, @password : String, proxy = true)
+      def initialize(@config : Config, @id : Int32, @password : String, proxy = true, @vr_state : VRState? = nil)
         System.maximize_fd_limit
         @data_dir = config.data_dir
         @files = Hash(String, File).new do |h, k|
@@ -115,18 +125,15 @@ module LavinMQ
           spawn unix_mqtt_proxy.forward_to(host, @config.mqtt_port), name: "MQTT proxy"
         end
         loop do
-          @socket = socket = TCPSocket.new(host, port)
-          socket.sync = true
-          socket.read_buffering = false # use lz4 buffering
-          lz4 = Compress::LZ4::Reader.new(socket)
-          sync(socket, lz4)
-          @connected.set(1)
-          Log.info { "Streaming changes" }
-          stream_changes(socket, lz4)
+          begin
+            follow_once(host, port, 2)
+          rescue ex : LegacyProtocol
+            Log.info { "Server #{host}:#{port} does not support clustering protocol v2, falling back to v1 replication" }
+            follow_once(host, port, 1)
+          end
         rescue ex : IO::Error
           @connected.set(0)
-          lz4.try &.close
-          socket.try &.close
+          @socket.try &.close
           break if @closed
           Log.info { "Disconnected from server #{host}:#{port} (#{ex}), retrying..." }
           sleep 1.seconds
@@ -134,6 +141,24 @@ module LavinMQ
       ensure
         @connected.set(0)
         @follower_done.send(nil)
+      end
+
+      private def follow_once(host : String, port : Int32, protocol_version : Int32) : Nil
+        @socket = socket = TCPSocket.new(host, port)
+        socket.sync = true
+        socket.read_buffering = false # use lz4 buffering
+        @protocol_version = protocol_version
+        lz4 = Compress::LZ4::Reader.new(socket)
+        begin
+          sync(socket, lz4)
+          @connected.set(1)
+          Log.info { "Streaming changes using clustering protocol v#{@protocol_version}" }
+          stream_changes(socket, lz4)
+        rescue ex
+          lz4.close
+          socket.close
+          raise ex
+        end
       end
 
       def connected? : Bool
@@ -166,6 +191,10 @@ module LavinMQ
         sync_files(socket, lz4)
         Log.info { "Bulk synchronised" }
         sync_files(socket, lz4)
+        if v2?
+          op_number = lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
+          @vr_state.try &.apply_op!(op_number)
+        end
         Log.info { "Fully synchronised" }
       end
 
@@ -315,7 +344,7 @@ module LavinMQ
       end
 
       private def stream_changes(socket, lz4)
-        acks = @acks = Channel(Int64).new(ACK_BUFFER_CAPACITY)
+        acks = @acks = Channel(StreamAck).new(ACK_BUFFER_CAPACITY)
         @ack_loops.spawn(name: "Send ack loop") { send_ack_loop(acks, socket) }
         spawn log_streamed_bytes_loop, name: "Log streamed bytes loop"
         loop do
@@ -324,6 +353,7 @@ module LavinMQ
           filename = lz4.read_string(filename_len)
 
           len = lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
+          op_number = v2? ? lz4.read_bytes(Int64, IO::ByteFormat::LittleEndian) : 0_i64
           # For append/replace the framing bytes (length headers + filename)
           # are acked up front and the payload is acked incrementally as it's
           # written (see stream_with_checksum), so a single large action keeps
@@ -331,27 +361,27 @@ module LavinMQ
           # it's done. For a delete the framing is the entire record — acking
           # it tells the leader the deletion is durable — so it's only acked
           # once the deletion has been applied.
-          framing = sizeof(Int32) + filename_len + sizeof(Int64)
+          framing = sizeof(Int32) + filename_len + sizeof(Int64) + (v2? ? sizeof(Int64) : 0)
           case len
           when .negative? # append bytes to file
             ack(framing)
-            append(filename, len, lz4)
+            append(filename, len, lz4, op_number)
           when .zero? # file is deleted
             delete(filename)
-            ack(framing)
+            ack(framing, op_number)
           when .positive? # replace file
             ack(framing)
-            replace(filename, len, lz4)
+            replace(filename, len, lz4, op_number)
           end
         end
       ensure
         @acks.close
       end
 
-      private def append(filename, len, lz4)
+      private def append(filename, len, lz4, op_number : Int64)
         Log.debug { "Appending #{len.abs} bytes to #{filename}" }
         f = @files[filename]
-        stream_with_checksum(filename, lz4, f, len.abs)
+        stream_with_checksum(filename, lz4, f, len.abs, op_number: op_number)
       end
 
       private def delete(filename)
@@ -397,7 +427,7 @@ module LavinMQ
         end
       end
 
-      private def replace(filename, len, lz4)
+      private def replace(filename, len, lz4, op_number : Int64)
         Log.debug { "Replacing file #{filename} (#{len} bytes)" }
         @files.delete(filename).try &.close
 
@@ -413,13 +443,13 @@ module LavinMQ
           # file; hold it back until the rename has installed the file.
           deferred = stream_with_checksum(filename, lz4, f, len, defer_final_ack: true)
           f.rename f.path[0..-5]
-          ack(deferred)
+          ack(deferred, op_number)
         end
       end
 
       # Read from lz4, update SHA1, and write to file incrementally.
       # Returns the number of bytes received but not yet acked (see below).
-      private def stream_with_checksum(filename : String, lz4 : IO, file : IO, length : Int64, defer_final_ack = false) : Int64
+      private def stream_with_checksum(filename : String, lz4 : IO, file : IO, length : Int64, defer_final_ack = false, op_number : Int64 = 0_i64) : Int64
         # Get or create SHA1 digest for this file
         sha1 = @file_digests[filename] ||= Digest::SHA1.new
 
@@ -440,16 +470,16 @@ module LavinMQ
           sha1.update(bytes)
           remaining -= len
           return len.to_i64 if remaining.zero? && defer_final_ack
-          ack(len)
+          ack(len, remaining.zero? ? op_number : 0_i64)
         end
         0i64
       end
 
       # Count streamed bytes and forward the count to the ack-sending fiber.
-      private def ack(bytes : Int) : Nil
+      private def ack(bytes : Int | Int64, op_number : Int64 = 0_i64) : Nil
         n = bytes.to_i64
         @streamed_bytes &+= n
-        @acks.send(n)
+        @acks.send(StreamAck.new(n, op_number > 0 ? op_number : nil))
       end
 
       # Concatenate as many acks as possible to generate few TCP packets.
@@ -460,11 +490,23 @@ module LavinMQ
       # while the blocking syncfs runs.
       private def send_ack_loop(acks, socket)
         socket.tcp_nodelay = true
-        while ack_bytes = acks.receive?
-          while ack_bytes2 = acks.try_receive?
-            ack_bytes += ack_bytes2
+        while ack = acks.receive?
+          ack_bytes = ack.bytes
+          op_number = ack.op_number
+          while ack2 = acks.try_receive?
+            ack_bytes += ack2.bytes
+            if op2 = ack2.op_number
+              if current_op = op_number
+                op_number = Math.max(current_op, op2)
+              else
+                op_number = op2
+              end
+            end
           end
           sync_to_disk
+          if op = op_number
+            @vr_state.try &.apply_op!(op)
+          end
           socket.write_bytes ack_bytes, IO::ByteFormat::LittleEndian # ack
         end
       rescue Channel::ClosedError
@@ -502,17 +544,23 @@ module LavinMQ
       end
 
       private def authenticate(socket)
-        socket.write Start
+        socket.write(v2? ? StartV2 : Start)
         socket.write_bytes @password.bytesize.to_u8, IO::ByteFormat::LittleEndian
         socket.write @password.to_slice
         case socket.read_byte
         when 0 # ok
-        when 1   then raise AuthenticationError.new
-        when nil then raise IO::EOFError.new
+        when 1        then raise AuthenticationError.new
+        when nil      then raise IO::EOFError.new
+        when Start[0] then raise LegacyProtocol.new
         else
           raise Error.new("Unknown response from authentication")
         end
         socket.write_bytes @id, IO::ByteFormat::LittleEndian
+        socket.write_byte ConnectionKind::Replication.value if v2?
+      end
+
+      private def v2? : Bool
+        @protocol_version >= 2
       end
 
       def close
@@ -559,6 +607,8 @@ module LavinMQ
           super("Authentication error")
         end
       end
+
+      class LegacyProtocol < Error; end
     end
   end
 end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -2,6 +2,7 @@ require "../data_dir_lock"
 require "../clustering"
 require "../rate_limiter"
 require "./checksums"
+require "./metadata"
 require "./proxy"
 require "lz4"
 require "http/server"
@@ -35,6 +36,7 @@ module LavinMQ
       @streamed_bytes = 0_u64
       @file_digests = Hash(String, Digest::SHA1).new
       @follower_done = Channel(Nil).new
+      @connected = Atomic(Int32).new(0)
       # Buffers acks from the stream-reading fiber to the ack-sending fiber.
       # Replaced with a fresh channel on each (re)connect in #stream_changes.
       @acks = Channel(Int64).new
@@ -114,6 +116,7 @@ module LavinMQ
         end
         loop do
           @socket = socket = TCPSocket.new(host, port)
+          @connected.set(1)
           socket.sync = true
           socket.read_buffering = false # use lz4 buffering
           lz4 = Compress::LZ4::Reader.new(socket)
@@ -121,6 +124,7 @@ module LavinMQ
           Log.info { "Streaming changes" }
           stream_changes(socket, lz4)
         rescue ex : IO::Error
+          @connected.set(0)
           lz4.try &.close
           socket.try &.close
           break if @closed
@@ -128,7 +132,12 @@ module LavinMQ
           sleep 1.seconds
         end
       ensure
+        @connected.set(0)
         @follower_done.send(nil)
+      end
+
+      def connected? : Bool
+        @connected.get == 1
       end
 
       def follows?(_nil : Nil) : Bool
@@ -267,7 +276,7 @@ module LavinMQ
             yield path
             ls_r(path, &blk)
           else
-            next if child.in?(".lock", ".clustering_id")
+            next if Clustering.metadata_file?(child)
             yield path
           end
         end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -116,11 +116,11 @@ module LavinMQ
         end
         loop do
           @socket = socket = TCPSocket.new(host, port)
-          @connected.set(1)
           socket.sync = true
           socket.read_buffering = false # use lz4 buffering
           lz4 = Compress::LZ4::Reader.new(socket)
           sync(socket, lz4)
+          @connected.set(1)
           Log.info { "Streaming changes" }
           stream_changes(socket, lz4)
         rescue ex : IO::Error

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -1,8 +1,11 @@
 require "../etcd"
 require "./client"
 require "./etcd_coordinator"
+require "./leader_hooks"
 
 class LavinMQ::Clustering::Controller
+  include LavinMQ::Clustering::LeaderHooks
+
   Log = LavinMQ::Log.for "clustering.controller"
 
   getter id : Int32
@@ -33,14 +36,14 @@ class LavinMQ::Clustering::Controller
     @coordinator.campaign(@advertised_uri, @id) # blocks until becoming leader, captures the fencing token
     @elected_leader.set(true)
     ensure_in_isr!
-    execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
+    run_leader_elected_hook
     @repli_client.try &.close
     yield
     loop do
       lease.wait(1.hour) # blocks until the lease expires (raises Expired)
     end
   rescue Etcd::Lease::Expired
-    execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
+    run_leader_lost_hook
     unless @stopped
       Log.fatal { "Lease expired, lost leadership" }
       exit 3
@@ -170,25 +173,6 @@ class LavinMQ::Clustering::Controller
         when in_sync.receive?
           Log.info { "In sync with leader" }
         end
-      end
-    end
-  end
-
-  private def execute_shell_command(command : String, event : String)
-    return if command.empty?
-
-    Log.info { "Executing #{event} hook in background: #{command}" }
-
-    spawn name: "#{event} hook" do
-      begin
-        status = Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
-        if status.success?
-          Log.info { "#{event} hook completed successfully" }
-        else
-          Log.warn { "#{event} hook failed with exit code #{status.exit_code}" }
-        end
-      rescue ex
-        Log.error(exception: ex) { "Failed to execute #{event} hook" }
       end
     end
   end

--- a/src/lavinmq/clustering/durable_file.cr
+++ b/src/lavinmq/clustering/durable_file.cr
@@ -1,0 +1,36 @@
+module LavinMQ
+  module Clustering
+    module DurableFile
+      def self.replace(path : String, perm : Int32 = 0o600, & : File -> Nil) : Nil
+        dir = File.dirname(path)
+        Dir.mkdir_p(dir)
+
+        tmp_path = nil
+        File.tempfile("#{File.basename(path)}.", ".tmp", dir: dir) do |io|
+          tmp_path = io.path
+          io.chmod(perm)
+          yield io
+          io.fsync
+        end
+        if tmp = tmp_path
+          File.rename(tmp, path)
+          sync_dir(dir)
+        else
+          raise "Temporary file was not created for #{path}"
+        end
+      ensure
+        if tmp = tmp_path
+          File.delete?(tmp)
+        end
+      end
+
+      private def self.sync_dir(dir : String) : Nil
+        {% if flag?(:unix) %}
+          File.open(dir) do |io|
+            io.fsync
+          end
+        {% end %}
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -36,9 +36,11 @@ module LavinMQ
       # when it was marked synced. Incremental appends below this offset are
       # already in the snapshot and must be skipped to avoid duplicating them.
       @synced_baseline = Hash(String, Int64).new
+      @protocol_version = 1
       getter id = -1
       getter remote_address
       getter state
+      getter protocol_version
 
       def initialize(@socket : TCPSocket, @data_dir : String, @file_index : FileIndex)
         @socket.sync = true # Use buffering in lz4
@@ -48,11 +50,16 @@ module LavinMQ
         @lz4 = Compress::LZ4::Writer.new(@socket, Compress::LZ4::CompressOptions.new(auto_flush: false, block_mode_linked: true))
       end
 
-      def negotiate!(password) : Nil
+      def negotiate!(password) : ConnectionKind
         @socket.read_timeout = 5.seconds # prevent idling non-authed sockets
-        validate_header!
+        @protocol_version = validate_header!
         authenticate!(password)
         @id = @socket.read_bytes Int32, IO::ByteFormat::LittleEndian
+        kind = ConnectionKind::Replication
+        if @protocol_version >= 2
+          byte = @socket.read_byte || raise IO::EOFError.new
+          kind = ConnectionKind.from_value(byte.to_u8)
+        end
         if keepalive = Config.instance.tcp_keepalive
           @socket.keepalive = true
           @socket.tcp_keepalive_idle = keepalive[0]
@@ -60,7 +67,8 @@ module LavinMQ
           @socket.tcp_keepalive_count = keepalive[2]
         end
         @socket.read_timeout = nil # assumed authed followers are well behaving
-        Log.info { "Accepted ID #{@id.to_s(36)}" }
+        Log.info { "Accepted ID #{@id.to_s(36)} protocol=v#{@protocol_version} kind=#{kind}" }
+        kind
       end
 
       # `caps` (last sync of a joining follower) limits each file to the byte
@@ -178,11 +186,15 @@ module LavinMQ
         false
       end
 
-      private def validate_header! : Nil
+      private def validate_header! : Int32
         buf = uninitialized UInt8[8]
         slice = buf.to_slice
         @socket.read_fully(slice)
-        if slice != Start
+        if slice == Start
+          1
+        elsif slice == StartV2
+          2
+        else
           @socket.write(Start)
           raise InvalidStartHeaderError.new(slice)
         end
@@ -270,48 +282,61 @@ module LavinMQ
         end
       end
 
-      def replace(path) : Int64
+      def send_snapshot_op(op_number : Int64) : Nil
+        return unless v2?
+
+        @write_lock.synchronize do
+          @lz4.write_bytes op_number, IO::ByteFormat::LittleEndian
+          @lz4.flush
+        end
+      end
+
+      def replace(path, op_number : Int64 = 0_i64) : Int64
         @write_lock.synchronize do
           File.open(File.join(@data_dir, path)) do |file|
             file_size = file.size
-            lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + file_size).to_i64
+            lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + operation_frame_size + file_size).to_i64
             @sent_bytes.add(lag_size)
             send_filename(path)
             @lz4.write_bytes file_size.to_i64, IO::ByteFormat::LittleEndian
+            send_operation_op(op_number)
             IO.copy(file, @lz4, file_size) == file_size || raise IO::EOFError.new
             lag_size
           end
         end
       end
 
-      def append(path : String, bytes : Bytes) : Int64
+      def append(path : String, bytes : Bytes, op_number : Int64 = 0_i64) : Int64
         @write_lock.synchronize do
-          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + bytes.bytesize).to_i64
+          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + operation_frame_size + bytes.bytesize).to_i64
           @sent_bytes.add(lag_size)
           send_filename(path)
           @lz4.write_bytes -bytes.bytesize.to_i64, IO::ByteFormat::LittleEndian
+          send_operation_op(op_number)
           @lz4.write bytes
           lag_size
         end
       end
 
-      def append(path : String, value : UInt32 | Int32) : Int64
+      def append(path : String, value : UInt32 | Int32, op_number : Int64 = 0_i64) : Int64
         @write_lock.synchronize do
-          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + 4).to_i64
+          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + operation_frame_size + 4).to_i64
           @sent_bytes.add(lag_size)
           send_filename(path)
           @lz4.write_bytes -4i64, IO::ByteFormat::LittleEndian
+          send_operation_op(op_number)
           @lz4.write_bytes value, IO::ByteFormat::LittleEndian
           lag_size
         end
       end
 
-      def delete(path) : Int64
+      def delete(path, op_number : Int64 = 0_i64) : Int64
         @write_lock.synchronize do
-          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64)).to_i64
+          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + operation_frame_size).to_i64
           @sent_bytes.add(lag_size)
           send_filename(path)
           @lz4.write_bytes 0i64 # delete marker (endian-agnostic)
+          send_operation_op(op_number)
           lag_size
         end
       end
@@ -319,6 +344,22 @@ module LavinMQ
       private def send_filename(path)
         @lz4.write_bytes path.bytesize.to_i32, IO::ByteFormat::LittleEndian
         @lz4.write path.to_slice
+      end
+
+      private def send_operation_op(op_number : Int64) : Nil
+        @lz4.write_bytes op_number, IO::ByteFormat::LittleEndian if v2?
+      end
+
+      private def operation_frame_size : Int32
+        v2? ? sizeof(Int64) : 0
+      end
+
+      def v2? : Bool
+        @protocol_version >= 2
+      end
+
+      def vr_quorum_capable? : Bool
+        v2?
       end
 
       def close

--- a/src/lavinmq/clustering/leader_hooks.cr
+++ b/src/lavinmq/clustering/leader_hooks.cr
@@ -1,0 +1,33 @@
+module LavinMQ
+  module Clustering
+    module LeaderHooks
+      Log = LavinMQ::Log.for "clustering.leader_hooks"
+
+      private def run_leader_elected_hook : Nil
+        execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
+      end
+
+      private def run_leader_lost_hook : Nil
+        execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
+      end
+
+      private def execute_shell_command(command : String, event : String) : Nil
+        return if command.empty?
+
+        Log.info { "Executing #{event} hook in background: #{command}" }
+        spawn name: "#{event} hook" do
+          begin
+            status = Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+            if status.success?
+              Log.info { "#{event} hook completed successfully" }
+            else
+              Log.warn { "#{event} hook failed with exit code #{status.exit_code}" }
+            end
+          rescue ex
+            Log.error(exception: ex) { "Failed to execute #{event} hook" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/metadata.cr
+++ b/src/lavinmq/clustering/metadata.cr
@@ -1,0 +1,9 @@
+module LavinMQ
+  module Clustering
+    METADATA_FILES = {".lock", ".clustering_id", ".clustering_password", ".clustering_vr_state"}
+
+    def self.metadata_file?(name : String) : Bool
+      METADATA_FILES.includes?(name)
+    end
+  end
+end

--- a/src/lavinmq/clustering/metadata.cr
+++ b/src/lavinmq/clustering/metadata.cr
@@ -1,9 +1,10 @@
 module LavinMQ
   module Clustering
-    METADATA_FILES = {".lock", ".clustering_id", ".clustering_password", ".clustering_vr_state"}
+    METADATA_FILES         = {".lock", ".clustering_id", ".clustering_password", ".clustering_vr_state"}
+    METADATA_FILE_PREFIXES = {".clustering_password.", ".clustering_vr_state."}
 
     def self.metadata_file?(name : String) : Bool
-      METADATA_FILES.includes?(name)
+      METADATA_FILES.includes?(name) || METADATA_FILE_PREFIXES.any? { |prefix| name.starts_with?(prefix) }
     end
   end
 end

--- a/src/lavinmq/clustering/password_store.cr
+++ b/src/lavinmq/clustering/password_store.cr
@@ -1,0 +1,43 @@
+require "random/secure"
+require "./metadata"
+
+module LavinMQ
+  module Clustering
+    class PasswordStore
+      FILE_NAME = ".clustering_password"
+      FILE_MODE = 0o600
+
+      getter path : String
+
+      def initialize(data_dir : String)
+        @path = File.join(data_dir, FILE_NAME)
+      end
+
+      def password(seed : String? = nil) : String
+        if File.exists?(@path)
+          enforce_mode
+          stored = File.read(@path).strip
+          if seed && seed != stored
+            raise Error.new("Configured clustering secret does not match #{@path}")
+          end
+          return stored
+        end
+
+        secret = seed || Random::Secure.base64(32)
+        Dir.mkdir_p(File.dirname(@path))
+        File.write(@path, secret)
+        File.chmod(@path, FILE_MODE)
+        secret
+      end
+
+      private def enforce_mode : Nil
+        info = File.info(@path)
+        mode = info.permissions.value & 0o777
+        return if mode == FILE_MODE
+        raise Error.new("#{@path} must have mode 0600, got #{mode.to_s(8)}")
+      end
+
+      class Error < Exception; end
+    end
+  end
+end

--- a/src/lavinmq/clustering/password_store.cr
+++ b/src/lavinmq/clustering/password_store.cr
@@ -1,4 +1,5 @@
 require "random/secure"
+require "./durable_file"
 require "./metadata"
 
 module LavinMQ
@@ -24,9 +25,9 @@ module LavinMQ
         end
 
         secret = seed || Random::Secure.base64(32)
-        Dir.mkdir_p(File.dirname(@path))
-        File.write(@path, secret)
-        File.chmod(@path, FILE_MODE)
+        DurableFile.replace(@path, FILE_MODE) do |io|
+          io.print secret
+        end
         secret
       end
 

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -33,6 +33,7 @@ module LavinMQ
       abstract def listen(server : TCPServer)
       abstract def clear
       abstract def password : String
+      abstract def status
     end
   end
 end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -90,9 +90,9 @@ module LavinMQ
           files[path] = nil
           checksums.delete(path)
         end
-        record_operation
+        op_number = record_operation
         each_follower do |f|
-          f.replace(path)
+          f.replace(path, op_number)
           # The whole file was just resent; a synced baseline for it (captured
           # at this follower's join) no longer describes its content and would
           # wrongly skip appends at offsets below the old cut (e.g. after a
@@ -114,10 +114,10 @@ module LavinMQ
         raise ArgumentError.new("append(pos, length) requires an MFile-registered path: #{path}") unless mfile
         bytes = mfile.to_slice(pos.to_i64, length.to_i64)
         offset = pos.to_i64
-        record_operation
+        op_number = record_operation
         each_follower do |f|
           skip = f.already_synced(path, offset, bytes.size.to_i64)
-          f.append(path, bytes[skip..]) if skip < bytes.size
+          f.append(path, bytes[skip..], op_number) if skip < bytes.size
         end
       end
 
@@ -129,17 +129,17 @@ module LavinMQ
         path = strip_datadir path
         @file_index.lock { |_files, checksums| checksums.delete(path) }
         size = sizeof(Int32).to_i64 # value is 4 bytes on the wire (Int32 or UInt32)
-        record_operation
+        op_number = record_operation
         each_follower do |f|
           case skip = f.already_synced(path, offset, size)
-          when 0    then f.append(path, value)
+          when 0    then f.append(path, value, op_number)
           when size then next # entirely within the follower's full_sync snapshot
           else
             # A 4-byte value is written in a single call, so a cut inside it
             # shouldn't happen; stay byte-exact anyway and send the tail.
             buf = uninitialized UInt8[4]
             IO::ByteFormat::LittleEndian.encode(value, buf.to_slice)
-            f.append(path, buf.to_slice[skip..])
+            f.append(path, buf.to_slice[skip..], op_number)
           end
         end
       end
@@ -149,10 +149,10 @@ module LavinMQ
       def append_bytes(path : String, bytes : Bytes, offset : Int64)
         path = strip_datadir path
         @file_index.lock { |_files, checksums| checksums.delete(path) }
-        record_operation
+        op_number = record_operation
         each_follower do |f|
           skip = f.already_synced(path, offset, bytes.bytesize.to_i64)
-          f.append(path, bytes[skip..]) if skip < bytes.bytesize
+          f.append(path, bytes[skip..], op_number) if skip < bytes.bytesize
         end
       end
 
@@ -162,9 +162,9 @@ module LavinMQ
           files.delete(path)
           checksums.delete(path)
         end
-        record_operation
+        op_number = record_operation
         each_follower do |f|
-          f.delete(path)
+          f.delete(path, op_number)
           f.forget_baseline(path) # path may be reused by a future file
         end
       end
@@ -324,25 +324,15 @@ module LavinMQ
       private def handle_socket(socket : TCPSocket)
         Log.context.set(follower: socket.remote_address.to_s)
         follower = Follower.new(socket, @data_dir, self)
-        follower.negotiate!(@password)
-        if follower.id == @id
-          Log.error { "Disconnecting follower with the clustering id of the leader" }
+        kind = follower.negotiate!(@password)
+        return unless known_peer?(follower)
+        if kind.control?
+          handle_control_rpc(socket, follower.id)
           return
         end
-        if members = @members
-          unless members.includes?(follower.id)
-            Log.error { "Disconnecting follower with unknown VR member id #{follower.id}" }
-            return
-          end
-        end
-        @lock.synchronize do
-          if stale_follower = @followers.find { |f| f.id == follower.id }
-            Log.error { "Disconnecting stale follower with id #{follower.id.to_s(36)}" }
-            @followers.delete(stale_follower)
-            stale_follower.close
-          end
-          @followers << follower # Starts in Syncing state
-        end
+        return unless accepts_replication?
+
+        register_follower(follower)
         sync_and_serve(follower)
       rescue ex : AuthenticationError
         Log.warn { "Follower negotiation error" }
@@ -354,6 +344,39 @@ module LavinMQ
         Log.warn(exception: ex) { "Follower disonnected: #{ex.message}" }
       ensure
         follower.try &.close
+      end
+
+      private def known_peer?(follower : Follower) : Bool
+        if follower.id == @id
+          Log.error { "Disconnecting follower with the clustering id of the leader" }
+          return false
+        end
+        if members = @members
+          unless members.includes?(follower.id)
+            Log.error { "Disconnecting follower with unknown VR member id #{follower.id}" }
+            return false
+          end
+        end
+        true
+      end
+
+      private def accepts_replication? : Bool
+        if @members && (state = @vr_state) && state.role != "primary"
+          Log.warn { "Rejecting replication connection on non-primary VR node id=#{@id}" }
+          return false
+        end
+        true
+      end
+
+      private def register_follower(follower : Follower) : Nil
+        @lock.synchronize do
+          if stale_follower = @followers.find { |f| f.id == follower.id }
+            Log.error { "Disconnecting stale follower with id #{follower.id.to_s(36)}" }
+            @followers.delete(stale_follower)
+            stale_follower.close
+          end
+          @followers << follower # Starts in Syncing state
+        end
       end
 
       # Full-sync an already-registered follower into the Synced state, then
@@ -375,6 +398,7 @@ module LavinMQ
             cut = snapshot_sizes
             follower.full_sync(cut) # sync the last, capped at the cut
             follower.capture_synced_baseline(cut)
+            follower.send_snapshot_op(@vr_state.try(&.op_number) || 0_i64)
             follower.mark_synced! # Change state to Synced
             update_isr
           end
@@ -517,8 +541,8 @@ module LavinMQ
         path[@data_dir.bytesize + 1..]
       end
 
-      private def record_operation : Nil
-        @vr_state.try &.next_op!
+      private def record_operation : Int64
+        @vr_state.try(&.next_op!) || 0_i64
       end
 
       private def wait_for_quorum : Nil
@@ -529,7 +553,7 @@ module LavinMQ
         return state.commit!(target_op) if needed_followers <= 0
 
         loop do
-          current_followers = followers.select { |f| members.includes?(f.id) }
+          current_followers = followers.select { |f| members.includes?(f.id) && f.vr_quorum_capable? }
           unless current_followers.size >= needed_followers
             return unless wait_for_followers_changed
             next
@@ -564,6 +588,41 @@ module LavinMQ
 
       private def wait_for_followers_changed : Bool
         @followers_changed.receive? || false
+      end
+
+      private def handle_control_rpc(socket : TCPSocket, requester_id : Int32) : Nil
+        members = @members
+        state = @vr_state
+        unless members && state
+          write_control_response(socket, false, 0_i64, 0_i64)
+          return
+        end
+
+        request_byte = socket.read_byte || raise IO::EOFError.new
+        case ControlRequest.from_value(request_byte.to_u8)
+        when .vote?
+          view = socket.read_bytes Int64, IO::ByteFormat::LittleEndian
+          candidate_id = socket.read_bytes Int32, IO::ByteFormat::LittleEndian
+          candidate_op = socket.read_bytes Int64, IO::ByteFormat::LittleEndian
+          granted = requester_id == candidate_id &&
+                    state.grant_vote?(candidate_id, view, candidate_op, members.primary_id(view))
+          write_control_response(socket, granted, state.view, state.op_number)
+        when .authority?
+          view = socket.read_bytes Int64, IO::ByteFormat::LittleEndian
+          primary_id = socket.read_bytes Int32, IO::ByteFormat::LittleEndian
+          granted = requester_id == primary_id &&
+                    state.grant_authority?(primary_id, view, members.primary_id(view))
+          write_control_response(socket, granted, state.view, state.op_number)
+        end
+      rescue ex : ArgumentError
+        Log.warn(exception: ex) { "Invalid VR control request from #{requester_id}" }
+      end
+
+      private def write_control_response(socket : TCPSocket, granted : Bool, view : Int64, op_number : Int64) : Nil
+        socket.write_byte(granted ? 1_u8 : 0_u8)
+        socket.write_bytes view, IO::ByteFormat::LittleEndian
+        socket.write_bytes op_number, IO::ByteFormat::LittleEndian
+        socket.flush
       end
     end
   end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -33,6 +33,7 @@ module LavinMQ
       @lock = Mutex.new(:unchecked)
       @sync_lock = Mutex.new(:unchecked)
       @followers = Array(Follower).new(4)
+      @followers_changed = Channel(Bool).new(1)
       @password : String
       @dirty_isr = true
       @id : Int32
@@ -377,6 +378,7 @@ module LavinMQ
             follower.mark_synced! # Change state to Synced
             update_isr
           end
+          notify_followers_changed
         end
         # Wait for follower to disconnect or be closed
         follower.ack_loop
@@ -385,8 +387,10 @@ module LavinMQ
         # raised or an update_isr that failed right after mark_synced! — a
         # follower left in @followers as Synced with no ack_loop running
         # would hang every wait_for_confirm forever.
+        notify_followers = false
         @lock.synchronize do
-          @followers.delete(follower)
+          removed = @followers.delete(follower)
+          notify_followers = !removed.nil? && follower.synced?
           if follower.synced?
             # If the follower was behind (unacked replicated data) when it
             # dropped, it may be missing data that's about to be confirmed via
@@ -409,6 +413,7 @@ module LavinMQ
             end
           end
         end
+        notify_followers_changed if notify_followers
       end
 
       private def update_isr
@@ -471,6 +476,7 @@ module LavinMQ
 
       def close
         @listeners.each &.close
+        @followers_changed.close
         @lock.synchronize do
           @followers.each &.close
           @followers.clear
@@ -519,21 +525,45 @@ module LavinMQ
         members = @members || raise Error.new("VR quorum requested without members")
         state = @vr_state || raise Error.new("VR quorum requested without state")
         target_op = state.op_number
-        return state.commit!(target_op) if members.quorum_size <= 1
+        needed_followers = members.quorum_size - 1
+        return state.commit!(target_op) if needed_followers <= 0
 
         loop do
-          acked = 1 # the primary already fsynced locally before this barrier
-          followers.each do |f|
-            next unless members.includes?(f.id)
-            acked += 1 if f.wait_for_confirm
-            break if acked >= members.quorum_size
+          current_followers = followers.select { |f| members.includes?(f.id) }
+          unless current_followers.size >= needed_followers
+            return unless wait_for_followers_changed
+            next
           end
-          if acked >= members.quorum_size
-            state.commit!(target_op)
-            return
+
+          results = Channel(Bool).new(current_followers.size)
+          current_followers.each do |f|
+            spawn(name: "VR quorum wait follower #{f.id.to_s(36)}") do
+              results.send(f.wait_for_confirm)
+            end
           end
-          sleep 100.milliseconds
+
+          acked_followers = 0
+          current_followers.size.times do
+            if results.receive
+              acked_followers += 1
+              if acked_followers >= needed_followers
+                state.commit!(target_op)
+                return
+              end
+            end
+          end
+
+          return unless wait_for_followers_changed
         end
+      end
+
+      private def notify_followers_changed : Nil
+        @followers_changed.try_send(true)
+      rescue Channel::ClosedError
+      end
+
+      private def wait_for_followers_changed : Bool
+        @followers_changed.receive? || false
       end
     end
   end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -4,6 +4,8 @@ require "./replicator"
 require "./follower"
 require "./checksums"
 require "./coordinator"
+require "./static_members"
+require "./vr_state"
 require "../config"
 require "../message"
 require "../mfile"
@@ -35,6 +37,8 @@ module LavinMQ
       @dirty_isr = true
       @id : Int32
       @config : Config
+      @members : StaticMembers?
+      @vr_state : VRState?
       # Maps relative paths to their MFile (for sparse, mmap-backed files) or
       # nil (for regular files where File.size is authoritative). MFile-backed
       # segments are sparse: ftruncate'd to capacity then appended from the
@@ -43,7 +47,8 @@ module LavinMQ
       # disk via fresh File handles; only the append hot path reads the mmap.
       @file_index : Sync::Shared(Tuple(Hash(String, MFile?), Checksums))
 
-      def initialize(config : Config, @coordinator : Coordinator, @id : Int32)
+      def initialize(config : Config, @coordinator : Coordinator, @id : Int32,
+                     @members : StaticMembers? = nil, @vr_state : VRState? = nil)
         Log.info { "ID: #{@id.to_s(36)}" }
         @config = config
         @data_dir = @config.data_dir
@@ -84,6 +89,7 @@ module LavinMQ
           files[path] = nil
           checksums.delete(path)
         end
+        record_operation
         each_follower do |f|
           f.replace(path)
           # The whole file was just resent; a synced baseline for it (captured
@@ -107,6 +113,7 @@ module LavinMQ
         raise ArgumentError.new("append(pos, length) requires an MFile-registered path: #{path}") unless mfile
         bytes = mfile.to_slice(pos.to_i64, length.to_i64)
         offset = pos.to_i64
+        record_operation
         each_follower do |f|
           skip = f.already_synced(path, offset, bytes.size.to_i64)
           f.append(path, bytes[skip..]) if skip < bytes.size
@@ -121,6 +128,7 @@ module LavinMQ
         path = strip_datadir path
         @file_index.lock { |_files, checksums| checksums.delete(path) }
         size = sizeof(Int32).to_i64 # value is 4 bytes on the wire (Int32 or UInt32)
+        record_operation
         each_follower do |f|
           case skip = f.already_synced(path, offset, size)
           when 0    then f.append(path, value)
@@ -140,6 +148,7 @@ module LavinMQ
       def append_bytes(path : String, bytes : Bytes, offset : Int64)
         path = strip_datadir path
         @file_index.lock { |_files, checksums| checksums.delete(path) }
+        record_operation
         each_follower do |f|
           skip = f.already_synced(path, offset, bytes.bytesize.to_i64)
           f.append(path, bytes[skip..]) if skip < bytes.bytesize
@@ -152,6 +161,7 @@ module LavinMQ
           files.delete(path)
           checksums.delete(path)
         end
+        record_operation
         each_follower do |f|
           f.delete(path)
           f.forget_baseline(path) # path may be reused by a future file
@@ -273,6 +283,28 @@ module LavinMQ
         @coordinator.password
       end
 
+      def quorum_size : Int32
+        @members.try(&.quorum_size) || 1
+      end
+
+      def status
+        if members = @members
+          if state = @vr_state
+            primary_id = members.primary_id(state.view)
+            primary_uri = members.uri(primary_id).to_s
+            state.to_named_tuple(primary_id, primary_uri, @id, members.quorum_size)
+          else
+            raise Error.new("VR members configured without VR state")
+          end
+        else
+          {
+            backend: "etcd",
+            node_id: @id,
+            role:    "primary",
+          }
+        end
+      end
+
       @listeners = Array(TCPServer).new(1)
 
       def listen(server : TCPServer)
@@ -295,6 +327,12 @@ module LavinMQ
         if follower.id == @id
           Log.error { "Disconnecting follower with the clustering id of the leader" }
           return
+        end
+        if members = @members
+          unless members.includes?(follower.id)
+            Log.error { "Disconnecting follower with unknown VR member id #{follower.id}" }
+            return
+          end
         end
         @lock.synchronize do
           if stale_follower = @followers.find { |f| f.id == follower.id }
@@ -424,6 +462,8 @@ module LavinMQ
       # acknowledged, so its removal must be committed to the coordinator
       # before this returns (see flush_isr).
       def wait_for_followers : Nil
+        return wait_for_quorum if @members
+
         all_acked = true
         followers.each { |f| all_acked &= f.wait_for_confirm }
         flush_isr if !all_acked || isr_dirty?
@@ -464,11 +504,36 @@ module LavinMQ
           end
           dirty = @dirty_isr
         end
-        flush_isr if dirty
+        flush_isr if dirty && @members.nil?
       end
 
       private def strip_datadir(path : String) : String
         path[@data_dir.bytesize + 1..]
+      end
+
+      private def record_operation : Nil
+        @vr_state.try &.next_op!
+      end
+
+      private def wait_for_quorum : Nil
+        members = @members || raise Error.new("VR quorum requested without members")
+        state = @vr_state || raise Error.new("VR quorum requested without state")
+        target_op = state.op_number
+        return state.commit!(target_op) if members.quorum_size <= 1
+
+        loop do
+          acked = 1 # the primary already fsynced locally before this barrier
+          followers.each do |f|
+            next unless members.includes?(f.id)
+            acked += 1 if f.wait_for_confirm
+            break if acked >= members.quorum_size
+          end
+          if acked >= members.quorum_size
+            state.commit!(target_op)
+            return
+          end
+          sleep 100.milliseconds
+        end
       end
     end
   end

--- a/src/lavinmq/clustering/static_members.cr
+++ b/src/lavinmq/clustering/static_members.cr
@@ -1,0 +1,82 @@
+require "uri"
+
+module LavinMQ
+  module Clustering
+    class StaticMembers
+      getter members : Hash(Int32, URI)
+
+      def self.parse(raw : String) : self
+        members = Hash(Int32, URI).new
+        raw.split(',') do |entry|
+          entry = entry.strip
+          next if entry.empty?
+
+          id_raw, uri_raw = entry.split('=', 2)
+          id = id_raw.to_i32
+          raise Error.new("Duplicate clustering member id #{id}") if members.has_key?(id)
+
+          uri = URI.parse(uri_raw)
+          raise Error.new("Clustering member #{id} is missing a host: #{uri_raw}") unless uri.hostname
+          members[id] = uri
+        rescue ex : IndexError | ArgumentError
+          raise Error.new("Invalid clustering member entry '#{entry}', expected id=uri")
+        end
+        raise Error.new("clustering.members must not be empty") if members.empty?
+        new(members)
+      end
+
+      def initialize(@members : Hash(Int32, URI))
+      end
+
+      def ids : Array(Int32)
+        @members.keys.sort!
+      end
+
+      def size : Int32
+        @members.size
+      end
+
+      def quorum_size : Int32
+        (size // 2) + 1
+      end
+
+      def includes?(id : Int32) : Bool
+        @members.has_key?(id)
+      end
+
+      def uri(id : Int32) : URI
+        @members[id]
+      end
+
+      def primary_id(view : Int64) : Int32
+        sorted = ids
+        sorted[(view % sorted.size).to_i]
+      end
+
+      def derive_node_id(advertised_uri : String?) : Int32
+        raise Error.new("clustering.node_id is required when clustering.advertised_uri is not set") unless advertised_uri
+        parsed = URI.parse(advertised_uri)
+        matches = @members.select { |_id, uri| equivalent_uri?(uri, parsed) }.keys
+        case matches.size
+        when 1 then matches.first
+        when 0 then raise Error.new("clustering.advertised_uri #{advertised_uri} does not match clustering.members")
+        else        raise Error.new("clustering.advertised_uri #{advertised_uri} matches multiple clustering.members")
+        end
+      end
+
+      private def equivalent_uri?(a : URI, b : URI) : Bool
+        a.scheme == b.scheme &&
+          a.hostname == b.hostname &&
+          (a.port || default_port(a.scheme)) == (b.port || default_port(b.scheme))
+      end
+
+      private def default_port(scheme : String?) : Int32?
+        case scheme
+        when "tcp", "lavinmq" then 5679
+        end
+      end
+
+      class Error < Exception; end
+    end
+  end
+end

--- a/src/lavinmq/clustering/static_members.cr
+++ b/src/lavinmq/clustering/static_members.cr
@@ -1,3 +1,4 @@
+require "socket"
 require "uri"
 
 module LavinMQ
@@ -65,15 +66,31 @@ module LavinMQ
       end
 
       private def equivalent_uri?(a : URI, b : URI) : Bool
-        a.scheme == b.scheme &&
-          a.hostname == b.hostname &&
-          (a.port || default_port(a.scheme)) == (b.port || default_port(b.scheme))
+        a_scheme = a.scheme.try &.downcase
+        b_scheme = b.scheme.try &.downcase
+        return false unless a_scheme == b_scheme
+
+        a_host = a.hostname
+        b_host = b.hostname
+        return false unless a_host && b_host
+
+        a_port = a.port || default_port(a_scheme)
+        b_port = b.port || default_port(b_scheme)
+        return false unless a_port && b_port
+
+        a_port == b_port && normalize_host(a_host) == normalize_host(b_host)
       end
 
       private def default_port(scheme : String?) : Int32?
         case scheme
         when "tcp", "lavinmq" then 5679
         end
+      end
+
+      private def normalize_host(host : String) : String
+        host = host.downcase
+        return Socket::IPAddress.new(host, 0).address if Socket::IPAddress.valid?(host)
+        host
       end
 
       class Error < Exception; end

--- a/src/lavinmq/clustering/vr_controller.cr
+++ b/src/lavinmq/clustering/vr_controller.cr
@@ -1,0 +1,122 @@
+require "./client"
+require "./static_members"
+require "./vr_coordinator"
+require "./vr_state"
+
+module LavinMQ
+  module Clustering
+    class VRController
+      Log = LavinMQ::Log.for "clustering.vr_controller"
+
+      HEARTBEAT_TIMEOUT = 3.seconds
+
+      getter node_id : Int32
+      getter members : StaticMembers
+      getter state : VRState
+      getter coordinator : VRCoordinator
+
+      @client : Client?
+      @stopped = false
+      @stop_channel = Channel(Nil).new
+
+      def initialize(@config : Config)
+        @members = StaticMembers.parse(@config.clustering_members)
+        advertised_uri = @config.clustering_advertised_uri ||
+                         "tcp://#{System.hostname}:#{@config.clustering_port}"
+        @node_id = @config.clustering_node_id || @members.derive_node_id(advertised_uri)
+        unless @members.includes?(@node_id)
+          raise StaticMembers::Error.new("clustering.node_id #{@node_id} is not in clustering.members")
+        end
+        @state = VRState.new(@config.data_dir)
+        @coordinator = VRCoordinator.new(@config)
+        Log.info { "VR node #{@node_id}, quorum #{@members.quorum_size}/#{@members.size}" }
+      end
+
+      def id : Int32
+        @node_id
+      end
+
+      def run(&)
+        loop do
+          return if @stopped
+          primary_id = @members.primary_id(@state.view)
+          if primary_id == @node_id
+            run_as_primary { yield }
+            return
+          end
+          follow_primary(primary_id)
+          return if @stopped
+        end
+      rescue ex : StaticMembers::Error | PasswordStore::Error | VRState::Error
+        Log.fatal { ex.message }
+        exit 3
+      end
+
+      def stop
+        return if @stopped
+        @stopped = true
+        @client.try &.close
+        @stop_channel.close
+      end
+
+      private def run_as_primary(&)
+        @state.role = "primary"
+        execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
+        Log.info { "VR primary view=#{@state.view} node_id=#{@node_id}" }
+        yield
+        @stop_channel.receive?
+      end
+
+      private def follow_primary(primary_id : Int32) : Nil
+        uri = @members.uri(primary_id)
+        @state.role = "backup"
+        Log.info { "VR backup view=#{@state.view} following primary #{primary_id} at #{uri}" }
+        client = Client.new(@config, @node_id, @coordinator.password)
+        @client = client
+        spawn(name: "VR follower #{uri}") do
+          client.follow(uri)
+        end
+
+        disconnected_since : Time::Instant? = nil
+        loop do
+          select
+          when @stop_channel.receive?
+            return
+          when timeout(500.milliseconds)
+            if client.connected?
+              disconnected_since = nil
+            else
+              disconnected_since ||= Time.instant
+              if Time.instant - disconnected_since > HEARTBEAT_TIMEOUT
+                new_view = @state.advance_view!
+                Log.warn { "VR primary #{primary_id} unavailable, starting view #{new_view}" }
+                return
+              end
+            end
+          end
+        end
+      ensure
+        @client.try &.close
+        @client = nil
+      end
+
+      private def execute_shell_command(command : String, event : String)
+        return if command.empty?
+
+        Log.info { "Executing #{event} hook in background: #{command}" }
+        spawn name: "#{event} hook" do
+          begin
+            status = Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+            if status.success?
+              Log.info { "#{event} hook completed successfully" }
+            else
+              Log.warn { "#{event} hook failed with exit code #{status.exit_code}" }
+            end
+          rescue ex
+            Log.error(exception: ex) { "Failed to execute #{event} hook" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/vr_controller.cr
+++ b/src/lavinmq/clustering/vr_controller.cr
@@ -1,4 +1,5 @@
 require "./client"
+require "./leader_hooks"
 require "./static_members"
 require "./vr_coordinator"
 require "./vr_state"
@@ -6,6 +7,8 @@ require "./vr_state"
 module LavinMQ
   module Clustering
     class VRController
+      include LeaderHooks
+
       Log = LavinMQ::Log.for "clustering.vr_controller"
 
       HEARTBEAT_TIMEOUT = 3.seconds
@@ -60,11 +63,16 @@ module LavinMQ
       end
 
       private def run_as_primary(&)
+        elected_hook_started = false
         @state.role = "primary"
-        execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
         Log.info { "VR primary view=#{@state.view} node_id=#{@node_id}" }
         yield
+        return if @stopped
+        run_leader_elected_hook
+        elected_hook_started = true
         @stop_channel.receive?
+      ensure
+        run_leader_lost_hook if elected_hook_started
       end
 
       private def follow_primary(primary_id : Int32) : Nil
@@ -98,24 +106,6 @@ module LavinMQ
       ensure
         @client.try &.close
         @client = nil
-      end
-
-      private def execute_shell_command(command : String, event : String)
-        return if command.empty?
-
-        Log.info { "Executing #{event} hook in background: #{command}" }
-        spawn name: "#{event} hook" do
-          begin
-            status = Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
-            if status.success?
-              Log.info { "#{event} hook completed successfully" }
-            else
-              Log.warn { "#{event} hook failed with exit code #{status.exit_code}" }
-            end
-          rescue ex
-            Log.error(exception: ex) { "Failed to execute #{event} hook" }
-          end
-        end
       end
     end
   end

--- a/src/lavinmq/clustering/vr_controller.cr
+++ b/src/lavinmq/clustering/vr_controller.cr
@@ -18,6 +18,15 @@ module LavinMQ
       getter state : VRState
       getter coordinator : VRCoordinator
 
+      struct ControlResponse
+        getter? granted : Bool
+        getter view : Int64
+        getter op_number : Int64
+
+        def initialize(@granted : Bool, @view : Int64, @op_number : Int64)
+        end
+      end
+
       @client : Client?
       @stopped = false
       @stop_channel = Channel(Nil).new
@@ -44,8 +53,13 @@ module LavinMQ
           return if @stopped
           primary_id = @members.primary_id(@state.view)
           if primary_id == @node_id
-            run_as_primary { yield }
-            return
+            if win_election?
+              run_as_primary { yield }
+              return
+            end
+            new_view = @state.advance_view!
+            Log.warn { "VR election failed for node #{@node_id} in view #{new_view - 1}, starting view #{new_view}" }
+            next
           end
           follow_primary(primary_id)
           return if @stopped
@@ -64,13 +78,21 @@ module LavinMQ
 
       private def run_as_primary(&)
         elected_hook_started = false
+        authority_lost = Channel(Int64).new(1)
         @state.role = "primary"
         Log.info { "VR primary view=#{@state.view} node_id=#{@node_id}" }
         yield
         return if @stopped
         run_leader_elected_hook
         elected_hook_started = true
-        @stop_channel.receive?
+        spawn(name: "VR authority monitor") { monitor_authority(authority_lost) }
+        select
+        when @stop_channel.receive?
+        when higher_view = authority_lost.receive
+          @state.observe_view!(higher_view)
+          Log.fatal { "Lost VR majority authority in view #{@state.view}, stepping down" }
+          exit 1
+        end
       ensure
         run_leader_lost_hook if elected_hook_started
       end
@@ -79,7 +101,7 @@ module LavinMQ
         uri = @members.uri(primary_id)
         @state.role = "backup"
         Log.info { "VR backup view=#{@state.view} following primary #{primary_id} at #{uri}" }
-        client = Client.new(@config, @node_id, @coordinator.password)
+        client = Client.new(@config, @node_id, @coordinator.password, vr_state: @state)
         @client = client
         spawn(name: "VR follower #{uri}") do
           client.follow(uri)
@@ -106,6 +128,127 @@ module LavinMQ
       ensure
         @client.try &.close
         @client = nil
+      end
+
+      private def win_election? : Bool
+        view = @state.view
+        primary_id = @members.primary_id(view)
+        return false unless primary_id == @node_id
+        return false unless @state.grant_vote?(@node_id, view, @state.op_number, primary_id)
+
+        votes = 1
+        return true if votes >= @members.quorum_size
+
+        peers = @members.ids.reject { |id| id == @node_id }
+        responses = Channel(ControlResponse?).new(peers.size)
+        peers.each do |peer_id|
+          spawn(name: "VR vote request #{peer_id}") do
+            responses.send(request_vote(peer_id, view, @state.op_number))
+          end
+        end
+
+        peers.size.times do
+          if response = responses.receive
+            @state.observe_view!(response.view) if response.view > view
+            votes += 1 if response.granted?
+            return true if votes >= @members.quorum_size
+          end
+        end
+        false
+      end
+
+      private def monitor_authority(authority_lost : Channel(Int64)) : Nil
+        failed_since : Time::Instant? = nil
+        view = @state.view
+        loop do
+          return if @stopped
+
+          authorized, highest_view = authority_status(view)
+          if highest_view > view
+            authority_lost.try_send(highest_view)
+            return
+          end
+
+          if authorized
+            failed_since = nil
+          else
+            now = Time.instant
+            failed_since ||= now
+            if now - failed_since > HEARTBEAT_TIMEOUT
+              authority_lost.try_send(view)
+              return
+            end
+          end
+
+          sleep 500.milliseconds
+        end
+      end
+
+      private def authority_status(view : Int64) : {Bool, Int64}
+        votes = 1
+        highest_view = view
+        return {true, highest_view} if votes >= @members.quorum_size
+
+        peers = @members.ids.reject { |id| id == @node_id }
+        responses = Channel(ControlResponse?).new(peers.size)
+        peers.each do |peer_id|
+          spawn(name: "VR authority request #{peer_id}") do
+            responses.send(request_authority(peer_id, view))
+          end
+        end
+
+        peers.size.times do
+          if response = responses.receive
+            highest_view = Math.max(highest_view, response.view)
+            votes += 1 if response.granted?
+          end
+        end
+        {votes >= @members.quorum_size, highest_view}
+      end
+
+      private def request_vote(peer_id : Int32, view : Int64, op_number : Int64) : ControlResponse?
+        control_request(peer_id, ControlRequest::Vote) do |socket|
+          socket.write_bytes view, IO::ByteFormat::LittleEndian
+          socket.write_bytes @node_id, IO::ByteFormat::LittleEndian
+          socket.write_bytes op_number, IO::ByteFormat::LittleEndian
+        end
+      end
+
+      private def request_authority(peer_id : Int32, view : Int64) : ControlResponse?
+        control_request(peer_id, ControlRequest::Authority) do |socket|
+          socket.write_bytes view, IO::ByteFormat::LittleEndian
+          socket.write_bytes @node_id, IO::ByteFormat::LittleEndian
+        end
+      end
+
+      private def control_request(peer_id : Int32, request : ControlRequest, & : TCPSocket -> Nil) : ControlResponse?
+        uri = @members.uri(peer_id)
+        host = uri.hostname || raise StaticMembers::Error.new("Clustering member #{peer_id} is missing a host")
+        socket = TCPSocket.new(host, uri.port || 5679)
+        socket.sync = true
+        socket.read_timeout = 1.second
+        socket.write_timeout = 1.second
+        socket.write StartV2
+        password = @coordinator.password
+        socket.write_bytes password.bytesize.to_u8, IO::ByteFormat::LittleEndian
+        socket.write password.to_slice
+        return unless socket.read_byte == 0
+
+        socket.write_bytes @node_id, IO::ByteFormat::LittleEndian
+        socket.write_byte ConnectionKind::Control.value
+        socket.write_byte request.value
+        yield socket
+        socket.flush
+
+        granted = socket.read_byte == 1
+        response_view = socket.read_bytes Int64, IO::ByteFormat::LittleEndian
+        response_op = socket.read_bytes Int64, IO::ByteFormat::LittleEndian
+        ControlResponse.new(granted, response_view, response_op)
+      rescue ex : IO::Error | Socket::Error | KeyError
+        Log.debug(exception: ex) { "VR control #{request} to node #{peer_id} failed" }
+        nil
+      ensure
+        socket.close if socket
       end
     end
   end

--- a/src/lavinmq/clustering/vr_coordinator.cr
+++ b/src/lavinmq/clustering/vr_coordinator.cr
@@ -1,0 +1,20 @@
+require "./coordinator"
+require "./password_store"
+
+module LavinMQ
+  module Clustering
+    class VRCoordinator < Coordinator
+      def initialize(@config : Config)
+        @password_store = PasswordStore.new(@config.data_dir)
+      end
+
+      def update_isr(synced_node_ids : Set(Int32)) : Nil
+        synced_node_ids
+      end
+
+      def password : String
+        @password_store.password(@config.clustering_secret)
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/vr_state.cr
+++ b/src/lavinmq/clustering/vr_state.cr
@@ -1,4 +1,5 @@
 require "json"
+require "./durable_file"
 
 module LavinMQ
   module Clustering
@@ -10,7 +11,7 @@ module LavinMQ
       @lock = Mutex.new(:unchecked)
       @view : Int64 = 0_i64
       @role : String = "backup"
-      @op_number : Int64 = 0_i64
+      @op_number = Atomic(Int64).new(0_i64)
       @commit_number : Int64 = 0_i64
 
       def initialize(data_dir : String)
@@ -27,7 +28,7 @@ module LavinMQ
       end
 
       def op_number : Int64
-        @lock.synchronize { @op_number }
+        @op_number.get(:relaxed)
       end
 
       def commit_number : Int64
@@ -51,10 +52,7 @@ module LavinMQ
       end
 
       def next_op! : Int64
-        @lock.synchronize do
-          @op_number += 1
-          @op_number
-        end
+        @op_number.add(1_i64, :relaxed) + 1_i64
       end
 
       def commit!(op : Int64) : Nil
@@ -74,7 +72,7 @@ module LavinMQ
             view:          @view,
             primary_id:    primary_id,
             primary_uri:   primary_uri,
-            op_number:     @op_number,
+            op_number:     @op_number.get(:relaxed),
             commit_number: @commit_number,
             quorum_size:   quorum_size,
           }
@@ -87,19 +85,18 @@ module LavinMQ
         json = JSON.parse(File.read(@path))
         @view = json["view"].as_i64
         @role = json["role"].as_s
-        @op_number = json["op_number"].as_i64
+        @op_number.set(json["op_number"].as_i64, :relaxed)
         @commit_number = json["commit_number"].as_i64
       rescue ex : JSON::ParseException | KeyError | TypeCastError
         raise Error.new("Invalid VR state file #{@path}: #{ex.message}")
       end
 
       private def store : Nil
-        Dir.mkdir_p(File.dirname(@path))
-        File.open(@path, "w") do |io|
+        DurableFile.replace(@path) do |io|
           {
             view:          @view,
             role:          @role,
-            op_number:     @op_number,
+            op_number:     @op_number.get(:relaxed),
             commit_number: @commit_number,
           }.to_json(io)
         end

--- a/src/lavinmq/clustering/vr_state.cr
+++ b/src/lavinmq/clustering/vr_state.cr
@@ -13,6 +13,8 @@ module LavinMQ
       @role : String = "backup"
       @op_number = Atomic(Int64).new(0_i64)
       @commit_number : Int64 = 0_i64
+      @voted_view : Int64 = -1_i64
+      @voted_for : Int32?
 
       def initialize(data_dir : String)
         @path = File.join(data_dir, FILE_NAME)
@@ -52,7 +54,21 @@ module LavinMQ
       end
 
       def next_op! : Int64
-        @op_number.add(1_i64, :relaxed) + 1_i64
+        @lock.synchronize do
+          op = @op_number.get(:relaxed) + 1_i64
+          @op_number.set(op, :relaxed)
+          store
+          op
+        end
+      end
+
+      def apply_op!(op : Int64) : Nil
+        @lock.synchronize do
+          return if op <= @op_number.get(:relaxed)
+
+          @op_number.set(op, :relaxed)
+          store
+        end
       end
 
       def commit!(op : Int64) : Nil
@@ -79,6 +95,67 @@ module LavinMQ
         end
       end
 
+      def grant_vote?(candidate_id : Int32, requested_view : Int64, candidate_op : Int64, primary_id : Int32) : Bool
+        @lock.synchronize do
+          changed = false
+          if requested_view > @view
+            @view = requested_view
+            @role = "backup"
+            changed = true
+          end
+
+          granted = false
+          if requested_view == @view && candidate_id == primary_id && candidate_op >= @op_number.get(:relaxed)
+            if @voted_view == requested_view
+              granted = @voted_for == candidate_id
+            else
+              @voted_view = requested_view
+              @voted_for = candidate_id
+              changed = true
+              granted = true
+            end
+          end
+
+          store if changed
+          granted
+        end
+      end
+
+      def grant_authority?(primary_id : Int32, requested_view : Int64, expected_primary_id : Int32) : Bool
+        @lock.synchronize do
+          changed = false
+          if requested_view > @view
+            @view = requested_view
+            @role = "backup"
+            changed = true
+          end
+
+          granted = requested_view == @view &&
+                    primary_id == expected_primary_id &&
+                    @voted_view <= requested_view
+          store if changed
+          granted
+        end
+      end
+
+      def observe_view!(seen_view : Int64) : Nil
+        @lock.synchronize do
+          return if seen_view <= @view
+
+          @view = seen_view
+          @role = "backup"
+          store
+        end
+      end
+
+      def voted_view : Int64
+        @lock.synchronize { @voted_view }
+      end
+
+      def voted_for : Int32?
+        @lock.synchronize { @voted_for }
+      end
+
       private def restore : Nil
         return unless File.exists?(@path)
 
@@ -87,6 +164,10 @@ module LavinMQ
         @role = json["role"].as_s
         @op_number.set(json["op_number"].as_i64, :relaxed)
         @commit_number = json["commit_number"].as_i64
+        @voted_view = json["voted_view"]?.try(&.as_i64) || -1_i64
+        if voted_for = json["voted_for"]?
+          @voted_for = voted_for.raw.nil? ? nil : voted_for.as_i
+        end
       rescue ex : JSON::ParseException | KeyError | TypeCastError
         raise Error.new("Invalid VR state file #{@path}: #{ex.message}")
       end
@@ -98,6 +179,8 @@ module LavinMQ
             role:          @role,
             op_number:     @op_number.get(:relaxed),
             commit_number: @commit_number,
+            voted_view:    @voted_view,
+            voted_for:     @voted_for,
           }.to_json(io)
         end
       end

--- a/src/lavinmq/clustering/vr_state.cr
+++ b/src/lavinmq/clustering/vr_state.cr
@@ -4,7 +4,11 @@ require "./durable_file"
 module LavinMQ
   module Clustering
     class VRState
-      FILE_NAME = ".clustering_vr_state"
+      FILE_NAME               = ".clustering_vr_state"
+      OP_NUMBER_FILE_NAME     = "#{FILE_NAME}.op_number"
+      COMMIT_NUMBER_FILE_NAME = "#{FILE_NAME}.commit_number"
+      COMPACT_BYTES           = 8_i64 * 1024 * 1024
+      COUNTER_BYTES           = 8_i64
 
       getter path : String
 
@@ -15,9 +19,21 @@ module LavinMQ
       @commit_number : Int64 = 0_i64
       @voted_view : Int64 = -1_i64
       @voted_for : Int32?
+      @op_path : String
+      @commit_path : String
+      @op_file : File?
+      @commit_file : File?
+      @op_bytes_written = 0_i64
+      @commit_bytes_written = 0_i64
+      @op_needs_compaction = false
+      @commit_needs_compaction = false
+      @compact_bytes : Int64
 
-      def initialize(data_dir : String)
+      def initialize(data_dir : String, compact_bytes : Int64 = COMPACT_BYTES)
+        @compact_bytes = compact_bytes
         @path = File.join(data_dir, FILE_NAME)
+        @op_path = File.join(data_dir, OP_NUMBER_FILE_NAME)
+        @commit_path = File.join(data_dir, COMMIT_NUMBER_FILE_NAME)
         restore
       end
 
@@ -40,7 +56,7 @@ module LavinMQ
       def role=(role : String) : Nil
         @lock.synchronize do
           @role = role
-          store
+          store_state
         end
       end
 
@@ -48,7 +64,7 @@ module LavinMQ
         @lock.synchronize do
           @view += 1
           @role = "backup"
-          store
+          store_state
           @view
         end
       end
@@ -57,7 +73,7 @@ module LavinMQ
         @lock.synchronize do
           op = @op_number.get(:relaxed) + 1_i64
           @op_number.set(op, :relaxed)
-          store
+          append_op_number(op)
           op
         end
       end
@@ -67,7 +83,7 @@ module LavinMQ
           return if op <= @op_number.get(:relaxed)
 
           @op_number.set(op, :relaxed)
-          store
+          append_op_number(op)
         end
       end
 
@@ -75,7 +91,7 @@ module LavinMQ
         @lock.synchronize do
           return if op <= @commit_number
           @commit_number = op
-          store
+          append_commit_number(op)
         end
       end
 
@@ -116,7 +132,7 @@ module LavinMQ
             end
           end
 
-          store if changed
+          store_state if changed
           granted
         end
       end
@@ -133,7 +149,7 @@ module LavinMQ
           granted = requested_view == @view &&
                     primary_id == expected_primary_id &&
                     @voted_view <= requested_view
-          store if changed
+          store_state if changed
           granted
         end
       end
@@ -144,7 +160,7 @@ module LavinMQ
 
           @view = seen_view
           @role = "backup"
-          store
+          store_state
         end
       end
 
@@ -157,31 +173,146 @@ module LavinMQ
       end
 
       private def restore : Nil
+        restore_state
+        restore_op_number
+        restore_commit_number
+      end
+
+      private def restore_state : Nil
         return unless File.exists?(@path)
 
-        json = JSON.parse(File.read(@path))
-        @view = json["view"].as_i64
-        @role = json["role"].as_s
-        @op_number.set(json["op_number"].as_i64, :relaxed)
-        @commit_number = json["commit_number"].as_i64
-        @voted_view = json["voted_view"]?.try(&.as_i64) || -1_i64
-        if voted_for = json["voted_for"]?
-          @voted_for = voted_for.raw.nil? ? nil : voted_for.as_i
-        end
-      rescue ex : JSON::ParseException | KeyError | TypeCastError
+        restore_state_json(JSON.parse(File.read(@path)))
+      rescue ex : IO::Error | JSON::ParseException | KeyError | TypeCastError
         raise Error.new("Invalid VR state file #{@path}: #{ex.message}")
       end
 
-      private def store : Nil
-        DurableFile.replace(@path) do |io|
+      private def restore_state_json(json : JSON::Any) : Nil
+        @view = json["view"].as_i64
+        @role = json["role"].as_s
+        @voted_view = json["voted_view"]?.try(&.as_i64) || -1_i64
+        @voted_for = nil
+        if voted_for = json["voted_for"]?
+          @voted_for = voted_for.raw.nil? ? nil : voted_for.as_i
+        end
+      end
+
+      private def restore_op_number : Nil
+        counter = restore_counter(@op_path)
+        if value = counter[:value]
+          @op_number.set(value, :relaxed)
+        end
+        @op_bytes_written = counter[:bytes_written]
+        @op_needs_compaction = counter[:needs_compaction]
+      end
+
+      private def restore_commit_number : Nil
+        counter = restore_counter(@commit_path)
+        if value = counter[:value]
+          @commit_number = value
+        end
+        @commit_bytes_written = counter[:bytes_written]
+        @commit_needs_compaction = counter[:needs_compaction]
+      end
+
+      private def restore_counter(path : String)
+        return {value: nil.as(Int64?), bytes_written: 0_i64, needs_compaction: false} unless File.exists?(path)
+
+        size = File.size(path)
+        complete_size = size - (size % COUNTER_BYTES)
+        value = nil.as(Int64?)
+        if complete_size > 0
+          File.open(path) do |file|
+            file.seek(complete_size - COUNTER_BYTES)
+            value = file.read_bytes(Int64, IO::ByteFormat::LittleEndian)
+          end
+        end
+        {value: value, bytes_written: size, needs_compaction: complete_size != size}
+      rescue ex : IO::Error
+        raise Error.new("Invalid VR counter file #{path}: #{ex.message}")
+      end
+
+      private def store_state : Nil
+        DurableFile.replace(@path, File::DEFAULT_CREATE_PERMISSIONS.value.to_i32) do |io|
           {
-            view:          @view,
-            role:          @role,
-            op_number:     @op_number.get(:relaxed),
-            commit_number: @commit_number,
-            voted_view:    @voted_view,
-            voted_for:     @voted_for,
+            view:       @view,
+            role:       @role,
+            voted_view: @voted_view,
+            voted_for:  @voted_for,
           }.to_json(io)
+        end
+      end
+
+      private def append_op_number(op : Int64) : Nil
+        if @op_needs_compaction || (@op_bytes_written > 0 && @op_bytes_written + COUNTER_BYTES >= @compact_bytes)
+          close_op_file
+          @op_file = compact_counter(@op_path, op)
+          @op_bytes_written = COUNTER_BYTES
+          @op_needs_compaction = false
+        else
+          append_counter(op_file, op)
+          @op_bytes_written += COUNTER_BYTES
+        end
+      end
+
+      private def append_commit_number(op : Int64) : Nil
+        if @commit_needs_compaction || (@commit_bytes_written > 0 && @commit_bytes_written + COUNTER_BYTES >= @compact_bytes)
+          close_commit_file
+          @commit_file = compact_counter(@commit_path, op)
+          @commit_bytes_written = COUNTER_BYTES
+          @commit_needs_compaction = false
+        else
+          append_counter(commit_file, op)
+          @commit_bytes_written += COUNTER_BYTES
+        end
+      end
+
+      private def append_counter(file : File, value : Int64) : Nil
+        file.write_bytes(value, IO::ByteFormat::LittleEndian)
+      end
+
+      private def compact_counter(path : String, value : Int64) : File
+        tmp_path = "#{path}.tmp"
+
+        Dir.mkdir_p(File.dirname(path))
+        file = File.open(tmp_path, "w")
+        begin
+          file.sync = true
+          file.write_bytes(value, IO::ByteFormat::LittleEndian)
+          File.rename(tmp_path, path)
+          file
+        rescue ex
+          file.close unless file.closed?
+          File.delete?(tmp_path)
+          raise ex
+        end
+      end
+
+      private def op_file : File
+        @op_file ||= open_counter_file(@op_path)
+      end
+
+      private def commit_file : File
+        @commit_file ||= open_counter_file(@commit_path)
+      end
+
+      private def open_counter_file(path : String) : File
+        Dir.mkdir_p(File.dirname(path))
+        File.open(path, "a").tap do |file|
+          file.sync = true
+        end
+      end
+
+      private def close_op_file : Nil
+        if file = @op_file
+          file.close
+          @op_file = nil
+        end
+      end
+
+      private def close_commit_file : Nil
+        if file = @commit_file
+          file.close
+          @commit_file = nil
         end
       end
 

--- a/src/lavinmq/clustering/vr_state.cr
+++ b/src/lavinmq/clustering/vr_state.cr
@@ -1,0 +1,111 @@
+require "json"
+
+module LavinMQ
+  module Clustering
+    class VRState
+      FILE_NAME = ".clustering_vr_state"
+
+      getter path : String
+
+      @lock = Mutex.new(:unchecked)
+      @view : Int64 = 0_i64
+      @role : String = "backup"
+      @op_number : Int64 = 0_i64
+      @commit_number : Int64 = 0_i64
+
+      def initialize(data_dir : String)
+        @path = File.join(data_dir, FILE_NAME)
+        restore
+      end
+
+      def view : Int64
+        @lock.synchronize { @view }
+      end
+
+      def role : String
+        @lock.synchronize { @role }
+      end
+
+      def op_number : Int64
+        @lock.synchronize { @op_number }
+      end
+
+      def commit_number : Int64
+        @lock.synchronize { @commit_number }
+      end
+
+      def role=(role : String) : Nil
+        @lock.synchronize do
+          @role = role
+          store
+        end
+      end
+
+      def advance_view! : Int64
+        @lock.synchronize do
+          @view += 1
+          @role = "backup"
+          store
+          @view
+        end
+      end
+
+      def next_op! : Int64
+        @lock.synchronize do
+          @op_number += 1
+          @op_number
+        end
+      end
+
+      def commit!(op : Int64) : Nil
+        @lock.synchronize do
+          return if op <= @commit_number
+          @commit_number = op
+          store
+        end
+      end
+
+      def to_named_tuple(primary_id : Int32, primary_uri : String, node_id : Int32, quorum_size : Int32)
+        @lock.synchronize do
+          {
+            backend:       "vr",
+            node_id:       node_id,
+            role:          @role,
+            view:          @view,
+            primary_id:    primary_id,
+            primary_uri:   primary_uri,
+            op_number:     @op_number,
+            commit_number: @commit_number,
+            quorum_size:   quorum_size,
+          }
+        end
+      end
+
+      private def restore : Nil
+        return unless File.exists?(@path)
+
+        json = JSON.parse(File.read(@path))
+        @view = json["view"].as_i64
+        @role = json["role"].as_s
+        @op_number = json["op_number"].as_i64
+        @commit_number = json["commit_number"].as_i64
+      rescue ex : JSON::ParseException | KeyError | TypeCastError
+        raise Error.new("Invalid VR state file #{@path}: #{ex.message}")
+      end
+
+      private def store : Nil
+        Dir.mkdir_p(File.dirname(@path))
+        File.open(@path, "w") do |io|
+          {
+            view:          @view,
+            role:          @role,
+            op_number:     @op_number,
+            commit_number: @commit_number,
+          }.to_json(io)
+        end
+      end
+
+      class Error < Exception; end
+    end
+  end
+end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -291,10 +291,30 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_CLUSTERING")]
       property? clustering = false
 
+      @[CliOpt("", "--clustering-backend=BACKEND", "Clustering backend: etcd or vr (default: etcd)", section: "clustering")]
+      @[IniOpt(ini_name: backend, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_BACKEND")]
+      property clustering_backend = "etcd"
+
       @[CliOpt("", "--clustering-advertised-uri=URI", "Advertised URI for the clustering server", section: "clustering")]
       @[IniOpt(ini_name: advertised_uri, section: "clustering")]
       @[EnvOpt("LAVINMQ_CLUSTERING_ADVERTISED_URI")]
       property clustering_advertised_uri : String? = nil
+
+      @[CliOpt("", "--clustering-members=MEMBERS", "Static VR member roster, e.g. 1=tcp://node1:5679,2=tcp://node2:5679", section: "clustering")]
+      @[IniOpt(ini_name: members, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_MEMBERS")]
+      property clustering_members = ""
+
+      @[CliOpt("", "--clustering-node-id=ID", "Static VR node id. If omitted it is derived from advertised_uri.", section: "clustering")]
+      @[IniOpt(ini_name: node_id, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_NODE_ID")]
+      property clustering_node_id : Int32? = nil
+
+      @[CliOpt("", "--clustering-secret=SECRET", "Seed for the shared clustering password file", section: "clustering")]
+      @[IniOpt(ini_name: secret, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_SECRET")]
+      property clustering_secret : String? = nil
 
       @[CliOpt("", "--clustering-bind=BIND", "Listen for clustering followers on this address (default: localhost)", section: "clustering")]
       @[IniOpt(ini_name: bind, section: "clustering")]

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -136,6 +136,12 @@ module LavinMQ
           context
         end
 
+        get "/api/clustering/status" do |context, _params|
+          refuse_unless_administrator(context, user(context))
+          @amqp_server.clustering_status.to_json(context.response)
+          context
+        end
+
         # Run GC on the current node, without having to know its name
         post "/api/nodes/gc_collect" do |context, _params|
           refuse_unless_administrator(context, user(context))

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -25,6 +25,7 @@ module LavinMQ
     @data_dir_lock : DataDirLock?
     @closed = false
     @replicator : Clustering::Server?
+    @clustering_listener_started = false
 
     def initialize(@config : Config)
       print_environment_info
@@ -86,6 +87,7 @@ module LavinMQ
     end
 
     def run
+      start_vr_clustering_listener
       @runner.run do
         start
       end
@@ -194,8 +196,9 @@ module LavinMQ
         end
       end
 
-      if clustering_bind = @config.clustering_bind
+      if (clustering_bind = @config.clustering_bind) && !@clustering_listener_started
         spawn amqp_server.listen_clustering(clustering_bind, @config.clustering_port), name: "Clustering listener"
+        @clustering_listener_started = true
       end
 
       unless @config.unix_path.empty?
@@ -233,6 +236,19 @@ module LavinMQ
       unless @config.mqtt_unix_path.empty?
         spawn amqp_server.listen_unix(@config.mqtt_unix_path, Server::Protocol::MQTT), name: "MQTT listening at #{@config.unix_path}"
       end
+    end
+
+    private def start_vr_clustering_listener : Nil
+      return unless @config.clustering? && @config.clustering_backend == "vr"
+      return if @clustering_listener_started
+      return unless clustering_bind = @config.clustering_bind
+      return unless replicator = @replicator
+
+      tcp_server = TCPServer.new(clustering_bind, @config.clustering_port)
+      @clustering_listener_started = true
+      spawn replicator.listen(tcp_server), name: "VR clustering listener"
+    rescue ex : Socket::BindError
+      abort "Error: #{ex.message}"
     end
 
     private def dump_debug_info

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -10,6 +10,7 @@ require "./pidfile"
 require "./etcd"
 require "./clustering/controller"
 require "./clustering/etcd_coordinator"
+require "./clustering/vr_controller"
 require "./standalone_runner"
 require "./definitions"
 require "../stdlib/openssl_on_server_name"
@@ -40,10 +41,18 @@ module LavinMQ
       end
 
       if @config.clustering?
-        etcd = Etcd.new(@config.clustering_etcd_endpoints)
-        coordinator = Clustering::EtcdCoordinator.new(@config, etcd)
-        @runner = controller = Clustering::Controller.new(@config, etcd, coordinator)
-        @replicator = Clustering::Server.new(@config, coordinator, controller.id)
+        case @config.clustering_backend
+        when "etcd"
+          etcd = Etcd.new(@config.clustering_etcd_endpoints)
+          coordinator = Clustering::EtcdCoordinator.new(@config, etcd)
+          @runner = controller = Clustering::Controller.new(@config, etcd, coordinator)
+          @replicator = Clustering::Server.new(@config, coordinator, controller.id)
+        when "vr"
+          @runner = controller = Clustering::VRController.new(@config)
+          @replicator = Clustering::Server.new(@config, controller.coordinator, controller.id, controller.members, controller.state)
+        else
+          abort "Unknown clustering backend '#{@config.clustering_backend}', expected etcd or vr"
+        end
       else
         @runner = StandaloneRunner.new
       end

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -93,6 +93,13 @@ module LavinMQ
       @replicator.try(&.all_followers) || Array(Clustering::Follower).new
     end
 
+    def clustering_status
+      @replicator.try(&.status) || {
+        backend: "standalone",
+        role:    "primary",
+      }
+    end
+
     def amqp_url
       addr = @listeners
         .select { |_, v| v.amqp? }


### PR DESCRIPTION
## Summary
- Add the VR clustering backend with static membership, quorum commit behavior, persistent VR state, password storage, and clustering status reporting.
- Keep etcd as the default compatibility backend while allowing VR via clustering.backend/config flags.
- Update the local tmux cluster helper to launch VR nodes with a static roster, per-node control sockets, and clean local data dirs by default.
- Isolate the join-race clustering spec by disabling the follower metrics listener.

## Testing
- bash -n extras/start-cluster-in-tmux.sh
- make test SPEC=spec/clustering/join_race_spec.cr
- make test SPEC=spec/clustering
- make lint
- make test (1924 examples, 0 failures, 10 pending)
- Manual fresh 3-node VR launch: followers full-synced to node 1; primary logged in-sync replicas [2, 3, 1].

Jepsen has not been run yet in this branch.