### PR TITLE
Fix: return 400 instead of 500 for unsupported hashing_algorithm

### DIFF
--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -234,6 +234,15 @@ describe LavinMQ::HTTP::Server do
       end
     end
 
+    it "returns 400 when importing a user with an unsupported hashing_algorithm" do
+      with_http_server do |http, s|
+        body = %({"users":[{"name":"bogus","password_hash":"abc","hashing_algorithm":"bogus","tags":[]}]})
+        response = http.post("/api/definitions", body: body)
+        response.status_code.should eq 400
+        s.users["bogus"]?.should be_nil
+      end
+    end
+
     it "imports passwordless user (password_hash empty string)" do
       with_http_server do |http, s|
         body = %({"users":[{"name":"nopass","password_hash":"","hashing_algorithm":null,"tags":""}]})

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -120,6 +120,22 @@ describe LavinMQ::HTTP::UsersController do
       end
     end
 
+    it "should return 400 for an unsupported hashing_algorithm" do
+      with_http_server do |http, _|
+        body = %({"password_hash": "abc", "hashing_algorithm": "rabbit_password_hashing_xyz"})
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 400
+      end
+    end
+
+    it "should return 400 for an empty hashing_algorithm" do
+      with_http_server do |http, _|
+        body = %({"password_hash": "abc", "hashing_algorithm": ""})
+        response = http.put("/api/users/alan", body: body)
+        response.status_code.should eq 400
+      end
+    end
+
     it "should create user with empty password_hash" do
       with_http_server do |http, _|
         body = %({

--- a/src/lavinmq/auth/user.cr
+++ b/src/lavinmq/auth/user.cr
@@ -147,7 +147,7 @@ module LavinMQ
         end
       end
 
-      class UnknownHashAlgoritm < Exception; end
+      class UnknownHashAlgoritm < ArgumentError; end
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?

`PUT /api/users/:name` and `POST /api/definitions` returned HTTP **500** instead of **400** when given an unsupported or empty `hashing_algorithm`.

`Auth::User::UnknownHashAlgoritm` was defined as a bare `Exception`, so it slipped past the `ApiErrorHandler`'s `ArgumentError`/`JSON::Error` → 400 rescue and hit the generic `Exception` → 500 branch. This makes it inherit from `ArgumentError` instead — one line — so it maps to 400, consistent with the sibling `InvalidPasswordHash < ArgumentError` in the same module.

**Not a regression from the passwordless PR (#1898).** I bisected to its parent (`dca5f65a`) and reproduced the same 500 there: the buggy `else → raise UnknownHashAlgoritm` branch and the bare-`Exception` classification both predate it (the class dates back to #584). #1898 only touched nil/empty handling and never this branch.

### HOW can this pull request be tested?

Specs added (fail on old code with 500, pass now with 400):
- `spec/api/users_spec.cr` — `PUT /api/users/:name` with an unsupported and with an empty `hashing_algorithm`
- `spec/api/definitions_spec.cr` — `POST /api/definitions` importing a user with an unsupported `hashing_algorithm`

Full suite green: `1943 examples, 0 failures`. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)