### PR TITLE
Fix OAuthUser refresh blocking read_loop after token expiry

### DIFF
--- a/spec/oauth_spec.cr
+++ b/spec/oauth_spec.cr
@@ -506,6 +506,22 @@ describe LavinMQ::Auth::OAuthUser do
       callback_called.should be_true
     end
 
+    it "closes the token-update channel when the watcher exits so a late refresh can't block (#2075)" do
+      permissions = {"/" => {config: /.*/, read: /.*/, write: /.*/}}
+      # Already-expired token: the watcher fires its timeout immediately and exits.
+      user = OAuthUserHelper.create_user(RoughTime.utc - 1.hour, permissions)
+
+      user.on_expiration { }
+
+      # Once the watcher fiber has exited, the notification channel must be closed,
+      # otherwise refresh's `@token_updated.send` would block the read_loop forever.
+      wait_for { user.@token_updated.closed? }
+
+      expect_raises(Channel::ClosedError) do
+        user.@token_updated.send nil
+      end
+    end
+
     it "stops fiber when user is closed" do
       permissions = {"/" => {config: /.*/, read: /.*/, write: /.*/}}
       # Create user with token that expires in the future

--- a/src/lavinmq/auth/oauth_user.cr
+++ b/src/lavinmq/auth/oauth_user.cr
@@ -31,6 +31,10 @@ module LavinMQ
           end
         rescue Channel::ClosedError
           # Channel closed, exit gracefully
+        ensure
+          # Close the channel when the watcher exits so a later refresh (e.g. a
+          # post-expiry UpdateSecret) can't block forever on a receiverless send.
+          @token_updated.close
         end
       end
 
@@ -51,7 +55,16 @@ module LavinMQ
         @permissions = claims.permissions
         @expires_at = claims.expires_at
         clear_permissions_cache
+        notify_token_updated
+      end
+
+      # Best-effort notification to the on_expiration watcher that the token was
+      # refreshed so it recomputes its timeout. If the watcher has already exited
+      # (token expired, connection closing) the channel is closed and there is
+      # nothing to notify.
+      private def notify_token_updated
         @token_updated.send nil
+      rescue Channel::ClosedError
       end
 
       def find_permission(vhost : String) : Permissions?

--- a/src/lavinmq/auth/oauth_user.cr
+++ b/src/lavinmq/auth/oauth_user.cr
@@ -55,16 +55,10 @@ module LavinMQ
         @permissions = claims.permissions
         @expires_at = claims.expires_at
         clear_permissions_cache
-        notify_token_updated
-      end
-
-      # Best-effort notification to the on_expiration watcher that the token was
-      # refreshed so it recomputes its timeout. If the watcher has already exited
-      # (token expired, connection closing) the channel is closed and there is
-      # nothing to notify.
-      private def notify_token_updated
         @token_updated.send nil
       rescue Channel::ClosedError
+        # The on_expiration watcher already exited (token expired, connection
+        # closing), so there is nothing to notify.
       end
 
       def find_permission(vhost : String) : Permissions?


### PR DESCRIPTION
`OAuthUser#refresh` ends with a blocking send on the unbuffered `@token_updated` channel. The only receiver is the `on_expiration` watcher fiber, which exits once its timeout fires on token expiry. A post-expiry `Connection.UpdateSecret` is dispatched by `read_loop`, reaches `refresh`, and its send blocks forever on the now receiverless channel. The read_loop fiber hangs, no heartbeat or socket timeout fires, and the connection and socket FD leak.

Fix: `on_expiration` now closes `@token_updated` when the watcher exits, and `refresh` sends through a helper that rescues `Channel::ClosedError`. A late refresh becomes a no-op instead of blocking. `Channel#close` is idempotent and wakes any blocked sender, so the narrow race during watcher teardown also resolves immediately. The fix lives in the shared `OAuthUser`, so it covers both AMQP and MQTT.

Added a regression spec that fails before the fix (times out) and passes after.

Fixes #2075
