### PR TITLE
fix: bound the initial PROXY-protocol peek with a read timeout

### DIFF
--- a/spec/proxy_protocol_spec.cr
+++ b/spec/proxy_protocol_spec.cr
@@ -147,6 +147,15 @@ describe "ProxyProtocol" do
       conn_info = LavinMQ::ProxyProtocol.parse(r)
       conn_info.should be_nil
     end
+
+    it "times out on the initial peek when the peer sends nothing" do
+      r, _w = IO.pipe
+      expect_raises(IO::TimeoutError) do
+        LavinMQ::ProxyProtocol.parse(r, timeout: 100.milliseconds)
+      end
+      # read_timeout must be reset so it doesn't leak into the connection handler
+      r.read_timeout.should be_nil
+    end
   end
 
   describe "trusted sources" do

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -14,7 +14,13 @@ module LavinMQ
 
     class UnsupportedTLVType < Error; end
 
-    def self.parse(io : IO) : ConnectionInfo?
+    # Bound how long a pre-auth connection may keep the accept fiber (and its FD)
+    # parked while we wait for the first bytes. Without this the initial peek
+    # blocks forever on a peer that completes the handshake but sends nothing.
+    HANDSHAKE_TIMEOUT = 15.seconds
+
+    def self.parse(io : IO, timeout : Time::Span = HANDSHAKE_TIMEOUT) : ConnectionInfo?
+      io.read_timeout = timeout
       peeked = io.peek
       if peeked.size >= 5 && peeked[0, 5] == "PROXY".to_slice
         ProxyProtocol::V1.parse(io)
@@ -23,6 +29,8 @@ module LavinMQ
       else
         nil
       end
+    ensure
+      io.read_timeout = nil
     end
 
     struct V1
@@ -31,7 +39,7 @@ module LavinMQ
       # PROXY TCP6 ffff:f...f:ffff ffff:f...f:ffff 65535 65535\r\n
       # PROXY UNKNOWN\r\n
       def self.parse(io)
-        io.read_timeout = 15.seconds
+        io.read_timeout = HANDSHAKE_TIMEOUT
         header = io.gets('\n', 107) || raise IO::EOFError.new
 
         src_addr = "127.0.0.1"
@@ -105,7 +113,7 @@ module LavinMQ
       end
 
       def self.parse(io)
-        io.read_timeout = 15.seconds
+        io.read_timeout = HANDSHAKE_TIMEOUT
         buffer = uninitialized UInt8[16]
         io.read(buffer.to_slice)
         signature = buffer.to_slice[0, 12]


### PR DESCRIPTION
## Problem

`ProxyProtocol.parse` called `io.peek` before any read timeout was set. A peer that completed the TCP/unix handshake but sent zero bytes parked the accept fiber forever, holding its FD (slowloris / FD exhaustion). The `read_timeout = 15.seconds` was only set later inside `V1.parse`/`V2.parse`, after the peek had already blocked.

Affected paths:
- TCP listeners with `tcp_proxy_protocol = true`
- All unix-socket connections (default config)
- Clustering follower-address TCP connections

Regressed by `ad80d79c` (#1601), which introduced auto-detection via `peek`.

## Fix

Set `io.read_timeout` before the peek and reset it in `ensure`. Reuse a single `HANDSHAKE_TIMEOUT` constant across `parse`/`V1.parse`/`V2.parse` instead of repeating `15.seconds`. On timeout the peek raises `IO::TimeoutError`, which the existing `rescue` in `accept_tcp`/`accept_unix` catches and closes the connection.

## Test plan

- New regression spec: an idle pipe raises `IO::TimeoutError` instead of blocking, and `read_timeout` is reset to `nil` afterwards.
- `make test SPEC=spec/proxy_protocol_spec.cr` (20 examples, 0 failures)
- `make lint` (0 failures)

Fixes #2079