### PR TITLE
perf(mqtt): zero-allocation subscription-tree match

### DIFF
--- a/spec/mqtt/bytes_token_iterator_spec.cr
+++ b/spec/mqtt/bytes_token_iterator_spec.cr
@@ -1,0 +1,46 @@
+require "./spec_helper"
+require "../../src/lavinmq/mqtt/bytes_token_iterator"
+
+describe LavinMQ::MQTT::BytesTokenIterator do
+  # Must match StringTokenIterator's splitting semantics, including empty parts.
+  [
+    {"a", ["a"]},
+    {"/", ["", ""]},
+    {"a/", ["a", ""]},
+    {"/a", ["", "a"]},
+    {"a/b/c", ["a", "b", "c"]},
+    {"a//c", ["a", "", "c"]},
+    {"a//b/c/aa", ["a", "", "b", "c", "aa"]},
+    {"long name here/and another long here",
+     ["long name here", "and another long here"]},
+  ].each do |input, expected|
+    it "splits #{input.inspect} correctly" do
+      itr = LavinMQ::MQTT::BytesTokenIterator.new(input.to_slice, '/')
+      res = Array(String).new
+      while itr.next?
+        if val = itr.next
+          res << String.new(val)
+        end
+      end
+      itr.next?.should be_false
+      res.should eq expected
+    end
+  end
+
+  it "yields views into the backing buffer, never copies" do
+    # Every token must point into the original buffer, not a fresh copy. This is
+    # what keeps the subscription-tree match path allocation-free.
+    buf = "aa/b/cccc/d/e".to_slice
+    buf_start = buf.to_unsafe.address
+    buf_end = buf_start + buf.size
+    itr = LavinMQ::MQTT::BytesTokenIterator.new(buf, '/')
+    tokens = [] of String
+    while token = itr.next
+      ptr = token.to_unsafe.address
+      ptr.should be >= buf_start
+      (ptr + token.size).should be <= buf_end
+      tokens << String.new(token)
+    end
+    tokens.should eq ["aa", "b", "cccc", "d", "e"]
+  end
+end

--- a/spec/mqtt/subscription_tree_spec.cr
+++ b/spec/mqtt/subscription_tree_spec.cr
@@ -199,6 +199,21 @@ describe LavinMQ::MQTT::SubscriptionTree do
     tree.each_entry "a/b" { |_sess, qos| qos.should eq 1u8 }
   end
 
+  it "matches topic levels with multibyte UTF-8 characters" do
+    tree = LavinMQ::MQTT::SubscriptionTree(String).new
+    tree.subscribe("café/naïve/日本", "exact", 0u8)
+    tree.subscribe("café/+/日本", "wildcard", 0u8)
+
+    matched = [] of String
+    tree.each_entry("café/naïve/日本") { |session, _qos| matched << session }
+    matched.sort.should eq ["exact", "wildcard"]
+
+    # A different (also multibyte) middle level only hits the wildcard
+    matched.clear
+    tree.each_entry("café/résumé/日本") { |session, _qos| matched << session }
+    matched.should eq ["wildcard"]
+  end
+
   it "can iterate all entries" do
     tree = LavinMQ::MQTT::SubscriptionTree(String).new
     test_data = [

--- a/src/lavinmq/mqtt/bytes_token_iterator.cr
+++ b/src/lavinmq/mqtt/bytes_token_iterator.cr
@@ -1,0 +1,34 @@
+module LavinMQ
+  module MQTT
+    # Splits a buffer on a delimiter byte, yielding each part as a `Bytes` view
+    # into the buffer (no allocation per token). Empty parts are returned, so
+    # "/" yields two empty tokens and "a//b" yields "a", "" and "b".
+    #
+    # The delimiter must be a single ASCII byte; splitting on ASCII over a UTF-8
+    # buffer is safe because UTF-8 multi-byte sequences only use bytes >= 0x80.
+    struct BytesTokenIterator
+      def initialize(@bytes : Bytes, delimiter : Char = '/')
+        @delimiter = delimiter.ord.to_u8
+        @pos = 0
+        @iteration = 0
+      end
+
+      def next : Bytes?
+        return if @pos >= @bytes.size
+        # Skip the previous token's delimiter, except on the first iteration so
+        # a leading delimiter yields an empty token.
+        @pos += 1 unless @iteration.zero?
+        @iteration += 1
+        head = @pos
+        while @pos < @bytes.size && @bytes.unsafe_fetch(@pos) != @delimiter
+          @pos += 1
+        end
+        @bytes[head, @pos - head]
+      end
+
+      def next?
+        @pos < @bytes.size
+      end
+    end
+  end
+end

--- a/src/lavinmq/mqtt/subscription_tree.cr
+++ b/src/lavinmq/mqtt/subscription_tree.cr
@@ -1,9 +1,13 @@
 require "./session"
-require "./string_token_iterator"
+require "./bytes_token_iterator"
 
 module LavinMQ
   module MQTT
     class SubscriptionTree(T)
+      # MQTT wildcard markers, compared by content against the Bytes tokens.
+      HASH = "#".to_slice
+      PLUS = "+".to_slice
+
       @wildcard_rest = Hash(T, UInt8).new
       @plus : SubscriptionTree(T)?
       @leafs = Hash(T, UInt8).new
@@ -12,7 +16,10 @@ module LavinMQ
       @non_wildcards = Hash(String, Hash(T, UInt8)).new do |h, k|
         h[k] = Hash(T, UInt8).new.compare_by_identity
       end
-      @sublevels = Hash(String, SubscriptionTree(T)).new
+      # Keyed by owned Bytes copies of each level. Bytes hash and compare by
+      # content, so matching can look up with zero-allocation views into the
+      # published topic.
+      @sublevels = Hash(Bytes, SubscriptionTree(T)).new
 
       def initialize
         @wildcard_rest.compare_by_identity
@@ -24,27 +31,26 @@ module LavinMQ
           @non_wildcards[filter][session] = qos
           return
         end
-        subscribe(StringTokenIterator.new(filter), session, qos)
+        subscribe(BytesTokenIterator.new(filter.to_slice), session, qos)
       end
 
-      protected def subscribe(filter : StringTokenIterator, session : T, qos : UInt8)
+      protected def subscribe(filter : BytesTokenIterator, session : T, qos : UInt8)
         unless current = filter.next
           @leafs[session] = qos
           return
         end
-        if current == "#"
+        if current == HASH
           @wildcard_rest[session] = qos
           return
         end
-        if current == "+"
+        if current == PLUS
           plus = (@plus ||= SubscriptionTree(T).new)
           plus.subscribe filter, session, qos
           return
         end
-        if !(sublevels = @sublevels[current]?)
-          sublevels = @sublevels[current] ||= SubscriptionTree(T).new
-        end
-        sublevels.subscribe filter, session, qos
+        # dup the token to own it as a persistent hash key (subscribe is cold)
+        sublevel = @sublevels[current]? || (@sublevels[current.dup] = SubscriptionTree(T).new)
+        sublevel.subscribe filter, session, qos
         return
       end
 
@@ -57,18 +63,18 @@ module LavinMQ
             return
           end
         end
-        unsubscribe(StringTokenIterator.new(filter), session)
+        unsubscribe(BytesTokenIterator.new(filter.to_slice), session)
       end
 
-      protected def unsubscribe(filter : StringTokenIterator, session : T)
+      protected def unsubscribe(filter : BytesTokenIterator, session : T)
         unless current = filter.next
           @leafs.delete session
           return
         end
-        if current == "#"
+        if current == HASH
           @wildcard_rest.delete session
         end
-        if (plus = @plus) && current == "+"
+        if (plus = @plus) && current == PLUS
           plus.unsubscribe filter, session
         end
         if sublevel = @sublevels[current]?
@@ -84,10 +90,10 @@ module LavinMQ
         if subs = @non_wildcards[filter]?
           return !subs.empty?
         end
-        any?(StringTokenIterator.new(filter))
+        any?(BytesTokenIterator.new(filter.to_slice))
       end
 
-      protected def any?(filter : StringTokenIterator)
+      protected def any?(filter : BytesTokenIterator)
         return !@leafs.empty? unless current = filter.next
         return true if !@wildcard_rest.empty?
         return true if @plus.try &.any?(filter)
@@ -110,17 +116,19 @@ module LavinMQ
         if subs = @non_wildcards[topic]?
           subs.each &block
         end
-        each_entry(StringTokenIterator.new(topic), &block)
+        # Nothing to walk when there are no wildcard subscriptions.
+        return if @wildcard_rest.empty? && @plus.nil? && @sublevels.empty?
+        each_entry(BytesTokenIterator.new(topic.to_slice), &block)
       end
 
-      protected def each_entry(topic : StringTokenIterator, &block : (T, UInt8) -> _)
+      protected def each_entry(topic : BytesTokenIterator, &block : (T, UInt8) -> _)
         unless current = topic.next
           @leafs.each &block
           return
         end
         @wildcard_rest.each &block
         @plus.try &.each_entry topic, &block
-        if sublevel = @sublevels.fetch(current, nil)
+        if sublevel = @sublevels[current]?
           sublevel.each_entry topic, &block
         end
       end


### PR DESCRIPTION
The subscription-tree match runs on every MQTT publish. The tokenizer allocated one throwaway `String` per topic level; this slices the topic on bytes so tokens are zero-allocation views into the topic buffer.

## Changes

- Add `BytesTokenIterator` yielding `Bytes` views instead of `String` copies.
- Key `SubscriptionTree#@sublevels` by `Bytes` (`Bytes` hash/compare by content), so matching looks up with zero-allocation views; `subscribe` `dup`s tokens to own the persistent keys.
- Skip the tree walk entirely when there are no wildcard subscriptions.

## Performance

| Benchmark | before | after | delta |
|---|---|---|---|
| Allocations per match | 224 B/op | 0 B/op | zero-alloc |
| Isolated match throughput | 1.92M ops/s | 5.30M ops/s | ~2.8x |
| E2E publish throughput (wildcard path, 8 publishers) | ~1.33M msgs/s | ~1.62M msgs/s | +22% |

Isolated numbers from an in-process micro-benchmark; e2e from a broker run with deep wildcard subscriptions (mean of 6 trials, non-overlapping distributions). Measured on a dev machine, treat as indicative. The gain applies to the wildcard-match path; exact-match / publish-only throughput is unchanged, as it's bound by frame parsing and IO rather than the tree walk.

## Test plan

- `make test SPEC=spec/mqtt` (178 examples)
- New specs: `BytesTokenIterator` splitting semantics + a deterministic view-not-copy assertion (token pointers fall within the backing buffer), and a UTF-8 multibyte topic match test.