### PR TITLE
Apply security headers and login redirect to .html views (#2057)

### DIFF
--- a/spec/http_views_spec.cr
+++ b/spec/http_views_spec.cr
@@ -69,4 +69,30 @@ describe LavinMQ::HTTP::MainController do
       hashes.each { |h| csp.should contain(h) }
     end
   end
+
+  it "sets security headers on .html pages requested directly" do
+    with_http_server do |http, _|
+      response = http.get "/overview.html", HEADERS
+      response.status_code.should eq 200
+      response.headers["X-Frame-Options"].should eq "SAMEORIGIN"
+      response.headers["Referrer-Policy"].should eq "same-origin"
+      response.headers["Content-Security-Policy"]?.should_not be_nil
+    end
+  end
+
+  it "redirects unauthenticated .html requests to login" do
+    with_http_server do |http, _|
+      response = http.get "/queues.html"
+      response.status_code.should eq 307
+      response.headers["Location"].should eq "login"
+    end
+  end
+
+  it "serves login.html without requiring authentication" do
+    with_http_server do |http, _|
+      response = http.get "/login.html"
+      response.status_code.should eq 200
+      response.headers["Content-Security-Policy"]?.should_not be_nil
+    end
+  end
 end

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -8,14 +8,47 @@ module LavinMQ
 
       PUBLIC_DIR = "#{__DIR__}/../../../../static"
 
+      LAYOUT_INLINE_JS_SHA    = "sha256-xCBzVV2TewAz4Dk/CrTquSJ4NTH48Y5fckwTF8Lg5bE="
+      LOGIN_INLINE_JS_SHA     = "sha256-3bUZcnRc7hbNc+igS1dxqJNEEypKXCvZ9ozHwAxXIvc="
+      CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; script-src 'self' '#{LAYOUT_INLINE_JS_SHA}' '#{LOGIN_INLINE_JS_SHA}'"
+
+      # HTML views reachable without a session
+      PUBLIC_HTML = {"/login.html", "/401.html", "/404.html"}
+
       def call(context)
         path = context.request.path
         if context.request.method.in?("GET", "HEAD") && !path.starts_with?("/api/")
           path = "/docs/index.html" if path == "/docs/"
+          if html_view?(path)
+            return context if redirect_unless_logged_in(context, path)
+            add_security_headers(context)
+          end
           serve(context, path) || call_next(context)
         else
           call_next(context)
         end
+      end
+
+      # Management UI pages are baked as static .html files and are therefore
+      # directly addressable. They must carry the same security headers and
+      # login redirect whether reached through the clean route (ViewsController
+      # rewrites the path to .html) or requested directly. The docs are exempt.
+      private def html_view?(path)
+        path.ends_with?(".html") && !path.starts_with?("/docs/")
+      end
+
+      private def add_security_headers(context)
+        context.response.headers.add("X-Frame-Options", "SAMEORIGIN")
+        context.response.headers.add("Referrer-Policy", "same-origin")
+        context.response.headers.add("Content-Security-Policy", CONTENT_SECURITY_POLICY)
+      end
+
+      private def redirect_unless_logged_in(context, path)
+        return false if path.in?(PUBLIC_HTML)
+        return false if context.request.cookies.has_key?("m") || context.request.cookies.has_key?("oauth_token")
+        context.response.status = ::HTTP::Status::TEMPORARY_REDIRECT
+        context.response.headers["Location"] = "login"
+        true
       end
 
       {% if flag?(:release) || flag?(:bake_static) %}

--- a/src/lavinmq/http/controller/views.cr
+++ b/src/lavinmq/http/controller/views.cr
@@ -8,7 +8,7 @@ module LavinMQ
 
       def initialize
         static_view "/", view: "overview"
-        static_view "/login", auth_required: false
+        static_view "/login"
         static_view "/federation"
         static_view "/shovels"
         static_view "/connections"
@@ -32,27 +32,16 @@ module LavinMQ
         static_view "/operator-policies"
       end
 
-      macro static_view(path, *, auth_required = true, view = nil)
+      # Maps a clean route (e.g. /queues) to its baked static page
+      # (/queues.html). The security headers and login redirect are applied by
+      # StaticController (next in chain), so that direct .html requests are
+      # protected the same way.
+      macro static_view(path, *, view = nil)
         {% view = path[1..] if view.nil? %}
         get {{ path }} do |context, params|
-          redirect_unless_logged_in! if {{ auth_required }}
-          context.response.headers.add("X-Frame-Options", "SAMEORIGIN")
-          context.response.headers.add("Referrer-Policy", "same-origin")
-          layout_inline_js_sha = "sha256-xCBzVV2TewAz4Dk/CrTquSJ4NTH48Y5fckwTF8Lg5bE="
-          login_inline_js_sha = "sha256-3bUZcnRc7hbNc+igS1dxqJNEEypKXCvZ9ozHwAxXIvc="
-          context.response.headers.add("Content-Security-Policy", "default-src 'none'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; script-src 'self' '#{layout_inline_js_sha}' '#{login_inline_js_sha}'")
-          # Rewrite path to .html so StaticController (next in chain)
           context.request.path = {{ "/#{view.id}.html" }}
           call_next(context)
           context
-        end
-      end
-
-      macro redirect_unless_logged_in!
-        if !context.request.cookies.has_key?("m") && !context.request.cookies.has_key?("oauth_token")
-          context.response.status = ::HTTP::Status::TEMPORARY_REDIRECT
-          context.response.headers["Location"] = "login"
-          next context
         end
       end
     end


### PR DESCRIPTION
Fixes #2057

## Problem

Every management UI page is reachable by appending `.html` to its path (e.g. `/overview.html`, `/queues.html`, `/login.html`). These `.html` paths are served directly by `StaticController`, which set neither the `Content-Security-Policy`/`X-Frame-Options`/`Referrer-Policy` headers nor the login redirect.

Those protections lived only in the `static_view` macro in `ViewsController`, which applied them on the clean routes (`/queues`) before rewriting the request path to `.html` and delegating to `StaticController`. Requesting the `.html` path directly skipped `ViewsController` entirely, so:

1. The three security headers were absent on every `.html` page (clickjacking / CSP bypass).
2. Auth-protected pages were reachable without a session — `/queues` redirects to login, but `/queues.html` returned 200 with the page.

Introduced by the ECR → SHTML conversion (#1703), which baked page bodies as directly-addressable static files.

## Fix

Move both concerns into `StaticController`, where every `.html` request lands regardless of how it is reached (direct request or `ViewsController`'s internal rewrite):

- Redirect to `login` unless the request is authenticated or the page is public (`login.html`, `401.html`, `404.html`).
- Add `Content-Security-Policy`, `X-Frame-Options` and `Referrer-Policy`.
- Docs (`/docs/`) are exempt — their strict CSP would break Swagger/Redoc and they were never auth-gated.

`ViewsController`'s `static_view` macro is reduced to the clean-route → `.html` path rewrite, so the headers aren't set twice.

## Tests

Added assertions in `spec/http_views_spec.cr`:
- Security headers present on a direct `/overview.html` request.
- Unauthenticated `/queues.html` returns 307 → `login`.
- `/login.html` stays public and still carries the CSP.

`make test SPEC=spec/http_views_spec.cr` → 9 examples, 0 failures. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)