### PR TITLE
fix: fail loud on invalid proxy_protocol_trusted_sources entries

### DIFF
--- a/spec/proxy_protocol_spec.cr
+++ b/spec/proxy_protocol_spec.cr
@@ -203,16 +203,20 @@ describe "ProxyProtocol" do
       config.proxy_protocol_trusted_sources[3].matches?("::2").should be_false
     end
 
-    it "handles invalid entries gracefully" do
-      config = LavinMQ::Config.new
-      # This should print warnings to STDERR but not fail
-      config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list(
-        "10.0.0.1, invalid-ip, 192.168.0.0/24, 300.0.0.1")
+    it "raises on an invalid entry mixed with valid ones" do
+      # A typo must fail loudly rather than silently dropping the entry and
+      # degrading the allow-list (potentially to trust-all).
+      expect_raises(ArgumentError, /Invalid IP\/CIDR 'invalid-ip'/) do
+        LavinMQ::IPMatcher.parse_list("10.0.0.1, invalid-ip, 192.168.0.0/24")
+      end
+    end
 
-      # Only valid entries should be parsed
-      config.proxy_protocol_trusted_sources.size.should eq 2
-      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
-      config.proxy_protocol_trusted_sources[1].matches?("192.168.0.50").should be_true
+    it "raises when every entry is invalid instead of collapsing to trust-all" do
+      # Regression for #2083: an all-invalid list must not parse to an empty
+      # array (which trusted_proxy_source? treats as trust-all).
+      expect_raises(ArgumentError, /Invalid IP\/CIDR/) do
+        LavinMQ::IPMatcher.parse_list("10.0.0.0/33, 300.0.0.1")
+      end
     end
 
     it "handles whitespace correctly" do

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -50,17 +50,18 @@ module LavinMQ
       raise ArgumentError.new("Invalid IP address: #{ip_str}")
     end
 
-    # Parse a comma-separated list of IP addresses or CIDR ranges from config
+    # Parse a comma-separated list of IP addresses or CIDR ranges from config.
+    # Raises on any invalid entry so a misconfigured trusted-source list fails
+    # loudly at startup instead of silently collapsing to an empty (trust-all) list.
     def self.parse_list(sources : String) : Array(IPMatcher)
       sources.split(',')
         .map(&.strip)
         .reject(&.empty?)
-        .compact_map do |source|
+        .map do |source|
           begin
             parse(source)
           rescue ex : Socket::Error | ArgumentError
-            Log.error(exception: ex) { "Invalid IP/CIDR: #{source}" }
-            nil
+            raise ArgumentError.new("Invalid IP/CIDR '#{source}': #{ex.message}")
           end
         end
     end


### PR DESCRIPTION
Fixes #2083

`IPMatcher.parse_list` silently dropped invalid CIDR/IP entries. If every entry was malformed the list became empty, which `trusted_proxy_source?` treats as trust-all - silently reverting a locked-down config and letting any peer spoof its source IP via a forged PROXY header.

`parse_list` now raises on any invalid entry. The INI parser's existing `rescue/abort` wrapper turns that into a clean startup abort instead of a degraded allow-list. An empty parsed list can now only come from genuinely unset config, so the trust-all backward-compat path stays unambiguous.

## Test plan

- New spec: an invalid entry mixed with valid ones raises.
- New regression spec: an all-invalid list raises instead of collapsing to an empty (trust-all) list.
- Replaced the old "handles invalid entries gracefully" spec, which encoded the buggy silent-drop behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)