### PR TITLE
Fix clustered localhost listener bind failures

### DIFF
--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -1,3 +1,4 @@
+require "log/spec"
 require "./spec_helper"
 require "../src/lavinmq/launcher"
 require "../src/lavinmq/clustering/client"
@@ -71,6 +72,48 @@ class SelfLeaderController < LavinMQ::Clustering::Controller
 
   def mark_elected_for_spec
     @elected_leader.set(true)
+  end
+end
+
+class ProxyBindEtcd < LavinMQ::Etcd
+  def initialize(@leader_uri : String)
+    super("localhost:1")
+  end
+
+  def elect_listen(_name, &)
+    yield @leader_uri
+  end
+
+  def get(_key) : String?
+    "secret"
+  end
+end
+
+describe LavinMQ::Clustering::Controller do
+  it "reports follower proxy bind failures without the generic unhandled exception log" do
+    blocker = TCPServer.new("127.0.0.1", 0)
+    with_datadir do |data_dir|
+      config = LavinMQ::Config.new
+      config.data_dir = data_dir
+      config.amqp_bind = "127.0.0.1"
+      config.amqp_port = blocker.local_address.port
+      config.http_port = 0
+      config.mqtt_port = 0
+      config.metrics_http_port = -1
+      config.clustering_advertised_uri = "tcp://127.0.0.1:5679"
+      etcd = ProxyBindEtcd.new("tcp://192.0.2.10:5679")
+      coordinator = LavinMQ::Clustering::EtcdCoordinator.new(config, etcd)
+      controller = SelfLeaderController.new(config, etcd, coordinator)
+
+      Log.capture("lmq.clustering.controller", :fatal) do |logs|
+        ex = expect_raises(SpecExit) { controller.follow_leader_public }
+        ex.code.should eq 36
+        logs.check(:fatal, /Could not bind to '127\.0\.0\.1:#{blocker.local_address.port}'/)
+        logs.entry.to_s.should_not contain "Unhandled exception while following leader"
+      end
+    end
+  ensure
+    blocker.try &.close
   end
 end
 

--- a/spec/control_socket_spec.cr
+++ b/spec/control_socket_spec.cr
@@ -1,6 +1,12 @@
 require "./spec_helper"
 require "../src/lavinmq/clustering/client"
 
+class LavinMQ::Clustering::Client
+  def local_leader_host_for_spec?(host : String)
+    local_leader_host?(host)
+  end
+end
+
 describe "control socket" do
   # Regression test for running multiple instances on one host: the control
   # socket path must be configurable, and both the bind and the no-auth bypass
@@ -170,11 +176,12 @@ describe "control socket" do
     end
 
     it "recognizes loopback leader hosts as local" do
+      client = LavinMQ::Clustering::Client.allocate
       {"localhost", "LOCALHOST", "127.0.0.1", "127.1", "::1", "[::1]", System.hostname}.each do |host|
-        LavinMQ::Clustering::Client.local_leader_host?(host).should be_true
+        client.local_leader_host_for_spec?(host).should be_true
       end
 
-      LavinMQ::Clustering::Client.local_leader_host?("192.0.2.10").should be_false
+      client.local_leader_host_for_spec?("192.0.2.10").should be_false
     end
   end
 end

--- a/spec/control_socket_spec.cr
+++ b/spec/control_socket_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../src/lavinmq/clustering/client"
 
 describe "control socket" do
   # Regression test for running multiple instances on one host: the control
@@ -139,6 +140,41 @@ describe "control socket" do
       server.try &.close
       config.control_unix_path = original_path if config && original_path
       File.delete?(socket_path) if socket_path
+    end
+  end
+
+  describe "clustering follower control socket" do
+    it "does not bind before the leader host is known" do
+      original_config = LavinMQ::Config.instance
+      socket_path = File.tempname("lavinmqctl-spec", ".sock")
+      config = LavinMQ::Config.new
+      config.control_unix_path = socket_path
+      config.metrics_http_port = -1
+
+      begin
+        LavinMQ::Config.instance = config
+        with_datadir do |data_dir|
+          config.data_dir = data_dir
+          client : LavinMQ::Clustering::Client? = nil
+          begin
+            client = LavinMQ::Clustering::Client.new(config, 1, "secret", proxy: false)
+            File.exists?(socket_path).should be_false
+          ensure
+            client.try &.close
+          end
+        end
+      ensure
+        LavinMQ::Config.instance = original_config
+        File.delete?(socket_path)
+      end
+    end
+
+    it "recognizes loopback leader hosts as local" do
+      {"localhost", "LOCALHOST", "127.0.0.1", "127.1", "::1", "[::1]", System.hostname}.each do |host|
+        LavinMQ::Clustering::Client.local_leader_host?(host).should be_true
+      end
+
+      LavinMQ::Clustering::Client.local_leader_host?("192.0.2.10").should be_false
     end
   end
 end

--- a/spec/launcher_bind_spec.cr
+++ b/spec/launcher_bind_spec.cr
@@ -1,0 +1,38 @@
+require "./spec_helper"
+require "../src/lavinmq/launcher"
+
+class LavinMQ::Launcher
+  def start_for_spec
+    start
+  end
+end
+
+describe LavinMQ::Launcher do
+  it "aborts startup when the AMQP listener can not bind" do
+    blocker = TCPServer.new("127.0.0.1", 0)
+    with_datadir do |data_dir|
+      launcher : LavinMQ::Launcher? = nil
+      config = LavinMQ::Config.new
+      config.data_dir = data_dir
+      config.data_dir_lock = false
+      config.amqp_bind = "127.0.0.1"
+      config.amqp_port = blocker.local_address.port
+      config.amqps_port = -1
+      config.http_port = -1
+      config.https_port = -1
+      config.mqtt_port = -1
+      config.mqtts_port = -1
+      config.metrics_http_port = -1
+      config.control_unix_path = File.join(data_dir, "control.sock")
+      launcher = LavinMQ::Launcher.new(config)
+
+      expect_raises(SpecExit, /Exiting with code 1/) do
+        launcher.not_nil!.start_for_spec
+      end
+    ensure
+      launcher.try &.stop
+    end
+  ensure
+    blocker.try &.close
+  end
+end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -151,10 +151,10 @@ module LavinMQ
 
       def self.local_leader_host?(host : String) : Bool
         host = host.downcase
-        return true if host == "localhost" || host == System.hostname.downcase
-        return true if host.starts_with?("127.") || host == "::1" || host == "[::1]"
+        return true if host == System.hostname.downcase
+        host = host[1...-1] if host.starts_with?("[") && host.ends_with?("]")
 
-        Socket::IPAddress.new(host, 0).loopback?
+        Socket::Addrinfo.tcp(host, 0).any?(&.ip_address.loopback?)
       rescue Socket::Error
         false
       end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -69,7 +69,6 @@ module LavinMQ
           @unix_mqtt_proxy = Proxy.new(@config.mqtt_unix_path) unless @config.mqtt_unix_path.empty?
         end
         start_metrics_server unless @config.metrics_http_port == -1
-        @internal_http_server = HTTP::Server.follower_internal_socket_http_server
       end
 
       private def start_metrics_server
@@ -94,6 +93,7 @@ module LavinMQ
         Log.info { "Following #{host}:#{port}" }
         @host = host
         @port = port
+        @internal_http_server ||= HTTP::Server.follower_internal_socket_http_server unless self.class.local_leader_host?(host)
         if amqp_proxy = @amqp_proxy
           spawn amqp_proxy.forward_to(host, @config.amqp_port, true), name: "AMQP proxy"
         end
@@ -147,6 +147,16 @@ module LavinMQ
 
       def follows?(host : String, port : Int32) : Bool
         @host == host && @port == port
+      end
+
+      def self.local_leader_host?(host : String) : Bool
+        host = host.downcase
+        return true if host == "localhost" || host == System.hostname.downcase
+        return true if host.starts_with?("127.") || host == "::1" || host == "[::1]"
+
+        Socket::IPAddress.new(host, 0).loopback?
+      rescue Socket::Error
+        false
       end
 
       private def sync(socket, lz4)

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -93,7 +93,7 @@ module LavinMQ
         Log.info { "Following #{host}:#{port}" }
         @host = host
         @port = port
-        @internal_http_server ||= HTTP::Server.follower_internal_socket_http_server unless self.class.local_leader_host?(host)
+        @internal_http_server ||= HTTP::Server.follower_internal_socket_http_server unless local_leader_host?(host)
         if amqp_proxy = @amqp_proxy
           spawn amqp_proxy.forward_to(host, @config.amqp_port, true), name: "AMQP proxy"
         end
@@ -149,7 +149,7 @@ module LavinMQ
         @host == host && @port == port
       end
 
-      def self.local_leader_host?(host : String) : Bool
+      private def local_leader_host?(host : String) : Bool
         host = host.downcase
         return true if host == System.hostname.downcase
         host = host[1...-1] if host.starts_with?("[") && host.ends_with?("]")

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -117,6 +117,9 @@ class LavinMQ::Clustering::Controller
   rescue ex : Error
     Log.fatal { ex.message }
     exit 36 # 36 for CF (Cluster Follower)
+  rescue ex : Socket::BindError
+    Log.fatal { ex.message }
+    exit 36 # 36 for CF (Cluster Follower)
   rescue ex
     Log.fatal(exception: ex) { "Unhandled exception while following leader" }
     exit 36 # 36 for CF (Cluster Follower)

--- a/src/lavinmq/http/http_server.cr
+++ b/src/lavinmq/http/http_server.cr
@@ -107,20 +107,25 @@ module LavinMQ
       # skipped and nil is returned, it's only a convenience for lavinmqctl users.
       def self.follower_internal_socket_http_server : ::HTTP::Server?
         path = Config.instance.control_unix_path
-        begin
-          prepare_control_socket(path)
-        rescue ex
-          Log.warn { "#{ex.message}, not serving lavinmqctl socket on this node" }
-          return
-        end
-
         http_server = ::HTTP::Server.new do |context|
           context.response.status_code = 503
           context.response.print "This node is a follower and does not handle lavinmqctl commands. \n" \
                                  "Please connect to the leader node by using the --host option."
         end
 
-        addr = http_server.bind_unix(path)
+        begin
+          prepare_control_socket(path)
+          addr = http_server.bind_unix(path)
+        rescue ex : Socket::BindError
+          Log.warn { "#{ex.message}, not serving lavinmqctl socket on this node" }
+          http_server.close
+          return
+        rescue ex
+          Log.warn { "#{ex.message}, not serving lavinmqctl socket on this node" }
+          http_server.close
+          return
+        end
+
         File.chmod(path, 0o660)
         Log.info { "Bound to #{addr}" }
 

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -73,6 +73,7 @@ module LavinMQ
       Log.info { "Finished startup in #{(Time.instant - started_at).total_seconds}s" }
       self
     rescue ex : Socket::BindError
+      stop
       abort "Error: #{ex.message}"
     end
 
@@ -174,23 +175,27 @@ module LavinMQ
     # ameba:disable Metrics/CyclomaticComplexity
     private def start_listeners(amqp_server, http_server)
       if @config.amqp_port > 0
-        spawn amqp_server.listen(@config.amqp_bind, @config.amqp_port, Server::Protocol::AMQP),
+        amqp_listener = TCPServer.new(@config.amqp_bind, @config.amqp_port)
+        spawn amqp_server.listen(amqp_listener, Server::Protocol::AMQP),
           name: "AMQP listening on #{@config.amqp_port}"
       end
 
       if @config.amqps_port > 0
         if ctx = @amqp_tls_context
-          spawn amqp_server.listen_tls(@config.amqp_bind, @config.amqps_port, ctx, Server::Protocol::AMQP),
+          amqps_listener = TCPServer.new(@config.amqp_bind, @config.amqps_port)
+          spawn amqp_server.listen_tls(amqps_listener, ctx, Server::Protocol::AMQP),
             name: "AMQPS listening on #{@config.amqps_port}"
         end
       end
 
       if clustering_bind = @config.clustering_bind
-        spawn amqp_server.listen_clustering(clustering_bind, @config.clustering_port), name: "Clustering listener"
+        clustering_listener = TCPServer.new(clustering_bind, @config.clustering_port)
+        spawn amqp_server.listen_clustering(clustering_listener), name: "Clustering listener"
       end
 
       unless @config.unix_path.empty?
-        spawn amqp_server.listen_unix(@config.unix_path, Server::Protocol::AMQP), name: "AMQP listening at #{@config.unix_path}"
+        amqp_unix_listener = bind_unix(@config.unix_path)
+        spawn amqp_server.listen(amqp_unix_listener, Server::Protocol::AMQP), name: "AMQP listening at #{@config.unix_path}"
       end
 
       if @config.http_port > 0
@@ -211,19 +216,27 @@ module LavinMQ
       end
 
       if @config.mqtt_port > 0
-        spawn amqp_server.listen(@config.mqtt_bind, @config.mqtt_port, Server::Protocol::MQTT),
+        mqtt_listener = TCPServer.new(@config.mqtt_bind, @config.mqtt_port)
+        spawn amqp_server.listen(mqtt_listener, Server::Protocol::MQTT),
           name: "MQTT listening on #{@config.mqtt_port}"
       end
 
       if @config.mqtts_port > 0
         if ctx = @mqtt_tls_context
-          spawn amqp_server.listen_tls(@config.mqtt_bind, @config.mqtts_port, ctx, Server::Protocol::MQTT),
+          mqtts_listener = TCPServer.new(@config.mqtt_bind, @config.mqtts_port)
+          spawn amqp_server.listen_tls(mqtts_listener, ctx, Server::Protocol::MQTT),
             name: "MQTTS listening on #{@config.mqtts_port}"
         end
       end
       unless @config.mqtt_unix_path.empty?
-        spawn amqp_server.listen_unix(@config.mqtt_unix_path, Server::Protocol::MQTT), name: "MQTT listening at #{@config.unix_path}"
+        mqtt_unix_listener = bind_unix(@config.mqtt_unix_path)
+        spawn amqp_server.listen(mqtt_unix_listener, Server::Protocol::MQTT), name: "MQTT listening at #{@config.unix_path}"
       end
+    end
+
+    private def bind_unix(path : String) : UNIXServer
+      File.delete?(path)
+      UNIXServer.new(path).tap { File.chmod(path, 0o666) }
     end
 
     private def dump_debug_info

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -279,6 +279,10 @@ module LavinMQ
       @replicator.try &.listen(bind_tcp(bind, port))
     end
 
+    def listen_clustering(server : TCPServer)
+      @replicator.try &.listen(server)
+    end
+
     def close
       @closed.set(true)
       Log.debug { "Closing listeners" }


### PR DESCRIPTION
- skip follower control socket conflicts when another local node already owns the socket
- bind leader TCP/UNIX listeners synchronously so startup exits on address conflicts
- exit followers cleanly with the cluster-follower exit code when proxy bind fails