### PR TITLE
Deduplication looks at queue content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,12 @@ This release adds OAuth2/OIDC SSO login to the management UI, sends publish conf
 - Replace periodic GC.collect with on-demand GC [#2016](https://github.com/cloudamqp/lavinmq/pull/2016)
 - Batch persistence during definitions import [#2014](https://github.com/cloudamqp/lavinmq/pull/2014)
 - `tcp_proxy_protocol` now accepts boolean values (`true`/`false`/`yes`/`no`); legacy `1`/`2` are treated as enabled, `0` disables. Protocol version is auto-detected [#1601](https://github.com/cloudamqp/lavinmq/pull/1601)
+- Queue-level deduplication now checks against the messages currently in the queue instead of a separate cache: an identifier is deduplicated only while a message bearing it is in the queue, and is released when that message leaves (ack/expire/dead-letter/overflow/purge). The index is rebuilt from persisted messages on queue start
 
 ### Removed
 
 - `unix_proxy_protocol` config option; Unix sockets always auto-detect PROXY protocol headers [#1601](https://github.com/cloudamqp/lavinmq/pull/1601)
+- `x-cache-size` and `x-cache-ttl` queue arguments no longer have any effect (they applied to the removed queue dedup cache); they remain valid on exchanges. Use `x-message-ttl` for time-bounded queue deduplication
 
 ### Fixed
 

--- a/docs/deduplication.md
+++ b/docs/deduplication.md
@@ -6,8 +6,10 @@ LavinMQ supports message deduplication at the exchange and queue levels, prevent
 
 Deduplication can be configured at the exchange level, the queue level, or both, with different effects:
 
-- **Exchange-level** — duplicate messages are not forwarded to any bound queue.
-- **Queue-level** — the message is routed as usual but not stored in the queue if already seen. This avoids inflating the "unroutable message" statistic that exchange-level dedup would produce when a duplicate fails to reach any queue.
+- **Exchange-level** — duplicate messages are not forwarded to any bound queue. Backed by a bounded, TTL-based cache (see [Exchange-level cache](#exchange-level-cache)).
+- **Queue-level** — the message is routed as usual but not stored in the queue if a message with the same dedup identifier is **already in the queue**. This avoids inflating the "unroutable message" statistic that exchange-level dedup would produce when a duplicate fails to reach any queue.
+
+The two levels use different models. Exchange-level dedup remembers identifiers in a separate cache for a configurable time/size. Queue-level dedup has no separate cache: an identifier is considered "seen" exactly while a message bearing it is still in the queue, and is forgotten as soon as that message leaves.
 
 ## Enabling Deduplication
 
@@ -19,28 +21,51 @@ x-message-deduplication: true
 
 ## Configuration
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `x-message-deduplication` | Bool | `false` | Enable deduplication |
-| `x-cache-size` | Int | `128` | Maximum entries in the dedup cache. Larger caches catch more duplicates at the cost of memory. |
-| `x-cache-ttl` | Int | (none) | Default TTL for cache entries (milliseconds). No default limit. |
-| `x-deduplication-header` | String | `x-deduplication-header` | Message header that holds the dedup identifier |
+| Argument | Type | Applies to | Default | Description |
+|----------|------|------------|---------|-------------|
+| `x-message-deduplication` | Bool | exchange, queue | `false` | Enable deduplication |
+| `x-deduplication-header` | String | exchange, queue | `x-deduplication-header` | Message header that holds the dedup identifier |
+| `x-cache-size` | Int | exchange only | `128` | Maximum entries in the exchange dedup cache |
+| `x-cache-ttl` | Int | exchange only | (none) | Default TTL for exchange cache entries (milliseconds) |
+
+> **Note:** `x-cache-size` and `x-cache-ttl` apply only to **exchange-level** deduplication. They are ignored on queues — declaring a queue with them still succeeds, but the values have no effect. For time-bounded queue deduplication, give the messages a lifetime with [`x-message-ttl`](ttl.md) (or a per-message `expiration`): when a message expires out of the queue, its dedup identifier is released automatically.
 
 ## How It Works
 
-1. When a message arrives at a dedup-enabled exchange or queue, the server reads the dedup header from the message
-2. If the header value already exists in the cache, the message is considered a duplicate and is dropped (not routed/enqueued)
-3. If the value is not in the cache, the message is routed/enqueued normally and the value is added to the cache
+When a message arrives at a dedup-enabled exchange or queue, the server reads the dedup identifier from the configured header. Messages without that header are never deduplicated (they are always considered unique).
 
-## Cache Behavior
+### Exchange-level
 
-- The cache is an in-memory hash map with a maximum size
-- When the cache is full, the oldest entry is evicted (FIFO)
-- Entries can have a TTL. Expired entries are lazily removed on the next lookup
-- Per-message TTL can be set via the `x-cache-ttl` message header (Int32, milliseconds), overriding the queue/exchange default
+1. If the identifier exists in the exchange's cache, the message is dropped (not routed).
+2. Otherwise the message is routed and the identifier is added to the cache.
+
+### Queue-level
+
+1. If a message with the same identifier is currently in the queue (waiting to be delivered, or delivered but not yet acknowledged), the incoming message is dropped.
+2. Otherwise the message is enqueued and its identifier is tracked.
+3. When the message leaves the queue — acknowledged, expired, dead-lettered, dropped by overflow, or purged — its identifier is released, so a future message with the same identifier is accepted again.
+
+This means queue-level deduplication is bounded by the contents of the queue, not by a separate cache size or TTL. There is no FIFO eviction and no cache that can hold an identifier after its message is gone.
+
+## Exchange-level cache
+
+- The cache is an in-memory hash map with a maximum size (`x-cache-size`).
+- When the cache is full, the oldest entry is evicted (FIFO).
+- Entries can have a TTL. Expired entries are lazily removed on the next lookup.
+- Per-message TTL can be set via the `x-cache-ttl` message header (Int32, milliseconds), overriding the exchange default.
 
 ## Limitations
 
-- The dedup cache is in memory only. It is lost on server restart and on leadership transfer in a cluster.
-- The dedup cache is not replicated across cluster nodes.
+- Deduplication state is in memory only and is not replicated across cluster nodes. It is lost on leadership transfer in a cluster.
 - Deduplication is best-effort: after a restart or failover, previously seen messages may be accepted again.
+
+### Queue-level restart behavior
+
+The queue's dedup index is rebuilt from the persisted messages when the queue starts (on broker boot and on queue restart). The rebuild runs in the background so the broker starts quickly, which has two consequences:
+
+- **Brief under-enforcement during rebuild.** While a queue's index is being rebuilt, duplicates of messages that the scan has not reached yet may slip through. The window is per-queue and lasts only until that queue's scan completes.
+- **Transient over-suppression.** If a message is consumed while the rebuild is still scanning, its identifier can be re-added to the index even though the message is gone, briefly blocking that identifier. This clears on the next restart.
+
+### Enabling on a non-empty queue
+
+Turning on `x-message-deduplication` for a queue that already holds messages (for example, via a policy change at runtime) does **not** retroactively index the existing messages. Deduplication takes effect for newly published messages; the pre-existing messages are not protected until they leave the queue. To index existing messages, restart the queue.

--- a/docs/queues.md
+++ b/docs/queues.md
@@ -41,8 +41,6 @@ A non-durable, non-exclusive queue is called a transient queue. Its messages are
 | `x-single-active-consumer` | Bool | Only one consumer receives messages at a time |
 | `x-max-priority` | Int (0-255) | Enable priority queue with this many priority levels |
 | `x-message-deduplication` | Bool | Enable message deduplication. See [Deduplication](deduplication.md). |
-| `x-cache-size` | Int (>= 0) | Deduplication cache size |
-| `x-cache-ttl` | Int (>= 0) | Deduplication cache TTL in milliseconds |
 | `x-deduplication-header` | String | Header to use for deduplication key |
 
 ## Overflow Behavior

--- a/spec/deduplication_spec.cr
+++ b/spec/deduplication_spec.cr
@@ -45,6 +45,31 @@ describe LavinMQ::Deduplication do
       end
     end
   end
+
+  describe LavinMQ::Deduplication::SetCache do
+    it "insert? returns true the first time and false for a duplicate" do
+      cache = LavinMQ::Deduplication::SetCache(String).new
+      cache.insert?("a").should be_true
+      cache.insert?("a").should be_false
+    end
+
+    it "delete makes a key insertable again" do
+      cache = LavinMQ::Deduplication::SetCache(String).new
+      cache.insert?("a")
+      cache.delete("a")
+      cache.contains?("a").should be_false
+      cache.insert?("a").should be_true
+    end
+
+    it "clear removes all keys" do
+      cache = LavinMQ::Deduplication::SetCache(String).new
+      cache.insert?("a")
+      cache.insert?("b")
+      cache.clear
+      cache.contains?("a").should be_false
+      cache.contains?("b").should be_false
+    end
+  end
 end
 
 class MockCache < LavinMQ::Deduplication::Cache(AMQ::Protocol::Field)
@@ -61,12 +86,31 @@ class MockCache < LavinMQ::Deduplication::Cache(AMQ::Protocol::Field)
     @counter["insert"] << {key.as(String), ttl}
   end
 
+  def delete(key)
+    @counter["delete"] << {key.as(String), nil}
+  end
+
+  def clear
+  end
+
   def calls(key : String)
     @counter[key]
   end
 end
 
 describe LavinMQ::Deduplication::Deduper do
+  describe "dedup_key" do
+    it "returns the dedup header value, or nil when absent" do
+      deduper = LavinMQ::Deduplication::Deduper.new(MockCache.new)
+      with_header = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+        "x-deduplication-header" => "msg1",
+      }))
+      without = LavinMQ::AMQP::Properties.new
+      deduper.dedup_key(LavinMQ::Message.new("ex", "rk", "body", with_header)).should eq "msg1"
+      deduper.dedup_key(LavinMQ::Message.new("ex", "rk", "body", without)).should be_nil
+    end
+  end
+
   describe "duplicate?" do
     it "should return false if \"x-deduplication-header\" is missing (no identifier, always unique)" do
       mock = MockCache.new

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -809,6 +809,195 @@ describe LavinMQ::AMQP::Queue do
         end
       end
     end
+
+    it "drops a duplicate while the original is delivered but unacked" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          queue_name = "dedup-inflight-queue"
+          q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+          }))
+          props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+            "x-deduplication-header" => "msg1",
+          }))
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          sq = s.vhosts["/"].queue(queue_name)
+          # deliver but do NOT ack: the message is in-flight, not in the ready store
+          q1.get(no_ack: false).not_nil!
+          wait_for { sq.message_count.zero? }
+          # duplicate is still dropped because the in-flight message keeps the key
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          sq.dedup_count.should eq 1
+          sq.message_count.should eq 0
+        end
+      end
+    end
+
+    it "accepts the same key again once the original has expired" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          queue_name = "dedup-expire-queue"
+          ch.queue(queue_name, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+          }))
+          headers = LavinMQ::AMQP::Table.new({"x-deduplication-header" => "msg1"})
+          expiring = LavinMQ::AMQP::Properties.new(headers: headers, expiration: "50")
+          persistent = LavinMQ::AMQP::Properties.new(headers: headers)
+          sq = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Queue)
+          ch.default_exchange.publish_confirm("body", queue_name, props: expiring)
+          # wait for the message to expire out and its dedup key to be released
+          wait_for { sq.message_count.zero? && sq.@dedup_cache.not_nil!.@store.empty? }
+          # same key is accepted again now that the original has expired
+          ch.default_exchange.publish_confirm("body", queue_name, props: persistent)
+          wait_for { sq.message_count == 1 }
+          sq.dedup_count.should eq 0
+        end
+      end
+    end
+
+    it "accepts the same key again once the original has been dead-lettered" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          src_name = "dedup-dl-src"
+          dlq_name = "dedup-dl-dlq"
+          ch.queue(src_name, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication"   => true,
+            "x-dead-letter-exchange"    => "",
+            "x-dead-letter-routing-key" => dlq_name,
+          }))
+          dlq = ch.queue(dlq_name)
+          headers = LavinMQ::AMQP::Table.new({"x-deduplication-header" => "msg1"})
+          expiring = LavinMQ::AMQP::Properties.new(headers: headers, expiration: "50")
+          persistent = LavinMQ::AMQP::Properties.new(headers: headers)
+          src = s.vhosts["/"].queue(src_name).as(LavinMQ::AMQP::Queue)
+          ch.default_exchange.publish_confirm("body", src_name, props: expiring)
+          # message is dead-lettered out of the source, releasing its dedup key
+          wait_for { dlq.get(no_ack: true) }
+          wait_for { src.message_count.zero? && src.@dedup_cache.not_nil!.@store.empty? }
+          # same key is accepted again on the source queue
+          ch.default_exchange.publish_confirm("body", src_name, props: persistent)
+          wait_for { src.message_count == 1 }
+          src.dedup_count.should eq 0
+        end
+      end
+    end
+
+    it "does not leave a phantom key when a publish is rejected by overflow" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          queue_name = "dedup-overflow-queue"
+          q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+            "x-max-length"            => 1_i64,
+            "x-overflow"              => "reject-publish",
+          }))
+          props_a = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+            "x-deduplication-header" => "A",
+          }))
+          props_b = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+            "x-deduplication-header" => "B",
+          }))
+          sq = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Queue)
+          ch.default_exchange.publish_confirm("a", queue_name, props: props_a).should be_true
+          # B is rejected by overflow, so its key must not be recorded
+          ch.default_exchange.publish_confirm("b", queue_name, props: props_b).should be_false
+          # drain A so there is room again
+          q1.get(no_ack: false).not_nil!.ack
+          wait_for { sq.message_count.zero? }
+          # B is accepted now — it was never phantomed by the rejected publish
+          ch.default_exchange.publish_confirm("b", queue_name, props: props_b).should be_true
+          sq.dedup_count.should eq 0
+        end
+      end
+    end
+
+    it "accepts the same key again after the queue is purged" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          queue_name = "dedup-purge-queue"
+          q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+          }))
+          props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+            "x-deduplication-header" => "msg1",
+          }))
+          sq = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Queue)
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          q1.purge
+          wait_for { sq.message_count.zero? }
+          # purge released the dedup key, so the same key is accepted again
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          wait_for { sq.message_count == 1 }
+          sq.dedup_count.should eq 0
+        end
+      end
+    end
+
+    it "rebuilds the dedup index from persisted messages after a restart" do
+      with_amqp_server do |s|
+        queue_name = "dedup-restart-queue"
+        props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+          "x-deduplication-header" => "msg1",
+        }))
+        with_channel(s) do |ch|
+          ch.queue(queue_name, durable: true, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+          }))
+          ch.default_exchange.publish_confirm("body",
+            queue_name, props: AMQP::Client::Properties.new(delivery_mode: 2_u8, headers: AMQP::Client::Arguments.new({
+            "x-deduplication-header" => "msg1",
+          })))
+        end
+        s.restart
+        sq = s.vhosts["/"].queue(queue_name).as(LavinMQ::AMQP::Queue)
+        # rebuild restores the persisted message's key into the index
+        wait_for { sq.@dedup_cache.not_nil!.@store.includes?("msg1".as(AMQ::Protocol::Field)) }
+        with_channel(s) do |ch|
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+        end
+        sq.dedup_count.should eq 1
+        sq.message_count.should eq 1
+      end
+    end
+
+    it "ignores the removed x-cache-size/x-cache-ttl arguments" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("dedup-legacy-args", durable: true, auto_delete: false,
+          arguments: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+            "x-cache-size"            => 700,
+            "x-cache-ttl"             => 800,
+          }))
+        effective = vhost.queue("dedup-legacy-args").details_tuple[:effective_arguments]
+        effective.should contain "x-message-deduplication"
+        effective.should_not contain "x-cache-size"
+        effective.should_not contain "x-cache-ttl"
+      end
+    end
+
+    it "accepts the same key again once the original has been consumed" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          queue_name = "dedup-reuse-queue"
+          q1 = ch.queue(queue_name, args: AMQP::Client::Arguments.new({
+            "x-message-deduplication" => true,
+          }))
+          props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
+            "x-deduplication-header" => "msg1",
+          }))
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          # duplicate dropped while the original is still in the queue
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          msg = q1.get(no_ack: false).not_nil!
+          msg.ack
+          wait_for { s.vhosts["/"].queue(queue_name).message_count.zero? }
+          # same key is accepted again now that the original has left the queue
+          ch.default_exchange.publish_confirm("body", queue_name, props: props)
+          wait_for { s.vhosts["/"].queue(queue_name).message_count == 1 }
+        end
+      end
+    end
   end
 
   describe "unacked_bytesize" do
@@ -849,8 +1038,6 @@ describe LavinMQ::AMQP::Queue do
       {"x-delivery-limit": 500},
       {"x-consumer-timeout": 600},
       {"x-single-active-consumer": true},
-      {"x-message-deduplication": true, "x-cache-size": 700},
-      {"x-message-deduplication": true, "x-cache-ttl": 800},
       {"x-message-deduplication": true, "x-deduplication-header": "foo"},
     }
     arguments.each do |args|

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -207,6 +207,10 @@ module LavinMQ::AMQP
     Log = LavinMQ::Log.for "queue"
     @metadata : ::Log::Metadata
     @deduper : Deduplication::Deduper?
+    # The dedup index mirrors the messages currently in the queue. Kept as a
+    # direct reference (separate from @deduper) so removal sites can drop a
+    # leaving message's key without going through the Deduper interface.
+    @dedup_cache : Deduplication::SetCache(AMQ::Protocol::Field)?
 
     protected def initialize(@vhost : VHost, @name : String,
                              @exclusive : Bool = false, @auto_delete : Bool = false,
@@ -237,10 +241,40 @@ module LavinMQ::AMQP
           @paused.set(true)
         end
         handle_arguments
+        start_dedup_index_rebuild
         spawn queue_expire_loop, name: "Queue#queue_expire_loop #{@vhost.name}/#{@name}" if @expires
         start_message_expire_loop if should_start_expire_fiber?
         true
       end
+    end
+
+    # Reset the dedup index to mirror the (re)loaded message store. Runs on both
+    # initial boot and restart!; the clear matters for restart! where @deduper
+    # (and its stale set) survives the reset. The rebuild scan runs in a fiber so
+    # the broker keeps starting fast and only this queue pays for the scan;
+    # duplicates published during the scan may briefly slip through, and Cheap-A
+    # iteration means a message consumed mid-scan can leave a transient phantom
+    # key (cleared on the next restart). See the deduplication docs.
+    private def start_dedup_index_rebuild : Nil
+      return unless c = @dedup_cache
+      c.clear
+      return if @msg_store.empty?
+      spawn rebuild_dedup_index, name: "Queue#rebuild_dedup_index #{@vhost.name}/#{@name}"
+    end
+
+    private def rebuild_dedup_index : Nil
+      d = @deduper || return
+      c = @dedup_cache || return
+      @msg_store_lock.synchronize do
+        @msg_store.each do |msg|
+          if key = d.dedup_key(msg)
+            c.insert(key)
+          end
+        end
+      end
+      @log.debug { "Rebuilt deduplication index" }
+    rescue ex
+      @log.error(exception: ex) { "Failed to rebuild deduplication index" }
     end
 
     def restart! : Bool
@@ -454,15 +488,15 @@ module LavinMQ::AMQP
       @effective_args << "x-consumer-timeout" if @consumer_timeout
       if parse_header("x-message-deduplication", Bool)
         @effective_args << "x-message-deduplication"
-        size = parse_header("x-cache-size", Int).try(&.to_u32)
-        @effective_args << "x-cache-size" if size
-        ttl = parse_header("x-cache-ttl", Int).try(&.to_u32)
-        @effective_args << "x-cache-ttl" if ttl
         header_key = parse_header("x-deduplication-header", String)
         @effective_args << "x-deduplication-header" if header_key
         @deduper ||= begin
-          cache = Deduplication::MemoryCache(AMQ::Protocol::Field).new(size)
-          Deduplication::Deduper.new(cache, ttl, header_key)
+          # Queue dedup checks against the messages currently in the queue, so
+          # the cache is an unbounded set with no TTL (x-cache-size/x-cache-ttl
+          # no longer apply; use x-message-ttl for time-bounded dedup).
+          cache = Deduplication::SetCache(AMQ::Protocol::Field).new
+          @dedup_cache = cache
+          Deduplication::Deduper.new(cache, nil, header_key)
         end
       end
     end
@@ -608,17 +642,19 @@ module LavinMQ::AMQP
     # ameba:disable Metrics/CyclomaticComplexity
     protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks? = nil) : PublishResult
       return PublishResult::Dropped if @closed
-      if d = @deduper
-        if d.duplicate?(msg)
-          @dedup_count.add(1, :relaxed)
-          return PublishResult::Dropped
-        end
-        d.add(msg)
-      end
+      # The dedup key (if any) is computed up front, but the duplicate check and
+      # insert happen together under @msg_store_lock so the index stays in
+      # lockstep with the queue's contents (see #delete_message for removal).
+      dedup_key = @deduper.try &.dedup_key(msg)
+      return drop_duplicate if dedup_duplicate?(dedup_key)
       return PublishResult::Overflow if reject_on_overflow?(msg)
       was_empty = false
       pushed = false
       @msg_store_lock.synchronize do
+        # Atomic gate: register_dedup? returns false if another publish inserted
+        # the same key first. Done before push so an overflow-rejected message
+        # (above) never leaves a phantom key behind.
+        return drop_duplicate unless register_dedup?(dedup_key)
         was_empty = @msg_store.empty?
         @msg_store.push(msg)
         pushed = true
@@ -642,6 +678,27 @@ module LavinMQ::AMQP
       @log.error(ex) { "Queue closed due to error" }
       close
       raise ex
+    end
+
+    # True if a message with this dedup key is already in the queue. A nil key
+    # (no dedup header, or dedup disabled) is never a duplicate.
+    private def dedup_duplicate?(key : AMQ::Protocol::Field?) : Bool
+      return false unless key
+      @dedup_cache.try(&.contains?(key)) || false
+    end
+
+    # Atomically record the key, returning true if it was newly added (publish
+    # should proceed) and false if it was already present (a duplicate). A nil
+    # key or disabled dedup is treated as newly added.
+    private def register_dedup?(key : AMQ::Protocol::Field?) : Bool
+      return true unless key
+      c = @dedup_cache || return true
+      c.insert?(key)
+    end
+
+    private def drop_duplicate : PublishResult
+      @dedup_count.add(1, :relaxed)
+      PublishResult::Dropped
     end
 
     private def reject_on_overflow?(msg) : Bool
@@ -801,7 +858,7 @@ module LavinMQ::AMQP
       @log.debug { "Expiring #{sp} now due to #{reason}" }
 
       @dead_letter.route(msg, reason, dlx_tasks) do
-        delete_message sp
+        delete_message(sp, msg)
       end
     end
 
@@ -863,7 +920,7 @@ module LavinMQ::AMQP
             @msg_store_lock.synchronize { @msg_store.requeue(sp) }
             raise ex
           end
-          delete_message(sp)
+          delete_message(sp, env.message)
         else
           @unacked_count.add(1, :relaxed)
           @unacked_bytesize.add(sp.bytesize, :relaxed)
@@ -914,7 +971,7 @@ module LavinMQ::AMQP
       delete_message(sp)
     end
 
-    protected def delete_message(sp : SegmentPosition) : Nil
+    protected def delete_message(sp : SegmentPosition, msg : BytesMessage? = nil) : Nil
       # Close tears down @msg_store under @msg_store_lock; a dead-letter routed
       # callback (or any other in-flight delete) racing with close would hit
       # MessageStore::ClosedError on @msg_store.delete. The store is gone
@@ -925,6 +982,17 @@ module LavinMQ::AMQP
       {% end %}
       @deliveries.delete(sp) if @delivery_limit
       @msg_store_lock.synchronize do
+        # The message is leaving the queue, so drop its dedup key from the index
+        # (a no-op when dedup is disabled or the message carries no key). Done
+        # under the same lock as the store mutation so index and queue contents
+        # change together. Callers that already hold the Envelope pass msg to
+        # avoid re-reading it from the store.
+        if (d = @deduper) && (c = @dedup_cache)
+          m = msg || @msg_store[sp]
+          if key = d.dedup_key(m)
+            c.delete(key)
+          end
+        end
         @msg_store.delete(sp)
       end
     end
@@ -1024,9 +1092,22 @@ module LavinMQ::AMQP
       if unacked_count == 0 && max_count >= message_count
         # If there's no unacked and we're purging all messages, we can purge faster by deleting files
         delete_count = message_count
-        @msg_store_lock.synchronize { @msg_store.purge_all }
+        @msg_store_lock.synchronize do
+          @msg_store.purge_all
+          # No unacked and everything purged, so the dedup index must be empty.
+          @dedup_cache.try(&.clear)
+        end
       else
-        delete_count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
+        delete_count = @msg_store_lock.synchronize do
+          purged = @msg_store.purge(max_count)
+          # Purge removes ready messages in bulk without going through
+          # #delete_message, so their keys can't be dropped individually. Clear
+          # the whole index instead: any surviving unacked keys are re-checked on
+          # ack and re-added on requeue, so the worst case is a transient missed
+          # dedup (never a permanent phantom). See dedup docs.
+          @dedup_cache.try(&.clear)
+          purged
+        end
       end
       @log.info { "Purged #{delete_count} messages" }
       # Signal expire loop to recalculate wait time for next message, and

--- a/src/lavinmq/deduplication.cr
+++ b/src/lavinmq/deduplication.cr
@@ -3,6 +3,8 @@ module LavinMQ
     abstract class Cache(T)
       abstract def contains?(key : T) : Bool
       abstract def insert(key : T, ttl : UInt32?)
+      abstract def delete(key : T)
+      abstract def clear
     end
 
     class MemoryCache(T) < Cache(T)
@@ -30,6 +32,46 @@ module LavinMQ
           @store[key] = val
         end
       end
+
+      def delete(key : T)
+        @lock.synchronize { @store.delete(key) }
+      end
+
+      def clear
+        @lock.synchronize { @store.clear }
+      end
+    end
+
+    # Cache whose membership mirrors the messages currently in a queue.
+    # Unlike MemoryCache it has no TTL or size bound: a key is present exactly
+    # while a message bearing it is in the queue, and is removed (#delete) when
+    # that message leaves. The +ttl+ argument is ignored.
+    class SetCache(T) < Cache(T)
+      def initialize
+        @store = Set(T).new
+      end
+
+      def contains?(key : T) : Bool
+        @store.includes?(key)
+      end
+
+      def insert(key : T, ttl : UInt32? = nil)
+        @store.add(key)
+      end
+
+      # Atomically insert the key, returning true if it was newly added and
+      # false if it was already present (i.e. a duplicate).
+      def insert?(key : T, ttl : UInt32? = nil) : Bool
+        @store.add?(key)
+      end
+
+      def delete(key : T)
+        @store.delete(key)
+      end
+
+      def clear
+        @store.clear
+      end
     end
 
     class Deduper
@@ -51,7 +93,7 @@ module LavinMQ
         @cache.contains?(key)
       end
 
-      private def dedup_key(msg)
+      def dedup_key(msg)
         headers = msg.properties.headers
         return unless headers
         key = @header_key || DEFAULT_HEADER_KEY

--- a/src/lavinmq/deduplication.cr
+++ b/src/lavinmq/deduplication.cr
@@ -48,29 +48,30 @@ module LavinMQ
     # that message leaves. The +ttl+ argument is ignored.
     class SetCache(T) < Cache(T)
       def initialize
+        @lock = Mutex.new
         @store = Set(T).new
       end
 
       def contains?(key : T) : Bool
-        @store.includes?(key)
+        @lock.synchronize { @store.includes?(key) }
       end
 
       def insert(key : T, ttl : UInt32? = nil)
-        @store.add(key)
+        @lock.synchronize { @store.add(key) }
       end
 
       # Atomically insert the key, returning true if it was newly added and
       # false if it was already present (i.e. a duplicate).
       def insert?(key : T, ttl : UInt32? = nil) : Bool
-        @store.add?(key)
+        @lock.synchronize { @store.add?(key) }
       end
 
       def delete(key : T)
-        @store.delete(key)
+        @lock.synchronize { @store.delete(key) }
       end
 
       def clear
-        @store.clear
+        @lock.synchronize { @store.clear }
       end
     end
 

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -173,6 +173,27 @@ module LavinMQ
       end
     end
 
+    # Non-destructive iteration over every message currently in the store
+    # (ready and in-flight), skipping acked positions. Reads straight from the
+    # mmap'd segments via slices so it neither consumes messages nor disturbs
+    # the @rfile read cursor. Requeued messages still live in their segments and
+    # are not marked deleted, so the segment walk yields them too.
+    def each(& : BytesMessage ->) : Nil
+      raise ClosedError.new if @closed
+      @segments.each do |seg, mfile|
+        pos = 4u32
+        size = mfile.size.to_u32
+        while pos < size
+          ts = IO::ByteFormat::SystemEndian.decode(Int64, mfile.to_slice(pos, 8))
+          break if ts.zero? # rest of the segment is zero padding
+          msg = BytesMessage.from_bytes(mfile.to_slice + pos)
+          yield msg unless deleted?(seg, pos)
+          pos += msg.bytesize
+        end
+        Fiber.yield
+      end
+    end
+
     def delete(sp) : Nil
       raise ClosedError.new if @closed
       afile = @acks[sp.segment]


### PR DESCRIPTION
### WHAT is this pull request doing?

Deduplication currently works by looking at the separate cache that gets populated on each publish and removed after a configured time, same for exchange deduplication. 
But on queue level it makes more sense to look at the content in a queue to decide if the message is a duplicate or not. This PR changes the deduplication behavior to look at current messages in the queue. 

### HOW can this pull request be tested?

New specs for the new changes.