### PR TITLE
fix: remove dead follower inline in each_follower (#2084)

### DIFF
--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -102,6 +102,39 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
     end
   end
 
+  describe "#each_follower broken-follower cleanup" do
+    it "removes a synced follower whose dispatch raises a socket error" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      server = LavinMQ::Clustering::Server.new(
+        LavinMQ::Config.instance,
+        NullCoordinator.new,
+        0)
+      fi = FakeFileIndex.new(data_dir)
+      sock, client = FakeSocket.pair
+      follower = LavinMQ::Clustering::Follower.new(sock, data_dir, fi)
+      follower.mark_synced!
+      server.@followers << follower
+
+      path = File.join(data_dir, "broken_follower_seg")
+      File.write(path, "")
+      server.register_file(path)
+
+      client.close # break the follower's peer socket
+
+      # Incompressible payloads large enough to force an LZ4 flush to the dead
+      # socket, raising IO::Error inside each_follower.
+      payload = Random::Secure.random_bytes(256 * 1024)
+      10.times { server.append_bytes(path, payload, 0i64) }
+
+      server.@followers.should_not contain(follower)
+    ensure
+      sock.try &.close
+      client.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+  end
+
   describe "#append" do
     it "raises ArgumentError when no MFile is registered for the path" do
       data_dir = LavinMQ::Config.instance.data_dir

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -455,13 +455,22 @@ module LavinMQ
       private def each_follower(& : Follower -> Nil) : Nil
         dirty = false
         @lock.synchronize do
+          broken = nil
           @followers.each do |f|
             next if f.syncing? # Performing a full sync
             yield f
           rescue IO::Error | Socket::Error
             Log.info { "Follower disconnected address=#{f.remote_address} id=#{f.id.to_s(36)}" }
-            Fiber.yield # Allow other fiber to run to remove the follower from array
+            # Remove the dead follower inline: the lock is already held and
+            # @lock guards every @followers mutation, so a Fiber.yield here
+            # can't hand off to a removal path. The follower's handler fiber
+            # ensure remains the safety net (its @followers.delete becomes a
+            # no-op). A synced follower leaving dirties the ISR so it's
+            # committed before this operation is acknowledged.
+            (broken ||= Array(Follower).new) << f
+            @dirty_isr = true if f.synced?
           end
+          broken.try &.each { |f| @followers.delete(f) }
           dirty = @dirty_isr
         end
         flush_isr if dirty


### PR DESCRIPTION
Closes #2084

## Problem

When a replicated write to a follower failed, `each_follower` (`clustering/server.cr`) logged the disconnect and called `Fiber.yield` "to let another fiber remove the follower from the array". That handoff can never happen: the yield runs while holding `@lock`, and every `@followers` removal path (stale eviction, `sync_and_serve`'s ensure teardown, `close`) needs that same `@lock`. `Fiber.yield` doesn't release a held mutex, so no removal path can make progress during the yield — it was a no-op for its stated purpose.

There's no correctness impact (dead followers are already excluded from the ISR via `dead?`, and the entry is removed once the follower's `ack_loop` notices the dead socket). The visible effect is **log spam** — a repeated "Follower disconnected" on every subsequent replicated op during the window — plus wasted writes to a dead socket.

## Fix

Remove the dead follower inline in the rescue, where `@lock` is already held. Failed followers are collected into a side array and deleted after the `each` loop completes — deleting mid-iteration would shift indices and skip the next follower (Crystal's `Array#each` iterates by index). A synced follower leaving dirties the ISR so it's committed before the operation is acknowledged, matching the existing teardown semantics. The handler fiber's `ensure` remains the safety net; its `@followers.delete` is now an idempotent no-op.

The `Fiber.yield` in `close` is fine (it runs after the `@lock` block) and is left untouched.

## Test

Added a regression spec that registers a synced follower, closes its peer socket, then dispatches replicated appends with incompressible payloads large enough to force an LZ4 flush into the dead socket (raising inside `each_follower`). It asserts the follower is removed from `@followers` synchronously — no fiber handoff. Verified it fails on the old code and passes with the fix. `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)