### PR TITLE
Fix clustered stream consumer-offsets compaction crash (#2068)

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -750,6 +750,50 @@ describe LavinMQ::Clustering::Client, tags: %w[etcd slow] do
     end
   end
 
+  it "compacts and replicates a stream's consumer_offsets file when it fills [#2068]" do
+    with_clustering do |cluster|
+      expected = Bytes.new(0)
+      follower_offsets_path = ""
+      ctag = "ctag-" + "x" * 100
+      with_amqp_server(replicator: cluster.replicator) do |s|
+        wait_for { cluster.replicator.followers.first?.try &.synced? }
+        queue_name = Random::Secure.hex
+        with_channel(s) do |ch|
+          q = ch.queue(queue_name, args: AMQP::Client::Arguments.new({"x-queue-type": "stream"}))
+          q.publish_confirm "m"
+        end
+
+        store = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Queue).@msg_store.as(LavinMQ::AMQP::StreamMessageStore)
+        offsets_path = store.@consumer_offsets.path
+        follower_offsets_path = File.join(cluster.follower_config.data_dir, offsets_path[(s.data_dir.size + 1)..])
+
+        # Fill consumer_offsets past its capacity to trigger compaction. Before
+        # #2068's fix the first compaction raised ArgumentError because the
+        # rebuilt .tmp MFile was never replication-registered.
+        cap = store.@consumer_offsets.capacity
+        entry = 1 + ctag.bytesize + 8
+        ((cap // entry) + 10).times do |i|
+          store.store_consumer_offset(ctag, i.to_i64 + 1)
+        end
+        store.@consumer_offsets.size.should be < cap # got compacted
+
+        # A write AFTER compaction must still succeed and replicate, proving the
+        # MFile stayed registered through replace_file.
+        store.store_consumer_offset(ctag, 9999_i64)
+        store.last_offset_by_consumer_tag(ctag).should eq 9999_i64
+
+        wait_for { cluster.replicator.followers.first?.try &.lag_in_bytes == 0 }
+        expected = store.@consumer_offsets.to_slice.dup
+      end
+
+      # The follower received the compacted file verbatim — its real data
+      # length, not the sparse ftruncate capacity.
+      File.exists?(follower_offsets_path).should be_true
+      follower_bytes = File.open(follower_offsets_path, &.getb_to_end)
+      follower_bytes.should eq expected
+    end
+  end
+
   it "does not replicate .queue file for non-durable queue" do
     with_clustering do |cluster|
       with_amqp_server(replicator: cluster.replicator) do |s|

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -42,6 +42,9 @@ class DiskVisibilitySpyReplicator
   def replace_file(path : String)
   end
 
+  def replace_file(mfile : MFile)
+  end
+
   def append(path : String, pos : Int, length : Int)
   end
 

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -27,6 +27,10 @@ class SpyReplicator
     @replaced_files << path
   end
 
+  def replace_file(mfile : MFile)
+    @replaced_files << mfile.path
+  end
+
   def append(path : String, pos : Int, length : Int)
   end
 

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -196,20 +196,21 @@ module LavinMQ::AMQP
           capacity += ctag.bytesize + 1 + 8
         end
       end
-      @consumer_offset_positions = Hash(String, Int64).new
-      replace_offsets_file(capacity * 1000) do
-        offsets_to_save.each do |ctag, offset|
-          store_consumer_offset(ctag, offset)
-        end
-      end
+      replace_offsets_file(capacity * 1000, offsets_to_save)
     end
 
-    def replace_offsets_file(capacity : Int, &)
-      @replicator.try &.delete_file(@consumer_offsets.path) # FIXME: this is not entirely safe, but replace_file is worse
+    private def replace_offsets_file(capacity : Int, offsets_to_save : Hash(String, Int64))
       old_consumer_offsets = @consumer_offsets
+      @consumer_offset_positions = Hash(String, Int64).new
       @consumer_offsets = MFile.new("#{old_consumer_offsets.path}.tmp", capacity)
-      yield # fill the new file with correct data in this block
+      offsets_to_save.each do |consumer_tag, offset|
+        @consumer_offsets.write_byte consumer_tag.bytesize.to_u8
+        @consumer_offsets.write consumer_tag.to_slice
+        @consumer_offset_positions[consumer_tag] = @consumer_offsets.size
+        @consumer_offsets.write_bytes offset
+      end
       @consumer_offsets.rename(old_consumer_offsets.path)
+      @replicator.try &.replace_file(@consumer_offsets)
       old_consumer_offsets.close(truncate_to_size: false)
     end
 

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -284,6 +284,22 @@ module LavinMQ
         end
       end
 
+      # Replace a file's whole content from an in-memory slice (the leader's
+      # mmap, read capped at mfile.size). A positive length on the wire marks a
+      # replace; the follower streams it to <path>.tmp then renames atomically.
+      # An empty slice writes a 0 length, which the follower applies as a delete
+      # (an emptied file carries no data to restore anyway).
+      def replace(path : String, bytes : Bytes) : Int64
+        @write_lock.synchronize do
+          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + bytes.bytesize).to_i64
+          @sent_bytes.add(lag_size)
+          send_filename(path)
+          @lz4.write_bytes bytes.bytesize.to_i64, IO::ByteFormat::LittleEndian
+          @lz4.write bytes
+          lag_size
+        end
+      end
+
       def append(path : String, bytes : Bytes) : Int64
         @write_lock.synchronize do
           lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + bytes.bytesize).to_i64

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -6,7 +6,8 @@ module LavinMQ
       abstract def register_file(path : String)
       abstract def register_file(file : File)
       abstract def register_file(mfile : MFile)
-      abstract def replace_file(path : String) # only non mfiles are ever replaced
+      abstract def replace_file(path : String) # regular files, re-read from disk
+      abstract def replace_file(mfile : MFile) # mmap-backed files, read from the mmap (capped at mfile.size)
       abstract def append(path : String, pos : Int, length : Int)
       # `offset` is the absolute byte position the value/bytes are written at on
       # the leader; used to skip appends a just-joined follower already received

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -78,7 +78,7 @@ module LavinMQ
         end
       end
 
-      def replace_file(path : String) # only non mfiles are ever replaced
+      def replace_file(path : String) # regular files, re-read from disk
         path = strip_datadir path
         @file_index.lock do |files, checksums|
           files[path] = nil
@@ -90,6 +90,25 @@ module LavinMQ
           # at this follower's join) no longer describes its content and would
           # wrongly skip appends at offsets below the old cut (e.g. after a
           # definitions compaction shrinks the file).
+          f.forget_baseline(path)
+        end
+      end
+
+      # Replace an mmap-backed file's entire content on all followers — used
+      # after an in-place compaction (e.g. a stream's consumer_offsets file).
+      # Unlike replace_file(path) the MFile stays registered, so the
+      # zero-syscall append(path, pos, length) overload keeps working for later
+      # writes, and the bytes are read from the mmap capped at mfile.size
+      # (File.size would be the sparse ftruncate capacity, not the data length).
+      def replace_file(mfile : MFile)
+        path = strip_datadir mfile.path
+        bytes = mfile.to_slice
+        @file_index.lock do |files, checksums|
+          files[path] = mfile
+          checksums.delete(path)
+        end
+        each_follower do |f|
+          f.replace(path, bytes)
           f.forget_baseline(path)
         end
       end


### PR DESCRIPTION
## Problem

On a clustered leader, the first time a stream queue's `consumer_offsets` file fills, `cleanup_consumer_offsets → replace_offsets_file` raised:

```
ArgumentError: append(pos, length) requires an MFile-registered path: <queue>/consumer_offsets.tmp
```

The offsets MFile was then left unregistered, so **every later** offset write for that queue kept raising too. Leader/clustered only; a regression from `a011ec99`, which split `Replicator#append` into the registration-requiring mmap overload (v2.8.1 used the by-value overload with no registration requirement).

Root cause: `replace_offsets_file` rebuilt the file into a `consumer_offsets.tmp` MFile that was never `register_file`'d, then replicated each entry via `Server#append(path, pos, length)` — which `raise`s unless the path is MFile-registered. `MFile#rename` doesn't (re-)register either.

## Fix

Add an mmap-aware `replace_file(mfile : MFile)` overload instead of the existing `replace_file(path : String)`, which is wrong for mmap-backed files because it (a) un-registers the MFile (`files[path] = nil`), re-breaking the `append(pos, length)` overload, and (b) `Follower#replace` reads `File.size` — but MFiles are sparse (ftruncate'd to capacity, only truncated to data length on graceful close), so that's the capacity, not the data length.

The new overload:
- keeps `files[path] = mfile` so subsequent `append(pos, length)` keeps working, and
- streams `mfile.to_slice` (capped at `mfile.size`) via a new `Follower#replace(path, bytes : Bytes)`.

`StreamMessageStore#replace_offsets_file` now builds the compacted file, renames it, and ships it whole via `replace_file` — no per-entry replication during the rebuild — so followers receive the compacted `consumer_offsets` **verbatim** instead of diverging.

## Tests

End-to-end regression spec in `spec/clustering_spec.cr` ("compacts and replicates a stream's consumer_offsets file when it fills [#2068]"): a real leader+follower via `with_clustering` fills the offsets file until it compacts, asserts a post-compaction write still succeeds (proves the MFile stayed registered), and checks the follower's bytes equal the leader's `to_slice`. Verified it fails with the original `ArgumentError` when the un-register bug is reintroduced.

`make lint` clean; clustering / message_store / stream_queue / definitions_replication specs all pass.

Fixes #2068

🤖 Generated with [Claude Code](https://claude.com/claude-code)