### PR TITLE
Avoid config parsing for version output

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -528,6 +528,27 @@ describe LavinMQ::Config do
     io.to_s.should match(/\[http\] is deprecated/)
   end
 
+  it "does not parse config before printing version information" do
+    config_dir = File.tempname("lavinmq-conf")
+    Dir.mkdir_p(config_dir)
+    File.write(File.join(config_dir, "lavinmq.ini"), <<-CONFIG
+      [http]
+      port = 15699
+      CONFIG
+    )
+    io = IO::Memory.new
+    config = LavinMQ::Config.new(io)
+    begin
+      ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = config_dir
+      ex = expect_raises(SpecExit) { config.parse(["--version"]) }
+      ex.code.should eq 0
+      io.to_s.should be_empty
+    ensure
+      ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
+      FileUtils.rm_rf(config_dir)
+    end
+  end
+
   it "will not parse ini sections that do not exist" do
     config_file = File.tempfile do |file|
       file.print <<-CONFIG

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -32,6 +32,7 @@ module LavinMQ
     # Command line arguments take precedence over environment variables,
     # which take precedence over the configuration file.
     def parse(argv = ARGV)
+      parse_info_option(argv)
       config_dir = ENV.fetch("LAVINMQ_CONFIGURATION_DIRECTORY") { ENV.fetch("CONFIGURATION_DIRECTORY", "/etc/lavinmq") }
       @config_file = File.exists?(
         File.join(config_dir, "lavinmq.ini")) ? File.join(config_dir, "lavinmq.ini") : ""
@@ -43,6 +44,19 @@ module LavinMQ
       setup_logger
       if (@oauth_mgmt_base_url || @oauth_client_id) && !oauth_mgmt_ui_enabled?
         Log.warn { oauth_mgmt_ui_disabled_reason }
+      end
+    end
+
+    private def parse_info_option(argv)
+      return unless argv.size == 1
+
+      case argv.first
+      when "-v", "--version"
+        puts LavinMQ::VERSION
+        exit 0
+      when "--build-info"
+        puts LavinMQ::BUILD_INFO
+        exit 0
       end
     end
 


### PR DESCRIPTION
Closes #2112

- Exit early for exact version/build-info requests before reading lavinmq.ini
- Keep normal config parsing and deprecation warnings for startup
- Add a regression spec for deprecated config files with --version
