### PR TITLE
Raft migration improvements

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -95,6 +95,10 @@ lavinmqctl raft_join http://node2.example.com:15672
 
 The imperative `raft_join` path is retained specifically for this recovery scenario.
 
+#### Known limitation — ISR commits under quorum loss
+
+On the raft backend, the in-sync replica set (ISR) is committed through raft consensus while the leader holds its replication-dispatch lock. If the raft cluster loses quorum (e.g. two of three nodes down), an ISR commit blocks until leadership is lost (an election timeout), which can stall the data plane for that window — even when leader→follower data replication is otherwise healthy. This is not a regression from the etcd backend, which commits the ISR under the same lock (with a bounded single PUT); it is a worse latency profile specific to raft's blocking consensus. Moving the ISR commit out from under that lock is tracked as a follow-up.
+
 ## Replication
 
 ### Bulk Sync

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -84,7 +84,7 @@ If you skip this, only the node that bootstraps will have a secret (it auto-gene
 
 To rebuild a node that has lost or diverged its raft state:
 
-1. Run `lavinmqctl raft_reset` on the affected node. This wipes raft state from the data directory and signals the running node to exit. If the node is currently running and belongs to a multi-peer cluster (or its status cannot be verified), the command requires `--force` to override the safety guard; a stopped node is wiped unconditionally without `--force`.
+1. Run `lavinmqctl raft_reset` on the affected node. This wipes raft state from the data directory and, if a node is running, signals it to exit. The command **fails closed**: it proceeds without `--force` only when it can prove the node is safe to discard — a running node whose `/raft/status` reports a single-node cluster (≤1 peer). A node that is **stopped** (no control socket / unreachable), a follower, in a multi-peer cluster, or whose status omits the peer list cannot be verified, so it requires `--force` to override the guard. (Most recovery scenarios involve a stopped or unhealthy node, so expect to pass `--force`.)
 2. Restart lavinmq. If `seed_uris` is configured, the node rejoins automatically.
 
 **Exception — recovering the lowest-host node:** after `raft_reset`, the lowest-host node sees no peers and would bootstrap a new cluster, splitting the existing one. Use `lavinmqctl raft_join <other-member-uri>` instead. This writes a `.join_target` marker that forces the node to join on restart rather than bootstrap:

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -584,6 +584,25 @@ describe LavinMQ::Config do
       config.clustering_seed_uris = "http://a:15672, http://b:15672"
       config.seed_uris.map(&.host).should eq ["a", "b"]
     end
+
+    it "raises on a scheme-less seed entry instead of silently dropping it" do
+      config = LavinMQ::Config.new
+      # No http:// — URI.parse treats "node-a" as the scheme and host is nil, so
+      # the entry would otherwise vanish from the bootstrap decision and the
+      # cluster would never form, with no error pointing at the typo.
+      config.clustering_seed_uris = "node-a:15672,node-b:15672"
+      expect_raises(Exception, /node-a:15672/) do
+        config.seed_uris
+      end
+    end
+
+    it "raises on a seed entry with no host" do
+      config = LavinMQ::Config.new
+      config.clustering_seed_uris = "http://"
+      expect_raises(Exception, /seed URI/i) do
+        config.seed_uris
+      end
+    end
   end
 
   describe "stats_interval" do

--- a/spec/http/raft_metrics_spec.cr
+++ b/spec/http/raft_metrics_spec.cr
@@ -108,6 +108,50 @@ describe "ISR Prometheus metrics" do
     end
   end
 
+  it "emits a bracket-free peer_host label for an IPv6 advertised address" do
+    dir = tmp_data_dir
+    backend = nil.as(LavinMQ::Raft::Backend?)
+    begin
+      File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+      config = LavinMQ::Config.new
+      config.data_dir = dir
+      config.clustering_bind = "::1"
+      config.clustering_raft_port = 0
+      config.clustering_port = 5679
+      config.clustering_advertised_uri = "tcp://[::1]:5679"
+      backend = LavinMQ::Raft::Backend.new(config)
+      r = backend.not_nil!
+      r.server.start
+      r.server.bootstrap
+      select
+      when r.server.is_leader.when_true.receive
+      when timeout(3.seconds)
+        fail "did not become leader"
+      end
+      # Add a peer advertising an IPv6 address (it need not be reachable — we
+      # only care about the configuration entry) so server.peers carries a
+      # bracketed IPv6 host for the emitter to render.
+      ipv6 = LavinMQ::Raft::PeerAddress.new("[::1]", 5680, 5679).to_s
+      r.server.add_server(2, ipv6).should be_true
+      deadline = Time.instant + 2.seconds
+      until r.server.peers.any?(&.id.==(2))
+        fail "configuration apply timed out" if Time.instant > deadline
+        Fiber.yield
+      end
+
+      controller = LavinMQ::HTTP::FollowerPrometheusController.new(raft_backend: r)
+      io = IO::Memory.new
+      writer = LavinMQ::HTTP::PrometheusWriter.new(io, "lavinmq")
+      controller.raft_metrics(writer, r)
+      output = io.to_s
+      output.should contain(%(peer_host="::1"))
+      output.should_not contain(%(peer_host="[::1]"))
+    ensure
+      backend.try &.stop rescue nil
+      FileUtils.rm_rf(dir)
+    end
+  end
+
   it "does not emit raft metrics when no backend is set" do
     with_metrics_server do |http, _|
       response = http.get("/metrics")

--- a/spec/lavinmqctl/raft_spec.cr
+++ b/spec/lavinmqctl/raft_spec.cr
@@ -258,6 +258,39 @@ describe "LavinMQCtl raft_*" do
       end
     end
 
+    it "refuses with a --force hint (not a generic abort) when the local control socket is absent (#4)" do
+      data_dir = File.tempname("raft-reset-nosock-spec")
+      begin
+        Dir.mkdir_p(File.join(data_dir, "raft"))
+        File.write(File.join(data_dir, "raft", "raft_meta"), "fake meta")
+        File.write(File.join(data_dir, ".clustering_id"), "1")
+        missing_sock = File.join(data_dir, "absent.sock")
+
+        stdout = IO::Memory.new
+        original_argv = ARGV.dup
+        begin
+          ARGV.clear
+          # Default unix-socket path (no --uri) pointing at a socket that does
+          # not exist: a stopped node must fail closed with an actionable
+          # message and a clean CtlExit, not `connect`'s "Is LavinMQ running?"
+          # process exit that bypasses the safety message entirely.
+          ARGV.concat(["--control-unix-path=#{missing_sock}", "raft_reset", "--data-dir=#{data_dir}"])
+          cli = LavinMQCtl.new(stdout)
+          expect_raises(LavinMQCtl::CtlExit) do
+            cli.run_cmd
+          end
+        ensure
+          ARGV.clear
+          ARGV.concat(original_argv)
+        end
+
+        Dir.exists?(File.join(data_dir, "raft")).should be_true
+        stdout.to_s.should contain("--force")
+      ensure
+        FileUtils.rm_rf(data_dir)
+      end
+    end
+
     it "refuses without --force when /raft/status omits the peer list" do
       stub = HTTP::Server.new do |context|
         context.response.status_code = 200

--- a/spec/raft/backend_spec.cr
+++ b/spec/raft/backend_spec.cr
@@ -745,6 +745,32 @@ describe LavinMQ::Raft::Backend do
     end
   end
 
+  describe "replication client lifecycle" do
+    it "closes and clears the replication client on stop (no leak) (#5)" do
+      dir = tmp_data_dir
+      backend = nil.as(LavinMQ::Raft::Backend?)
+      begin
+        File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+        config = backend_config(dir, free_port, free_port)
+        config.metrics_http_port = -1 # don't bind a metrics server for the test client
+        backend = LavinMQ::Raft::Backend.new(config)
+        b = backend.not_nil!
+        # Install an (unconnected) follower client, as reconcile_replication would.
+        client = LavinMQ::Clustering::Client.new(config, b.node_id, "secret", proxy: false)
+        pointerof(b.@repli_client).value = client
+        # close() blocks on the follower loop; we never started following, so
+        # release it so the test doesn't wait out the 5s timeout.
+        spawn { client.@follower_done.send(nil) }
+        b.stop
+        client.@closed.should be_true # closed under the guarded swap
+        b.@repli_client.should be_nil # and cleared — old stop() left it dangling
+      ensure
+        backend.try &.stop rescue nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
+
   describe "coordinator role" do
     it "commits the ISR via update_isr" do
       dir = tmp_data_dir

--- a/spec/raft/backend_spec.cr
+++ b/spec/raft/backend_spec.cr
@@ -557,6 +557,31 @@ describe LavinMQ::Raft::Backend do
       end
     end
 
+    it "raises JoinExhausted (not a bare Exception) after exhausting attempts" do
+      reject = HTTP::Server.new do |ctx|
+        ctx.response.status_code = 503
+        ctx.response.print "not leader"
+      end
+      addr = reject.bind_tcp("127.0.0.1", 0)
+      spawn(name: "stub-always-503") { reject.listen }
+      dir = tmp_data_dir
+      backend = nil.as(LavinMQ::Raft::Backend?)
+      begin
+        File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+        backend = LavinMQ::Raft::Backend.new(backend_config(dir, free_port, free_port))
+        started = Time.instant
+        expect_raises(LavinMQ::Raft::Backend::JoinExhausted, /exhausted/) do
+          backend.not_nil!.join_via_seeds([URI.parse("http://#{addr}")],
+            max_attempts: 2, retry_interval: 1.millisecond)
+        end
+        (Time.instant - started).should be < 1.second
+      ensure
+        reject.close
+        backend.try &.stop rescue nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+
     it "tries seeds in turn and succeeds on the first that returns 200" do
       hit = [] of String
       reject = HTTP::Server.new do |ctx|
@@ -584,6 +609,59 @@ describe LavinMQ::Raft::Backend do
       ensure
         reject.close
         accept.close
+        backend.try &.stop rescue nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
+
+  describe "join_with_retry" do
+    it "recovers across an exhausted sweep instead of crashing the boot fiber (#6)" do
+      # 503 for the first request (one whole max_attempts:1 sweep), then 200.
+      # A single join_via_seeds would raise JoinExhausted; join_with_retry must
+      # retry the next sweep and succeed, so a slow-to-appear bootstrapper never
+      # crashes campaign with an unhandled backtrace.
+      attempts = 0
+      stub = HTTP::Server.new do |ctx|
+        attempts += 1
+        if attempts == 1
+          ctx.response.status_code = 503
+          ctx.response.print "not leader yet"
+        else
+          ctx.response.status_code = 200
+          ctx.response.print %({"status":"added"})
+        end
+      end
+      addr = stub.bind_tcp("127.0.0.1", 0)
+      spawn(name: "stub-late-leader") { stub.listen }
+      dir = tmp_data_dir
+      backend = nil.as(LavinMQ::Raft::Backend?)
+      begin
+        File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+        backend = LavinMQ::Raft::Backend.new(backend_config(dir, free_port, free_port))
+        joined = backend.not_nil!.join_with_retry([URI.parse("http://#{addr}")],
+          max_attempts: 1, retry_interval: 1.millisecond)
+        joined.should be_true
+        attempts.should be >= 2
+      ensure
+        stub.close
+        backend.try &.stop rescue nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "propagates a permanent error instead of retrying forever" do
+      dir = tmp_data_dir
+      backend = nil.as(LavinMQ::Raft::Backend?)
+      begin
+        File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+        backend = LavinMQ::Raft::Backend.new(backend_config(dir, free_port, free_port))
+        # Empty seed list is a config error, not JoinExhausted, so it must not
+        # be swallowed by the retry loop.
+        expect_raises(Exception, /no seed/) do
+          backend.not_nil!.join_with_retry([] of URI, max_attempts: 1, retry_interval: 1.millisecond)
+        end
+      ensure
         backend.try &.stop rescue nil
         FileUtils.rm_rf(dir)
       end

--- a/spec/raft/backend_spec.cr
+++ b/spec/raft/backend_spec.cr
@@ -713,6 +713,54 @@ describe LavinMQ::Raft::Backend do
       end
     end
 
+    it "regenerates when .clustering_password exists but is empty (leader)" do
+      dir = tmp_data_dir
+      backend = nil.as(LavinMQ::Raft::Backend?)
+      begin
+        File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+        # A crash between File.open(\"w\") truncation and the write, a failed
+        # `openssl rand`, or an operator `touch` leaves a 0-byte file. It must
+        # not be used verbatim — that would authenticate every follower with a
+        # blank replication secret.
+        File.write(File.join(dir, ".clustering_password"), "")
+        backend = LavinMQ::Raft::Backend.new(backend_config(dir, free_port, free_port))
+        b = backend.not_nil!
+        b.server.start
+        b.server.bootstrap.should be_true
+        select
+        when b.server.is_leader.when_true.receive
+        when timeout(2.seconds); fail "timed out waiting for leadership"
+        end
+        pw = b.password
+        pw.should_not be_empty
+        File.read(File.join(dir, ".clustering_password")).strip.should eq pw
+      ensure
+        backend.try &.stop rescue nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+
+    it "treats a whitespace-only .clustering_password as empty (leader regenerates)" do
+      dir = tmp_data_dir
+      backend = nil.as(LavinMQ::Raft::Backend?)
+      begin
+        File.write(File.join(dir, ".clustering_id"), 1.to_s(36))
+        File.write(File.join(dir, ".clustering_password"), "   \n")
+        backend = LavinMQ::Raft::Backend.new(backend_config(dir, free_port, free_port))
+        b = backend.not_nil!
+        b.server.start
+        b.server.bootstrap.should be_true
+        select
+        when b.server.is_leader.when_true.receive
+        when timeout(2.seconds); fail "timed out waiting for leadership"
+        end
+        b.password.should_not be_empty
+      ensure
+        backend.try &.stop rescue nil
+        FileUtils.rm_rf(dir)
+      end
+    end
+
     it "reads an existing .clustering_password without regenerating" do
       dir = tmp_data_dir
       backend = nil.as(LavinMQ::Raft::Backend?)

--- a/spec/raft/server_spec.cr
+++ b/spec/raft/server_spec.cr
@@ -251,6 +251,19 @@ describe LavinMQ::Raft::Server do
         leader.peers.should_not be(leader.@node.peers)
       end
     end
+
+    it "exposes voters as a stable applied-config snapshot (read off the tick fiber)" do
+      with_cluster(3) do |_transports, servers|
+        leader = form_cluster(servers)
+        leader.voters.to_set.should eq servers.map(&.node_id.to_u64).to_set
+        # Maintained on configuration apply and returned by reference: two reads
+        # share one object. The old `@node.voters.map(&.id)` allocated a fresh
+        # array each call AND scanned @node's peer list live — a torn read when
+        # hand_off_leadership (campaign fiber) raced a tick-fiber membership
+        # change. The snapshot removes that off-tick @node access.
+        leader.voters.should be(leader.voters)
+      end
+    end
   end
 
   describe "leadership loss" do

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -360,10 +360,20 @@ module LavinMQ
     end
 
     # Parsed form of clustering_seed_uris. Blank/whitespace entries dropped.
+    # Each entry must be an http(s) management URL with a host; a scheme-less
+    # entry like "node-a:15672" parses with a nil host and would silently vanish
+    # from cluster formation, so reject it up front with a clear message rather
+    # than letting the cluster fail to form for no visible reason.
     def seed_uris : Array(URI)
       clustering_seed_uris.split(',').compact_map do |s|
         s = s.strip
-        URI.parse(s) unless s.empty?
+        next if s.empty?
+        uri = URI.parse(s)
+        scheme = uri.scheme
+        if (scheme != "http" && scheme != "https") || uri.host.to_s.empty?
+          raise "Invalid clustering seed URI #{s.inspect}: expected an http(s) management URL with a host, e.g. http://node1:15672"
+        end
+        uri
       end
     end
 

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -150,8 +150,10 @@ module LavinMQ
                         "group_id" => "0",
                       }})
         server.peers.each do |peer|
-          raft_addr, _, _data_addr = peer.address.partition(",")
-          host, _, _port = raft_addr.rpartition(":")
+          # Reuse the tested PeerAddress codec rather than hand-parsing: it
+          # strips IPv6 brackets (rpartition kept them -> "[::1]") and yields ""
+          # for an unparseable address instead of a half-parsed host.
+          host = LavinMQ::Raft::PeerAddress.parse?(peer.address).try(&.raft_endpoint.[0]) || ""
           writer.write({name:   "raft_peer_info",
                         type:   "gauge",
                         value:  1_i64,

--- a/src/lavinmq/raft/backend.cr
+++ b/src/lavinmq/raft/backend.cr
@@ -66,9 +66,18 @@ module LavinMQ::Raft
     # so replication can't delete it.
     def password : String
       path = File.join(@config.data_dir, PASSWORD_FILE)
-      return File.read(path).strip if File.exists?(path)
+      if File.exists?(path)
+        existing = File.read(path).strip
+        return existing unless existing.empty?
+        # A 0-byte/whitespace-only file (a crash between File.open("w")
+        # truncation and the write, a failed `openssl rand`, or an operator
+        # `touch`) must NOT be used verbatim — a blank secret would authenticate
+        # every follower. Treat it as missing: regenerate if we're the leader,
+        # else fail fast just like an absent file.
+        Log.warn { "Replication secret file is empty: #{path}; treating as missing" }
+      end
       unless @server.is_leader.value
-        Log.fatal { "Replication secret file missing: #{path}. Copy it from another node in the cluster." }
+        Log.fatal { "Replication secret file missing or empty: #{path}. Copy it from another node in the cluster." }
         exit 3
       end
       secret = Random::Secure.base64(32)

--- a/src/lavinmq/raft/backend.cr
+++ b/src/lavinmq/raft/backend.cr
@@ -52,6 +52,15 @@ module LavinMQ::Raft
     # leadership, or overwritten by a newer leader (false). Returning that bool
     # lets Clustering::Server stall a confirm and retry rather than acknowledge
     # against a stale ISR.
+    #
+    # KNOWN LIMITATION: Clustering::Server calls this while holding its @lock
+    # (the publish/replication-dispatch lock), so a raft-quorum loss makes this
+    # block — and stalls the data plane — until leadership is lost (an election
+    # timeout), even when leader→follower data replication is otherwise healthy.
+    # This is not a regression: the etcd backend commits the ISR under the same
+    # @lock, just with a bounded single PUT. Removing the under-@lock commit
+    # (collect ids under @lock, commit outside it, serialize commits to keep
+    # last-writer-wins) is a deliberate follow-up — see docs/clustering.md.
     def update_isr(synced_node_ids : Enumerable(Int32)) : Bool
       @server.propose_committed(ClusterCommand::SetIsr.new(synced_node_ids.to_set))
     end

--- a/src/lavinmq/raft/backend.cr
+++ b/src/lavinmq/raft/backend.cr
@@ -165,7 +165,7 @@ module LavinMQ::Raft
       if File.exists?(join_target_path)
         leader_uri = File.read(join_target_path).strip
         Log.info { "Found .join_target — joining cluster at #{leader_uri}" }
-        perform_join(leader_uri)
+        return unless with_join_retry { perform_join(leader_uri) } # interrupted by stop
         File.delete(join_target_path)
         return
       end
@@ -180,7 +180,7 @@ module LavinMQ::Raft
         end
       in .join?
         Log.info { "Joining via seed URIs: #{@config.seed_uris.map(&.to_s).join(", ")}" }
-        join_via_seeds(@config.seed_uris)
+        join_with_retry(@config.seed_uris)
       end
     end
 
@@ -193,15 +193,50 @@ module LavinMQ::Raft
     JOIN_MAX_ATTEMPTS   = 30
     JOIN_RETRY_INTERVAL = 1.second
 
+    # Every seed was unreachable or still electing after a full sweep. Transient
+    # by nature (the lowest-host bootstrapper may not be up yet), so the boot
+    # path retries it rather than treating it as fatal. A malformed seed (bad
+    # scheme / empty list) is a separate, permanent error and is NOT this type.
+    class JoinExhausted < Exception; end
+
     def perform_join(leader_uri : String) : Nil
       uri = URI.parse(leader_uri)
       raise "invalid leader URI scheme: #{uri.scheme.inspect}" unless uri.scheme == "http" || uri.scheme == "https"
       join_via_seeds([uri])
     end
 
+    # Retry a join sweep until it succeeds or stop() is called. join_via_seeds
+    # raises JoinExhausted when every seed is unreachable or still electing; on
+    # simultaneous boot the lowest-host bootstrapper may simply not be up yet,
+    # so retry rather than let the exception escape campaign as an unhandled
+    # backtrace. Returns true once joined, false if interrupted by stop().
+    # A permanent error (bad scheme / empty list) is not JoinExhausted and
+    # propagates.
+    def join_with_retry(seeds : Array(URI), max_attempts : Int32 = JOIN_MAX_ATTEMPTS,
+                        retry_interval : Time::Span = JOIN_RETRY_INTERVAL) : Bool
+      with_join_retry(retry_interval) { join_via_seeds(seeds, max_attempts, retry_interval) }
+    end
+
+    private def with_join_retry(retry_interval : Time::Span = JOIN_RETRY_INTERVAL, & : -> Nil) : Bool
+      until @stopped
+        begin
+          yield
+          return true
+        rescue ex : JoinExhausted
+          return false if @stopped
+          Log.warn { "#{ex.message}; retrying join sweep" }
+          sleep retry_interval
+        end
+      end
+      false
+    end
+
     # Cycle the seed URIs, asking each to add us, until one accepts (HTTP 200).
     # A non-leader seed answers non-200; the lowest seed may still be starting.
-    def join_via_seeds(seeds : Array(URI)) : Nil
+    # Raises JoinExhausted after max_attempts full sweeps so the caller can
+    # decide whether to retry (declarative boot) or surface it.
+    def join_via_seeds(seeds : Array(URI), max_attempts : Int32 = JOIN_MAX_ATTEMPTS,
+                       retry_interval : Time::Span = JOIN_RETRY_INTERVAL) : Nil
       raise "no seed URIs to join" if seeds.empty?
       seeds.each do |uri|
         unless uri.scheme == "http" || uri.scheme == "https"
@@ -210,7 +245,7 @@ module LavinMQ::Raft
       end
       address = build_advertised_address
       last_error = "unknown error"
-      JOIN_MAX_ATTEMPTS.times do |attempt|
+      max_attempts.times do |attempt|
         seeds.each do |uri|
           begin
             # The route and payload format are raft.cr's contract; AdminClient
@@ -221,15 +256,15 @@ module LavinMQ::Raft
               return
             end
             last_error = "HTTP #{status.code} from #{uri}"
-            Log.warn { "Join attempt #{attempt + 1}/#{JOIN_MAX_ATTEMPTS} to #{uri} got HTTP #{status.code}" }
+            Log.warn { "Join attempt #{attempt + 1}/#{max_attempts} to #{uri} got HTTP #{status.code}" }
           rescue ex
             last_error = "#{uri}: #{ex.message}"
-            Log.warn { "Join attempt #{attempt + 1}/#{JOIN_MAX_ATTEMPTS} to #{uri} failed: #{ex.message}" }
+            Log.warn { "Join attempt #{attempt + 1}/#{max_attempts} to #{uri} failed: #{ex.message}" }
           end
         end
-        sleep JOIN_RETRY_INTERVAL unless attempt == JOIN_MAX_ATTEMPTS - 1
+        sleep retry_interval unless attempt == max_attempts - 1
       end
-      raise "join exhausted #{JOIN_MAX_ATTEMPTS} attempts: #{last_error}"
+      raise JoinExhausted.new("join exhausted #{max_attempts} attempts: #{last_error}")
     end
 
     HANDOFF_RETRY_INTERVAL = 1.second

--- a/src/lavinmq/raft/backend.cr
+++ b/src/lavinmq/raft/backend.cr
@@ -21,6 +21,12 @@ module LavinMQ::Raft
     getter server : Server
     getter transport : ::Raft::TCPTransport
     @repli_client : ::LavinMQ::Clustering::Client? = nil
+    # @repli_client is mutated from three fibers — campaign (main), stop (signal
+    # path) and reconcile_replication (the follow_leader fiber). Without
+    # serialization a close can interleave with a rebuild, installing a client
+    # nobody closes or leaving one following a stale leader after we became
+    # leader. Every read/close/assign goes through this lock.
+    @repli_client_lock = Mutex.new
     @leader_changes = ::Channel(UInt64?).new(8)
     @stopped = false
 
@@ -134,7 +140,7 @@ module LavinMQ::Raft
       wait_for_insync_leadership
       return if @stopped
       execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
-      @repli_client.try &.close
+      close_repli_client # we're the leader now; stop following anyone
       yield
 
       # receive? (not receive): stop() closes is_leader, which would otherwise
@@ -149,9 +155,17 @@ module LavinMQ::Raft
     def stop : Nil
       @stopped = true
       @leader_changes.close
-      @repli_client.try &.close
+      close_repli_client
       @server.stop
       @transport.stop
+    end
+
+    # Close and clear the replication client under the lock. Idempotent.
+    private def close_repli_client : Nil
+      @repli_client_lock.synchronize do
+        @repli_client.try &.close
+        @repli_client = nil
+      end
     end
 
     # The boot action this node would take given its config and current raft
@@ -394,24 +408,28 @@ module LavinMQ::Raft
         data_uri = lookup_data_uri(new_leader_id)
       end
 
-      # Are we already replicating from that leader? If so, leave it alone.
-      already_following = false
-      if uri = data_uri
-        already_following = @repli_client.try(&.follows?(uri)) || false
-      end
+      # Hold the lock across the follows? read AND the swap so a concurrent
+      # close (campaign/stop) can't interleave with a rebuild here.
+      @repli_client_lock.synchronize do
+        # Are we already replicating from that leader? If so, leave it alone.
+        already_following = false
+        if uri = data_uri
+          already_following = @repli_client.try(&.follows?(uri)) || false
+        end
 
-      case Backend.leader_change_action(new_leader_id, self_id, data_uri, already_following)
-      in .keep?
-        # leave the current replication client untouched
-      in .stop_following?
-        @repli_client.try &.close
-        @repli_client = nil
-      in .follow?
-        if uri = data_uri # always set when the action is Follow
+        case Backend.leader_change_action(new_leader_id, self_id, data_uri, already_following)
+        in .keep?
+          # leave the current replication client untouched
+        in .stop_following?
           @repli_client.try &.close
-          @repli_client = client = ::LavinMQ::Clustering::Client.new(
-            @config, @server.node_id, password, raft_backend: self)
-          spawn(name: "Clustering client #{uri}") { client.follow(uri) }
+          @repli_client = nil
+        in .follow?
+          if uri = data_uri # always set when the action is Follow
+            @repli_client.try &.close
+            @repli_client = client = ::LavinMQ::Clustering::Client.new(
+              @config, @server.node_id, password, raft_backend: self)
+            spawn(name: "Clustering client #{uri}") { client.follow(uri) }
+          end
         end
       end
     end

--- a/src/lavinmq/raft/server.cr
+++ b/src/lavinmq/raft/server.cr
@@ -30,6 +30,12 @@ module LavinMQ::Raft
     # scrape, boot decision) get a consistent view instead of racing @node.peers,
     # which the tick fiber mutates. Replaced wholesale; never mutated in place.
     @peers_snapshot = [] of ::Raft::Peer
+    # Voter node ids from the last applied configuration, kept under the same
+    # lock for the same reason: hand_off_leadership reads it off the tick fiber
+    # (the campaign fiber), so it must not iterate @node.voters live — that
+    # selects over @node's peer array while the tick fiber replaces it wholesale
+    # during a membership change, a torn read that can crash.
+    @voters_snapshot = [] of UInt64
     @on_leader_change : Proc(UInt64?, Nil)?
     @on_configuration_change : Proc(Array(::Raft::Peer), Nil)?
     @last_observed_leader_id : UInt64? = nil
@@ -187,9 +193,11 @@ module LavinMQ::Raft
       @peer_addresses_lock.synchronize { @peers_snapshot }
     end
 
-    # The node ids currently in the voting set (learners excluded).
+    # The node ids in the last applied voting set (learners excluded). A
+    # consistent snapshot captured on the tick fiber, safe to read from any
+    # fiber — see @voters_snapshot. Reflects the last applied configuration.
     def voters : Array(UInt64)
-      @node.voters.map(&.id)
+      @peer_addresses_lock.synchronize { @voters_snapshot }
     end
 
     def state : ClusterState
@@ -291,9 +299,14 @@ module LavinMQ::Raft
         host, port = addr.raft_endpoint
         @transport.register_peer(peer.id, host, port)
       end
+      # Equivalent to @node.voters (which selects voter? over @node.peers), but
+      # computed here from the applied config on the tick/start fiber so off-tick
+      # readers never touch @node.
+      voters = peers.compact_map { |peer| peer.id if peer.voter? }
       @peer_addresses_lock.synchronize do
         @peer_addresses = addresses
         @peers_snapshot = peers.dup # snapshot taken on the tick/start fiber; safe
+        @voters_snapshot = voters
       end
     end
 

--- a/src/lavinmqctl/raft.cr
+++ b/src/lavinmqctl/raft.cr
@@ -4,6 +4,7 @@ require "json"
 require "uri"
 require "file_utils"
 require "../lavinmq/data_dir_lock"
+require "../lavinmq/http/constants"
 
 class LavinMQCtl
   class CtlExit < Exception
@@ -156,6 +157,18 @@ class LavinMQCtl
   # nothing — both require --force.
   private def ensure_safe_to_stop : Nil
     return if @options["force"]?
+    # A stopped node exposes no /raft/status, so we can't prove it's a safe
+    # single-node leader. When the default control socket is absent, `connect`
+    # would `exit` with a generic "is LavinMQ running?" before we ever reach the
+    # rescue below — produce the actionable fail-closed message instead. (An
+    # explicit --uri/--host/--hostname is a TCP endpoint whose connection
+    # failure is caught by the rescue.)
+    if local_control_socket_missing?
+      @io.puts "raft_reset: refusing — node is not running (no control socket at " \
+               "#{@options["control_unix_path"]? || LavinMQ::HTTP::DEFAULT_CONTROL_UNIX_PATH}), " \
+               "so its cluster membership can't be verified. Use --force to discard this node's state."
+      raise CtlExit.new(1)
+    end
     begin
       response = http.get("/raft/status", @headers)
       if response.status_code == 200
@@ -177,6 +190,16 @@ class LavinMQCtl
       @io.puts "raft_reset: refusing — node is running but /raft/status is unreachable (#{ex.message}). Use --force to override."
     end
     raise CtlExit.new(1)
+  end
+
+  # True when the local control socket the ctl would dial does not exist, i.e.
+  # no node is running locally. Only meaningful for the default unix-socket
+  # path; an explicit --uri/--host/--hostname is a remote TCP endpoint we let
+  # the HTTP call probe (its failure is rescued, not aborted).
+  private def local_control_socket_missing? : Bool
+    return false if @options["host"]? || @options["uri"]? || @options["hostname"]?
+    path = @options["control_unix_path"]? || LavinMQ::HTTP::DEFAULT_CONTROL_UNIX_PATH
+    !File.exists?(path)
   end
 
   def raft_join


### PR DESCRIPTION
This Pr consists of 8 commits where each corresponds with a fix for each of the issues found. 
They can be picked individually if we want some of them or merge the entire branch into `raft-migration`. 

Summary

| Severity | Commit ID (git SHA) | Commit title |
|----------|---------------------|--------------|
| High | 647f0f8e6e2581ae5ef5e5c6fecfc9612215eeff | Raft::Server#voters: return a tick-fiber snapshot, not live @node.voters |
| High | ab781047f6bfeb6ac931511db93a2ca67d0d8f38 | Raft::Backend: document the ISR-commit-under-lock quorum-loss stall |
| Medium | 533e6a36e0ca8cfe9bd8ca9915166d19f123e6a0 | Raft::Backend: treat an empty .clustering_password as missing |
| Medium | 0b1bcb0a7beabf9cc42ab5eb89b82d05ca9a412a | Raft::Backend: retry seed join on boot instead of crashing campaign |
| Medium | ff6f409316882e31baf3c59cb89eb6a52f375b55 | lavinmqctl raft_reset: actionable refusal when control socket is absent |
| Medium | 16a3dea66372256bd250f0d81df517d1217d2913 | Raft::Backend: guard @repli_client with a mutex across all three fibers |
| Low | 70ab04b47f76d9e38e9152b00aae0d81918f6b3a | Config: reject seed URIs without an http(s) scheme and host |
| Low | 5e01705017611a3b99fd9dd442dcb17bbe97061f | Prometheus: render raft peer_host via the PeerAddress codec |

**Note:** the second High item (ab781047) is documentation only — the ISR-commit-under-`@lock` stall is a deferred follow-up (not a regression vs. the etcd backend), documented at the call site and in `docs/clustering.md` rather than fixed in code.