### PR TITLE
fix: bound pre-auth JWT verification cost (#2077)

### DIFF
--- a/spec/oauth_spec.cr
+++ b/spec/oauth_spec.cr
@@ -84,18 +84,45 @@ describe LavinMQ::Auth::JWT::PublicKeys do
   end
 end
 
+# Builds an (unsigned) JWT with the given kid in its header. A nil kid omits
+# the header field entirely.
+def jwt_with_kid(kid : String?, signature = "c2lnbmF0dXJl") : String
+  header = kid.nil? ? %({"alg":"RS256","typ":"JWT"}) : %({"alg":"RS256","typ":"JWT","kid":"#{kid}"})
+  header_b64 = Base64.urlsafe_encode(header, padding: false)
+  payload_b64 = Base64.urlsafe_encode(%({"sub":"1234567890"}), padding: false)
+  "#{header_b64}.#{payload_b64}.#{signature}"
+end
+
 describe LavinMQ::Auth::JWT::PublicKeys do
   describe "#decode" do
+    # GH #2077: a forged token with no kid must be rejected cheaply, without
+    # attempting an RS256 verification against any of the cached keys.
+    it "raises VerificationError when the token has no kid header" do
+      public_keys = LavinMQ::Auth::JWT::PublicKeys.new
+      public_keys.update({"key1" => "dummy_pem", "key2" => "dummy_pem"}, 1.hour)
+
+      expect_raises(LavinMQ::Auth::JWT::VerificationError, "missing kid header") do
+        public_keys.decode(jwt_with_kid(nil))
+      end
+    end
+
+    # GH #2077: a kid that matches no cached key is rejected without iterating
+    # (and verifying against) every key.
+    it "raises VerificationError when no key matches the token's kid" do
+      public_keys = LavinMQ::Auth::JWT::PublicKeys.new
+      public_keys.update({"key1" => "dummy_pem", "key2" => "dummy_pem"}, 1.hour)
+
+      expect_raises(LavinMQ::Auth::JWT::VerificationError, "No key matching kid 'unknown'") do
+        public_keys.decode(jwt_with_kid("unknown"))
+      end
+    end
+
     it "raises VerificationError when no keys are provided" do
       public_keys = LavinMQ::Auth::JWT::PublicKeys.new
-      empty_keys = {} of String => String
-      public_keys.update(empty_keys, 1.hour)
+      public_keys.update({} of String => String, 1.hour)
 
-      # Sample JWT token (invalid signature for our keys)
-      token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.POstGetfAytaZS82wHcjoTyoqhMyxXiWdR7Nn7A29DNSl0EiXLdwJ6xC6AfgZWF1bOsS_TuYI3OG85AmiExREkrS6tDfTQ2B3WXlrr-wp5AokiRbz3_oB4OxG-W9KcEEbDRcZc0nH3L7LzYptiy1PtAylQGxHTWZXtGz4ht0bAecBgmpdgXMguEIcoqPJ1n3pIWk_dUZegpqx0Lka21H6XxUTxiy8OcaarA8zdnPUnV6AmNP3ecFawIFYdvJB_cm-GvpCSbr8G8y_Mllj8f4x9nBH8pQux89_6gUY618iYv7tuPWBFfEbLxtF2pZS6YC1aSfLQxeNe8djT9YjpvRZA"
-
-      expect_raises(LavinMQ::Auth::JWT::VerificationError, "Could not verify JWT with any key") do
-        public_keys.decode(token)
+      expect_raises(LavinMQ::Auth::JWT::VerificationError, "No key matching kid 'key1'") do
+        public_keys.decode(jwt_with_kid("key1"))
       end
     end
 
@@ -108,10 +135,8 @@ describe LavinMQ::Auth::JWT::PublicKeys do
       }
       public_keys.update(invalid_keys, 1.hour)
 
-      token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.POstGetfAytaZS82wHcjoTyoqhMyxXiWdR7Nn7A29DNSl0EiXLdwJ6xC6AfgZWF1bOsS_TuYI3OG85AmiExREkrS6tDfTQ2B3WXlrr-wp5AokiRbz3_oB4OxG-W9KcEEbDRcZc0nH3L7LzYptiy1PtAylQGxHTWZXtGz4ht0bAecBgmpdgXMguEIcoqPJ1n3pIWk_dUZegpqx0Lka21H6XxUTxiy8OcaarA8zdnPUnV6AmNP3ecFawIFYdvJB_cm-GvpCSbr8G8y_Mllj8f4x9nBH8pQux89_6gUY618iYv7tuPWBFfEbLxtF2pZS6YC1aSfLQxeNe8djT9YjpvRZA"
-
       expect_raises(LavinMQ::Auth::JWT::VerificationError) do
-        public_keys.decode(token)
+        public_keys.decode(jwt_with_kid("key1"))
       end
     end
 
@@ -133,10 +158,8 @@ describe LavinMQ::Auth::JWT::PublicKeys do
       public_keys.update(keys, 1.hour)
 
       # Valid JWT structure but empty signature
-      token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0."
-
       expect_raises(LavinMQ::Auth::JWT::VerificationError) do
-        public_keys.decode(token)
+        public_keys.decode(jwt_with_kid("key1", signature: ""))
       end
     end
 
@@ -145,10 +168,8 @@ describe LavinMQ::Auth::JWT::PublicKeys do
       keys = {"key1" => ""}
       public_keys.update(keys, 1.hour)
 
-      token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature"
-
       expect_raises(LavinMQ::Auth::JWT::DecodeError) do
-        public_keys.decode(token)
+        public_keys.decode(jwt_with_kid("key1", signature: "signature"))
       end
     end
   end
@@ -541,6 +562,43 @@ describe LavinMQ::HTTP::OAuthController do
     with_http_server(authenticator: oauth) do |http, _|
       response = http.get "/oauth/enabled"
       response.status_code.should eq 200
+    end
+  end
+
+  # GH #2077: the oauth_token cookie must only be verified on management API
+  # paths, so a forged cookie can't force JWT verification on every request.
+  describe "oauth_token cookie authentication" do
+    # Well-formed token (passes prevalidation) but with a bogus signature.
+    forged_token = begin
+      header = Base64.urlsafe_encode(%({"alg":"RS256","typ":"JWT"}), padding: false)
+      payload = Base64.urlsafe_encode(%({"sub":"x","exp":9999999999}), padding: false)
+      "#{header}.#{payload}.c2lnbmF0dXJl"
+    end
+
+    it "ignores the cookie on non-API paths" do
+      oauth = create_oauth_test_authenticator
+      # Pretend the JWKS keys have already been fetched.
+      oauth.token_verifier.fetcher.public_keys.update({"k1" => "not-a-real-pem"}, 1.hour)
+      with_http_server(authenticator: oauth) do |http, _|
+        req = ::HTTP::Request.new("GET", "/oauth/enabled",
+          ::HTTP::Headers{"Cookie" => "oauth_token=#{forged_token}"})
+        response = http.exec(req)
+        response.status_code.should eq 200
+        # Cookie was never inspected, so it isn't expired.
+        response.headers.get?("Set-Cookie").should be_nil
+      end
+    end
+
+    it "verifies and expires an invalid cookie on management API paths" do
+      oauth = create_oauth_test_authenticator
+      oauth.token_verifier.fetcher.public_keys.update({"k1" => "not-a-real-pem"}, 1.hour)
+      with_http_server(authenticator: oauth) do |http, _|
+        req = ::HTTP::Request.new("GET", "/api/overview",
+          ::HTTP::Headers{"Cookie" => "oauth_token=#{forged_token}"})
+        response = http.exec(req)
+        set_cookies = response.headers.get?("Set-Cookie") || [] of String
+        set_cookies.any?(&.starts_with?("oauth_token=")).should be_true
+      end
     end
   end
 end

--- a/src/lavinmq/auth/jwt/public_keys.cr
+++ b/src/lavinmq/auth/jwt/public_keys.cr
@@ -46,21 +46,22 @@ module LavinMQ
         # Decodes and verifies a JWT token using the stored public keys.
         # Returns the decoded JWT::Token if verification succeeds.
         # Raises JWT::VerificationError if no key can verify the token or keys are unavailable/expired.
+        #
+        # The token must carry a `kid` header that matches one of the cached
+        # keys; we then verify against that single key only. Iterating over
+        # every key would let an unauthenticated caller force an RS256
+        # verification per cached key with a forged token (GH #2077).
         def decode(token : String) : JWT::Token
           keys = get?
           raise JWT::ExpiredKeysError.new("Public keys unavailable or expired") unless keys
 
-          kid = JWT::RS256Parser.decode_header(token).kid rescue nil
-          # If we know the kid matches a key we can avoid iterating through all keys
-          if kid && keys[kid]?
-            return JWT::RS256Parser.decode(token, keys[kid], verify: true)
-          end
+          kid = JWT::RS256Parser.decode_header(token).kid
+          raise JWT::VerificationError.new("Token is missing kid header") if kid.nil? || kid.empty?
 
-          keys.each_value do |key|
-            return JWT::RS256Parser.decode(token, key, verify: true)
-          rescue JWT::VerificationError
-          end
-          raise JWT::VerificationError.new("Could not verify JWT with any key")
+          key = keys[kid]?
+          raise JWT::VerificationError.new("No key matching kid '#{kid}'") unless key
+
+          JWT::RS256Parser.decode(token, key, verify: true)
         end
 
         private def expired? : Bool

--- a/src/lavinmq/http/controller/oauth.cr
+++ b/src/lavinmq/http/controller/oauth.cr
@@ -17,8 +17,16 @@ module LavinMQ
       end
 
       def call(context)
-        authenticate_jwt_cookie(context)
+        authenticate_jwt_cookie(context) if management_api_request?(context)
         super
+      end
+
+      # The oauth_token cookie is only consumed to authenticate management HTTP
+      # API requests. Limiting the (relatively expensive) JWT verification to
+      # the /api path keeps a forged cookie from forcing signature checks on
+      # every unrelated request, e.g. static assets or the login page (GH #2077).
+      private def management_api_request?(context) : Bool
+        context.request.path.starts_with?("/api/")
       end
 
       private def authenticate_jwt_cookie(context)


### PR DESCRIPTION
## Summary

Fixes #2077 — an unauthenticated JWT RSA-verification CPU amplification via the `oauth_token` cookie.

When OAuth is configured, a forged/unsigned token in the `oauth_token` cookie could force up to `keys.size` full RS256 (RSA-2048) verifications per request, on any path, before authentication — saturating CPU with no credentials.

Two changes close this:

1. **Reject when `kid` is absent/empty/non-matching instead of trying all keys** (`PublicKeys#decode`). Verification is now bounded to at most one RSA operation: the token must carry a `kid` header matching a cached JWKS key, and we verify against that single key only. An absent/empty `kid`, or one that matches no cached key, is rejected immediately. Every real OIDC/JWKS provider stamps a `kid`, and the previous loop gave no key-rotation benefit (a genuinely new key isn't in the cache for the loop to find).

2. **Only run cookie auth on management API paths** (`OAuthController#call`). The `oauth_token` cookie is now only verified for `/api/*` requests, so a forged cookie attached to static assets, the login page, or any unrelated request no longer triggers JWT verification at all.

## Tests

- Rewrote the `#decode` specs around the `kid`-required semantics (new `jwt_with_kid` helper), with explicit regression cases for absent-`kid` and non-matching-`kid` rejection.
- Added `OAuthController` integration tests: the cookie is ignored on `/oauth/enabled` (no `Set-Cookie`) but verified-and-expired on `/api/overview`.

`make test SPEC=spec/oauth_spec.cr`, `make test SPEC=spec/oauth_authenticator_spec.cr`, and `make lint` all pass.

## Compatibility note

Requiring a matching `kid` is now mandatory for cookie/JWT auth. This matches the issue's recommended fix and standard provider behavior, but a provider that omits `kid` with a single signing key would now be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)