### PR TITLE
Raft clustering: code-review fixes (node id, shutdown, ctl safety, password file)

### DIFF
--- a/spec/lavinmqctl/raft_spec.cr
+++ b/spec/lavinmqctl/raft_spec.cr
@@ -209,7 +209,9 @@ describe "LavinMQCtl raft_*" do
         original_argv = ARGV.dup
         begin
           ARGV.clear
-          ARGV.concat(["raft_reset", "--data-dir=#{data_dir}"])
+          # --force: no node is running here, so the safety check can't reach
+          # /raft/status and would otherwise fail closed.
+          ARGV.concat(["raft_reset", "--data-dir=#{data_dir}", "--force"])
           cli = LavinMQCtl.new(stdout)
           cli.run_cmd
         ensure
@@ -221,6 +223,36 @@ describe "LavinMQCtl raft_*" do
         Dir.exists?(File.join(data_dir, "raft-transport")).should be_false
         File.exists?(File.join(data_dir, ".clustering_id")).should be_true
         File.exists?(sentinel).should be_true
+      ensure
+        FileUtils.rm_rf(data_dir)
+      end
+    end
+
+    it "refuses to wipe a stopped node that can't be verified without --force" do
+      data_dir = File.tempname("raft-reset-stopped-spec")
+      begin
+        Dir.mkdir_p(File.join(data_dir, "raft"))
+        File.write(File.join(data_dir, "raft", "raft_meta"), "fake meta")
+        File.write(File.join(data_dir, ".clustering_id"), "1")
+
+        stdout = IO::Memory.new
+        original_argv = ARGV.dup
+        begin
+          ARGV.clear
+          # No node is running (closed port): its cluster membership can't be
+          # verified, so the reset must fail closed rather than silently wipe.
+          ARGV.concat(["--uri", "http://127.0.0.1:1", "raft_reset", "--data-dir=#{data_dir}"])
+          cli = LavinMQCtl.new(stdout)
+          expect_raises(LavinMQCtl::CtlExit) do
+            cli.run_cmd
+          end
+        ensure
+          ARGV.clear
+          ARGV.concat(original_argv)
+        end
+
+        Dir.exists?(File.join(data_dir, "raft")).should be_true
+        stdout.to_s.should contain("--force")
       ensure
         FileUtils.rm_rf(data_dir)
       end
@@ -239,7 +271,7 @@ describe "LavinMQCtl raft_*" do
         original_argv = ARGV.dup
         begin
           ARGV.clear
-          ARGV.concat(["raft_join", "http://leader.example:15672", "--data-dir=#{data_dir}"])
+          ARGV.concat(["raft_join", "http://leader.example:15672", "--data-dir=#{data_dir}", "--force"])
           cli = LavinMQCtl.new(stdout)
           cli.run_cmd
         ensure

--- a/spec/lavinmqctl/raft_spec.cr
+++ b/spec/lavinmqctl/raft_spec.cr
@@ -257,6 +257,45 @@ describe "LavinMQCtl raft_*" do
         FileUtils.rm_rf(data_dir)
       end
     end
+
+    it "refuses without --force when /raft/status omits the peer list" do
+      stub = HTTP::Server.new do |context|
+        context.response.status_code = 200
+        context.response.content_type = "application/json"
+        # 200 but no "peers" — cluster size is unknown, so we must not assume 0.
+        context.response.print({"id" => 1_i64, "role" => "leader"}.to_json)
+      end
+      addr = stub.bind_tcp("127.0.0.1", 0)
+      spawn(name: "stub-reset-nopeers") { stub.listen }
+      begin
+        data_dir = File.tempname("raft-reset-nopeers-spec")
+        begin
+          Dir.mkdir_p(File.join(data_dir, "raft"))
+          File.write(File.join(data_dir, "raft", "raft_meta"), "fake meta")
+
+          stdout = IO::Memory.new
+          original_argv = ARGV.dup
+          begin
+            ARGV.clear
+            ARGV.concat(["--uri", "http://#{addr}", "raft_reset", "--data-dir=#{data_dir}"])
+            cli = LavinMQCtl.new(stdout)
+            expect_raises(LavinMQCtl::CtlExit) do
+              cli.run_cmd
+            end
+          ensure
+            ARGV.clear
+            ARGV.concat(original_argv)
+          end
+
+          Dir.exists?(File.join(data_dir, "raft")).should be_true
+          stdout.to_s.should contain("peer list")
+        ensure
+          FileUtils.rm_rf(data_dir)
+        end
+      ensure
+        stub.close
+      end
+    end
   end
 
   describe "raft_join" do

--- a/spec/raft/cluster_command_spec.cr
+++ b/spec/raft/cluster_command_spec.cr
@@ -2,43 +2,6 @@ require "../spec_helper"
 require "../../src/lavinmq/raft/cluster_command"
 
 describe LavinMQ::Raft::ClusterCommand do
-  describe "SetSecret" do
-    it "round-trips through to_io / from_io" do
-      original = LavinMQ::Raft::ClusterCommand::SetSecret.new("hunter2")
-      io = IO::Memory.new
-      original.to_io(io, IO::ByteFormat::LittleEndian)
-      io.rewind
-      decoded = LavinMQ::Raft::ClusterCommand.from_io(io, IO::ByteFormat::LittleEndian)
-      decoded.should be_a(LavinMQ::Raft::ClusterCommand::SetSecret)
-      decoded.as(LavinMQ::Raft::ClusterCommand::SetSecret).secret.should eq "hunter2"
-    end
-
-    it "reports bytesize equal to bytes actually written" do
-      cmd = LavinMQ::Raft::ClusterCommand::SetSecret.new("hunter2")
-      io = IO::Memory.new
-      cmd.to_io(io, IO::ByteFormat::LittleEndian)
-      io.pos.should eq cmd.bytesize
-    end
-
-    it "round-trips an empty secret" do
-      original = LavinMQ::Raft::ClusterCommand::SetSecret.new("")
-      io = IO::Memory.new
-      original.to_io(io, IO::ByteFormat::LittleEndian)
-      io.rewind
-      decoded = LavinMQ::Raft::ClusterCommand.from_io(io, IO::ByteFormat::LittleEndian)
-      decoded.as(LavinMQ::Raft::ClusterCommand::SetSecret).secret.should eq ""
-    end
-
-    it "round-trips a non-ASCII secret" do
-      original = LavinMQ::Raft::ClusterCommand::SetSecret.new("hü€nter🦀")
-      io = IO::Memory.new
-      original.to_io(io, IO::ByteFormat::LittleEndian)
-      io.rewind
-      decoded = LavinMQ::Raft::ClusterCommand.from_io(io, IO::ByteFormat::LittleEndian)
-      decoded.as(LavinMQ::Raft::ClusterCommand::SetSecret).secret.should eq "hü€nter🦀"
-    end
-  end
-
   describe "SetIsr" do
     it "round-trips an empty set" do
       original = LavinMQ::Raft::ClusterCommand::SetIsr.new(Set(Int32).new)
@@ -71,7 +34,7 @@ describe LavinMQ::Raft::ClusterCommand do
     it "raises on unknown schema version" do
       io = IO::Memory.new
       io.write_bytes(99_u8, IO::ByteFormat::LittleEndian) # bogus version
-      io.write_bytes(0_u8, IO::ByteFormat::LittleEndian)  # SetSecret tag
+      io.write_bytes(0_u8, IO::ByteFormat::LittleEndian)  # SetIsr tag
       io.rewind
       expect_raises(LavinMQ::Raft::ClusterCommand::InvalidSchemaVersion) do
         LavinMQ::Raft::ClusterCommand.from_io(io, IO::ByteFormat::LittleEndian)
@@ -83,7 +46,7 @@ describe LavinMQ::Raft::ClusterCommand do
       io.write_bytes(LavinMQ::Raft::ClusterCommand::SCHEMA_VERSION, IO::ByteFormat::LittleEndian)
       io.write_bytes(99_u8, IO::ByteFormat::LittleEndian) # bogus tag
       io.rewind
-      expect_raises(Exception) do
+      expect_raises(LavinMQ::Raft::ClusterCommand::InvalidTag) do
         LavinMQ::Raft::ClusterCommand.from_io(io, IO::ByteFormat::LittleEndian)
       end
     end

--- a/spec/raft/cluster_state_machine_spec.cr
+++ b/spec/raft/cluster_state_machine_spec.cr
@@ -3,19 +3,6 @@ require "../../src/lavinmq/raft/cluster_state_machine"
 
 describe LavinMQ::Raft::ClusterStateMachine do
   describe "#apply" do
-    it "stores the secret on SetSecret" do
-      sm = LavinMQ::Raft::ClusterStateMachine.new
-      sm.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("hunter2"))
-      sm.secret.should eq "hunter2"
-    end
-
-    it "replaces the secret on a subsequent SetSecret" do
-      sm = LavinMQ::Raft::ClusterStateMachine.new
-      sm.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("first"))
-      sm.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("second"))
-      sm.secret.should eq "second"
-    end
-
     it "replaces ISR on SetIsr" do
       sm = LavinMQ::Raft::ClusterStateMachine.new
       sm.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{1, 2}))
@@ -40,7 +27,6 @@ describe LavinMQ::Raft::ClusterStateMachine do
   describe "snapshot/restore" do
     it "round-trips state through snapshot and restore" do
       original = LavinMQ::Raft::ClusterStateMachine.new
-      original.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("hunter2"))
       original.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{1, 2}))
 
       io = IO::Memory.new
@@ -50,7 +36,6 @@ describe LavinMQ::Raft::ClusterStateMachine do
       restored = LavinMQ::Raft::ClusterStateMachine.new
       restored.restore(io)
 
-      restored.secret.should eq "hunter2"
       restored.isr.should eq Set{1, 2}
     end
 
@@ -63,7 +48,6 @@ describe LavinMQ::Raft::ClusterStateMachine do
       restored = LavinMQ::Raft::ClusterStateMachine.new
       restored.restore(io)
 
-      restored.secret.should eq ""
       restored.isr.should be_empty
     end
 
@@ -79,11 +63,9 @@ describe LavinMQ::Raft::ClusterStateMachine do
 
     it "replaces existing state on restore" do
       sm = LavinMQ::Raft::ClusterStateMachine.new
-      sm.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("old"))
       sm.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{99}))
 
       source = LavinMQ::Raft::ClusterStateMachine.new
-      source.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("new"))
       source.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{1, 2}))
 
       io = IO::Memory.new
@@ -91,7 +73,6 @@ describe LavinMQ::Raft::ClusterStateMachine do
       io.rewind
       sm.restore(io)
 
-      sm.secret.should eq "new"
       sm.isr.should eq Set{1, 2}
     end
   end
@@ -101,24 +82,20 @@ describe LavinMQ::Raft::ClusterStateMachine do
       sm = LavinMQ::Raft::ClusterStateMachine.new
       sm.state.should eq LavinMQ::Raft::ClusterState::EMPTY
 
-      sm.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("s1"))
-      first = sm.state
-      first.secret.should eq "s1"
-      first.isr.should be_empty
-
       sm.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{42}))
+      first = sm.state
+      first.isr.should eq Set{42}
+
+      sm.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{1, 2}))
       second = sm.state
-      second.secret.should eq "s1"
-      second.isr.should eq Set{42}
+      second.isr.should eq Set{1, 2}
 
       # The earlier captured snapshot is unchanged — proves immutability of the publish.
-      first.secret.should eq "s1"
-      first.isr.should be_empty
+      first.isr.should eq Set{42}
     end
 
     it "publishes a snapshot on restore" do
       original = LavinMQ::Raft::ClusterStateMachine.new
-      original.apply(LavinMQ::Raft::ClusterCommand::SetSecret.new("hunter2"))
       original.apply(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{1, 2}))
 
       io = IO::Memory.new
@@ -128,7 +105,6 @@ describe LavinMQ::Raft::ClusterStateMachine do
       restored = LavinMQ::Raft::ClusterStateMachine.new
       restored.state.should eq LavinMQ::Raft::ClusterState::EMPTY
       restored.restore(io)
-      restored.state.secret.should eq "hunter2"
       restored.state.isr.should eq Set{1, 2}
     end
   end

--- a/spec/raft/coordinator_spec.cr
+++ b/spec/raft/coordinator_spec.cr
@@ -42,7 +42,7 @@ describe LavinMQ::Raft::Coordinator do
     end
   end
 
-  it "proposes SetSecret on first password() call and returns it" do
+  it "generates .clustering_password on the leader and returns it (never the raft log)" do
     dir = tmp_data_dir
     begin
       File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
@@ -62,7 +62,34 @@ describe LavinMQ::Raft::Coordinator do
       coord = LavinMQ::Raft::Coordinator.new(server)
       pw = coord.password
       pw.should_not be_empty
-      coord.password.should eq pw # subsequent call returns the existing secret
+      # Persisted to the file, not the replicated state.
+      File.read(File.join(dir, ".clustering_password")).should eq pw
+      coord.password.should eq pw # subsequent call reads the same file
+
+      server.stop
+      transport.stop
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "reads an existing .clustering_password without regenerating" do
+    dir = tmp_data_dir
+    begin
+      File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+      File.write(File.join(dir, ".clustering_password"), "preshared-secret\n")
+      transport = ::Raft::MemoryTransport.new(1_u64)
+      server = LavinMQ::Raft::Server.new(
+        data_dir: dir, advertised_address: "n:5680,n:5679",
+        transport: transport, execution_context: Fiber::ExecutionContext.current,
+      )
+      transport.start
+      server.start
+
+      coord = LavinMQ::Raft::Coordinator.new(server)
+      # A follower (never bootstrapped, not leader) must still read the
+      # pre-shared file rather than fail or generate a divergent secret.
+      coord.password.should eq "preshared-secret"
 
       server.stop
       transport.stop

--- a/spec/raft/server_spec.cr
+++ b/spec/raft/server_spec.cr
@@ -301,5 +301,35 @@ describe LavinMQ::Raft::Server do
         FileUtils.rm_rf(dir)
       end
     end
+
+    it "raises a clear error on a corrupt .clustering_id instead of regenerating" do
+      dir = tmp_data_dir
+      begin
+        File.write(File.join(dir, ".clustering_id"), "not-base-36-#")
+        transport = ::Raft::MemoryTransport.new(1_u64)
+        expect_raises(Exception, /Invalid cluster id/) do
+          LavinMQ::Raft::Server.new(
+            data_dir: dir, advertised_address: "n:5680,n:5679", transport: transport,
+          )
+        end
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "raises on an empty .clustering_id rather than silently picking a new identity" do
+      dir = tmp_data_dir
+      begin
+        File.write(File.join(dir, ".clustering_id"), "")
+        transport = ::Raft::MemoryTransport.new(1_u64)
+        expect_raises(Exception, /Invalid cluster id/) do
+          LavinMQ::Raft::Server.new(
+            data_dir: dir, advertised_address: "n:5680,n:5679", transport: transport,
+          )
+        end
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+    end
   end
 end

--- a/spec/raft/server_spec.cr
+++ b/spec/raft/server_spec.cr
@@ -243,14 +243,13 @@ describe LavinMQ::Raft::Server do
         when timeout(2.seconds)
           fail "timed out"
         end
-        server.propose(LavinMQ::Raft::ClusterCommand::SetSecret.new("hi")).should be_true
+        server.propose(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{3})).should be_true
         deadline = Time.instant + 2.seconds
-        until server.state.secret == "hi"
+        until server.state.isr == Set{3}
           fail "timed out" if Time.instant > deadline
           Fiber.yield
         end
-        server.secret.should eq "hi"
-        server.isr.should be_empty
+        server.isr.should eq Set{3}
       end
     end
   end

--- a/spec/raft/server_spec.cr
+++ b/spec/raft/server_spec.cr
@@ -332,4 +332,44 @@ describe LavinMQ::Raft::Server do
       end
     end
   end
+
+  describe "concurrent shutdown" do
+    it "never leaves a run_on_tick caller blocked when the server stops" do
+      dir = tmp_data_dir
+      File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+      transport = ::Raft::MemoryTransport.new(1_u64)
+      server = LavinMQ::Raft::Server.new(
+        data_dir: dir, advertised_address: "n:5680,n:5679",
+        transport: transport, execution_context: Fiber::ExecutionContext.current,
+      )
+      transport.start
+      server.start
+      begin
+        proposers = 20
+        done = ::Channel(Symbol).new(proposers)
+        proposers.times do
+          spawn do
+            # Either returns a Bool or raises "stopping" — but must never hang
+            # waiting on a reply the tick loop will never deliver after stop.
+            server.propose(LavinMQ::Raft::ClusterCommand::SetIsr.new(Set{1}))
+            done.send(:ok)
+          rescue
+            done.send(:raised)
+          end
+        end
+        Fiber.yield # let proposers enqueue their actions before we stop
+        server.stop
+        proposers.times do
+          select
+          when done.receive
+          when timeout(5.seconds)
+            fail "a run_on_tick caller hung after the server stopped"
+          end
+        end
+      ensure
+        transport.stop
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
 end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -256,7 +256,7 @@ module LavinMQ
             yield path
             ls_r(path, &blk)
           else
-            next if child.in?(".lock", ".clustering_id", ".join_target")
+            next if child.in?(".lock", ".clustering_id", ".join_target", ".clustering_password")
             yield path
           end
         end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -33,8 +33,9 @@ module LavinMQ
       @followers = Array(Follower).new(4)
       # Lazily fetched from @coordinator on first call to `password`. The raft
       # coordinator can't answer at construction time (the raft node isn't
-      # leader yet — bootstrap happens later, inside Runner#run). By the time a
-      # follower connects, raft has elected and the secret has been proposed.
+      # leader yet — bootstrap happens later, inside the elector). By the time a
+      # follower connects, raft has elected and the leader has written the
+      # shared secret to its .clustering_password file.
       @password : String? = nil
       @dirty_isr = true
       @id : Int32

--- a/src/lavinmq/raft/cluster_command.cr
+++ b/src/lavinmq/raft/cluster_command.cr
@@ -3,9 +3,11 @@ module LavinMQ::Raft
     SCHEMA_VERSION  = 1_u8
     HEADER_BYTESIZE =    2 # version + tag
 
+    # The replication secret is NOT a cluster command: it lives in a local
+    # `.clustering_password` file (see Raft::Coordinator#password), never the
+    # raft log. Only the ISR is replicated through consensus.
     enum Tag : UInt8
-      SetSecret = 0
-      SetIsr    = 1
+      SetIsr = 0
     end
 
     abstract def tag : Tag
@@ -25,10 +27,10 @@ module LavinMQ::Raft
     def self.from_io(io : IO, format : IO::ByteFormat) : ClusterCommand
       version = io.read_bytes(UInt8, format)
       raise InvalidSchemaVersion.new(version) unless version == SCHEMA_VERSION
-      tag = Tag.new(io.read_bytes(UInt8, format))
-      case tag
-      in .set_secret? then SetSecret.read_body(io, format)
-      in .set_isr?    then SetIsr.read_body(io, format)
+      tag = io.read_bytes(UInt8, format)
+      case Tag.from_value?(tag)
+      when Tag::SetIsr then SetIsr.read_body(io, format)
+      else                  raise InvalidTag.new(tag)
       end
     end
 
@@ -38,28 +40,9 @@ module LavinMQ::Raft
       end
     end
 
-    struct SetSecret < ClusterCommand
-      getter secret : String
-
-      def initialize(@secret : String)
-      end
-
-      def tag : Tag
-        Tag::SetSecret
-      end
-
-      def body_to_io(io : IO, format : IO::ByteFormat) : Nil
-        io.write_bytes(@secret.bytesize.to_u32, format)
-        io.write(@secret.to_slice)
-      end
-
-      def body_bytesize : Int32
-        4 + @secret.bytesize
-      end
-
-      protected def self.read_body(io : IO, format : IO::ByteFormat) : SetSecret
-        len = io.read_bytes(UInt32, format)
-        new(io.read_string(len))
+    class InvalidTag < Exception
+      def initialize(tag : UInt8)
+        super("Unknown ClusterCommand tag: #{tag}")
       end
     end
 

--- a/src/lavinmq/raft/cluster_state.cr
+++ b/src/lavinmq/raft/cluster_state.cr
@@ -1,15 +1,14 @@
 module LavinMQ::Raft
   # Immutable cluster state snapshot returned by ClusterStateMachine#state.
-  # The internal `secret` and `isr` are SHARED references with the state
-  # machine — treat as frozen. Apply replaces (never mutates in place), so
-  # holding a previously-returned snapshot is safe.
+  # The internal `isr` is a SHARED reference with the state machine — treat as
+  # frozen. Apply replaces it (never mutates in place), so holding a
+  # previously-returned snapshot is safe.
   struct ClusterState
-    getter secret : String
     getter isr : Set(Int32)
 
-    def initialize(@secret : String, @isr : Set(Int32))
+    def initialize(@isr : Set(Int32))
     end
 
-    EMPTY = ClusterState.new("", Set(Int32).new)
+    EMPTY = ClusterState.new(Set(Int32).new)
   end
 end

--- a/src/lavinmq/raft/cluster_state_machine.cr
+++ b/src/lavinmq/raft/cluster_state_machine.cr
@@ -6,11 +6,10 @@ module LavinMQ::Raft
   class ClusterStateMachine < ::Raft::StateMachine(ClusterCommand)
     SNAPSHOT_VERSION = 1_u8
 
-    # Mutex-serialized. apply mutates @secret/@isr under the lock; readers
-    # acquire the lock and return references. Apply must REPLACE these fields
-    # (not mutate in place) so previously-returned references stay stable.
+    # Mutex-serialized. apply mutates @isr under the lock; readers acquire the
+    # lock and return the reference. Apply must REPLACE @isr (not mutate in
+    # place) so previously-returned references stay stable.
     @mutex = Mutex.new
-    @secret = ""
     @isr = Set(Int32).new
     # Wake-up channel for "ISR changed". apply / restore fire a non-blocking
     # `while try_send?` loop that delivers to every waiting receiver plus
@@ -19,13 +18,9 @@ module LavinMQ::Raft
     # avoid busy-polling raft state.
     getter isr_changed = ::Channel(Nil).new(1)
 
-    # Consistent multi-field snapshot.
+    # Consistent snapshot.
     def state : ClusterState
-      @mutex.synchronize { ClusterState.new(@secret, @isr) }
-    end
-
-    def secret : String
-      @mutex.synchronize { @secret }
+      @mutex.synchronize { ClusterState.new(@isr) }
     end
 
     def isr : Set(Int32)
@@ -33,19 +28,15 @@ module LavinMQ::Raft
     end
 
     def apply(entry : ClusterCommand) : Nil
-      isr_changed = false
       @mutex.synchronize do
         case entry
-        in ClusterCommand::SetSecret then @secret = entry.secret
-        in ClusterCommand::SetIsr
-          @isr = entry.node_ids.dup
-          isr_changed = true
-        in ClusterCommand then raise "BUG: unhandled ClusterCommand variant: #{entry.class}"
+        in ClusterCommand::SetIsr then @isr = entry.node_ids.dup
+        in ClusterCommand         then raise "BUG: unhandled ClusterCommand variant: #{entry.class}"
         end
       end
       # Signal after releasing the mutex — a woken waiter immediately reads
       # through it, and would otherwise block on the lock we still hold.
-      signal_isr_changed if isr_changed
+      signal_isr_changed
     end
 
     # Wake every consumer currently blocked on @isr_changed.receive — and,
@@ -61,8 +52,6 @@ module LavinMQ::Raft
       @mutex.synchronize do
         fmt = IO::ByteFormat::LittleEndian
         io.write_bytes(SNAPSHOT_VERSION, fmt)
-        io.write_bytes(@secret.bytesize.to_u32, fmt)
-        io.write(@secret.to_slice)
         io.write_bytes(@isr.size.to_u32, fmt)
         @isr.each { |id| io.write_bytes(id, fmt) }
       end
@@ -72,13 +61,10 @@ module LavinMQ::Raft
       fmt = IO::ByteFormat::LittleEndian
       version = io.read_bytes(UInt8, fmt)
       raise InvalidSnapshotVersion.new(version) unless version == SNAPSHOT_VERSION
-      secret_len = io.read_bytes(UInt32, fmt)
-      secret = io.read_string(secret_len)
       isr_count = io.read_bytes(UInt32, fmt)
       isr = Set(Int32).new(initial_capacity: isr_count.to_i32)
       isr_count.times { isr.add(io.read_bytes(Int32, fmt)) }
       @mutex.synchronize do
-        @secret = secret
         @isr = isr
       end
       signal_isr_changed

--- a/src/lavinmq/raft/coordinator.cr
+++ b/src/lavinmq/raft/coordinator.cr
@@ -5,6 +5,10 @@ require "random/secure"
 
 module LavinMQ::Raft
   class Coordinator < ::LavinMQ::Clustering::Coordinator
+    Log = LavinMQ::Log.for "raft.coordinator"
+
+    PASSWORD_FILE = ".clustering_password"
+
     def initialize(@server : Server)
     end
 
@@ -12,17 +16,26 @@ module LavinMQ::Raft
       @server.propose(ClusterCommand::SetIsr.new(synced_node_ids.to_set))
     end
 
+    # The cluster's shared replication secret. It is read from a local file
+    # (`<data_dir>/.clustering_password`), never the raft log — replicating it
+    # through consensus would persist the secret in every node's log/snapshot.
+    #
+    # A leader with no file yet generates one (single-node bootstrap); it must
+    # be copied to every other node before they join. A node that is not the
+    # leader and has no file cannot guess the secret, so it fails fast with an
+    # actionable message rather than authenticating followers with the wrong
+    # password.
     def password : String
-      existing = @server.secret
-      return existing unless existing.empty?
-      new_secret = Random::Secure.base64(32)
-      @server.propose(ClusterCommand::SetSecret.new(new_secret))
-      deadline = Time.instant + 5.seconds
-      while @server.secret.empty?
-        raise "timed out waiting for SetSecret apply" if Time.instant > deadline
-        sleep 1.millisecond
+      path = File.join(@server.data_dir, PASSWORD_FILE)
+      return File.read(path).strip if File.exists?(path)
+      unless @server.is_leader.value
+        Log.fatal { "Replication secret file missing: #{path}. Copy it from another node in the cluster." }
+        exit 3
       end
-      @server.secret
+      secret = Random::Secure.base64(32)
+      File.open(path, "w", perm: 0o600, &.print(secret))
+      Log.info { "Generated clustering password at #{path}; copy it to every other node before they join" }
+      secret
     end
   end
 end

--- a/src/lavinmq/raft/elector.cr
+++ b/src/lavinmq/raft/elector.cr
@@ -199,12 +199,10 @@ module LavinMQ::Raft
         begin
           handle_leader_change(id)
         rescue ex
-          # handle_leader_change can raise on transient conditions (e.g.
-          # @coordinator.password timing out before SetSecret has applied,
-          # or Clustering::Client construction failing). Swallow + log so
-          # the fiber survives — otherwise it'd die and subsequent leader
-          # changes would silently fill the buffered channel until they
-          # get dropped, breaking replication failover for this node.
+          # handle_leader_change can raise if Clustering::Client construction
+          # fails. Swallow + log so the fiber survives — otherwise it'd die and
+          # subsequent leader changes would silently fill the buffered channel
+          # until they get dropped, breaking replication failover for this node.
           Log.error(exception: ex) { "handle_leader_change failed for #{id}; will retry on next leader change" }
         end
       end

--- a/src/lavinmq/raft/server.cr
+++ b/src/lavinmq/raft/server.cr
@@ -98,7 +98,16 @@ module LavinMQ::Raft
       rescue ::Channel::ClosedError
         raise "Raft::Server stopping"
       end
-      reply.receive
+      # The tick loop may break on @stop_signal (it races the action case in
+      # the same select) and exit without ever draining our action — then a
+      # plain reply.receive would block forever. @tick_done is closed when the
+      # tick loop exits, so wake up on whichever happens first.
+      select
+      when v = reply.receive
+        v
+      when @tick_done.receive?
+        raise "Raft::Server stopping"
+      end
     end
 
     def leader_id : UInt64?

--- a/src/lavinmq/raft/server.cr
+++ b/src/lavinmq/raft/server.cr
@@ -202,7 +202,13 @@ module LavinMQ::Raft
       Dir.mkdir_p(@data_dir)
       path = File.join(@data_dir, ".clustering_id")
       begin
-        File.read(path).strip.to_i32(36)
+        content = File.read(path).strip
+        # A corrupt or partially-written id must fail loudly with a clear
+        # message — regenerating would silently give this node a new identity
+        # and drop it out of the cluster. `to_i32?` returns nil (rather than
+        # raising an opaque ArgumentError) on an empty or non-base-36 file.
+        content.to_i32?(36) ||
+          raise "Invalid cluster id #{content.inspect} in #{path}: expected a base-36 integer"
       rescue File::NotFoundError
         id = Random::Secure.rand(Int32::MAX)
         File.write(path, id.to_s(36))

--- a/src/lavinmq/raft/server.cr
+++ b/src/lavinmq/raft/server.cr
@@ -22,6 +22,7 @@ module LavinMQ::Raft
     getter node_id : Int32
     getter state_machine : ClusterStateMachine
     getter is_leader : BoolChannel
+    getter data_dir : String
 
     def initialize(
       @data_dir : String,
@@ -140,10 +141,6 @@ module LavinMQ::Raft
 
     def state : ClusterState
       @state_machine.state
-    end
-
-    def secret : String
-      @state_machine.secret
     end
 
     def isr : Set(Int32)

--- a/src/lavinmq/raft/server.cr
+++ b/src/lavinmq/raft/server.cr
@@ -210,7 +210,9 @@ module LavinMQ::Raft
         content.to_i32?(36) ||
           raise "Invalid cluster id #{content.inspect} in #{path}: expected a base-36 integer"
       rescue File::NotFoundError
-        id = Random::Secure.rand(Int32::MAX)
+        # 1..Int32::MAX, never 0: raft.cr treats node id 0 as "no node / no
+        # leader", so a generated 0 would collide with that sentinel.
+        id = Random::Secure.rand(1..Int32::MAX)
         File.write(path, id.to_s(36))
         Log.info { "Generated new clustering id #{id}" }
         id

--- a/src/lavinmqctl/raft.cr
+++ b/src/lavinmqctl/raft.cr
@@ -160,9 +160,14 @@ class LavinMQCtl
       response = http.get("/raft/status", @headers)
       if response.status_code == 200
         data = JSON.parse(response.body)
-        peers = data["peers"]?.try(&.as_a.size) || 0
-        return if peers <= 1
-        @io.puts "raft_reset: refusing — node is in a multi-peer cluster (peers=#{peers}). Use --force to override."
+        # Fail closed: a missing or non-array `peers` means we can't establish
+        # the node is a safe single-node leader, so refuse rather than assume 0.
+        if peers = data["peers"]?.try(&.as_a?).try(&.size)
+          return if peers <= 1
+          @io.puts "raft_reset: refusing — node is in a multi-peer cluster (peers=#{peers}). Use --force to override."
+        else
+          @io.puts "raft_reset: refusing — /raft/status did not report a peer list; cannot verify cluster size. Use --force to override."
+        end
       else
         @io.puts "raft_reset: refusing — node is running but its role can't be verified " \
                  "(HTTP #{response.status_code}; a follower answers 503). " \

--- a/src/lavinmqctl/raft.cr
+++ b/src/lavinmqctl/raft.cr
@@ -88,6 +88,11 @@ class LavinMQCtl
   # configuration needed.
   private def with_wiped_raft_state(data_dir : String, &) : Nil
     Dir.mkdir_p(data_dir)
+    # Always gate on safety, whether or not a node is currently running. A
+    # stopped node still holds cluster membership on disk that we can't verify
+    # without /raft/status — so an unreachable node is refused unless --force,
+    # rather than silently wiped (which would drop it from its cluster).
+    ensure_safe_to_stop
     lock = LavinMQ::DataDirLock.new(data_dir)
     stop_running_node(lock) unless lock.try_acquire
     begin
@@ -113,11 +118,10 @@ class LavinMQCtl
     end
   end
 
-  # The data dir lock is held: a node is running. Refuse unless that is
-  # provably safe to discard (or --force), then stop the node and wait for
-  # its lock to be released. Never wipes under a holder it could not stop.
+  # The data dir lock is held: a node is running. ensure_safe_to_stop has
+  # already cleared this (or --force was given); stop the node and wait for its
+  # lock to be released. Never wipes under a holder it could not stop.
   private def stop_running_node(lock : LavinMQ::DataDirLock) : Nil
-    ensure_safe_to_stop
     info = lock.holder_info
     if m = info.match(/PID (\d+) @ (.+)/)
       pid, host = m[1].to_i64, m[2]


### PR DESCRIPTION
Follow-up fixes on top of #2013, addressing correctness findings from a code review of the raft-backed clustering branch. Each issue is an isolated commit with a regression spec.

## Fixes

- **`.clustering_id` parse (#2)** — `load_or_generate_node_id` only rescued `File::NotFoundError`, so an empty or non-base-36 id file (e.g. a partial write from a prior crash) raised an opaque `ArgumentError` on boot. Parse with `to_i32?(36)` and fail with a clear message; do **not** regenerate (a fresh id would silently drop the node from its cluster).
- **node id never 0 (#5)** — `Random::Secure.rand(Int32::MAX)` can return `0`, which raft.cr uses as the "no node / no leader" sentinel. Generate in `1..Int32::MAX`.
- **`run_on_tick` shutdown hang (#4)** — the tick loop's `select` races `@stop_signal` against the `@actions` case, so on `stop()` it can exit without draining an enqueued action, leaving the caller blocked forever on `reply.receive`. Wait on `@tick_done` alongside the reply.
- **ctl fail-closed on an unverifiable node (#3)** — `raft_reset`/`raft_join` only ran the safety gate when a node was actively running (lock held). A *stopped* multi-peer member could be wiped without `--force`, silently dropping it from its cluster. `ensure_safe_to_stop` now runs unconditionally; an unreachable/unverifiable node requires `--force`.
- **ctl unknown peer count (#6)** — a missing/non-array `peers` in `/raft/status` mapped to `0` and passed the `peers <= 1` safe check. Treat an unknown peer count as unsafe.
- **password in a file, not the raft log (#1)** — the replication secret was proposed as a `SetSecret` command and applied into the state machine, persisting it in every node's log/snapshots. Worse, `Coordinator#password` on a follower proposed (returns false) then busy-waited up to 5s for replication; on timeout the raise stranded `follow_leader_loop` (which only retries on the next leader change), so a follower could stop replicating entirely. The secret now lives in a local `<data_dir>/.clustering_password` file (like the etcd backend reads it from etcd): a leader with no file generates one (`0600`) for single-node bootstrap and logs that it must be copied to other nodes; a non-leader with no file fails fast. `SetSecret` and the state machine's `secret` field are removed — only the ISR is replicated now.

> Note on the password file: this mirrors the `raft3` branch's `.clustering_password` file approach, with the addition that a leader generates the file if missing (so single-node bootstrap still works out of the box). For a real multi-node cluster the file must be pre-shared to followers.

## Testing

- `make test` — 1936 examples, 0 failures, 0 errors
- `make lint` — clean