### PR TITLE
Read the full AMQP protocol header in confirm_header

### DIFF
--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -315,4 +315,26 @@ describe LavinMQ::Server do
       end
     end
   end
+
+  describe "protocol header" do
+    it "accepts a protocol header delivered in fragments" do
+      with_amqp_server do |s|
+        io = TCPSocket.new("localhost", amqp_port(s))
+        io.read_timeout = 5.seconds
+        begin
+          header = AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
+          io.write header[0, 4]
+          io.flush
+          sleep 50.milliseconds
+          io.write header[4, 4]
+          io.flush
+
+          stream = AMQ::Protocol::Stream.new(io)
+          stream.next_frame.should be_a(AMQ::Protocol::Frame::Connection::Start)
+        ensure
+          io.close
+        end
+      end
+    end
+  end
 end

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -48,13 +48,12 @@ module LavinMQ
 
       def confirm_header(socket, log : Logger) : Bool
         proto = uninitialized UInt8[8]
-        count = socket.read(proto.to_slice)
-        if count.zero? # EOF, socket closed by peer
+        if socket.read_fully?(proto.to_slice).nil?
           false
         elsif proto != AMQP::PROTOCOL_START_0_9_1 && proto != AMQP::PROTOCOL_START_0_9
           socket.write AMQP::PROTOCOL_START_0_9_1.to_slice
           socket.flush
-          log.warn { "Unexpected protocol #{String.new(proto.to_unsafe, count).inspect}, closing socket" }
+          log.warn { "Unexpected protocol #{String.new(proto.to_slice).inspect}, closing socket" }
           false
         else
           true


### PR DESCRIPTION
### WHAT is this pull request doing?
A single IO#read into an uninitialized buffer could return a short count
when the 8-byte preamble is split across TLS records / TCP segments under
load, leaving the tail uninitialized; the protocol comparison then failed
and the server dropped the connection mid-handshake. Use read_fully? to
read all 8 bytes (bounded by the existing read_timeout), and add a
regression test for a fragmented header.

### HOW can this pull request be tested?
I ran into this issue when adding e2e testing to amqpstorm for lavinmq.
https://github.com/eandersson/amqpstorm/commits/backup_20260601/
https://github.com/eandersson/amqpstorm/actions/runs/27906654414/job/82576716040