### PR TITLE
fix: restart delayed queue expire loop on store error (#2074)

### DIFF
--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -315,8 +315,8 @@ describe "Delayed Message Exchange" do
       wait_for { queue.closed? }
       queue.closed?.should be_true
 
-      # delay() must return promptly (no unbuffered send to a dead fiber) even
-      # after the release fiber is gone.
+      # After the store error closes the queue, delay() must refuse promptly
+      # instead of blocking the publisher.
       msg = LavinMQ::Message.new("", queue.name, "after-error")
       done = Channel(Bool).new
       spawn { done.send(queue.delay(msg)) }

--- a/spec/delayed_message_exchange_spec.cr
+++ b/spec/delayed_message_exchange_spec.cr
@@ -286,6 +286,49 @@ describe "Delayed Message Exchange" do
     end
   end
 
+  it "closes cleanly without hanging the publisher when the expire loop hits a store error" do
+    with_amqp_server do |s|
+      with_channel(s) do |ch|
+        x = ch.exchange(x_name, "topic", args: x_args)
+        # Long delay so the message stays parked in the internal delayed queue
+        hdrs = AMQP::Client::Arguments.new({"x-delay" => 600_000})
+        x.publish_confirm "test message", "rk", props: AMQP::Client::Properties.new(headers: hdrs)
+      end
+      queue = s.vhosts["/"].queue(delay_q_name).as(LavinMQ::AMQP::DelayedExchangeQueue)
+      queue.message_count.should eq 1
+
+      store = queue.@msg_store.as(LavinMQ::AMQP::DelayedExchangeQueue::DelayedMessageStore)
+      seg_id = store.@segments.first_key
+      requeued = store.@requeued.as(LavinMQ::AMQP::DelayedExchangeQueue::DelayedMessageStore::DelayedRequeuedStore)
+
+      # Insert an index entry pointing past the segment data with an already-elapsed
+      # expire_at, so the expire loop reads it first and BytesMessage.from_bytes raises
+      # a MessageStore::Error (simulating a corrupt/truncated delayed segment).
+      bad_sp = LavinMQ::SegmentPosition.new(seg_id, 100_000_000u32, 0u32)
+      requeued.insert(bad_sp, 0i64)
+
+      # Wake the expire loop so it processes the (now-expired) bogus entry
+      queue.@message_ttl_change.send(nil)
+
+      # The store error must close the queue rather than silently killing the only
+      # release fiber and stranding all delayed messages forever.
+      wait_for { queue.closed? }
+      queue.closed?.should be_true
+
+      # delay() must return promptly (no unbuffered send to a dead fiber) even
+      # after the release fiber is gone.
+      msg = LavinMQ::Message.new("", queue.name, "after-error")
+      done = Channel(Bool).new
+      spawn { done.send(queue.delay(msg)) }
+      select
+      when result = done.receive
+        result.should be_false # closed queue refuses the message instead of blocking
+      when timeout 2.seconds
+        fail "delay() blocked the publisher after the expire fiber died"
+      end
+    end
+  end
+
   it "should prevent binding delayed exchange to its own internal queue" do
     with_amqp_server do |s|
       with_channel(s) do |ch|

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue.cr
@@ -47,7 +47,8 @@ module LavinMQ::AMQP
         @msg_store.push(msg)
       end
       @publish_count.add(1, :relaxed)
-      @message_ttl_change.send nil
+      @message_ttl_change.try_send? nil
+      ensure_expire_fiber # restart the release fiber if it died on a transient store error
       true
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -83,9 +84,14 @@ module LavinMQ::AMQP
           end
         end
       end
+    rescue ex : MessageStore::Error
+      @log.error(ex) { "Queue closed due to error" }
+      close
+      raise ex
     rescue ::Channel::ClosedError
     ensure
       @message_expire_fiber_active.set(false, :release)
+      ensure_expire_fiber # restart if msg arrived during teardown
       @log.debug { "message_expire_loop stopped" }
     end
 


### PR DESCRIPTION
Fixes #2074.

## Problem

`DelayedExchangeQueue#message_expire_loop` only rescued `::Channel::ClosedError`, and its `ensure` just flipped `@message_expire_fiber_active` to `false` with no restart. The base `Queue#message_expire_loop` by contrast rescues `MessageStore::Error` (closing the queue) and calls `ensure_expire_fiber`.

`expire_messages -> first_delayed?/shift_delayed?` can raise `MessageStore::Error` on a corrupt/truncated segment. In the override that propagated out uncaught, killing the only release fiber with nothing to restart it (`publish`/`basic_get`/`ack`/`reject` are no-ops on a delayed queue). All pending delayed messages were stranded forever. Worse, the next `delay()` did an unbuffered `@message_ttl_change.send nil` with no receiver, hanging the publishing fiber.

## Fix

- Mirror the base loop: `rescue MessageStore::Error` (close) and `ensure_expire_fiber` in the `ensure`.
- Switch `delay()`'s `send` to `try_send?` and call `ensure_expire_fiber` so the publisher never blocks on a dead fiber.

## Test

Added a regression spec that seeds the delayed index with an entry pointing past the segment data (so the expire loop's `BytesMessage.from_bytes` raises a `MessageStore::Error`, simulating a corrupt segment), wakes the loop, and asserts:
- the queue closes cleanly instead of silently stranding messages, and
- a subsequent `delay()` returns promptly rather than blocking the publisher.

The spec fails with "Execution expired" against the unfixed source and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)