### PR TITLE
Persist definitions with JSON snapshots and WAL

### DIFF
--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -254,6 +254,37 @@ module FollowerSpec
       end
     end
 
+    it "writes a File range with a negative size header" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+        file = File.open(File.join(data_dir, "append_source"), "w+")
+        file.write "0123456789".to_slice
+        file.flush
+
+        lag_ch = Channel(Int64).new(1)
+        spawn do
+          lag_ch.send follower.append("bar", file, 2i64, 5i64)
+          follower.close
+        end
+
+        client_lz4 = Compress::LZ4::Reader.new(client_socket)
+        read_filename(client_lz4).should eq "bar"
+        data_size = read_data_size(client_lz4)
+        data_size.should eq(-5i64)
+        buf = Bytes.new(-data_size)
+        client_lz4.read_fully(buf)
+        String.new(buf).should eq "23456"
+
+        lag_ch.receive.should eq(sizeof(Int32) + "bar".bytesize + sizeof(Int64) + 5)
+      ensure
+        file.try &.close
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
     it "writes Int32 value little-endian with a -4 size header" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -178,11 +178,11 @@ describe LavinMQ::Clustering::Server do
       coordinator.last_isr.not_nil!.includes?(follower_id).should be_true
 
       # Durable operations that don't go through the Persister (queue/exchange
-      # declares appending to definitions.wal, users.json replaces, segment
+      # declares appending to definitions.jsonl, users.json replaces, segment
       # deletes) must commit the shrunken ISR before they return — and thus
       # before they are acknowledged to any client — otherwise a leader crash
       # could elect the disconnected follower without the acknowledged change.
-      server.append_bytes(File.join(data_dir, "definitions.wal"), "frame".to_slice, 0i64)
+      server.append_bytes(File.join(data_dir, "definitions.jsonl"), "frame".to_slice, 0i64)
       coordinator.last_isr.not_nil!.includes?(follower_id).should be_false
     ensure
       client_io.try &.close

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -178,11 +178,11 @@ describe LavinMQ::Clustering::Server do
       coordinator.last_isr.not_nil!.includes?(follower_id).should be_true
 
       # Durable operations that don't go through the Persister (queue/exchange
-      # declares appending to definitions.amqp, users.json replaces, segment
+      # declares appending to definitions.wal, users.json replaces, segment
       # deletes) must commit the shrunken ISR before they return — and thus
       # before they are acknowledged to any client — otherwise a leader crash
       # could elect the disconnected follower without the acknowledged change.
-      server.append_bytes(File.join(data_dir, "definitions.amqp"), "frame".to_slice, 0i64)
+      server.append_bytes(File.join(data_dir, "definitions.wal"), "frame".to_slice, 0i64)
       coordinator.last_isr.not_nil!.includes?(follower_id).should be_false
     ensure
       client_io.try &.close

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -153,6 +153,46 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
     ensure
       FileUtils.rm_rf LavinMQ::Config.instance.data_dir
     end
+
+    it "streams a File range through append_bytes" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      server = LavinMQ::Clustering::Server.new(
+        LavinMQ::Config.instance,
+        NullCoordinator.new,
+        0)
+      fi = FakeFileIndex.new(data_dir)
+      sock, client = FakeSocket.pair
+      follower = LavinMQ::Clustering::Follower.new(sock, data_dir, fi)
+      follower.mark_synced!
+      server.@followers << follower
+      path = File.join(data_dir, "path_only_file")
+      file = File.open(path, "w+")
+      file.write "0123456789".to_slice
+      file.flush
+      server.register_file(file)
+
+      done = Channel(Nil).new(1)
+      spawn do
+        server.append_bytes(file, 2i64, 5i64)
+        follower.close
+        done.send nil
+      end
+
+      client_lz4 = Compress::LZ4::Reader.new(client)
+      len = client_lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
+      client_lz4.read_string(len).should eq "path_only_file"
+      data_size = client_lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
+      data_size.should eq(-5i64)
+      client_lz4.read_string(5).should eq "23456"
+      done.receive
+    ensure
+      file.try &.close
+      sock.try &.close
+      client.try &.close
+      server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
   end
 
   describe "join baseline (full_sync cut)" do

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -117,7 +117,6 @@ describe LavinMQ::Config do
           log_exchange = true
           free_disk_min = 1073741824
           free_disk_warn = 5368709120
-          max_deleted_definitions = 16384
           consumer_timeout = 3600
           consumer_timeout_loop_interval = 120
           auth_backends = ldap,basic
@@ -202,7 +201,6 @@ describe LavinMQ::Config do
       config.log_exchange?.should be_true
       config.free_disk_min.should eq 1073741824
       config.free_disk_warn.should eq 5368709120
-      config.max_deleted_definitions.should eq 16384
       config.consumer_timeout.should eq 3600
       config.consumer_timeout_loop_interval.should eq 120
       config.auth_backends.should eq ["ldap", "basic"]

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -29,6 +29,18 @@ class DiskVisibilitySpyReplicator
     @violations << "#{path}: dispatched but the file doesn't exist on disk"
   end
 
+  def append_bytes(file : File, offset : Int64, length : Int64)
+    path = file.path
+    File.open(path) do |f|
+      if f.size < offset + length
+        @violations << "#{path}: dispatched [#{offset}, #{offset + length}) but only #{f.size} bytes are on disk"
+        return
+      end
+    end
+  rescue File::NotFoundError
+    @violations << "#{path}: dispatched but the file doesn't exist on disk"
+  end
+
   # The rest of the interface is irrelevant to this spec.
   def register_file(path : String)
   end

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -14,7 +14,7 @@ class DiskVisibilitySpyReplicator
   getter dispatched_definitions = 0
 
   def append_bytes(path : String, bytes : Bytes, offset : Int64)
-    @dispatched_definitions += 1 if path.ends_with?("definitions.amqp")
+    @dispatched_definitions += 1 if path.ends_with?("definitions.wal")
     File.open(path) do |f|
       if f.size < offset + bytes.bytesize
         @violations << "#{path}: dispatched [#{offset}, #{offset + bytes.bytesize}) but only #{f.size} bytes are on disk"

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -14,7 +14,7 @@ class DiskVisibilitySpyReplicator
   getter dispatched_definitions = 0
 
   def append_bytes(path : String, bytes : Bytes, offset : Int64)
-    @dispatched_definitions += 1 if path.ends_with?("definitions.wal")
+    @dispatched_definitions += 1 if path.ends_with?("definitions.jsonl")
     File.open(path) do |f|
       if f.size < offset + bytes.bytesize
         @violations << "#{path}: dispatched [#{offset}, #{offset + bytes.bytesize}) but only #{f.size} bytes are on disk"

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -73,7 +73,7 @@ describe "LavinMQCtl" do
           %([{"name":"queue_rk"},{"name":"queue_empty"},{"name":"queue_wal"}]))
         File.write(File.join(vhost_dir, "bindings.json"),
           %([{"source":"direct","destination":"queue_rk","routing_key":"rk"},{"source":"fanout","destination":"queue_empty"}]))
-        File.write(File.join(vhost_dir, "definitions.wal"),
+        File.write(File.join(vhost_dir, "definitions.jsonl"),
           %({"op":"queue.bind","queue":"queue_wal","exchange":"fanout","routing_key":""}\n))
 
         snapshot_bindings = JSON.parse(File.read(File.join(vhost_dir, "bindings.json"))).as_a

--- a/spec/lavinmqctl_spec.cr
+++ b/spec/lavinmqctl_spec.cr
@@ -30,7 +30,78 @@ def run_lavinmqctl(http_addr : String, argv : Array(String))
   }
 end
 
+def run_lavinmqctl_offline(argv : Array(String))
+  stdout_capture = IO::Memory.new
+  stderr_capture = IO::Memory.new
+  stderr = ""
+  exit_code = 0
+
+  original_argv = ARGV.dup
+  begin
+    ARGV.clear
+    ARGV.concat(argv)
+
+    cli = LavinMQCtl.new(stdout_capture, stderr_capture)
+    cli.run_cmd
+  rescue ex
+    stderr = ex.message.to_s
+    exit_code = 1
+  ensure
+    ARGV.clear
+    ARGV.concat(original_argv)
+  end
+
+  {
+    stdout: stdout_capture.to_s,
+    stderr: stderr_capture.to_s + stderr,
+    exit:   exit_code,
+  }
+end
+
 describe "LavinMQCtl" do
+  describe "with offline data dir" do
+    it "exports bindings from compact snapshots with omitted default fields" do
+      with_datadir do |data_dir|
+        vhost_dir = File.join(data_dir, "vhost")
+        Dir.mkdir_p vhost_dir
+        File.write(File.join(data_dir, "vhosts.json"), %([{"name":"test","dir":"vhost"}]))
+        File.write(File.join(data_dir, "users.json"),
+          %([{"name":"guest","password_hash":"hash","hashing_algorithm":"SHA256","tags":"administrator","permissions":{"test":{"config":".*","read":".*","write":".*"}}}]))
+        File.write(File.join(vhost_dir, "exchanges.json"),
+          %([{"name":"direct","type":"direct"},{"name":"fanout","type":"fanout"}]))
+        File.write(File.join(vhost_dir, "queues.json"),
+          %([{"name":"queue_rk"},{"name":"queue_empty"},{"name":"queue_wal"}]))
+        File.write(File.join(vhost_dir, "bindings.json"),
+          %([{"source":"direct","destination":"queue_rk","routing_key":"rk"},{"source":"fanout","destination":"queue_empty"}]))
+        File.write(File.join(vhost_dir, "definitions.wal"),
+          %({"op":"queue.bind","queue":"queue_wal","exchange":"fanout","routing_key":""}\n))
+
+        snapshot_bindings = JSON.parse(File.read(File.join(vhost_dir, "bindings.json"))).as_a
+        queue_binding = snapshot_bindings.find! { |b| b["destination"].as_s == "queue_rk" }
+        queue_binding.as_h.has_key?("destination_type").should be_false
+        empty_routing_key_binding = snapshot_bindings.find! { |b| b["destination"].as_s == "queue_empty" }
+        empty_routing_key_binding.as_h.has_key?("destination_type").should be_false
+        empty_routing_key_binding.as_h.has_key?("routing_key").should be_false
+
+        result = run_lavinmqctl_offline(["definitions", data_dir])
+        result[:exit].should eq(0)
+
+        bindings = JSON.parse(result[:stdout])["bindings"].as_a
+        exported_queue_binding = bindings.find! { |b| b["destination"].as_s == "queue_rk" }
+        exported_queue_binding["destination_type"].as_s.should eq "queue"
+        exported_queue_binding["routing_key"].as_s.should eq "rk"
+
+        exported_empty_routing_key_binding = bindings.find! { |b| b["destination"].as_s == "queue_empty" }
+        exported_empty_routing_key_binding["destination_type"].as_s.should eq "queue"
+        exported_empty_routing_key_binding["routing_key"].as_s.should eq ""
+
+        exported_wal_binding = bindings.find! { |b| b["destination"].as_s == "queue_wal" }
+        exported_wal_binding["destination_type"].as_s.should eq "queue"
+        exported_wal_binding["routing_key"].as_s.should eq ""
+      end
+    end
+  end
+
   describe "with http server" do
     it "should list users" do
       with_http_server do |(http, s)|

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -40,6 +40,9 @@ class SpyReplicator
   def append_bytes(path : String, bytes : Bytes, offset : Int64)
   end
 
+  def append_bytes(file : File, offset : Int64, length : Int64)
+  end
+
   def delete_file(path : String)
     @deleted_files << path
   end

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -1,5 +1,12 @@
 require "./spec_helper"
 
+class LavinMQ::DefinitionsStore
+  def request_idle_compaction_for_spec
+    @last_definition_change = RoughTime.instant - WAL_COMPACT_IDLE - 1.second
+    @compact_requested.try_send nil
+  end
+end
+
 describe LavinMQ::VHost do
   it "should be able to create vhosts" do
     with_amqp_server do |s|
@@ -50,7 +57,7 @@ describe LavinMQ::VHost do
     end
     # the definitions file. This is to simulate a start after a "crash".
     # If this succeeds we assume it worked...?
-    LavinMQ::Server.new(config)
+    LavinMQ::Server.new(config).close
   end
 
   it "should be able to persist durable queues" do
@@ -72,6 +79,130 @@ describe LavinMQ::VHost do
       s.vhosts["test"].bind_queue("q", "e", "q")
       s.restart
       s.vhosts["test"].exchange("e").bindings_details.first.destination.name.should eq "q"
+    end
+  end
+
+  it "should replay definition wal records after json snapshots" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      v.bind_queue("q", "e", "q")
+
+      File.exists?(File.join(v.data_dir, "exchanges.json")).should be_true
+      File.exists?(File.join(v.data_dir, "queues.json")).should be_true
+      File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
+      File.size(File.join(v.data_dir, "definitions.wal")).should be > 0
+
+      s.restart
+      v = s.vhosts["test"]
+      v.exchange("e").should_not be_nil
+      v.queue("q").should_not be_nil
+      v.exchange("e").bindings_details.first.destination.name.should eq "q"
+    end
+  end
+
+  it "writes compact definition wal records" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      v.bind_queue("q", "e", "q")
+      v.declare_queue("ttl", true, true, arguments: AMQ::Protocol::Table.new({"x-message-ttl" => 123}))
+
+      records = [] of JSON::Any
+      File.each_line(File.join(v.data_dir, "definitions.wal")) do |line|
+        line = line.strip
+        records << JSON.parse(line) unless line.empty?
+      end
+
+      exchange = records.find! { |r| r["op"].as_s == "exchange.declare" && r["name"].as_s == "e" }
+      exchange.as_h.has_key?("durable").should be_false
+      exchange.as_h.has_key?("auto_delete").should be_false
+      exchange.as_h.has_key?("internal").should be_false
+      exchange.as_h.has_key?("arguments").should be_false
+
+      queue = records.find! { |r| r["op"].as_s == "queue.declare" && r["name"].as_s == "q" }
+      queue.as_h.has_key?("durable").should be_false
+      queue.as_h.has_key?("exclusive").should be_false
+      queue.as_h.has_key?("auto_delete").should be_false
+      queue.as_h.has_key?("arguments").should be_false
+
+      binding = records.find! { |r| r["op"].as_s == "queue.bind" && r["queue"].as_s == "q" }
+      binding.as_h.has_key?("arguments").should be_false
+
+      auto_delete_queue = records.find! { |r| r["op"].as_s == "queue.declare" && r["name"].as_s == "ttl" }
+      auto_delete_queue["auto_delete"].as_bool.should be_true
+      auto_delete_queue["arguments"].as_h.has_key?("x-message-ttl").should be_true
+    end
+  end
+
+  it "writes compact definition snapshots" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      v.declare_exchange("plain", "direct", true, false)
+      v.declare_exchange("internal", "direct", true, false, internal: true)
+      v.declare_queue("plain", true, false)
+      v.declare_queue("ttl", true, true, arguments: AMQ::Protocol::Table.new({"x-message-ttl" => 123}))
+      v.bind_queue("plain", "plain", "plain")
+      v.bind_queue("ttl", "internal", "rk", arguments: AMQ::Protocol::Table.new({"x-match" => "any"}))
+
+      definitions = v.@definitions.not_nil!
+      definitions.request_idle_compaction_for_spec
+      wait_for { File.size(File.join(v.data_dir, "definitions.wal")) == 0 }
+
+      exchanges = JSON.parse(File.read(File.join(v.data_dir, "exchanges.json"))).as_a
+      plain_exchange = exchanges.find! { |e| e["name"].as_s == "plain" }
+      plain_exchange.as_h.has_key?("durable").should be_false
+      plain_exchange.as_h.has_key?("auto_delete").should be_false
+      plain_exchange.as_h.has_key?("internal").should be_false
+      plain_exchange.as_h.has_key?("arguments").should be_false
+
+      internal_exchange = exchanges.find! { |e| e["name"].as_s == "internal" }
+      internal_exchange["internal"].as_bool.should be_true
+
+      queues = JSON.parse(File.read(File.join(v.data_dir, "queues.json"))).as_a
+      plain_queue = queues.find! { |q| q["name"].as_s == "plain" }
+      plain_queue.as_h.has_key?("durable").should be_false
+      plain_queue.as_h.has_key?("exclusive").should be_false
+      plain_queue.as_h.has_key?("auto_delete").should be_false
+      plain_queue.as_h.has_key?("arguments").should be_false
+
+      ttl_queue = queues.find! { |q| q["name"].as_s == "ttl" }
+      ttl_queue["auto_delete"].as_bool.should be_true
+      ttl_queue["arguments"].as_h.has_key?("x-message-ttl").should be_true
+
+      bindings = JSON.parse(File.read(File.join(v.data_dir, "bindings.json"))).as_a
+      plain_binding = bindings.find! { |b| b["destination"].as_s == "plain" }
+      plain_binding.as_h.has_key?("arguments").should be_false
+
+      binding_with_args = bindings.find! { |b| b["destination"].as_s == "ttl" }
+      binding_with_args["arguments"].as_h.has_key?("x-match").should be_true
+
+      s.restart
+      v = s.vhosts["test"]
+      v.exchange("plain").durable?.should be_true
+      v.exchange("internal").internal?.should be_true
+      v.queue("plain").durable?.should be_true
+      v.queue("ttl").auto_delete?.should be_true
+      v.queue("ttl").arguments.has_key?("x-message-ttl").should be_true
+      v.exchange("internal").bindings_details.first.destination.name.should eq "ttl"
+    end
+  end
+
+  it "should not restore stale queue bindings after queue delete and recreate" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      v.bind_queue("q", "e", "q")
+      v.delete_queue("q")
+      v.declare_queue("q", true, false)
+
+      s.restart
+      v = s.vhosts["test"]
+      v.queue("q").should_not be_nil
+      v.exchange("e").bindings_details.should be_empty
     end
   end
 
@@ -104,16 +235,19 @@ describe LavinMQ::VHost do
 
   it "should compact definitions during runtime" do
     with_amqp_server do |s|
-      LavinMQ::Config.instance.max_deleted_definitions = 8
       v = s.vhosts.create("test")
-      (LavinMQ::Config.instance.max_deleted_definitions - 1).times do
-        v.declare_queue("q", true, false)
-        v.delete_queue("q")
-      end
-      file_size = v.@definitions.not_nil!.@definitions_file.size
       v.declare_queue("q", true, false)
       v.delete_queue("q")
-      v.@definitions.not_nil!.@definitions_file.size.should be < file_size
+      definitions = v.@definitions.not_nil!
+      file_size = definitions.@definitions_file.size
+
+      definitions.request_idle_compaction_for_spec
+      wait_for { definitions.@definitions_file.size < file_size }
+
+      File.exists?(File.join(v.data_dir, "exchanges.json")).should be_true
+      File.exists?(File.join(v.data_dir, "queues.json")).should be_true
+      File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
+      File.size(File.join(v.data_dir, "definitions.wal")).should eq 0
     end
   end
   describe "auto add permissions" do

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -34,6 +34,17 @@ class LavinMQ::DefinitionsStore
   end
 end
 
+def with_crash_restarted_server(data_dir : String, &)
+  config = LavinMQ::Config.new
+  config.data_dir = data_dir
+  server = LavinMQ::Server.new(config)
+  begin
+    yield server
+  ensure
+    server.close
+  end
+end
+
 describe LavinMQ::VHost do
   it "should be able to create vhosts" do
     with_amqp_server do |s|
@@ -69,7 +80,6 @@ describe LavinMQ::VHost do
   end
 
   it "should be able to persist durable delayed exchanges when type = x-delayed-message" do
-    config = LavinMQ::Config.new
     with_amqp_server do |s|
       # This spec is to verify a fix where a server couldn't start again after a crash if
       # an delayed exchange had been declared by specifiying the type as "x-delayed-message".
@@ -78,13 +88,10 @@ describe LavinMQ::VHost do
       arguments = AMQ::Protocol::Table.new({"x-delayed-type": "direct"})
       v.declare_exchange("e", "x-delayed-message", true, false, arguments: arguments)
 
-      # Start a new server with the same data dir as `Server` without stopping
-      # `Server` first, because stopping would compact definitions and therefore "rewrite"
-      config.data_dir = s.data_dir
+      # Start a second server with the same data dir before closing `s`, because
+      # graceful close compacts definitions and removes the WAL records.
+      with_crash_restarted_server(s.data_dir) { }
     end
-    # the definitions file. This is to simulate a start after a "crash".
-    # If this succeeds we assume it worked...?
-    LavinMQ::Server.new(config).close
   end
 
   it "should be able to persist durable queues" do
@@ -121,11 +128,12 @@ describe LavinMQ::VHost do
       File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
       File.size(File.join(v.data_dir, "definitions.wal")).should be > 0
 
-      s.restart
-      v = s.vhosts["test"]
-      v.exchange("e").should_not be_nil
-      v.queue("q").should_not be_nil
-      v.exchange("e").bindings_details.first.destination.name.should eq "q"
+      with_crash_restarted_server(s.data_dir) do |restarted|
+        v = restarted.vhosts["test"]
+        v.exchange("e").should_not be_nil
+        v.queue("q").should_not be_nil
+        v.exchange("e").bindings_details.first.destination.name.should eq "q"
+      end
     end
   end
 
@@ -142,11 +150,12 @@ describe LavinMQ::VHost do
         f.print %({"op":"queue.declare","name":"tor)
       end
 
-      s.restart
-      v = s.vhosts["test"]
-      v.queue("q").should_not be_nil
-      v.queue?("tor").should be_nil
-      v.exchange("e").bindings_details.first.destination.name.should eq "q"
+      with_crash_restarted_server(s.data_dir) do |restarted|
+        v = restarted.vhosts["test"]
+        v.queue("q").should_not be_nil
+        v.queue?("tor").should be_nil
+        v.exchange("e").bindings_details.first.destination.name.should eq "q"
+      end
     end
   end
 
@@ -296,6 +305,23 @@ describe LavinMQ::VHost do
       File.exists?(File.join(v.data_dir, "queues.json")).should be_true
       File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
       File.size(File.join(v.data_dir, "definitions.wal")).should eq 0
+    end
+  end
+
+  it "compacts definitions on vhost close" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      v.declare_queue("q", true, false)
+      v.delete_queue("q")
+      wal_path = File.join(v.data_dir, "definitions.wal")
+      File.size(wal_path).should be > 0
+
+      v.close
+
+      File.exists?(File.join(v.data_dir, "exchanges.json")).should be_true
+      File.exists?(File.join(v.data_dir, "queues.json")).should be_true
+      File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
+      File.size(wal_path).should eq 0
     end
   end
 

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -45,6 +45,20 @@ def with_crash_restarted_server(data_dir : String, &)
   end
 end
 
+def read_legacy_definition_frames(path : String) : Array(AMQ::Protocol::Frame)
+  frames = [] of AMQ::Protocol::Frame
+  File.open(path) do |io|
+    LavinMQ::SchemaVersion.verify(io, :definition)
+    stream = AMQ::Protocol::Stream.new(io, format: IO::ByteFormat::SystemEndian)
+    loop do
+      frames << stream.next_frame
+    rescue IO::EOFError
+      break
+    end
+  end
+  frames
+end
+
 describe LavinMQ::VHost do
   it "should be able to create vhosts" do
     with_amqp_server do |s|
@@ -300,6 +314,59 @@ describe LavinMQ::VHost do
       v.exchange("internal").bindings_details.first.destination.name.should eq "ttl"
       v.exchange("fanout").bindings_details.find! { |b| b.destination.name == "empty_rk" }.routing_key.should eq ""
       v.exchange("plain").bindings_details.find! { |b| b.destination.name == "destination" }.routing_key.should eq ""
+    end
+  end
+
+  it "keeps appending to an existing legacy definitions file for downgrades" do
+    vhost_dir_name = Digest::SHA1.hexdigest("test")
+    vhost_dir = File.join(LavinMQ::Config.instance.data_dir, vhost_dir_name)
+    Dir.mkdir_p vhost_dir
+    File.open(File.join(LavinMQ::Config.instance.data_dir, "vhosts.json"), "w") do |f|
+      [{"name": "test", "dir": vhost_dir_name}].to_json(f)
+    end
+    legacy_path = File.join(vhost_dir, "definitions.amqp")
+    FileUtils.cp(File.join(__DIR__, "fixtures", "v243_e2e_binding.amqp"), legacy_path)
+    legacy_size = File.size(legacy_path)
+
+    with_amqp_server do |s|
+      v = s.vhosts["test"]
+
+      File.exists?(legacy_path).should be_true
+      v.declare_queue("downgrade-q", true, false)
+      File.size(legacy_path).should be > legacy_size
+      frames = read_legacy_definition_frames(legacy_path)
+      frames.any? do |frame|
+        frame.is_a?(AMQ::Protocol::Frame::Queue::Declare) && frame.queue_name == "downgrade-q"
+      end.should be_true
+
+      v.declare_queue("removed-before-compact", true, false)
+      v.delete_queue("removed-before-compact")
+      definitions = v.@definitions.not_nil!
+      definitions.request_idle_compaction_for_spec
+      wait_for { File.size(File.join(v.data_dir, "definitions.wal")) == 0 }
+      compacted_frames = read_legacy_definition_frames(legacy_path)
+      compacted_frames.any? do |frame|
+        frame.is_a?(AMQ::Protocol::Frame::Queue::Declare) && frame.queue_name == "downgrade-q"
+      end.should be_true
+      compacted_frames.any? do |frame|
+        frame.is_a?(AMQ::Protocol::Frame::Queue::Declare) && frame.queue_name == "removed-before-compact"
+      end.should be_false
+      compacted_frames.any?(AMQ::Protocol::Frame::Queue::Delete).should be_false
+
+      File.delete(legacy_path)
+      v.declare_queue("after-delete", true, false)
+      File.exists?(legacy_path).should be_false
+    end
+  end
+
+  it "does not create a legacy definitions file when none exists" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      legacy_path = File.join(v.data_dir, "definitions.amqp")
+
+      File.exists?(legacy_path).should be_false
+      v.declare_queue("q", true, false)
+      File.exists?(legacy_path).should be_false
     end
   end
 

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -234,7 +234,9 @@ describe LavinMQ::VHost do
       ttl_queue["auto_delete"].as_bool.should be_true
       ttl_queue["arguments"].as_h.has_key?("x-message-ttl").should be_true
 
-      bindings = JSON.parse(File.read(File.join(v.data_dir, "bindings.json"))).as_a
+      bindings_json = File.read(File.join(v.data_dir, "bindings.json"))
+      bindings_json.should contain("\n  {")
+      bindings = JSON.parse(bindings_json).as_a
       plain_binding = bindings.find! { |b| b["destination"].as_s == "plain" }
       plain_binding.as_h.has_key?("destination_type").should be_false
       plain_binding["routing_key"].as_s.should eq "plain"

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -129,6 +129,27 @@ describe LavinMQ::VHost do
     end
   end
 
+  it "tolerates a torn final definition wal record after a crash" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      v.declare_exchange("e", "direct", true, false)
+      v.declare_queue("q", true, false)
+      v.bind_queue("q", "e", "q")
+      File.size(File.join(v.data_dir, "definitions.wal")).should be > 0
+
+      # Simulate a crash that left a half-written final record on disk.
+      File.open(File.join(v.data_dir, "definitions.wal"), "a") do |f|
+        f.print %({"op":"queue.declare","name":"tor)
+      end
+
+      s.restart
+      v = s.vhosts["test"]
+      v.queue("q").should_not be_nil
+      v.queue?("tor").should be_nil
+      v.exchange("e").bindings_details.first.destination.name.should eq "q"
+    end
+  end
+
   it "writes compact definition wal records" do
     with_amqp_server do |s|
       v = s.vhosts.create("test")

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -159,6 +159,39 @@ describe LavinMQ::VHost do
     end
   end
 
+  it "round-trips binary and timestamp argument values losslessly" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      ts = Time.unix(1_700_000_000)
+      bin = Bytes[0_u8, 1_u8, 2_u8, 255_u8]
+      args = AMQ::Protocol::Table.new({
+        "x-bin" => bin,
+        "x-ts"  => ts,
+        "x-int" => 123,
+      } of String => AMQ::Protocol::Field)
+      v.declare_queue("q", true, false, arguments: args)
+
+      # WAL replay path
+      with_crash_restarted_server(s.data_dir) do |restarted|
+        reloaded = restarted.vhosts["test"].queue("q").arguments
+        reloaded["x-bin"].should eq bin
+        reloaded["x-ts"].should eq ts
+        reloaded["x-int"].should eq 123
+      end
+
+      # Snapshot (compaction) path
+      definitions = v.@definitions.not_nil!
+      definitions.request_idle_compaction_for_spec
+      wait_for { File.size(File.join(v.data_dir, "definitions.wal")) == 0 }
+      with_crash_restarted_server(s.data_dir) do |restarted|
+        reloaded = restarted.vhosts["test"].queue("q").arguments
+        reloaded["x-bin"].should eq bin
+        reloaded["x-ts"].should eq ts
+        reloaded["x-int"].should eq 123
+      end
+    end
+  end
+
   it "writes compact definition wal records" do
     with_amqp_server do |s|
       v = s.vhosts.create("test")

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -2,8 +2,35 @@ require "./spec_helper"
 
 class LavinMQ::DefinitionsStore
   def request_idle_compaction_for_spec
-    @last_definition_change = RoughTime.instant - WAL_COMPACT_IDLE - 1.second
+    @definitions_lock.synchronize do
+      @last_definition_change = RoughTime.instant - WAL_COMPACT_IDLE - 1.second
+    end
     @compact_requested.try_send nil
+  end
+
+  def compact_at_scheduled_with_wal_closed_for_spec : String | Exception
+    result = Channel(String | Exception).new(1)
+    @definitions_lock.synchronize do
+      @last_definition_change = RoughTime.instant - WAL_COMPACT_IDLE - 1.second
+      @definitions_file.close
+      begin
+        spawn do
+          begin
+            next_compact_at
+            result.send "ok"
+          rescue ex
+            result.send ex
+          end
+        end
+        100.times { Fiber.yield }
+        if early_result = result.try_receive?
+          return early_result
+        end
+      ensure
+        @definitions_file = File.open(@definitions_file_path, "a+")
+      end
+    end
+    result.receive
   end
 end
 
@@ -250,6 +277,16 @@ describe LavinMQ::VHost do
       File.size(File.join(v.data_dir, "definitions.wal")).should eq 0
     end
   end
+
+  it "snapshots definition WAL compaction scheduling state under the lock" do
+    with_amqp_server do |s|
+      v = s.vhosts.create("test")
+      definitions = v.@definitions.not_nil!
+
+      definitions.compact_at_scheduled_with_wal_closed_for_spec.should eq "ok"
+    end
+  end
+
   describe "auto add permissions" do
     it "should add permission to the user creating the vhost" do
       with_amqp_server do |s|

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -103,7 +103,7 @@ describe LavinMQ::VHost do
       v.declare_exchange("e", "x-delayed-message", true, false, arguments: arguments)
 
       # Start a second server with the same data dir before closing `s`, because
-      # graceful close compacts definitions and removes the WAL records.
+      # graceful close compacts definitions and removes the JSONL records.
       with_crash_restarted_server(s.data_dir) { }
     end
   end
@@ -130,7 +130,7 @@ describe LavinMQ::VHost do
     end
   end
 
-  it "should replay definition wal records after json snapshots" do
+  it "should replay definition JSONL records after json snapshots" do
     with_amqp_server do |s|
       v = s.vhosts.create("test")
       v.declare_exchange("e", "direct", true, false)
@@ -140,7 +140,7 @@ describe LavinMQ::VHost do
       File.exists?(File.join(v.data_dir, "exchanges.json")).should be_true
       File.exists?(File.join(v.data_dir, "queues.json")).should be_true
       File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
-      File.size(File.join(v.data_dir, "definitions.wal")).should be > 0
+      File.size(File.join(v.data_dir, "definitions.jsonl")).should be > 0
 
       with_crash_restarted_server(s.data_dir) do |restarted|
         v = restarted.vhosts["test"]
@@ -151,16 +151,16 @@ describe LavinMQ::VHost do
     end
   end
 
-  it "tolerates a torn final definition wal record after a crash" do
+  it "tolerates a torn final definition JSONL record after a crash" do
     with_amqp_server do |s|
       v = s.vhosts.create("test")
       v.declare_exchange("e", "direct", true, false)
       v.declare_queue("q", true, false)
       v.bind_queue("q", "e", "q")
-      File.size(File.join(v.data_dir, "definitions.wal")).should be > 0
+      File.size(File.join(v.data_dir, "definitions.jsonl")).should be > 0
 
       # Simulate a crash that left a half-written final record on disk.
-      File.open(File.join(v.data_dir, "definitions.wal"), "a") do |f|
+      File.open(File.join(v.data_dir, "definitions.jsonl"), "a") do |f|
         f.print %({"op":"queue.declare","name":"tor)
       end
 
@@ -185,7 +185,7 @@ describe LavinMQ::VHost do
       } of String => AMQ::Protocol::Field)
       v.declare_queue("q", true, false, arguments: args)
 
-      # WAL replay path
+      # JSONL replay path
       with_crash_restarted_server(s.data_dir) do |restarted|
         reloaded = restarted.vhosts["test"].queue("q").arguments
         reloaded["x-bin"].should eq bin
@@ -196,7 +196,7 @@ describe LavinMQ::VHost do
       # Snapshot (compaction) path
       definitions = v.@definitions.not_nil!
       definitions.request_idle_compaction_for_spec
-      wait_for { File.size(File.join(v.data_dir, "definitions.wal")) == 0 }
+      wait_for { File.size(File.join(v.data_dir, "definitions.jsonl")) == 0 }
       with_crash_restarted_server(s.data_dir) do |restarted|
         reloaded = restarted.vhosts["test"].queue("q").arguments
         reloaded["x-bin"].should eq bin
@@ -206,7 +206,7 @@ describe LavinMQ::VHost do
     end
   end
 
-  it "writes compact definition wal records" do
+  it "writes compact definition JSONL records" do
     with_amqp_server do |s|
       v = s.vhosts.create("test")
       v.declare_exchange("e", "direct", true, false)
@@ -215,7 +215,7 @@ describe LavinMQ::VHost do
       v.declare_queue("ttl", true, true, arguments: AMQ::Protocol::Table.new({"x-message-ttl" => 123}))
 
       records = [] of JSON::Any
-      File.each_line(File.join(v.data_dir, "definitions.wal")) do |line|
+      File.each_line(File.join(v.data_dir, "definitions.jsonl")) do |line|
         line = line.strip
         records << JSON.parse(line) unless line.empty?
       end
@@ -258,7 +258,7 @@ describe LavinMQ::VHost do
 
       definitions = v.@definitions.not_nil!
       definitions.request_idle_compaction_for_spec
-      wait_for { File.size(File.join(v.data_dir, "definitions.wal")) == 0 }
+      wait_for { File.size(File.join(v.data_dir, "definitions.jsonl")) == 0 }
 
       exchanges = JSON.parse(File.read(File.join(v.data_dir, "exchanges.json"))).as_a
       plain_exchange = exchanges.find! { |e| e["name"].as_s == "plain" }
@@ -343,7 +343,7 @@ describe LavinMQ::VHost do
       v.delete_queue("removed-before-compact")
       definitions = v.@definitions.not_nil!
       definitions.request_idle_compaction_for_spec
-      wait_for { File.size(File.join(v.data_dir, "definitions.wal")) == 0 }
+      wait_for { File.size(File.join(v.data_dir, "definitions.jsonl")) == 0 }
       compacted_frames = read_legacy_definition_frames(legacy_path)
       compacted_frames.any? do |frame|
         frame.is_a?(AMQ::Protocol::Frame::Queue::Declare) && frame.queue_name == "downgrade-q"
@@ -427,7 +427,7 @@ describe LavinMQ::VHost do
       File.exists?(File.join(v.data_dir, "exchanges.json")).should be_true
       File.exists?(File.join(v.data_dir, "queues.json")).should be_true
       File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
-      File.size(File.join(v.data_dir, "definitions.wal")).should eq 0
+      File.size(File.join(v.data_dir, "definitions.jsonl")).should eq 0
     end
   end
 
@@ -436,19 +436,19 @@ describe LavinMQ::VHost do
       v = s.vhosts.create("test")
       v.declare_queue("q", true, false)
       v.delete_queue("q")
-      wal_path = File.join(v.data_dir, "definitions.wal")
-      File.size(wal_path).should be > 0
+      jsonl_path = File.join(v.data_dir, "definitions.jsonl")
+      File.size(jsonl_path).should be > 0
 
       v.close
 
       File.exists?(File.join(v.data_dir, "exchanges.json")).should be_true
       File.exists?(File.join(v.data_dir, "queues.json")).should be_true
       File.exists?(File.join(v.data_dir, "bindings.json")).should be_true
-      File.size(wal_path).should eq 0
+      File.size(jsonl_path).should eq 0
     end
   end
 
-  it "snapshots definition WAL compaction scheduling state under the lock" do
+  it "snapshots definition log compaction scheduling state under the lock" do
     with_amqp_server do |s|
       v = s.vhosts.create("test")
       definitions = v.@definitions.not_nil!

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -199,10 +199,15 @@ describe LavinMQ::VHost do
       v = s.vhosts.create("test")
       v.declare_exchange("plain", "direct", true, false)
       v.declare_exchange("internal", "direct", true, false, internal: true)
+      v.declare_exchange("fanout", "fanout", true, false)
+      v.declare_exchange("destination", "direct", true, false)
       v.declare_queue("plain", true, false)
       v.declare_queue("ttl", true, true, arguments: AMQ::Protocol::Table.new({"x-message-ttl" => 123}))
+      v.declare_queue("empty_rk", true, false)
       v.bind_queue("plain", "plain", "plain")
       v.bind_queue("ttl", "internal", "rk", arguments: AMQ::Protocol::Table.new({"x-match" => "any"}))
+      v.bind_queue("empty_rk", "fanout", "")
+      v.bind_exchange("destination", "plain", "")
 
       definitions = v.@definitions.not_nil!
       definitions.request_idle_compaction_for_spec
@@ -231,19 +236,35 @@ describe LavinMQ::VHost do
 
       bindings = JSON.parse(File.read(File.join(v.data_dir, "bindings.json"))).as_a
       plain_binding = bindings.find! { |b| b["destination"].as_s == "plain" }
+      plain_binding.as_h.has_key?("destination_type").should be_false
+      plain_binding["routing_key"].as_s.should eq "plain"
       plain_binding.as_h.has_key?("arguments").should be_false
 
+      implicit_binding = bindings.find! { |b| b["destination"].as_s == "empty_rk" }
+      implicit_binding.as_h.has_key?("destination_type").should be_false
+      implicit_binding.as_h.has_key?("routing_key").should be_false
+
+      exchange_binding = bindings.find! { |b| b["destination"].as_s == "destination" }
+      exchange_binding["destination_type"].as_s.should eq "exchange"
+      exchange_binding.as_h.has_key?("routing_key").should be_false
+
       binding_with_args = bindings.find! { |b| b["destination"].as_s == "ttl" }
+      binding_with_args.as_h.has_key?("destination_type").should be_false
+      binding_with_args["routing_key"].as_s.should eq "rk"
       binding_with_args["arguments"].as_h.has_key?("x-match").should be_true
 
       s.restart
       v = s.vhosts["test"]
       v.exchange("plain").durable?.should be_true
       v.exchange("internal").internal?.should be_true
+      v.exchange("destination").durable?.should be_true
       v.queue("plain").durable?.should be_true
       v.queue("ttl").auto_delete?.should be_true
+      v.queue("empty_rk").durable?.should be_true
       v.queue("ttl").arguments.has_key?("x-message-ttl").should be_true
       v.exchange("internal").bindings_details.first.destination.name.should eq "ttl"
+      v.exchange("fanout").bindings_details.find! { |b| b.destination.name == "empty_rk" }.routing_key.should eq ""
+      v.exchange("plain").bindings_details.find! { |b| b.destination.name == "destination" }.routing_key.should eq ""
     end
   end
 

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -311,6 +311,22 @@ module LavinMQ
         end
       end
 
+      def append(path : String, file : File, offset : Int64, length : Int64) : Int64
+        raise ArgumentError.new("append length must not be negative") if length < 0
+        return 0i64 if length.zero?
+
+        @write_lock.synchronize do
+          lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + length).to_i64
+          @sent_bytes.add(lag_size)
+          send_filename(path)
+          @lz4.write_bytes -length, IO::ByteFormat::LittleEndian
+          file.read_at(offset, length) do |io|
+            IO.copy(io, @lz4, length) == length || raise IO::EOFError.new
+          end
+          lag_size
+        end
+      end
+
       def append(path : String, value : UInt32 | Int32) : Int64
         @write_lock.synchronize do
           lag_size = (sizeof(Int32) + path.bytesize + sizeof(Int64) + 4).to_i64

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -15,6 +15,7 @@ module LavinMQ
       # the positional append(path, pos, length) overload.
       abstract def append_value(path : String, value : UInt32 | Int32, offset : Int64)
       abstract def append_bytes(path : String, bytes : Bytes, offset : Int64)
+      abstract def append_bytes(file : File, offset : Int64, length : Int64)
       abstract def delete_file(path : String)
       abstract def followers : Array(Follower)
       abstract def syncing_followers : Array(Follower)

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -165,6 +165,22 @@ module LavinMQ
         end
       end
 
+      # Replicate `length` bytes from a regular File, starting at `offset`.
+      # The file must already be flushed far enough for File#read_at to see
+      # the range. This avoids materializing the appended bytes in memory on
+      # the leader while keeping the same append frame on the wire.
+      def append_bytes(file : File, offset : Int64, length : Int64)
+        raise ArgumentError.new("append_bytes length must not be negative") if length < 0
+        return if length.zero?
+
+        path = strip_datadir file.path
+        @file_index.lock { |_files, checksums| checksums.delete(path) }
+        each_follower do |f|
+          skip = f.already_synced(path, offset, length)
+          f.append(path, file, offset + skip, length - skip) if skip < length
+        end
+      end
+
       def delete_file(path : String)
         path = strip_datadir path
         @file_index.lock do |files, checksums|

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -224,9 +224,6 @@ module LavinMQ
       property load_definitions = "" # path to a JSON definitions file to import on startup
 
       @[IniOpt(section: "main")]
-      property max_deleted_definitions = 8192 # number of deleted queues, unbinds etc that compacts the definitions file
-
-      @[IniOpt(section: "main")]
       property consumer_timeout : UInt64? = nil
 
       @[IniOpt(section: "main")]

--- a/src/lavinmq/definitions_arguments.cr
+++ b/src/lavinmq/definitions_arguments.cr
@@ -1,0 +1,98 @@
+require "json"
+require "base64"
+require "amq-protocol"
+
+module LavinMQ
+  # Type-aware JSON (de)serialization of AMQP argument tables for the
+  # definitions snapshots and WAL.
+  #
+  # JSON represents most AMQP field types natively (bool, number, string,
+  # array, table). The two it can't express are byte arrays and timestamps —
+  # plain `Table#to_json` degrades those to a (base64) string and an ISO-8601
+  # string, so a restart would read them back as `String` and silently change
+  # the argument's type and value. A top-level `Bytes`/`Time` argument value is
+  # therefore written as a tagged object so it round-trips losslessly:
+  #
+  #   {"@type": "bytes",     "value": "<base64>"}
+  #   {"@type": "timestamp", "value": <unix-seconds>}
+  #
+  # All other types stay native JSON. Integer widths collapse to Int64 and
+  # Float32 to Float64, which is harmless: AMQP `Table#==` and the argument
+  # readers compare numbers across widths.
+  #
+  # Caveat: only top-level argument values are tagged. A `Bytes`/`Time` value
+  # nested inside a table- or array-valued argument still degrades to a string
+  # (the library encoding) — those are vanishingly rare, and the recursive
+  # `Field` alias makes a fully recursive reconstruction impractical in Crystal.
+  #
+  # This tagging is internal to persistence only — it must never reach the
+  # untagged `/api/definitions` import reader, which would mistake a tagged
+  # object for a nested table. Reading tolerates the older, untagged on-disk
+  # format an upgrade may leave behind: an untagged base64/ISO string just
+  # stays a string (no worse than before, no crash). A real (non-tagged) table
+  # that happened to have exactly the keys `@type` (= "bytes"/"timestamp") and
+  # `value` would be misread, but AMQP argument tables don't use those keys.
+  module DefinitionsArguments
+    extend self
+
+    alias Field = AMQ::Protocol::Field
+    alias Table = AMQ::Protocol::Table
+
+    def to_json(json : JSON::Builder, table : Table) : Nil
+      json.object do
+        table.each do |key, value|
+          json.field(key) { write_value(json, value) }
+        end
+      end
+    end
+
+    def from_json(value : JSON::Any) : Table
+      hash = value.as_h?
+      return Table.new unless hash
+      fields = Hash(String, Field).new(hash.size)
+      hash.each { |key, val| fields[key] = decode_value(val) }
+      Table.new(fields)
+    end
+
+    private def write_value(json : JSON::Builder, value : Field) : Nil
+      case value
+      when Bytes
+        json.object do
+          json.field "@type", "bytes"
+          json.field "value", Base64.strict_encode(value)
+        end
+      when Time
+        json.object do
+          json.field "@type", "timestamp"
+          json.field "value", value.to_unix
+        end
+      else
+        # Native JSON for scalars; the library's own encoding for nested
+        # tables/arrays (lossy for Bytes/Time nested inside them, see caveat).
+        value.to_json(json)
+      end
+    end
+
+    private def decode_value(value : JSON::Any) : Field
+      if (hash = value.as_h?) && (type = tagged_type?(hash))
+        decode_tagged(type, hash["value"])
+      else
+        value # JSON::Any is itself a Field; the library handles native types
+      end
+    end
+
+    private def tagged_type?(hash : Hash(String, JSON::Any)) : String?
+      return unless hash.size == 2 && hash.has_key?("value")
+      type = hash["@type"]?.try &.as_s?
+      type if type.in?("bytes", "timestamp")
+    end
+
+    private def decode_tagged(type : String, value : JSON::Any) : Field
+      case type
+      when "bytes"     then Base64.decode(value.as_s)
+      when "timestamp" then Time.unix(value.as_i64)
+      else                  raise "Unknown tagged argument type #{type}"
+      end
+    end
+  end
+end

--- a/src/lavinmq/definitions_generator.cr
+++ b/src/lavinmq/definitions_generator.cr
@@ -1,5 +1,6 @@
 require "./version"
 require "../stdlib/slice"
+require "./definitions_arguments"
 require "json"
 require "amq-protocol"
 
@@ -341,9 +342,7 @@ class LavinMQCtl
 
     private def arguments_from_json(entry : JSON::Any) : AMQ::Protocol::Table
       if args = entry["arguments"]?
-        if hash = args.as_h?
-          return AMQ::Protocol::Table.new(hash)
-        end
+        return LavinMQ::DefinitionsArguments.from_json(args)
       end
       AMQ::Protocol::Table.new
     end

--- a/src/lavinmq/definitions_generator.cr
+++ b/src/lavinmq/definitions_generator.cr
@@ -234,9 +234,9 @@ class LavinMQCtl
       load_json_array(File.join(vhost_dir, "bindings.json")) do |entry|
         apply_definition_frame(state, binding_from_json(entry))
       end
-      wal_path = File.join(vhost_dir, "definitions.wal")
-      return unless File.exists?(wal_path)
-      File.each_line(wal_path) do |line|
+      jsonl_path = File.join(vhost_dir, "definitions.jsonl")
+      return unless File.exists?(jsonl_path)
+      File.each_line(jsonl_path) do |line|
         line = line.strip
         next if line.empty?
         begin
@@ -338,7 +338,7 @@ class LavinMQCtl
         Frame::Method::Queue::Unbind.new(0_u16, 0_u16, entry["queue"].as_s, entry["exchange"].as_s,
           entry["routing_key"].as_s, arguments_from_json(entry))
       else
-        raise "Unknown definition WAL operation #{op}"
+        raise "Unknown definition JSONL operation #{op}"
       end
     end
 

--- a/src/lavinmq/definitions_generator.cr
+++ b/src/lavinmq/definitions_generator.cr
@@ -9,6 +9,7 @@ class LavinMQCtl
       {"vhosts.json", "users.json"}.each do |f|
         abort "#{f} not found. Is #{@data_dir} a data directory?" unless File.exists?(File.join(@data_dir, f))
       end
+      @definitions_cache = Hash(String, DefinitionState).new
     end
 
     def generate(io)
@@ -183,80 +184,185 @@ class LavinMQCtl
 
     alias Frame = AMQ::Protocol::Frame
 
+    private class DefinitionState
+      getter queues = Array(Frame::Method::Queue::Declare).new
+      getter exchanges = Array(Frame::Method::Exchange::Declare).new
+      getter queue_bindings = Array(Frame::Method::Queue::Bind).new
+      getter exchange_bindings = Array(Frame::Method::Exchange::Bind).new
+    end
+
     private def queues(vhost_dir)
-      queues = Array(Frame::Method::Queue::Declare).new
-      File.open(File.join(vhost_dir, "definitions.amqp")) do |defs|
-        _schema = defs.read_bytes Int32
-        stream = AMQ::Protocol::Stream.new(defs, format: IO::ByteFormat::SystemEndian)
-        loop do
-          case frame = stream.next_frame
-          when Frame::Method::Queue::Declare
-            queues << frame
-          when Frame::Method::Queue::Delete
-            queues.reject! { |q| q.queue_name == frame.queue_name }
-          end
-        rescue IO::EOFError
-          break
-        end
-      end
-      queues
+      definitions(vhost_dir).queues
     end
 
     private def exchanges(vhost_dir)
-      exchanges = Array(Frame::Method::Exchange::Declare).new
-      File.open(File.join(vhost_dir, "definitions.amqp")) do |defs|
-        _schema = defs.read_bytes Int32
-        stream = AMQ::Protocol::Stream.new(defs, format: IO::ByteFormat::SystemEndian)
-        loop do
-          case frame = stream.next_frame
-          when Frame::Method::Exchange::Declare
-            exchanges << frame
-          when Frame::Method::Exchange::Delete
-            exchanges.reject! { |e| e.exchange_name == frame.exchange_name }
-          end
-        rescue IO::EOFError
-          break
-        end
-      end
-      exchanges
+      definitions(vhost_dir).exchanges
     end
 
     private def queue_bindings(vhost_dir)
-      bindings = Array(Frame::Method::Queue::Bind).new
-      File.open(File.join(vhost_dir, "definitions.amqp")) do |defs|
-        _schema = defs.read_bytes Int32
-        stream = AMQ::Protocol::Stream.new(defs, format: IO::ByteFormat::SystemEndian)
-        loop do
-          case frame = stream.next_frame
-          when Frame::Method::Queue::Bind
-            bindings << frame
-          when Frame::Method::Queue::Unbind
-            bindings.reject! { |b| b.exchange_name == frame.exchange_name && b.queue_name == frame.queue_name && b.routing_key == frame.routing_key && b.arguments == frame.arguments }
-          end
-        rescue IO::EOFError
-          break
-        end
-      end
-      bindings
+      definitions(vhost_dir).queue_bindings
     end
 
     private def exchange_bindings(vhost_dir)
-      bindings = Array(Frame::Method::Exchange::Bind).new
-      File.open(File.join(vhost_dir, "definitions.amqp")) do |defs|
+      definitions(vhost_dir).exchange_bindings
+    end
+
+    private def definitions(vhost_dir)
+      @definitions_cache[vhost_dir] ||= load_definitions(vhost_dir)
+    end
+
+    private def load_definitions(vhost_dir)
+      state = DefinitionState.new
+      if File.exists?(File.join(vhost_dir, "exchanges.json")) ||
+         File.exists?(File.join(vhost_dir, "queues.json")) ||
+         File.exists?(File.join(vhost_dir, "bindings.json"))
+        load_snapshot_definitions(vhost_dir, state)
+      elsif File.exists?(legacy_path = File.join(vhost_dir, "definitions.amqp"))
+        load_legacy_definitions(legacy_path, state)
+      end
+      state
+    end
+
+    private def load_snapshot_definitions(vhost_dir, state)
+      load_json_array(File.join(vhost_dir, "exchanges.json")) do |entry|
+        apply_definition_frame(state, exchange_declare_from_json(entry))
+      end
+      load_json_array(File.join(vhost_dir, "queues.json")) do |entry|
+        apply_definition_frame(state, queue_declare_from_json(entry))
+      end
+      load_json_array(File.join(vhost_dir, "bindings.json")) do |entry|
+        apply_definition_frame(state, binding_from_json(entry))
+      end
+      wal_path = File.join(vhost_dir, "definitions.wal")
+      return unless File.exists?(wal_path)
+      File.each_line(wal_path) do |line|
+        line = line.strip
+        next if line.empty?
+        apply_definition_frame(state, frame_from_wal_record(JSON.parse(line)))
+      end
+    end
+
+    private def load_json_array(path, &)
+      return unless File.exists?(path)
+      File.open(path) { |file| JSON.parse(file).as_a.each { |entry| yield entry } }
+    end
+
+    private def load_legacy_definitions(path, state)
+      File.open(path) do |defs|
         _schema = defs.read_bytes Int32
         stream = AMQ::Protocol::Stream.new(defs, format: IO::ByteFormat::SystemEndian)
         loop do
-          case frame = stream.next_frame
-          when Frame::Method::Exchange::Bind
-            bindings << frame
-          when Frame::Method::Exchange::Unbind
-            bindings.reject! { |b| b.source == frame.source && b.destination == frame.destination && b.routing_key == frame.routing_key && b.arguments == frame.arguments }
-          end
+          apply_definition_frame(state, stream.next_frame)
         rescue IO::EOFError
           break
         end
       end
-      bindings
+    end
+
+    private def apply_definition_frame(state, frame)
+      case frame
+      when Frame::Method::Queue::Declare
+        state.queues.reject! { |q| q.queue_name == frame.queue_name }
+        state.queues << frame
+      when Frame::Method::Queue::Delete
+        state.queues.reject! { |q| q.queue_name == frame.queue_name }
+        state.queue_bindings.reject! { |b| b.queue_name == frame.queue_name }
+      when Frame::Method::Queue::Bind
+        state.queue_bindings << frame unless state.queue_bindings.any? { |b| queue_binding_matches?(b, frame) }
+      when Frame::Method::Queue::Unbind
+        state.queue_bindings.reject! { |b| queue_binding_matches?(b, frame) }
+      when Frame::Method::Exchange::Declare
+        state.exchanges.reject! { |e| e.exchange_name == frame.exchange_name }
+        state.exchanges << frame
+      when Frame::Method::Exchange::Delete
+        state.exchanges.reject! { |e| e.exchange_name == frame.exchange_name }
+        state.exchange_bindings.reject! { |b| b.source == frame.exchange_name || b.destination == frame.exchange_name }
+        state.queue_bindings.reject! { |b| b.exchange_name == frame.exchange_name }
+      when Frame::Method::Exchange::Bind
+        state.exchange_bindings << frame unless state.exchange_bindings.any? { |b| exchange_binding_matches?(b, frame) }
+      when Frame::Method::Exchange::Unbind
+        state.exchange_bindings.reject! { |b| exchange_binding_matches?(b, frame) }
+      end
+    end
+
+    private def exchange_declare_from_json(entry : JSON::Any) : Frame::Method::Exchange::Declare
+      Frame::Method::Exchange::Declare.new(0_u16, 0_u16, entry["name"].as_s, entry["type"].as_s,
+        false, json_bool(entry, "durable", default: true), json_bool(entry, "auto_delete"), json_bool(entry, "internal"),
+        false, arguments_from_json(entry))
+    end
+
+    private def queue_declare_from_json(entry : JSON::Any) : Frame::Method::Queue::Declare
+      Frame::Method::Queue::Declare.new(0_u16, 0_u16, entry["name"].as_s, false,
+        json_bool(entry, "durable", default: true), json_bool(entry, "exclusive"),
+        json_bool(entry, "auto_delete"), false, arguments_from_json(entry))
+    end
+
+    private def binding_from_json(entry : JSON::Any) : Frame::Method
+      args = arguments_from_json(entry)
+      case entry["destination_type"].as_s
+      when "queue"
+        Frame::Method::Queue::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, args)
+      when "exchange"
+        Frame::Method::Exchange::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, args)
+      else
+        raise "Unknown binding destination type #{entry["destination_type"]}"
+      end
+    end
+
+    private def frame_from_wal_record(entry : JSON::Any) : Frame::Method
+      case op = entry["op"].as_s
+      when "exchange.declare" then exchange_declare_from_json(entry)
+      when "exchange.delete"  then Frame::Method::Exchange::Delete.new(0_u16, 0_u16, entry["name"].as_s, false, false)
+      when "exchange.bind"
+        Frame::Method::Exchange::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, arguments_from_json(entry))
+      when "exchange.unbind"
+        Frame::Method::Exchange::Unbind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, arguments_from_json(entry))
+      when "queue.declare" then queue_declare_from_json(entry)
+      when "queue.delete"  then Frame::Method::Queue::Delete.new(0_u16, 0_u16, entry["name"].as_s, false, false, false)
+      when "queue.bind"
+        Frame::Method::Queue::Bind.new(0_u16, 0_u16, entry["queue"].as_s, entry["exchange"].as_s,
+          entry["routing_key"].as_s, false, arguments_from_json(entry))
+      when "queue.unbind"
+        Frame::Method::Queue::Unbind.new(0_u16, 0_u16, entry["queue"].as_s, entry["exchange"].as_s,
+          entry["routing_key"].as_s, arguments_from_json(entry))
+      else
+        raise "Unknown definition WAL operation #{op}"
+      end
+    end
+
+    private def arguments_from_json(entry : JSON::Any) : AMQ::Protocol::Table
+      if args = entry["arguments"]?
+        if hash = args.as_h?
+          return AMQ::Protocol::Table.new(hash)
+        end
+      end
+      AMQ::Protocol::Table.new
+    end
+
+    private def json_bool(entry : JSON::Any, field : String, default = false) : Bool
+      if value = entry[field]?
+        value.as_bool
+      else
+        default
+      end
+    end
+
+    private def queue_binding_matches?(a : Frame::Method::Queue::Bind, b : Frame::Method::Queue::Bind | Frame::Method::Queue::Unbind) : Bool
+      a.queue_name == b.queue_name &&
+        a.exchange_name == b.exchange_name &&
+        a.routing_key == b.routing_key &&
+        a.arguments == b.arguments
+    end
+
+    private def exchange_binding_matches?(a : Frame::Method::Exchange::Bind, b : Frame::Method::Exchange::Bind | Frame::Method::Exchange::Unbind) : Bool
+      a.destination == b.destination &&
+        a.source == b.source &&
+        a.routing_key == b.routing_key &&
+        a.arguments == b.arguments
     end
   end
 end

--- a/src/lavinmq/definitions_generator.cr
+++ b/src/lavinmq/definitions_generator.cr
@@ -305,15 +305,17 @@ class LavinMQCtl
 
     private def binding_from_json(entry : JSON::Any) : Frame::Method
       args = arguments_from_json(entry)
-      case entry["destination_type"].as_s
+      destination_type = entry["destination_type"]?.try(&.as_s) || "queue"
+      routing_key = entry["routing_key"]?.try(&.as_s) || ""
+      case destination_type
       when "queue"
         Frame::Method::Queue::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
-          entry["routing_key"].as_s, false, args)
+          routing_key, false, args)
       when "exchange"
         Frame::Method::Exchange::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
-          entry["routing_key"].as_s, false, args)
+          routing_key, false, args)
       else
-        raise "Unknown binding destination type #{entry["destination_type"]}"
+        raise "Unknown binding destination type #{destination_type}"
       end
     end
 

--- a/src/lavinmq/definitions_generator.cr
+++ b/src/lavinmq/definitions_generator.cr
@@ -238,7 +238,12 @@ class LavinMQCtl
       File.each_line(wal_path) do |line|
         line = line.strip
         next if line.empty?
-        apply_definition_frame(state, frame_from_wal_record(JSON.parse(line)))
+        begin
+          frame = frame_from_wal_record(JSON.parse(line))
+        rescue JSON::ParseException | TypeCastError | KeyError
+          next # tolerate a torn final record / corrupt line, like the live store
+        end
+        apply_definition_frame(state, frame)
       end
     end
 

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -34,11 +34,9 @@ module LavinMQ
       @dirty_bindings = false
       @last_definition_change = RoughTime.instant
       @compact_requested = Channel(Nil).new(1)
-      @compact_loop_done = Channel(Nil).new
-      spawn name: "DefinitionsStore#compact_loop #{@vhost.name}" do
+      @compact_loop = WaitGroup.new
+      @compact_loop.spawn name: "DefinitionsStore#compact_loop #{@vhost.name}" do
         compact_loop
-      ensure
-        @compact_loop_done.close
       end
     end
 
@@ -236,7 +234,7 @@ module LavinMQ
       return if @closed.swap(true)
 
       @compact_requested.close
-      @compact_loop_done.receive?
+      @compact_loop.wait
       # Take the lock so the close can't race a writer still inside
       # store_definition/fsync (use-after-close on the fd).
       @definitions_lock.synchronize do

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./logger"
+require "./definitions_arguments"
 require "./schema"
 require "./event_type"
 require "./queue_factory"
@@ -409,9 +410,7 @@ module LavinMQ
 
     private def arguments_from_json(entry : JSON::Any) : AMQP::Table
       if args = entry["arguments"]?
-        if hash = args.as_h?
-          return AMQP::Table.new(hash)
-        end
+        return DefinitionsArguments.from_json(args)
       end
       AMQP::Table.new
     end
@@ -599,7 +598,7 @@ module LavinMQ
       return if arguments.nil?
       return if arguments.empty?
 
-      json.field("arguments") { arguments.to_json(json) }
+      json.field("arguments") { DefinitionsArguments.to_json(json, arguments) }
     end
 
     private def write_json_snapshot(path : String, &)

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -605,7 +605,7 @@ module LavinMQ
     private def write_json_snapshot(path : String, &)
       tmpfile = "#{path}.tmp"
       File.open(tmpfile, "w") do |file|
-        JSON.build(file) { |json| yield json }
+        JSON.build(file, indent: "  ") { |json| yield json }
         file.fsync
       end
       File.rename tmpfile, path

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -370,15 +370,17 @@ module LavinMQ
 
     private def binding_from_json(entry : JSON::Any) : AMQP::Frame
       args = arguments_from_json(entry)
-      case entry["destination_type"].as_s
+      destination_type = entry["destination_type"]?.try(&.as_s) || "queue"
+      routing_key = entry["routing_key"]?.try(&.as_s) || ""
+      case destination_type
       when "queue"
         AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
-          entry["routing_key"].as_s, false, args)
+          routing_key, false, args)
       when "exchange"
         AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
-          entry["routing_key"].as_s, false, args)
+          routing_key, false, args)
       else
-        raise "Unknown binding destination type #{entry["destination_type"]} in vhost #{@vhost.name}"
+        raise "Unknown binding destination type #{destination_type} in vhost #{@vhost.name}"
       end
     end
 
@@ -568,8 +570,8 @@ module LavinMQ
               json.object do
                 json.field "source", exchange.name
                 json.field "destination", binding.destination.name
-                json.field "destination_type", destination_type
-                json.field "routing_key", binding.routing_key
+                json.field "destination_type", destination_type unless destination_type == "queue"
+                json.field "routing_key", binding.routing_key unless binding.routing_key.empty?
                 write_arguments(json, binding.arguments)
               end
             end

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -704,7 +704,7 @@ module LavinMQ
       loop do
         select
         when @compact_requested.receive
-          compact_at = @last_definition_change + compact_delay
+          compact_at = next_compact_at
         when timeout compact_timeout(compact_at)
           if compact_at
             @definitions_lock.synchronize { compact_locked }
@@ -715,8 +715,14 @@ module LavinMQ
     rescue Channel::ClosedError
     end
 
-    private def compact_delay : Time::Span
-      size = @definitions_file.size
+    private def next_compact_at : Time::Instant
+      last_definition_change, definitions_file_size = @definitions_lock.synchronize do
+        {@last_definition_change, @definitions_file.size}
+      end
+      last_definition_change + compact_delay(definitions_file_size)
+    end
+
+    private def compact_delay(size : Int) : Time::Span
       return Time::Span.zero if size >= WAL_COMPACT_SIZE
 
       delay = WAL_COMPACT_IDLE * (size.to_f64 / WAL_COMPACT_SIZE)

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -239,7 +239,10 @@ module LavinMQ
       @compact_loop_done.receive?
       # Take the lock so the close can't race a writer still inside
       # store_definition/fsync (use-after-close on the fd).
-      @definitions_lock.synchronize { @definitions_file.close }
+      @definitions_lock.synchronize do
+        compact_locked(all: true) unless @definitions_file.size.zero?
+        @definitions_file.close
+      end
     end
 
     private def delete_legacy_definitions

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -1,30 +1,45 @@
+require "json"
 require "./logger"
 require "./schema"
 require "./event_type"
 require "./queue_factory"
+require "./rough_time"
 require "./amqp/exchange/*"
 require "./amqp/queue"
 
 module LavinMQ
   class DefinitionsStore
-    Log = LavinMQ::Log.for "definitions_store"
+    Log              = LavinMQ::Log.for "definitions_store"
+    WAL_COMPACT_IDLE = 30.seconds
+    WAL_COMPACT_SIZE = 8_i64 * 1024 * 1024
 
     @definitions_file : File
+    @closed = Atomic(Bool).new(false)
 
     def initialize(@vhost : VHost, @data_dir : String, @replicator : Clustering::Replicator?, @log : Logger)
       @exchanges = Hash(String, Exchange).new
       @queues = Hash(String, Queue).new
       @definitions_lock = Mutex.new(:reentrant)
-      @definitions_file_path = File.join(@data_dir, "definitions.amqp")
-      # Unbuffered (sync) writes: replication offsets (store_definition) and a
-      # joining follower's cut + full_sync (Clustering::Server#snapshot_sizes,
-      # #files_with_hash) read this file's size and content through separate
-      # fds, so a frame must never sit in a user-space write buffer where they
-      # can't see it — a follower joining in that window would be marked
-      # synced while permanently missing the frame.
-      @definitions_file = File.open(@definitions_file_path, "a+").tap &.sync = true
+      @legacy_definitions_file_path = File.join(@data_dir, "definitions.amqp")
+      @definitions_file_path = File.join(@data_dir, "definitions.wal")
+      @exchanges_file_path = File.join(@data_dir, "exchanges.json")
+      @queues_file_path = File.join(@data_dir, "queues.json")
+      @bindings_file_path = File.join(@data_dir, "bindings.json")
+      # Buffered writes are flushed before replication so the WAL record is
+      # visible through separate fds used by follower full sync.
+      @definitions_file = File.open(@definitions_file_path, "a+")
       @replicator.try &.register_file(@definitions_file)
-      @definitions_deletes = 0
+      @dirty_exchanges = false
+      @dirty_queues = false
+      @dirty_bindings = false
+      @last_definition_change = RoughTime.instant
+      @compact_requested = Channel(Nil).new(1)
+      @compact_loop_done = Channel(Nil).new
+      spawn name: "DefinitionsStore#compact_loop #{@vhost.name}" do
+        compact_loop
+      ensure
+        @compact_loop_done.close
+      end
     end
 
     # Flush buffered definition writes to disk. Used after a bulk operation
@@ -33,6 +48,7 @@ module LavinMQ
     # the per-frame path does.
     def fsync
       @definitions_lock.synchronize do
+        @definitions_file.flush
         @definitions_file.fsync
         @replicator.try &.wait_for_followers
       end
@@ -140,7 +156,7 @@ module LavinMQ
               end
             end
             x.delete
-            store_definition(f, dirty: true) if !loading && x.durable?
+            store_definition(f) if !loading && x.durable?
           else
             return false
           end
@@ -153,7 +169,7 @@ module LavinMQ
           src = @exchanges[f.source]? || return false
           dst = @exchanges[f.destination]? || return false
           return false unless src.unbind(dst, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && src.durable? && dst.durable?
+          store_definition(f) if !loading && src.durable? && dst.durable?
         when AMQP::Frame::Queue::Declare
           return false if @queues.has_key? f.queue_name
           q = @queues[f.queue_name] = QueueFactory.make(@vhost, f)
@@ -170,7 +186,7 @@ module LavinMQ
                 end
               end
             end
-            store_definition(f, dirty: true) if !loading && q.durable? && !q.exclusive?
+            store_definition(f) if !loading && q.durable? && !q.exclusive?
             @vhost.event_tick(EventType::QueueDeleted) unless loading
             q.delete
           else
@@ -185,7 +201,7 @@ module LavinMQ
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || return false
           return false unless x.unbind(q, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
+          store_definition(f) if !loading && x.durable? && q.durable? && !q.exclusive?
         else raise "Cannot apply frame #{f.class} in vhost #{@vhost.name}"
         end
         true
@@ -200,82 +216,252 @@ module LavinMQ
       [default_binding] + bindings
     end
 
-    # ameba:disable Metrics/CyclomaticComplexity
     def load!
+      @definitions_lock.synchronize do
+        if snapshot_definitions?
+          load_snapshot_definitions
+        elsif legacy_definitions?
+          load_legacy_definitions
+          compact_locked(all: true)
+        else
+          load_default_definitions
+          compact_locked(all: true)
+        end
+      end
+      request_compaction
+    end
+
+    def close : Nil
+      return if @closed.swap(true)
+
+      @compact_requested.close
+      @compact_loop_done.receive?
+      @definitions_file.close
+    end
+
+    private def snapshot_definitions? : Bool
+      File.exists?(@exchanges_file_path) ||
+        File.exists?(@queues_file_path) ||
+        File.exists?(@bindings_file_path)
+    end
+
+    private def legacy_definitions? : Bool
+      File.exists?(@legacy_definitions_file_path) && File.size(@legacy_definitions_file_path) > 0
+    end
+
+    private def wal_dirty? : Bool
+      @dirty_exchanges || @dirty_queues || @dirty_bindings
+    end
+
+    private def load_snapshot_definitions
       exchanges = Hash(String, AMQP::Frame::Exchange::Declare).new
       queues = Hash(String, AMQP::Frame::Queue::Declare).new
       queue_bindings = Hash(String, Array(AMQP::Frame::Queue::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Queue::Bind).new }
       exchange_bindings = Hash(String, Array(AMQP::Frame::Exchange::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Exchange::Bind).new }
-      should_compact = false
-      io = @definitions_file
-      if io.size.zero?
-        load_default_definitions
-        compact!
-        return
-      end
 
-      @log.info { "Loading definitions" }
-      @definitions_lock.synchronize do
-        @log.debug { "Verifying schema" }
+      @log.info { "Loading definition snapshots" }
+      if File.exists?(@exchanges_file_path)
+        load_json_array(@exchanges_file_path) { |entry| exchanges[entry["name"].as_s] = exchange_declare_from_json(entry) }
+      else
+        default_exchange_frames.each { |frame| exchanges[frame.exchange_name] = frame }
+      end
+      load_json_array(@queues_file_path) { |entry| queues[entry["name"].as_s] = queue_declare_from_json(entry) } if File.exists?(@queues_file_path)
+      load_json_array(@bindings_file_path) { |entry| add_binding_to_maps(binding_from_json(entry), queue_bindings, exchange_bindings) } if File.exists?(@bindings_file_path)
+      replay_wal(exchanges, queues, queue_bindings, exchange_bindings)
+      apply_definition_maps(exchanges, queues, queue_bindings, exchange_bindings)
+    end
+
+    private def load_legacy_definitions
+      exchanges = Hash(String, AMQP::Frame::Exchange::Declare).new
+      queues = Hash(String, AMQP::Frame::Queue::Declare).new
+      queue_bindings = Hash(String, Array(AMQP::Frame::Queue::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Queue::Bind).new }
+      exchange_bindings = Hash(String, Array(AMQP::Frame::Exchange::Bind)).new { |h, k| h[k] = Array(AMQP::Frame::Exchange::Bind).new }
+
+      @log.info { "Loading legacy definitions" }
+      File.open(@legacy_definitions_file_path) do |io|
         SchemaVersion.verify(io, :definition)
         stream = AMQ::Protocol::Stream.new(io, format: IO::ByteFormat::SystemEndian)
         loop do
-          f = stream.next_frame
-          @log.trace { "Reading frame #{f.inspect}" }
-          case f
-          when AMQP::Frame::Exchange::Declare
-            exchanges[f.exchange_name] = f
-          when AMQP::Frame::Exchange::Delete
-            exchanges.delete f.exchange_name
-            exchange_bindings.delete f.exchange_name
-            should_compact = true
-          when AMQP::Frame::Exchange::Bind
-            exchange_bindings[f.destination] << f
-          when AMQP::Frame::Exchange::Unbind
-            exchange_bindings[f.destination].reject! do |b|
-              b.source == f.source &&
-                b.routing_key == f.routing_key &&
-                b.arguments == f.arguments
-            end
-            should_compact = true
-          when AMQP::Frame::Queue::Declare
-            queues[f.queue_name] = f
-          when AMQP::Frame::Queue::Delete
-            queues.delete f.queue_name
-            queue_bindings.delete f.queue_name
-            should_compact = true
-          when AMQP::Frame::Queue::Bind
-            queue_bindings[f.queue_name] << f
-          when AMQP::Frame::Queue::Unbind
-            queue_bindings[f.queue_name].reject! do |b|
-              b.exchange_name == f.exchange_name &&
-                b.routing_key == f.routing_key &&
-                b.arguments == f.arguments
-            end
-            should_compact = true
-          else
-            raise "Cannot apply frame #{f.class} in vhost #{@vhost.name}"
-          end
+          frame = stream.next_frame
+          @log.trace { "Reading legacy frame #{frame.inspect}" }
+          apply_to_definition_maps(frame, exchanges, queues, queue_bindings, exchange_bindings)
         rescue ex : IO::EOFError
           break
         end
       end
-
-      @log.info { "Applying #{exchanges.size} exchanges" }
-      exchanges.each_value &->self.load_apply(AMQP::Frame)
-      @log.info { "Applying #{queues.size} queues" }
-      queues.each_value &->self.load_apply(AMQP::Frame)
-      @log.info { "Applying #{exchange_bindings.each_value.sum(0, &.size)} exchange bindings" }
-      exchange_bindings.each_value &.each(&->self.load_apply(AMQP::Frame))
-      @log.info { "Applying #{queue_bindings.each_value.sum(0, &.size)} queue bindings" }
-      queue_bindings.each_value &.each(&->self.load_apply(AMQP::Frame))
-
-      @log.info { "Definitions loaded" }
-      compact! if should_compact
+      apply_definition_maps(exchanges, queues, queue_bindings, exchange_bindings)
     end
 
-    def close : Nil
-      @definitions_file.close
+    private def replay_wal(exchanges, queues, queue_bindings, exchange_bindings)
+      return if @definitions_file.size.zero?
+
+      @log.info { "Replaying definition WAL" }
+      @definitions_file.rewind
+      @definitions_file.each_line do |line|
+        line = line.strip
+        next if line.empty?
+        frame = frame_from_wal_record(JSON.parse(line))
+        apply_to_definition_maps(frame, exchanges, queues, queue_bindings, exchange_bindings)
+        mark_snapshot_dirty(frame)
+      end
+      @definitions_file.seek(0, IO::Seek::End)
+    end
+
+    private def apply_definition_maps(exchanges, queues, queue_bindings, exchange_bindings)
+      @log.info { "Applying #{exchanges.size} exchanges" }
+      exchanges.each_value { |frame| load_apply(frame) }
+      @log.info { "Applying #{queues.size} queues" }
+      queues.each_value { |frame| load_apply(frame) }
+      @log.info { "Applying #{exchange_bindings.each_value.sum(0, &.size)} exchange bindings" }
+      exchange_bindings.each_value { |frames| frames.each { |frame| load_apply(frame) } }
+      @log.info { "Applying #{queue_bindings.each_value.sum(0, &.size)} queue bindings" }
+      queue_bindings.each_value { |frames| frames.each { |frame| load_apply(frame) } }
+      @log.info { "Definitions loaded" }
+    end
+
+    private def load_json_array(path : String, &)
+      File.open(path) do |file|
+        JSON.parse(file).as_a.each { |entry| yield entry }
+        @replicator.try &.register_file(file)
+      end
+    end
+
+    private def default_exchange_frames
+      [
+        AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, "", "direct", false, true, false, false, false, AMQP::Table.new),
+        AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, "amq.direct", "direct", false, true, false, false, false, AMQP::Table.new),
+        AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, "amq.fanout", "fanout", false, true, false, false, false, AMQP::Table.new),
+        AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, "amq.topic", "topic", false, true, false, false, false, AMQP::Table.new),
+        AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, "amq.headers", "headers", false, true, false, false, false, AMQP::Table.new),
+        AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, "amq.match", "headers", false, true, false, false, false, AMQP::Table.new),
+      ]
+    end
+
+    private def exchange_declare_from_json(entry : JSON::Any) : AMQP::Frame::Exchange::Declare
+      AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, entry["name"].as_s, entry["type"].as_s,
+        false, json_bool(entry, "durable", default: true), json_bool(entry, "auto_delete"), json_bool(entry, "internal"),
+        false, arguments_from_json(entry))
+    end
+
+    private def queue_declare_from_json(entry : JSON::Any) : AMQP::Frame::Queue::Declare
+      AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, entry["name"].as_s, false,
+        json_bool(entry, "durable", default: true), json_bool(entry, "exclusive"),
+        json_bool(entry, "auto_delete"), false, arguments_from_json(entry))
+    end
+
+    private def binding_from_json(entry : JSON::Any) : AMQP::Frame
+      args = arguments_from_json(entry)
+      case entry["destination_type"].as_s
+      when "queue"
+        AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, args)
+      when "exchange"
+        AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, args)
+      else
+        raise "Unknown binding destination type #{entry["destination_type"]} in vhost #{@vhost.name}"
+      end
+    end
+
+    private def frame_from_wal_record(entry : JSON::Any) : AMQP::Frame
+      case op = entry["op"].as_s
+      when "exchange.declare" then exchange_declare_from_json(entry)
+      when "exchange.delete"  then AMQP::Frame::Exchange::Delete.new(0_u16, 0_u16, entry["name"].as_s, false, false)
+      when "exchange.bind"
+        AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, arguments_from_json(entry))
+      when "exchange.unbind"
+        AMQP::Frame::Exchange::Unbind.new(0_u16, 0_u16, entry["destination"].as_s, entry["source"].as_s,
+          entry["routing_key"].as_s, false, arguments_from_json(entry))
+      when "queue.declare" then queue_declare_from_json(entry)
+      when "queue.delete"  then AMQP::Frame::Queue::Delete.new(0_u16, 0_u16, entry["name"].as_s, false, false, false)
+      when "queue.bind"
+        AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, entry["queue"].as_s, entry["exchange"].as_s,
+          entry["routing_key"].as_s, false, arguments_from_json(entry))
+      when "queue.unbind"
+        AMQP::Frame::Queue::Unbind.new(0_u16, 0_u16, entry["queue"].as_s, entry["exchange"].as_s,
+          entry["routing_key"].as_s, arguments_from_json(entry))
+      else
+        raise "Unknown definition WAL operation #{op} in vhost #{@vhost.name}"
+      end
+    end
+
+    private def arguments_from_json(entry : JSON::Any) : AMQP::Table
+      if args = entry["arguments"]?
+        if hash = args.as_h?
+          return AMQP::Table.new(hash)
+        end
+      end
+      AMQP::Table.new
+    end
+
+    private def json_bool(entry : JSON::Any, field : String, default = false) : Bool
+      if value = entry[field]?
+        value.as_bool
+      else
+        default
+      end
+    end
+
+    private def apply_to_definition_maps(frame, exchanges, queues, queue_bindings, exchange_bindings)
+      case frame
+      when AMQP::Frame::Exchange::Declare
+        exchanges[frame.exchange_name] = frame
+      when AMQP::Frame::Exchange::Delete
+        exchanges.delete frame.exchange_name
+        remove_exchange_bindings(frame.exchange_name, queue_bindings, exchange_bindings)
+      when AMQP::Frame::Exchange::Bind
+        add_binding_to_maps(frame, queue_bindings, exchange_bindings)
+      when AMQP::Frame::Exchange::Unbind
+        exchange_bindings[frame.destination].reject! { |b| exchange_binding_matches?(b, frame) }
+      when AMQP::Frame::Queue::Declare
+        queues[frame.queue_name] = frame
+      when AMQP::Frame::Queue::Delete
+        queues.delete frame.queue_name
+        queue_bindings.delete frame.queue_name
+      when AMQP::Frame::Queue::Bind
+        add_binding_to_maps(frame, queue_bindings, exchange_bindings)
+      when AMQP::Frame::Queue::Unbind
+        queue_bindings[frame.queue_name].reject! { |b| queue_binding_matches?(b, frame) }
+      else
+        raise "Cannot load frame #{frame.class} in vhost #{@vhost.name}"
+      end
+    end
+
+    private def add_binding_to_maps(frame : AMQP::Frame::Queue::Bind, queue_bindings, _exchange_bindings)
+      bindings = queue_bindings[frame.queue_name]
+      bindings << frame unless bindings.any? { |b| queue_binding_matches?(b, frame) }
+    end
+
+    private def add_binding_to_maps(frame : AMQP::Frame::Exchange::Bind, _queue_bindings, exchange_bindings)
+      bindings = exchange_bindings[frame.destination]
+      bindings << frame unless bindings.any? { |b| exchange_binding_matches?(b, frame) }
+    end
+
+    private def add_binding_to_maps(frame, queue_bindings, exchange_bindings)
+      case frame
+      when AMQP::Frame::Queue::Bind    then add_binding_to_maps(frame, queue_bindings, exchange_bindings)
+      when AMQP::Frame::Exchange::Bind then add_binding_to_maps(frame, queue_bindings, exchange_bindings)
+      else                                  raise "Cannot add frame #{frame.class} as a binding in vhost #{@vhost.name}"
+      end
+    end
+
+    private def queue_binding_matches?(a : AMQP::Frame::Queue::Bind, b : AMQP::Frame::Queue::Bind | AMQP::Frame::Queue::Unbind) : Bool
+      a.exchange_name == b.exchange_name &&
+        a.routing_key == b.routing_key &&
+        a.arguments == b.arguments
+    end
+
+    private def exchange_binding_matches?(a : AMQP::Frame::Exchange::Bind, b : AMQP::Frame::Exchange::Bind | AMQP::Frame::Exchange::Unbind) : Bool
+      a.source == b.source &&
+        a.routing_key == b.routing_key &&
+        a.arguments == b.arguments
+    end
+
+    private def remove_exchange_bindings(name : String, queue_bindings, exchange_bindings)
+      exchange_bindings.delete name
+      exchange_bindings.each_value &.reject! { |b| b.source == name }
+      queue_bindings.each_value &.reject! { |b| b.exchange_name == name }
     end
 
     protected def load_apply(frame : AMQP::Frame)
@@ -294,61 +480,125 @@ module LavinMQ
       @exchanges["amq.match"] = AMQP::HeadersExchange.new(@vhost, "amq.match", true, false, false)
     end
 
-    private def compact!
-      @definitions_lock.synchronize do
-        @log.info { "Compacting definitions" }
-        # sync = true for the same reason as in #initialize: this file becomes
-        # @definitions_file after the rename.
-        io = File.open("#{@definitions_file_path}.tmp", "a+").tap &.sync = true
-        SchemaVersion.prefix(io, :definition)
-        @exchanges.each_value.select(&.durable?).each do |e|
-          f = AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, e.name, e.type,
-            false, e.durable?, e.auto_delete?, e.internal?,
-            false, e.arguments)
-          io.write_bytes f
-        end
-        @queues.each_value.select(&.durable?).each do |q|
-          f = AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, q.name, false, q.durable?, q.exclusive?,
-            q.auto_delete?, false, q.arguments)
-          io.write_bytes f
-        end
-        @exchanges.each_value.select(&.durable?).each do |e|
-          e.bindings_details.each do |binding|
-            args = binding.arguments || AMQP::Table.new
-            frame = case binding.destination
-                    when Queue
-                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
-                    when Exchange
-                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
-                    end
-            if f = frame
-              io.write_bytes f
+    private def compact_locked(all = false)
+      return unless all || wal_dirty?
+
+      @log.info { "Compacting definitions" }
+      write_exchanges_snapshot if all || @dirty_exchanges
+      write_queues_snapshot if all || @dirty_queues
+      write_bindings_snapshot if all || @dirty_bindings
+      clear_wal
+      @dirty_exchanges = false
+      @dirty_queues = false
+      @dirty_bindings = false
+    end
+
+    private def write_exchanges_snapshot
+      write_json_snapshot(@exchanges_file_path) do |json|
+        json.array do
+          @exchanges.each_value.select(&.durable?).each do |exchange|
+            json.object do
+              json.field "name", exchange.name
+              json.field "type", exchange.type
+              write_true(json, "auto_delete", exchange.auto_delete?)
+              write_true(json, "internal", exchange.internal?)
+              write_arguments(json, exchange.arguments)
             end
           end
         end
-        io.fsync
-        File.rename io.path, @definitions_file_path
-        @replicator.try &.replace_file @definitions_file_path
-        @definitions_file.close
-        @definitions_file = io
       end
     end
 
-    private def store_definition(frame, dirty = false, fsync = true)
+    private def write_queues_snapshot
+      write_json_snapshot(@queues_file_path) do |json|
+        json.array do
+          @queues.each_value.each do |queue|
+            next if !queue.durable? || queue.exclusive?
+            json.object do
+              json.field "name", queue.name
+              write_true(json, "exclusive", queue.exclusive?)
+              write_true(json, "auto_delete", queue.auto_delete?)
+              write_arguments(json, queue.arguments)
+            end
+          end
+        end
+      end
+    end
+
+    private def write_bindings_snapshot
+      write_json_snapshot(@bindings_file_path) do |json|
+        json.array do
+          @exchanges.each_value.each do |exchange|
+            next unless exchange.durable?
+            exchange.bindings_details.each do |binding|
+              destination_type = persisted_destination_type?(binding.destination) || next
+              json.object do
+                json.field "source", exchange.name
+                json.field "destination", binding.destination.name
+                json.field "destination_type", destination_type
+                json.field "routing_key", binding.routing_key
+                write_arguments(json, binding.arguments)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    private def persisted_destination_type?(destination : Destination) : String?
+      case destination
+      when Queue
+        return if !destination.durable? || destination.exclusive?
+        "queue"
+      when Exchange
+        return unless destination.durable?
+        "exchange"
+      end
+    end
+
+    private def write_true(json : JSON::Builder, field : String, value : Bool) : Nil
+      json.field(field, true) if value
+    end
+
+    private def write_arguments(json : JSON::Builder, arguments : AMQP::Table?) : Nil
+      return if arguments.nil?
+      return if arguments.empty?
+
+      json.field("arguments") { arguments.to_json(json) }
+    end
+
+    private def write_json_snapshot(path : String, &)
+      tmpfile = "#{path}.tmp"
+      File.open(tmpfile, "w") do |file|
+        JSON.build(file) { |json| yield json }
+        file.fsync
+      end
+      File.rename tmpfile, path
+      @replicator.try &.replace_file path
+    end
+
+    private def clear_wal
+      @definitions_file.close
+      tmpfile = "#{@definitions_file_path}.tmp"
+      File.open(tmpfile, "w", &.fsync)
+      File.rename tmpfile, @definitions_file_path
+      @replicator.try &.delete_file @definitions_file_path
+      @definitions_file = File.open(@definitions_file_path, "a+")
+    end
+
+    private def store_definition(frame, fsync = true)
       @log.debug { "Storing definition: #{frame.inspect}" }
-      bytes = frame.to_slice
+      record = definition_record(frame)
+      bytes = record.to_slice
       offset = @definitions_file.size.to_i64
-      # The write goes straight to the file (sync = true), so by dispatch time
-      # the frame is readable at `offset` through any fd: a follower joining
-      # between write and dispatch gets it via its full_sync cut, and
-      # already_synced then skips (or tail-slices) this append against the
-      # baseline instead of duplicating it.
       @definitions_file.write bytes
+      @definitions_file.flush
+      @definitions_file.fsync if fsync
+      @replicator.try &.register_file(@definitions_file) if offset.zero?
       @replicator.try &.append_bytes @definitions_file_path, bytes, offset
+      @last_definition_change = RoughTime.instant
+      mark_snapshot_dirty(frame)
       if fsync
-        @definitions_file.fsync
         # The caller acknowledges the change to the client right after this
         # returns (Declare-Ok etc.), so like a publish confirm it must be
         # durable on every in-sync follower first — otherwise a leader crash
@@ -357,12 +607,127 @@ module LavinMQ
         # removal committed before this returns.
         @replicator.try &.wait_for_followers
       end
-      if dirty
-        if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions
-          compact!
-          @definitions_deletes = 0
+      if @definitions_file.size >= WAL_COMPACT_SIZE
+        compact_locked
+      else
+        request_compaction
+      end
+    end
+
+    private def definition_record(frame) : String
+      String.build do |io|
+        JSON.build(io) do |json|
+          json.object do
+            write_wal_fields(frame, json)
+          end
+        end
+        io << '\n'
+      end
+    end
+
+    private def write_wal_fields(frame, json : JSON::Builder)
+      case frame
+      when AMQP::Frame::Exchange::Declare
+        json.field "op", "exchange.declare"
+        json.field "name", frame.exchange_name
+        json.field "type", frame.exchange_type
+        write_true(json, "auto_delete", frame.auto_delete)
+        write_true(json, "internal", frame.internal)
+        write_arguments(json, frame.arguments)
+      when AMQP::Frame::Exchange::Delete
+        json.field "op", "exchange.delete"
+        json.field "name", frame.exchange_name
+      when AMQP::Frame::Exchange::Bind
+        json.field "op", "exchange.bind"
+        json.field "destination", frame.destination
+        json.field "source", frame.source
+        json.field "routing_key", frame.routing_key
+        write_arguments(json, frame.arguments)
+      when AMQP::Frame::Exchange::Unbind
+        json.field "op", "exchange.unbind"
+        json.field "destination", frame.destination
+        json.field "source", frame.source
+        json.field "routing_key", frame.routing_key
+        write_arguments(json, frame.arguments)
+      when AMQP::Frame::Queue::Declare
+        json.field "op", "queue.declare"
+        json.field "name", frame.queue_name
+        write_true(json, "exclusive", frame.exclusive)
+        write_true(json, "auto_delete", frame.auto_delete)
+        write_arguments(json, frame.arguments)
+      when AMQP::Frame::Queue::Delete
+        json.field "op", "queue.delete"
+        json.field "name", frame.queue_name
+      when AMQP::Frame::Queue::Bind
+        json.field "op", "queue.bind"
+        json.field "queue", frame.queue_name
+        json.field "exchange", frame.exchange_name
+        json.field "routing_key", frame.routing_key
+        write_arguments(json, frame.arguments)
+      when AMQP::Frame::Queue::Unbind
+        json.field "op", "queue.unbind"
+        json.field "queue", frame.queue_name
+        json.field "exchange", frame.exchange_name
+        json.field "routing_key", frame.routing_key
+        write_arguments(json, frame.arguments)
+      else
+        raise "Cannot store frame #{frame.class} in vhost #{@vhost.name}"
+      end
+    end
+
+    private def mark_snapshot_dirty(frame)
+      case frame
+      when AMQP::Frame::Exchange::Declare
+        @dirty_exchanges = true
+      when AMQP::Frame::Exchange::Delete
+        @dirty_exchanges = true
+        @dirty_bindings = true
+      when AMQP::Frame::Exchange::Bind, AMQP::Frame::Exchange::Unbind
+        @dirty_bindings = true
+      when AMQP::Frame::Queue::Declare
+        @dirty_queues = true
+      when AMQP::Frame::Queue::Delete
+        @dirty_queues = true
+        @dirty_bindings = true
+      when AMQP::Frame::Queue::Bind, AMQP::Frame::Queue::Unbind
+        @dirty_bindings = true
+      end
+    end
+
+    private def request_compaction
+      @compact_requested.try_send nil
+    rescue Channel::ClosedError
+    end
+
+    private def compact_loop
+      compact_at = nil
+      loop do
+        select
+        when @compact_requested.receive
+          compact_at = @last_definition_change + compact_delay
+        when timeout compact_timeout(compact_at)
+          if compact_at
+            @definitions_lock.synchronize { compact_locked }
+            compact_at = nil
+          end
         end
       end
+    rescue Channel::ClosedError
+    end
+
+    private def compact_delay : Time::Span
+      size = @definitions_file.size
+      return Time::Span.zero if size >= WAL_COMPACT_SIZE
+
+      delay = WAL_COMPACT_IDLE * (size.to_f64 / WAL_COMPACT_SIZE)
+      delay < 1.second ? 1.second : delay
+    end
+
+    private def compact_timeout(compact_at : Time::Instant?) : Time::Span
+      return 1.day unless compact_at
+
+      remaining = compact_at - RoughTime.instant
+      remaining > Time::Span.zero ? remaining : Time::Span.zero
     end
 
     private def make_exchange(vhost, name, type, durable, auto_delete, internal, arguments)

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -223,6 +223,7 @@ module LavinMQ
         elsif legacy_definitions?
           load_legacy_definitions
           compact_locked(all: true)
+          delete_legacy_definitions
         else
           load_default_definitions
           compact_locked(all: true)
@@ -236,7 +237,14 @@ module LavinMQ
 
       @compact_requested.close
       @compact_loop_done.receive?
-      @definitions_file.close
+      # Take the lock so the close can't race a writer still inside
+      # store_definition/fsync (use-after-close on the fd).
+      @definitions_lock.synchronize { @definitions_file.close }
+    end
+
+    private def delete_legacy_definitions
+      File.delete?(@legacy_definitions_file_path)
+      @replicator.try &.delete_file(@legacy_definitions_file_path)
     end
 
     private def snapshot_definitions? : Bool
@@ -300,7 +308,17 @@ module LavinMQ
       @definitions_file.each_line do |line|
         line = line.strip
         next if line.empty?
-        frame = frame_from_wal_record(JSON.parse(line))
+        begin
+          frame = frame_from_wal_record(JSON.parse(line))
+        rescue ex : JSON::ParseException | TypeCastError | KeyError
+          # A crash mid-append leaves a torn final record; a corrupt line can
+          # appear from bit-rot or a partial non-tail write. The legacy binary
+          # reader tolerated a truncated tail via IO::EOFError, so skip the bad
+          # record rather than aborting the whole vhost load — the next
+          # compaction rewrites the snapshots and clears the WAL.
+          @log.warn { "Skipping unreadable definition WAL record: #{ex.message}" }
+          next
+        end
         apply_to_definition_maps(frame, exchanges, queues, queue_bindings, exchange_bindings)
         mark_snapshot_dirty(frame)
       end
@@ -487,10 +505,20 @@ module LavinMQ
       write_exchanges_snapshot if all || @dirty_exchanges
       write_queues_snapshot if all || @dirty_queues
       write_bindings_snapshot if all || @dirty_bindings
+      # The snapshot renames must be durable before the WAL is truncated:
+      # write_json_snapshot fsyncs each file's content but not the directory
+      # entry created by the rename. Without this barrier a crash could leave
+      # the old (pre-compaction) snapshots on disk together with an already
+      # emptied WAL, permanently losing every change since the last compaction.
+      fsync_data_dir
       clear_wal
       @dirty_exchanges = false
       @dirty_queues = false
       @dirty_bindings = false
+    end
+
+    private def fsync_data_dir : Nil
+      File.open(@data_dir, &.fsync)
     end
 
     private def write_exchanges_snapshot
@@ -514,6 +542,10 @@ module LavinMQ
         json.array do
           @queues.each_value.each do |queue|
             next if !queue.durable? || queue.exclusive?
+            # Internal delayed-exchange queues are recreated by their exchange
+            # on load (register_queue), so the per-frame WAL path never persists
+            # them; keep the snapshot consistent and out of the exported defs.
+            next if queue.is_a?(AMQP::DelayedExchangeQueue)
             json.object do
               json.field "name", queue.name
               write_true(json, "exclusive", queue.exclusive?)
@@ -582,6 +614,7 @@ module LavinMQ
       tmpfile = "#{@definitions_file_path}.tmp"
       File.open(tmpfile, "w", &.fsync)
       File.rename tmpfile, @definitions_file_path
+      fsync_data_dir
       @replicator.try &.delete_file @definitions_file_path
       @definitions_file = File.open(@definitions_file_path, "a+")
     end
@@ -725,8 +758,10 @@ module LavinMQ
     private def compact_delay(size : Int) : Time::Span
       return Time::Span.zero if size >= WAL_COMPACT_SIZE
 
-      delay = WAL_COMPACT_IDLE * (size.to_f64 / WAL_COMPACT_SIZE)
-      delay < 1.second ? 1.second : delay
+      # Wait the full idle window when the WAL is small so bursts of declares
+      # batch into one compaction, and shrink the delay toward zero as the WAL
+      # approaches the size cap so a fast-growing WAL is compacted promptly.
+      WAL_COMPACT_IDLE * (1.0 - size.to_f64 / WAL_COMPACT_SIZE)
     end
 
     private def compact_timeout(compact_at : Time::Instant?) : Time::Span

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -23,12 +23,12 @@ module LavinMQ
       @queues = Hash(String, Queue).new
       @definitions_lock = Mutex.new(:reentrant)
       @legacy_definitions_file_path = File.join(@data_dir, "definitions.amqp")
-      @definitions_file_path = File.join(@data_dir, "definitions.wal")
+      @definitions_file_path = File.join(@data_dir, "definitions.jsonl")
       @exchanges_file_path = File.join(@data_dir, "exchanges.json")
       @queues_file_path = File.join(@data_dir, "queues.json")
       @bindings_file_path = File.join(@data_dir, "bindings.json")
       @legacy_definitions_file = open_legacy_definitions_file
-      # Buffered writes are flushed before replication so the WAL record is
+      # Buffered writes are flushed before replication so the JSONL record is
       # visible through separate fds used by follower full sync.
       @definitions_file = File.open(@definitions_file_path, "a+")
       @replicator.try &.register_file(@definitions_file)
@@ -304,7 +304,7 @@ module LavinMQ
     private def replay_wal(exchanges, queues, queue_bindings, exchange_bindings)
       return if @definitions_file.size.zero?
 
-      @log.info { "Replaying definition WAL" }
+      @log.info { "Replaying definition JSONL" }
       @definitions_file.rewind
       @definitions_file.each_line do |line|
         line = line.strip
@@ -316,8 +316,8 @@ module LavinMQ
           # appear from bit-rot or a partial non-tail write. The legacy binary
           # reader tolerated a truncated tail via IO::EOFError, so skip the bad
           # record rather than aborting the whole vhost load — the next
-          # compaction rewrites the snapshots and clears the WAL.
-          @log.warn { "Skipping unreadable definition WAL record: #{ex.message}" }
+          # compaction rewrites the snapshots and clears the JSONL log.
+          @log.warn { "Skipping unreadable definition JSONL record: #{ex.message}" }
           next
         end
         apply_to_definition_maps(frame, exchanges, queues, queue_bindings, exchange_bindings)
@@ -403,7 +403,7 @@ module LavinMQ
         AMQP::Frame::Queue::Unbind.new(0_u16, 0_u16, entry["queue"].as_s, entry["exchange"].as_s,
           entry["routing_key"].as_s, arguments_from_json(entry))
       else
-        raise "Unknown definition WAL operation #{op} in vhost #{@vhost.name}"
+        raise "Unknown definition JSONL operation #{op} in vhost #{@vhost.name}"
       end
     end
 
@@ -507,11 +507,11 @@ module LavinMQ
       write_queues_snapshot if all || @dirty_queues
       write_bindings_snapshot if all || @dirty_bindings
       write_legacy_definitions_snapshot
-      # The snapshot renames must be durable before the WAL is truncated:
+      # The snapshot renames must be durable before the definition log is truncated:
       # write_json_snapshot fsyncs each file's content but not the directory
       # entry created by the rename. Without this barrier a crash could leave
       # the old (pre-compaction) snapshots on disk together with an already
-      # emptied WAL, permanently losing every change since the last compaction.
+      # emptied definition log, permanently losing every change since the last compaction.
       fsync_data_dir
       clear_wal
       @dirty_exchanges = false
@@ -558,7 +558,7 @@ module LavinMQ
     private def persisted_queue?(queue : Queue) : Bool
       return false if !queue.durable? || queue.exclusive?
       # Internal delayed-exchange queues are recreated by their exchange on load
-      # (register_queue), so the per-frame WAL path never persists them; keep
+      # (register_queue), so the per-frame JSONL path never persists them; keep
       # snapshots consistent and out of exported defs.
       return false if queue.is_a?(AMQP::DelayedExchangeQueue)
 
@@ -871,9 +871,9 @@ module LavinMQ
     private def compact_delay(size : Int) : Time::Span
       return Time::Span.zero if size >= WAL_COMPACT_SIZE
 
-      # Wait the full idle window when the WAL is small so bursts of declares
-      # batch into one compaction, and shrink the delay toward zero as the WAL
-      # approaches the size cap so a fast-growing WAL is compacted promptly.
+      # Wait the full idle window when the definition log is small so bursts of declares
+      # batch into one compaction, and shrink the delay toward zero as the log
+      # approaches the size cap so a fast-growing log is compacted promptly.
       WAL_COMPACT_IDLE * (1.0 - size.to_f64 / WAL_COMPACT_SIZE)
     end
 

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -15,6 +15,7 @@ module LavinMQ
     WAL_COMPACT_SIZE = 8_i64 * 1024 * 1024
 
     @definitions_file : File
+    @legacy_definitions_file : File?
     @closed = Atomic(Bool).new(false)
 
     def initialize(@vhost : VHost, @data_dir : String, @replicator : Clustering::Replicator?, @log : Logger)
@@ -26,6 +27,7 @@ module LavinMQ
       @exchanges_file_path = File.join(@data_dir, "exchanges.json")
       @queues_file_path = File.join(@data_dir, "queues.json")
       @bindings_file_path = File.join(@data_dir, "bindings.json")
+      @legacy_definitions_file = open_legacy_definitions_file
       # Buffered writes are flushed before replication so the WAL record is
       # visible through separate fds used by follower full sync.
       @definitions_file = File.open(@definitions_file_path, "a+")
@@ -49,6 +51,7 @@ module LavinMQ
       @definitions_lock.synchronize do
         @definitions_file.flush
         @definitions_file.fsync
+        fsync_legacy_definitions
         @replicator.try &.wait_for_followers
       end
     end
@@ -222,7 +225,6 @@ module LavinMQ
         elsif legacy_definitions?
           load_legacy_definitions
           compact_locked(all: true)
-          delete_legacy_definitions
         else
           load_default_definitions
           compact_locked(all: true)
@@ -241,12 +243,9 @@ module LavinMQ
       @definitions_lock.synchronize do
         compact_locked(all: true) unless @definitions_file.size.zero?
         @definitions_file.close
+        @legacy_definitions_file.try &.close
+        @legacy_definitions_file = nil
       end
-    end
-
-    private def delete_legacy_definitions
-      File.delete?(@legacy_definitions_file_path)
-      @replicator.try &.delete_file(@legacy_definitions_file_path)
     end
 
     private def snapshot_definitions? : Bool
@@ -507,6 +506,7 @@ module LavinMQ
       write_exchanges_snapshot if all || @dirty_exchanges
       write_queues_snapshot if all || @dirty_queues
       write_bindings_snapshot if all || @dirty_bindings
+      write_legacy_definitions_snapshot
       # The snapshot renames must be durable before the WAL is truncated:
       # write_json_snapshot fsyncs each file's content but not the directory
       # entry created by the rename. Without this barrier a crash could leave
@@ -543,11 +543,7 @@ module LavinMQ
       write_json_snapshot(@queues_file_path) do |json|
         json.array do
           @queues.each_value.each do |queue|
-            next if !queue.durable? || queue.exclusive?
-            # Internal delayed-exchange queues are recreated by their exchange
-            # on load (register_queue), so the per-frame WAL path never persists
-            # them; keep the snapshot consistent and out of the exported defs.
-            next if queue.is_a?(AMQP::DelayedExchangeQueue)
+            next unless persisted_queue?(queue)
             json.object do
               json.field "name", queue.name
               write_true(json, "exclusive", queue.exclusive?)
@@ -557,6 +553,16 @@ module LavinMQ
           end
         end
       end
+    end
+
+    private def persisted_queue?(queue : Queue) : Bool
+      return false if !queue.durable? || queue.exclusive?
+      # Internal delayed-exchange queues are recreated by their exchange on load
+      # (register_queue), so the per-frame WAL path never persists them; keep
+      # snapshots consistent and out of exported defs.
+      return false if queue.is_a?(AMQP::DelayedExchangeQueue)
+
+      true
     end
 
     private def write_bindings_snapshot
@@ -611,6 +617,69 @@ module LavinMQ
       @replicator.try &.replace_file path
     end
 
+    private def write_legacy_definitions_snapshot : Nil
+      file = legacy_definitions_file? || return
+      file.close
+      @legacy_definitions_file = nil
+
+      tmpfile = "#{@legacy_definitions_file_path}.tmp"
+      File.open(tmpfile, "w") do |tmp|
+        SchemaVersion.prefix(tmp, :definition)
+        write_legacy_definition_frames(tmp)
+        tmp.fsync
+      end
+
+      unless File.exists?(@legacy_definitions_file_path)
+        File.delete?(tmpfile)
+        return
+      end
+
+      File.rename tmpfile, @legacy_definitions_file_path
+      @replicator.try &.replace_file @legacy_definitions_file_path
+    ensure
+      @legacy_definitions_file ||= open_legacy_definitions_file
+    end
+
+    private def write_legacy_definition_frames(io : IO) : Nil
+      @exchanges.each_value.select(&.durable?).each do |exchange|
+        legacy_exchange_declare(exchange).to_io(io, IO::ByteFormat::SystemEndian)
+      end
+      @queues.each_value.each do |queue|
+        next unless persisted_queue?(queue)
+
+        legacy_queue_declare(queue).to_io(io, IO::ByteFormat::SystemEndian)
+      end
+      @exchanges.each_value.each do |exchange|
+        next unless exchange.durable?
+
+        exchange.bindings_details.each do |binding|
+          legacy_binding_frame(exchange.name, binding).try &.to_io(io, IO::ByteFormat::SystemEndian)
+        end
+      end
+    end
+
+    private def legacy_exchange_declare(exchange : Exchange) : AMQP::Frame::Exchange::Declare
+      AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, exchange.name, exchange.type,
+        false, true, exchange.auto_delete?, exchange.internal?, false, exchange.arguments)
+    end
+
+    private def legacy_queue_declare(queue : Queue) : AMQP::Frame::Queue::Declare
+      AMQP::Frame::Queue::Declare.new(0_u16, 0_u16, queue.name, false,
+        true, queue.exclusive?, queue.auto_delete?, false, queue.arguments)
+    end
+
+    private def legacy_binding_frame(source : String, binding : BindingDetails) : AMQP::Frame?
+      args = binding.arguments || AMQP::Table.new
+      case destination = binding.destination
+      when Queue
+        return unless persisted_destination_type?(destination)
+        AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, destination.name, source, binding.routing_key, false, args)
+      when Exchange
+        return unless persisted_destination_type?(destination)
+        AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, destination.name, source, binding.routing_key, false, args)
+      end
+    end
+
     private def clear_wal
       @definitions_file.close
       tmpfile = "#{@definitions_file_path}.tmp"
@@ -631,6 +700,7 @@ module LavinMQ
       @definitions_file.fsync if fsync
       @replicator.try &.register_file(@definitions_file) if offset.zero?
       @replicator.try &.append_bytes @definitions_file_path, bytes, offset
+      append_legacy_definition(frame, fsync)
       @last_definition_change = RoughTime.instant
       mark_snapshot_dirty(frame)
       if fsync
@@ -647,6 +717,47 @@ module LavinMQ
       else
         request_compaction
       end
+    end
+
+    private def append_legacy_definition(frame, fsync : Bool) : Nil
+      file = legacy_definitions_file? || return
+
+      offset = file.size.to_i64
+      frame.to_io(file, IO::ByteFormat::SystemEndian)
+      length = frame.bytesize.to_i64 + 8
+
+      if replicator = @replicator
+        file.flush
+        replicator.append_bytes file, offset, length
+      elsif !fsync
+        file.flush
+      end
+      file.fsync if fsync
+    end
+
+    private def fsync_legacy_definitions : Nil
+      file = legacy_definitions_file? || return
+
+      file.flush
+      file.fsync
+    end
+
+    private def open_legacy_definitions_file : File?
+      return unless File.exists?(@legacy_definitions_file_path)
+
+      file = File.open(@legacy_definitions_file_path, "a+")
+      SchemaVersion.prefix(file, :definition) if file.size.zero?
+      @replicator.try &.register_file(file)
+      file
+    end
+
+    private def legacy_definitions_file? : File?
+      file = @legacy_definitions_file || return
+      path_info = File.info?(@legacy_definitions_file_path)
+      return file if path_info && file.info.same_file?(path_info)
+
+      file.close
+      @legacy_definitions_file = nil
     end
 
     private def definition_record(frame) : String

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -527,6 +527,7 @@ module LavinMQ
       write_json_snapshot(@exchanges_file_path) do |json|
         json.array do
           @exchanges.each_value.select(&.durable?).each do |exchange|
+            json.indent = 0
             json.object do
               json.field "name", exchange.name
               json.field "type", exchange.type
@@ -534,6 +535,7 @@ module LavinMQ
               write_true(json, "internal", exchange.internal?)
               write_arguments(json, exchange.arguments)
             end
+            json.indent = 2
           end
         end
       end
@@ -544,12 +546,14 @@ module LavinMQ
         json.array do
           @queues.each_value.each do |queue|
             next unless persisted_queue?(queue)
+            json.indent = 0
             json.object do
               json.field "name", queue.name
               write_true(json, "exclusive", queue.exclusive?)
               write_true(json, "auto_delete", queue.auto_delete?)
               write_arguments(json, queue.arguments)
             end
+            json.indent = 2
           end
         end
       end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -181,8 +181,13 @@ module LavinMQ
       @shovels = Shovel::Store.new(self)
       @upstreams = Federation::UpstreamStore.new(self)
       @definitions = DefinitionsStore.new(self, @data_dir, @replicator, @log)
-      load!
-      spawn check_consumer_timeouts_loop, name: "Consumer timeouts loop"
+      begin
+        load!
+        spawn check_consumer_timeouts_loop, name: "Consumer timeouts loop"
+      rescue ex
+        @definitions.try &.close
+        raise ex
+      end
     end
 
     private def check_consumer_timeouts_loop
@@ -447,7 +452,11 @@ module LavinMQ
     end
 
     def close(reason = "Broker shutdown")
-      return if @closed.swap(true)
+      if @closed.swap(true)
+        definitions.close
+        return
+      end
+
       stop_shovels
       stop_upstream_links
 
@@ -479,6 +488,7 @@ module LavinMQ
 
     def delete
       close(reason: "VHost deleted")
+      definitions.close
       Fiber.yield
       FileUtils.rm_rf @data_dir
     end


### PR DESCRIPTION
Summary:
- Persist definitions as per-vhost JSON snapshots plus a WAL in the vhost directory.
- Load snapshots plus WAL on boot and compact on request/idle or once the WAL reaches 8 MiB.
- Minimize snapshot JSON by omitting implicit defaults and empty arguments.

Tests:
- make test SPEC=spec/vhost_spec.cr
- make lint
- make test