### PR TITLE
Include ::MQTT::Protocol in LavinMQ::MQTT::Protocol to not pollute LavinMQ::MQTT

### DIFF
--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -72,7 +72,7 @@ module LavinMQ
         @vhost.rm_connection(client)
       end
 
-      def publish(packet : MQTT::Publish)
+      def publish(packet : Protocol::Publish)
         @exchange.publish(packet)
       end
 
@@ -87,7 +87,7 @@ module LavinMQ
             msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
             session.publish(msg)
           end
-          MQTT::SubAck::ReturnCode.from_int(tf.qos)
+          Protocol::SubAck::ReturnCode.from_int(tf.qos)
         end
       end
 

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -43,14 +43,14 @@ module LavinMQ
         nil
       end
 
-      def initialize(@io : MQTT::IO,
+      def initialize(@io : Protocol::IO,
                      @connection_info : ConnectionInfo,
                      @user : Auth::BaseUser,
                      @broker : MQTT::Broker,
                      @client_id : String,
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
-                     @will : MQTT::Will? = nil)
+                     @will : Protocol::Will? = nil)
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
@@ -86,12 +86,12 @@ module LavinMQ
           end
           # The disconnect packet has been handled and the socket has been closed.
           # If we dont breakt the loop here we'll get a IO/Error on next read.
-          if packet.is_a?(MQTT::Disconnect)
+          if packet.is_a?(Protocol::Disconnect)
             @log.debug { "Received disconnect" }
             break
           end
         end
-      rescue ex : ::MQTT::Protocol::Error::PacketDecode
+      rescue ex : Protocol::Error::PacketDecode
         @log.warn(exception: ex) { "Packet decode error" }
         publish_will
       rescue ex : ::IO::TimeoutError
@@ -127,13 +127,13 @@ module LavinMQ
         vhost.add_recv_bytes(packet.bytesize.to_u64)
 
         case packet
-        when MQTT::Publish     then recieve_publish(packet)
-        when MQTT::PubAck      then recieve_puback(packet)
-        when MQTT::Subscribe   then recieve_subscribe(packet)
-        when MQTT::Unsubscribe then recieve_unsubscribe(packet)
-        when MQTT::PingReq     then receive_pingreq(packet)
-        when MQTT::Disconnect  then return packet
-        else                        raise "received unexpected packet: #{packet}"
+        when Protocol::Publish     then recieve_publish(packet)
+        when Protocol::PubAck      then recieve_puback(packet)
+        when Protocol::Subscribe   then recieve_subscribe(packet)
+        when Protocol::Unsubscribe then recieve_unsubscribe(packet)
+        when Protocol::PingReq     then receive_pingreq(packet)
+        when Protocol::Disconnect  then return packet
+        else                            raise "received unexpected packet: #{packet}"
         end
         packet
       end
@@ -146,23 +146,23 @@ module LavinMQ
           vhost.add_send_bytes(packet.bytesize.to_u64)
         end
         case packet
-        when MQTT::Publish
+        when Protocol::Publish
           if packet.dup?
             vhost.event_tick(EventType::ClientRedeliver)
           else
             vhost.event_tick(EventType::ClientDeliverNoAck) if packet.qos == 0
             vhost.event_tick(EventType::ClientDeliver) if packet.qos > 0
           end
-        when MQTT::PubAck
+        when Protocol::PubAck
           vhost.event_tick(EventType::ClientPublishConfirm)
         end
       end
 
-      def receive_pingreq(packet : MQTT::PingReq)
-        send MQTT::PingResp.new
+      def receive_pingreq(packet : Protocol::PingReq)
+        send Protocol::PingResp.new
       end
 
-      def recieve_publish(packet : MQTT::Publish)
+      def recieve_publish(packet : Protocol::Publish)
         if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
           Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
           close_socket
@@ -172,16 +172,16 @@ module LavinMQ
         vhost.event_tick(EventType::ClientPublish)
         # Ok to not send anything if qos = 0 (fire and forget)
         if packet.qos > 0 && (packet_id = packet.packet_id)
-          send(MQTT::PubAck.new(packet_id))
+          send(Protocol::PubAck.new(packet_id))
         end
       end
 
-      def recieve_puback(packet : MQTT::PubAck)
+      def recieve_puback(packet : Protocol::PubAck)
         @broker.sessions[@client_id].ack(packet)
         vhost.event_tick(EventType::ClientAck)
       end
 
-      def recieve_subscribe(packet : MQTT::Subscribe)
+      def recieve_subscribe(packet : Protocol::Subscribe)
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
@@ -190,12 +190,12 @@ module LavinMQ
           end
         end
         qos = @broker.subscribe(self, packet.topic_filters)
-        send(MQTT::SubAck.new(qos, packet.packet_id))
+        send(Protocol::SubAck.new(qos, packet.packet_id))
       end
 
-      def recieve_unsubscribe(packet : MQTT::Unsubscribe)
+      def recieve_unsubscribe(packet : Protocol::Unsubscribe)
         @broker.unsubscribe(client_id, packet.topics)
-        send(MQTT::UnsubAck.new(packet.packet_id))
+        send(Protocol::UnsubAck.new(packet.packet_id))
       end
 
       def details_tuple
@@ -235,7 +235,7 @@ module LavinMQ
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
             return
           end
-          @broker.publish(MQTT::Publish.new(
+          @broker.publish(Protocol::Publish.new(
             topic: will.topic,
             payload: will.payload,
             packet_id: nil,
@@ -324,7 +324,7 @@ module LavinMQ
         true
       end
 
-      def deliver(msg : MQTT::Publish)
+      def deliver(msg : Protocol::Publish)
         @client.send(msg)
       end
 

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -20,24 +20,24 @@ module LavinMQ
         metadata = ::Log::Metadata.build({address: connection_info.remote_address.to_s})
         logger = Logger.new(Log, metadata)
         begin
-          io = MQTT::IO.new(socket, @config.mqtt_max_packet_size)
-          if packet = io.read_packet.as?(Connect)
+          io = Protocol::IO.new(socket, @config.mqtt_max_packet_size)
+          if packet = io.read_packet.as?(Protocol::Connect)
             logger.trace { "recv #{packet.inspect}" }
             if user_and_broker = authenticate(io, packet)
               user, broker = user_and_broker
               packet = assign_client_id(packet) if packet.client_id.empty?
               session_present = broker.session_present?(packet.client_id, packet.clean_session?)
-              connack io, session_present, Connack::ReturnCode::Accepted
+              connack io, session_present, Protocol::Connack::ReturnCode::Accepted
               return broker.add_client(io, connection_info, user, packet)
             else
               logger.warn { "Authentication failure for user \"#{packet.username}\"" }
-              connack io, false, Connack::ReturnCode::NotAuthorized
+              connack io, false, Protocol::Connack::ReturnCode::NotAuthorized
             end
           end
-        rescue ex : MQTT::Error::Connect
+        rescue ex : Protocol::Error::Connect
           logger.warn { "Connect error #{ex.inspect}" }
           if io
-            connack io, false, Connack::ReturnCode.new(ex.return_code)
+            connack io, false, Protocol::Connack::ReturnCode.new(ex.return_code)
           end
           socket.close
         rescue ex : ::IO::EOFError
@@ -48,12 +48,12 @@ module LavinMQ
         end
       end
 
-      private def connack(io : MQTT::IO, session_present : Bool, return_code : Connack::ReturnCode)
-        Connack.new(session_present, return_code).to_io(io)
+      private def connack(io : Protocol::IO, session_present : Bool, return_code : Protocol::Connack::ReturnCode)
+        Protocol::Connack.new(session_present, return_code).to_io(io)
         io.flush
       end
 
-      def authenticate(io : MQTT::IO, packet)
+      def authenticate(io : Protocol::IO, packet)
         return unless (username = packet.username) && (password = packet.password)
 
         vhost = @config.default_mqtt_vhost
@@ -75,7 +75,7 @@ module LavinMQ
 
       def assign_client_id(packet)
         client_id = Random::Secure.base64(32)
-        Connect.new(client_id,
+        Protocol::Connect.new(client_id,
           packet.clean_session?,
           packet.keepalive,
           packet.username,

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -39,7 +39,7 @@ module LavinMQ
         super(vhost, name, false, false, true)
       end
 
-      def publish(packet : MQTT::Publish) : UInt32
+      def publish(packet : Protocol::Publish) : UInt32
         @publish_in_count.add(1, :relaxed)
         properties = AMQP::Properties.new(headers: AMQP::Table.new)
         properties.delivery_mode = packet.qos

--- a/src/lavinmq/mqtt/protocol.cr
+++ b/src/lavinmq/mqtt/protocol.cr
@@ -1,7 +1,6 @@
 require "mqtt-protocol"
 
-module LavinMQ
-  module MQTT
-    include ::MQTT::Protocol
-  end
+module LavinMQ::MQTT::Protocol
+  # Just "copy" ::MQTT::Protocol to LavinMQ::MQTT::Protocol
+  include ::MQTT::Protocol
 end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -120,7 +120,7 @@ module LavinMQ
         @vhost.unbind_queue(@name, EXCHANGE, rk, arguments || AMQP::Table.new)
       end
 
-      private def get_packet(& : MQTT::Publish, UInt32 -> Nil) : Bool
+      private def get_packet(& : Protocol::Publish, UInt32 -> Nil) : Bool
         raise ClosedError.new if @closed
         loop do
           env = @msg_store_lock.synchronize { @msg_store.shift? } || break
@@ -164,13 +164,13 @@ module LavinMQ
         raise ClosedError.new(cause: ex)
       end
 
-      def build_packet(env, packet_id) : MQTT::Publish
+      def build_packet(env, packet_id) : Protocol::Publish
         msg = env.message
         retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
         qos = msg.properties.delivery_mode || 0u8
         qos = 1u8 if qos > 1
         dup = qos.zero? ? false : env.redelivered
-        MQTT::Publish.new(
+        Protocol::Publish.new(
           packet_id: packet_id,
           payload: msg.body,
           dup: dup,
@@ -206,7 +206,7 @@ module LavinMQ
         drop_overflow
       end
 
-      def ack(packet : MQTT::PubAck) : Nil
+      def ack(packet : Protocol::PubAck) : Nil
         id = packet.packet_id
         if sp = @unacked.delete(id)
           begin

--- a/src/lavinmqperf/mqtt/throughput.cr
+++ b/src/lavinmqperf/mqtt/throughput.cr
@@ -86,7 +86,7 @@ module LavinMQPerf
       @consumes = Atomic(UInt64).new(0_u64)
       @stopped = false
 
-      private def create_client(id : Int32, role : String) : {IO, LavinMQ::MQTT::IO}
+      private def create_client(id : Int32, role : String) : {IO, LavinMQ::MQTT::Protocol::IO}
         if @uri.host == @uri.port == nil
           @uri = URI.parse("mqtt://#{@uri.scheme}:#{@uri.path}")
         end
@@ -98,10 +98,10 @@ module LavinMQPerf
         password = @uri.password || "guest"
 
         socket = connect_socket(host, port, tls)
-        io = LavinMQ::MQTT::IO.new(socket)
+        io = LavinMQ::MQTT::Protocol::IO.new(socket)
 
         client_id = "#{role}-#{id}"
-        connect_packet = LavinMQ::MQTT::Connect.new(
+        connect_packet = LavinMQ::MQTT::Protocol::Connect.new(
           client_id: client_id,
           clean_session: @clean_session,
           keepalive: 0,
@@ -113,9 +113,9 @@ module LavinMQPerf
         connect_packet.to_io(io)
         io.flush
 
-        response = LavinMQ::MQTT::Packet.from_io(io)
-        unless response.is_a?(LavinMQ::MQTT::Connack) &&
-               response.as(LavinMQ::MQTT::Connack).return_code == LavinMQ::MQTT::Connack::ReturnCode::Accepted
+        response = LavinMQ::MQTT::Protocol::Packet.from_io(io)
+        unless response.is_a?(LavinMQ::MQTT::Protocol::Connack) &&
+               response.as(LavinMQ::MQTT::Protocol::Connack).return_code == LavinMQ::MQTT::Protocol::Connack::ReturnCode::Accepted
           socket.try &.close rescue nil
           raise "Failed to connect: #{response.inspect}"
         end
@@ -239,7 +239,7 @@ module LavinMQPerf
           @random.random_bytes(data) if @random_bodies
           packet_id = @qos > 0 ? packet_id_generator.next.as(UInt16) : nil
 
-          publish = LavinMQ::MQTT::Publish.new(
+          publish = LavinMQ::MQTT::Protocol::Publish.new(
             topic: @topic,
             payload: data,
             packet_id: packet_id,
@@ -251,8 +251,8 @@ module LavinMQPerf
           io.flush
 
           if @qos > 0
-            ack = LavinMQ::MQTT::Packet.from_io(io)
-            unless ack.is_a?(LavinMQ::MQTT::PubAck)
+            ack = LavinMQ::MQTT::Protocol::Packet.from_io(io)
+            unless ack.is_a?(LavinMQ::MQTT::Protocol::PubAck)
               raise "Expected PUBACK but got #{ack.inspect}"
             end
           end
@@ -272,7 +272,7 @@ module LavinMQPerf
             end
           end
         end
-        LavinMQ::MQTT::Disconnect.new.to_io(io) if socket && !socket.closed?
+        LavinMQ::MQTT::Protocol::Disconnect.new.to_io(io) if socket && !socket.closed?
       ensure
         socket.try &.close rescue nil
       end
@@ -286,21 +286,21 @@ module LavinMQPerf
         start = Time.instant
         consumes_this_second = 0
 
-        topic_filter = LavinMQ::MQTT::Subscribe::TopicFilter.new(@topic, @qos.to_u8)
-        LavinMQ::MQTT::Subscribe.new([topic_filter], packet_id: 1_u16).to_io(io)
+        topic_filter = LavinMQ::MQTT::Protocol::Subscribe::TopicFilter.new(@topic, @qos.to_u8)
+        LavinMQ::MQTT::Protocol::Subscribe.new([topic_filter], packet_id: 1_u16).to_io(io)
         io.flush
 
-        suback = LavinMQ::MQTT::Packet.from_io(io)
-        unless suback.is_a?(LavinMQ::MQTT::SubAck)
+        suback = LavinMQ::MQTT::Protocol::Packet.from_io(io)
+        unless suback.is_a?(LavinMQ::MQTT::Protocol::SubAck)
           raise "Expected SUBACK but got #{suback.inspect}"
         end
         individual_consumes = 0
         wait_until_all_are_connected(connected)
         until @stopped
           begin
-            packet = LavinMQ::MQTT::Packet.from_io(io)
+            packet = LavinMQ::MQTT::Protocol::Packet.from_io(io)
             case packet
-            when LavinMQ::MQTT::Publish
+            when LavinMQ::MQTT::Protocol::Publish
               consumes = @consumes.add(1, :relaxed) + 1
               individual_consumes += 1
 
@@ -309,7 +309,7 @@ module LavinMQPerf
               end
 
               if packet.qos > 0 && (packet_id = packet.packet_id)
-                LavinMQ::MQTT::PubAck.new(packet_id).to_io(io)
+                LavinMQ::MQTT::Protocol::PubAck.new(packet_id).to_io(io)
                 io.flush
               end
 
@@ -330,8 +330,8 @@ module LavinMQPerf
               else
                 Fiber.yield if individual_consumes % (128 * 1024) == 0
               end
-            when LavinMQ::MQTT::PingReq
-              LavinMQ::MQTT::PingResp.new.to_io(io)
+            when LavinMQ::MQTT::Protocol::PingReq
+              LavinMQ::MQTT::Protocol::PingResp.new.to_io(io)
               io.flush
             end
           rescue ex : IO::TimeoutError
@@ -340,7 +340,7 @@ module LavinMQPerf
           end
         end
         if socket && !socket.closed?
-          LavinMQ::MQTT::Disconnect.new.to_io(io)
+          LavinMQ::MQTT::Protocol::Disconnect.new.to_io(io)
           io.flush
         end
       ensure


### PR DESCRIPTION
### WHAT is this pull request doing?
Before this PR `::MQTT::Protocol` (from [mqtt-protocl.cr](github.com/84codes/mqtt-protocol.cr)) was included in `LavinMQ::MQTT` meaning that each packet ended upp in that namespace. One problem with this is that also `::MQTT::Protocol::Error` ends up in `LavinMQ::MQTT` blocking us from adding a "base" `LavinMQ::MQTT::Error` class.

This PR moves the include of `::MQTT::Protocol` to `LavinMQ::MQTT::Protocol`, which probably makes more sense.

### HOW can this pull request be tested?
Still compiles and specs passes
