### PR TITLE
Fix federation exchange link leaking a dead observer when deleted during startup

### DIFF
--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -723,6 +723,25 @@ describe LavinMQ::Federation::Upstream do
       end
     end
 
+    it "does not leave a dead observer when deleted during link startup" do
+      with_amqp_server do |s|
+        upstream, _, downstream_vhost =
+          UpstreamSpecHelpers.setup_federation(s, "ef delete during start", "upstream_ex")
+        downstream_vhost.declare_exchange("downstream_ex", "topic", true, false)
+        downstream_ex = downstream_vhost.exchange("downstream_ex").as(LavinMQ::AMQP::Exchange)
+
+        link = upstream.link(downstream_ex)
+        # Delete while the link is parked on the upstream connect, before it
+        # has registered itself as an observer of the downstream exchange. The
+        # link's unregister_observer is a no-op at this point, so without the
+        # post-register re-check the link would resume, register, and leak.
+        upstream.delete
+        wait_for { link.state.terminated? }
+
+        downstream_ex.@__lavinmq_exchangeevent_observers.includes?(link).should be_false
+      end
+    end
+
     it "set x-received-from" do
       with_amqp_server do |s|
         vhost1 = s.vhosts.create("one")

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -458,6 +458,11 @@ module LavinMQ
           # below (exchanges store bindings before notifying observers).
           @consumer_ex = consumer_ex
           @federated_ex.register_observer(self)
+          # A concurrent delete can set the link Terminating while we were
+          # parked on the upstream connect above; its unregister_observer ran
+          # before we registered, so re-check and unregister to avoid leaking
+          # a dead link in the exchange's observer set.
+          @federated_ex.unregister_observer(self) if stop_link?
           @federated_ex.bindings_details.each do |binding|
             updated, args = update_bound_from?(binding.arguments)
             if updated
@@ -471,6 +476,10 @@ module LavinMQ
         private def start_link
           setup_connection do |upstream_connection|
             upstream_channel, upstream_q = setup(upstream_connection)
+            # setup may have observed a concurrent delete and unregistered;
+            # don't go Running (which would defeat the run_loop terminate
+            # check and trigger a reconnect of a deleted link).
+            return if stop_link?
             upstream_channel.prefetch(count: @upstream.prefetch)
             no_ack = @upstream.ack_mode.no_ack?
             state(State::Running)


### PR DESCRIPTION
## Problem

`ExchangeLink#register_observer` runs in `setup()`, reached only after a blocking upstream connect and passive declares that yield the fiber. The terminate guard is checked once, *before* that connect.

A concurrent delete (HTTP fiber: `do_delete_upstream → ExchangeLink#delete → stop → unregister_observer`) can run while the link is parked on the connect: it calls `unregister_observer` (a no-op, since the link isn't registered yet) and sets `state=Terminating`. The link then resumes and registers an **already-Terminating** link. Nothing re-checks state after `register_observer`, so the dead link stays in the exchange's observer `Set` for the exchange's lifetime — a bounded memory leak (one stale observer per racing delete).

Reachable single-threaded via fiber interleaving (the connect yield lets the delete fiber run).

Fixes #2076.

## Fix

Two re-checks after the connect window in `src/lavinmq/federation/link.cr`:

1. In `setup`, right after `register_observer`, unregister again if the link is now `Terminating`/`Terminated` — closing the race window directly.
2. In `start_link`, bail out before going `Running` if the link is terminating — otherwise it would overwrite `Terminating` with `Running` and trigger an unwanted reconnect of a deleted link.

## Test

Added a regression spec ("does not leave a dead observer when deleted during link startup") that creates an exchange link and deletes the upstream while the link is parked on connect, then asserts the link terminates and is not left in the exchange's observer set. Verified it fails without the fix (the dead link never terminates) and passes with it.

`make lint` (0 failures) and the full `upstream_spec.cr` suite (31 examples, 0 failures) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)