### PR TITLE
Fix upstream set deletion and per-entry overrides

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -1,6 +1,7 @@
 require "./spec_helper"
 require "log/spec"
 require "../src/lavinmq/federation/upstream"
+require "../src/lavinmq/federation/upstream_store"
 
 module UpstreamSpecHelpers
   def self.setup_qs(ch) : {AMQP::Client::Exchange, AMQP::Client::Queue}
@@ -1023,6 +1024,27 @@ describe LavinMQ::Federation::Upstream do
             v3fe.publish_in_count.should eq 0
           end
         end
+      end
+    end
+  end
+
+  describe LavinMQ::Federation::UpstreamStore do
+    it "removes a deleted upstream from sets even when a non-matching entry comes first" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        store = vhost.upstreams.not_nil!
+        store.create_upstream("a", JSON.parse(%({"uri": "#{s.amqp_url}"})))
+        store.create_upstream("b", JSON.parse(%({"uri": "#{s.amqp_url}"})))
+        # The set lists a non-matching upstream ("a") before the one we
+        # delete ("b"). The bare `return` in do_delete_upstream used to abort
+        # the reject! on the first non-matching entry, leaving the deleted "b"
+        # lingering in the set: it showed up as a phantom in federation status
+        # and could be re-linked (revived) on the next link_set.
+        store.create_upstream_set("set1", JSON.parse(%([{"upstream": "a"}, {"upstream": "b"}])))
+
+        store.delete_upstream("b")
+
+        store.get_set("set1").map(&.name).should eq ["a"]
       end
     end
   end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -1047,6 +1047,35 @@ describe LavinMQ::Federation::Upstream do
         store.get_set("set1").map(&.name).should eq ["a"]
       end
     end
+
+    it "dups the upstream and applies per-entry overrides without sharing state" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        store = vhost.upstreams.not_nil!
+        store.create_upstream("a", JSON.parse(%({"uri": "#{s.amqp_url}", "prefetch-count": 10})))
+        # A set entry with more than the "upstream" key dups the upstream and
+        # applies the overrides to the copy. This used to crash by reading the
+        # override values off the whole set array instead of the entry, and the
+        # shallow dup shared its link tables with the original.
+        store.create_upstream_set("set1",
+          JSON.parse(%([{"upstream": "a", "uri": "#{s.amqp_url}", "prefetch-count": 99}])))
+
+        original = store.get_set("all").find! { |u| u.name == "a" }
+        member = store.get_set("set1").first
+
+        member.should_not be original
+        member.prefetch.should eq 99_u16
+        original.prefetch.should eq 10_u16
+
+        # Linking the dup must not touch the original's links (separate tables).
+        vhost.declare_queue("q", false, false)
+        member.link(vhost.queue("q"))
+        member.links.size.should eq 1
+        original.links.size.should eq 0
+      ensure
+        store.try &.stop_all
+      end
+    end
   end
 
   describe "shutdown" do

--- a/src/lavinmq/federation/upstream.cr
+++ b/src/lavinmq/federation/upstream.cr
@@ -25,6 +25,20 @@ module LavinMQ
         @uri = URI.parse(raw_uri)
       end
 
+      # Copy the upstream's configuration but give the copy its own, empty link
+      # tables. Used by upstream sets that override settings per entry; a plain
+      # shallow dup would share @q_links/@ex_links with the original.
+      def dup
+        copy = super
+        copy.clear_links
+        copy
+      end
+
+      protected def clear_links
+        @q_links = Hash(String, QueueLink).new
+        @ex_links = Hash(String, ExchangeLink).new
+      end
+
       # delete x-federation-upstream exchange on upstream
       # delete queue on upstream
       def stop_link(federated_exchange : Exchange)

--- a/src/lavinmq/federation/upstream_store.cr
+++ b/src/lavinmq/federation/upstream_store.cr
@@ -78,16 +78,16 @@ module LavinMQ
           upstream = @upstreams[cfg["upstream"].as_s]
           if cfg.as_h.keys.size > 1
             upstream = upstream.dup
-            config["uri"]?.try { |p| upstream.uri = URI.parse(p.as_a.first.to_s) }
-            config["prefetch-count"]?.try { |p| upstream.prefetch = p.as_i.to_u16 }
-            config["reconnect-delay"]?.try { |p| upstream.reconnect_delay = p.as_i.seconds }
-            ack_mode_str = config["ack-mode"]?.try(&.as_s.delete("-")).to_s
+            cfg["uri"]?.try { |p| upstream.uri = URI.parse(p.as_s) }
+            cfg["prefetch-count"]?.try { |p| upstream.prefetch = p.as_i.to_u16 }
+            cfg["reconnect-delay"]?.try { |p| upstream.reconnect_delay = p.as_i.seconds }
+            ack_mode_str = cfg["ack-mode"]?.try(&.as_s.delete("-")).to_s
             AckMode.parse?(ack_mode_str).try { |p| upstream.ack_mode = p }
-            config["exchange"]?.try { |p| upstream.exchange = p.as_s }
-            config["max-hops"]?.try { |p| upstream.max_hops = p.as_i64 }
-            config["expires"]?.try { |p| upstream.expires = p.as_i64 }
-            config["message-ttl"]?.try { |p| upstream.msg_ttl = p.as_i64 }
-            config["queue"]?.try { |p| upstream.queue = p.as_s }
+            cfg["exchange"]?.try { |p| upstream.exchange = p.as_s }
+            cfg["max-hops"]?.try { |p| upstream.max_hops = p.as_i64 }
+            cfg["expires"]?.try { |p| upstream.expires = p.as_i64 }
+            cfg["message-ttl"]?.try { |p| upstream.msg_ttl = p.as_i64 }
+            cfg["queue"]?.try { |p| upstream.queue = p.as_s }
           end
           upstreams << upstream
         end

--- a/src/lavinmq/federation/upstream_store.cr
+++ b/src/lavinmq/federation/upstream_store.cr
@@ -54,7 +54,7 @@ module LavinMQ
         @upstreams.delete(name).try(&.delete)
         @upstream_sets.each do |_, set|
           set.reject! do |upstream|
-            return false unless upstream.name == name
+            next false unless upstream.name == name
             upstream.delete
             true
           end


### PR DESCRIPTION
Fixes #2071 
`do_delete_upstream` used a bare return inside a `reject!` block, which returns from the method rather than the block. When iterating an upstream set it aborted on the first entry whose name did not match, so a matching upstream later in the set was never removed. It lingered as a stale entry, showed up in federation status, and could be revived on the next `link_set`. Changed to `next false `so `reject!` skips non-matching entries and continues.

While there, fixed a related bug in `create_upstream_set`: per-entry overrides were read off `config` (the whole set array) instead of `cfg` (the current entry), so any entry with more than the upstream key raised "Expected Hash ... not Array" and crashed. The uri override also assumed an array value. Overrides are now read from the entry, and the duplicated upstream gets its own link tables via a custom Upstream#dup, since the default shallow dup shared `@q_links`/`@ex_links` with the original.

Each fix is a separate commit with its own regression spec.
