### PR TITLE
fix: PROXY header TCP segment splits (#2082) and IPv4-mapped IPv6 trusted sources (#2070)

### DIFF
--- a/spec/ip_matcher_spec.cr
+++ b/spec/ip_matcher_spec.cr
@@ -327,14 +327,22 @@ describe LavinMQ::IPMatcher do
         matcher.matches?("2001:db8:0:2::").should be_false
       end
 
-      it "IPv4 matcher rejects IPv4-mapped IPv6" do
+      it "IPv4 matcher matches IPv4-mapped IPv6 (dual-stack listener)" do
         matcher = LavinMQ::IPMatcher.parse("192.168.1.1")
-        matcher.matches?("::ffff:192.168.1.1").should be_false
+        matcher.matches?("::ffff:192.168.1.1").should be_true
+        matcher.matches?("::ffff:192.168.1.2").should be_false
       end
 
-      it "IPv4 CIDR rejects IPv4-mapped IPv6" do
+      it "IPv4 CIDR matches IPv4-mapped IPv6 (dual-stack listener)" do
         matcher = LavinMQ::IPMatcher.parse("192.168.1.0/24")
-        matcher.matches?("::ffff:192.168.1.50").should be_false
+        matcher.matches?("::ffff:192.168.1.50").should be_true
+        matcher.matches?("::ffff:192.168.2.50").should be_false
+      end
+
+      it "IPv4 matcher doesn't match a real (non-mapped) IPv6 address" do
+        matcher = LavinMQ::IPMatcher.parse("192.168.1.1")
+        matcher.matches?("2001:db8::c0a8:0101").should be_false
+        matcher.matches?("::1").should be_false
       end
 
       it "IPv6 matcher rejects raw IPv4" do

--- a/spec/proxy_protocol_spec.cr
+++ b/spec/proxy_protocol_spec.cr
@@ -156,6 +156,42 @@ describe "ProxyProtocol" do
       # read_timeout must be reset so it doesn't leak into the connection handler
       r.read_timeout.should be_nil
     end
+
+    it "detects a V2 header split across TCP segments" do
+      pp_bytes = UInt8.static_array(
+        0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51,
+        0x55, 0x49, 0x54, 0x0a, 0x21, 0x11, 0x00, 0x0c,
+        0x7f, 0x00, 0x00, 0x01, 0x7f, 0x00, 0x00, 0x01,
+        0x92, 0x30, 0x16, 0x27
+      )
+      r, w = IO.pipe
+      ch = Channel(LavinMQ::ConnectionInfo?).new
+      spawn { ch.send LavinMQ::ProxyProtocol.parse(r) }
+
+      # First segment carries fewer than the 12 signature bytes
+      w.write pp_bytes.to_slice[0, 6]
+      Fiber.yield
+      w.write pp_bytes.to_slice[6..]
+
+      conn_info = ch.receive
+      conn_info.should_not be_nil
+      conn_info.not_nil!.remote_address.to_s.should eq "127.0.0.1:37424"
+    end
+
+    it "detects a V1 header split across TCP segments" do
+      header = "PROXY TCP4 1.2.3.4 127.0.0.2 34567 1234\r\n".to_slice
+      r, w = IO.pipe
+      ch = Channel(LavinMQ::ConnectionInfo?).new
+      spawn { ch.send LavinMQ::ProxyProtocol.parse(r) }
+
+      w.write header[0, 3] # "PRO"
+      Fiber.yield
+      w.write header[3..]
+
+      conn_info = ch.receive
+      conn_info.should_not be_nil
+      conn_info.not_nil!.remote_address.to_s.should eq "1.2.3.4:34567"
+    end
   end
 
   describe "trusted sources" do
@@ -243,6 +279,19 @@ describe "ProxyProtocol" do
       config.proxy_protocol_trusted_sources = LavinMQ::IPMatcher.parse_list("")
 
       config.proxy_protocol_trusted_sources.size.should eq 0
+    end
+
+    it "fails loudly on an invalid entry (does not collapse to trust-all)" do
+      expect_raises(ArgumentError, /Invalid IP\/CIDR/) do
+        LavinMQ::IPMatcher.parse_list("10.0.0.0/33, not-an-ip")
+      end
+    end
+
+    it "matches an IPv4 trusted source for an IPv4-mapped IPv6 peer (dual-stack)" do
+      sources = LavinMQ::IPMatcher.parse_list("10.0.0.0/24")
+      # An IPv4 load balancer behind a `bind = ::` listener arrives mapped
+      sources.any?(&.matches?("::ffff:10.0.0.5")).should be_true
+      sources.any?(&.matches?("::ffff:10.0.1.5")).should be_false
     end
   end
 end

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -97,7 +97,23 @@ module LavinMQ
     private def ip_to_bytes_v4(address : String) : Bytes?
       if fields = Socket::IPAddress.parse_v4_fields?(address)
         Bytes.new(4) { |i| fields[i] }
+      elsif fields = Socket::IPAddress.parse_v6_fields?(address)
+        # On a dual-stack (::) listener an IPv4 peer arrives as an IPv4-mapped
+        # IPv6 address (::ffff:a.b.c.d); extract the embedded IPv4 so an IPv4
+        # trusted source still matches (issue 2070).
+        ipv4_mapped_bytes(fields)
       end
+    end
+
+    # If *fields* is an IPv4-mapped IPv6 address (::ffff:a.b.c.d), return the
+    # embedded 4-byte IPv4 address, otherwise nil.
+    private def ipv4_mapped_bytes(fields : StaticArray(UInt16, 8)) : Bytes?
+      return nil unless fields[0].zero? && fields[1].zero? && fields[2].zero? &&
+                        fields[3].zero? && fields[4].zero? && fields[5] == 0xffff_u16
+      Bytes[
+        (fields[6] >> 8).to_u8, (fields[6] & 0xFF).to_u8,
+        (fields[7] >> 8).to_u8, (fields[7] & 0xFF).to_u8,
+      ]
     end
 
     # Convert IPv6 address string to bytes

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -21,16 +21,29 @@ module LavinMQ
 
     def self.parse(io : IO, timeout : Time::Span = HANDSHAKE_TIMEOUT) : ConnectionInfo?
       io.read_timeout = timeout
+      # A single peek can return fewer bytes than the full signature on a TCP
+      # segment split (issue 2082), so we only need the bytes we have to match
+      # the *start* of a signature. No supported protocol (AMQP "AMQP\0\0\9\1",
+      # MQTT, HTTP) begins with "PROXY" or the V2 signature, so a prefix match
+      # is unambiguous; the V1/V2 parsers then read the rest of the header.
       peeked = io.peek
-      if peeked.size >= 5 && peeked[0, 5] == "PROXY".to_slice
+      if header_prefix?(peeked, "PROXY".to_slice)
         ProxyProtocol::V1.parse(io)
-      elsif peeked.size >= 12 && peeked[0, 12] == ProxyProtocol::V2::Signature.to_slice
+      elsif header_prefix?(peeked, ProxyProtocol::V2::Signature.to_slice)
         ProxyProtocol::V2.parse(io)
       else
         nil
       end
     ensure
       io.read_timeout = nil
+    end
+
+    # True if the bytes seen so far match the start of *signature* (comparing
+    # only the bytes we have, since a segment split may give us a partial peek).
+    private def self.header_prefix?(peeked : Bytes, signature : Bytes) : Bool
+      n = Math.min(peeked.size, signature.size)
+      return false if n.zero?
+      peeked[0, n] == signature[0, n]
     end
 
     struct V1
@@ -115,7 +128,8 @@ module LavinMQ
       def self.parse(io)
         io.read_timeout = HANDSHAKE_TIMEOUT
         buffer = uninitialized UInt8[16]
-        io.read(buffer.to_slice)
+        # read_fully so a 16-byte header split across TCP segments isn't short-read (issue 2082)
+        io.read_fully(buffer.to_slice)
         signature = buffer.to_slice[0, 12]
         unless signature == Signature.to_slice
           raise InvalidSignature.new(signature.to_s)


### PR DESCRIPTION
## Fixes #2082 — PROXY header misread on TCP segment split
- Detection now uses a **prefix match** on the peeked bytes. A single `peek` can return fewer bytes than the full signature when the header is split across TCP segments, so we compare only the bytes we have against the *start* of each signature. No supported protocol (AMQP `AMQP\0\0\9\1`, MQTT, HTTP) begins with `"PROXY"` or the V2 signature, so the prefix match is unambiguous; the V1/V2 parsers then read the rest of the header.
- `V2.parse` uses `read_fully` for the 16-byte header instead of `io.read`, which silently ignored short reads on a split.

## Fixes #2070 — IPv4 trusted source vs IPv4-mapped IPv6 on dual-stack listeners
On a `bind = ::` listener an IPv4 load balancer arrives as `::ffff:10.0.0.1`. `IPMatcher#ip_to_bytes_v4` now falls back to extracting the embedded IPv4 from an `::ffff:` mapped address, so an IPv4 trusted-source entry still matches. The two `ip_matcher_spec` assertions that asserted the old (broken) behavior are flipped, with a non-mapped IPv6 guard added.

## Regression coverage for already-merged fixes
- #2079 (handshake timeout, merged in #2095): spec that the initial peek times out and `read_timeout` is reset.
- #2083 (fail-loud trusted sources, merged in #2096): spec that an invalid entry raises rather than collapsing to trust-all.

## Tests
- `spec/proxy_protocol_spec.cr` — V1/V2 segment-split detection, peek timeout, fail-loud, IPv4-mapped dual-stack match (25 examples, 0 failures)
- `spec/ip_matcher_spec.cr` — flipped 2 mapped-address assertions, added non-mapped IPv6 guard (51 examples, 0 failures)
- `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
