### PR TITLE
Clustering client send after read files

### DIFF
--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -181,16 +181,17 @@ module LavinMQ
               Log.info { "Mismatching hash: #{path}" }
               File.delete path
               requested_files << filename
-              request_file(filename, socket)
             else
               Log.debug { "Matching hash: #{path}" }
             end
           else
             requested_files << filename
-            request_file(filename, socket)
           end
           file_count &+= 1
           log_limiter.do { Log.info { "Compared #{file_count} files" } }
+        end
+        requested_files.each do |filename|
+          request_file(filename, socket)
         end
         end_of_file_list(socket)
         Log.info { "Compared #{file_count} files, #{requested_files.size} to sync" }


### PR DESCRIPTION
## What

During follower sync, the clustering client now reads the **entire** file/hash list from the leader before sending any file requests back, instead of requesting each mismatched/missing file inline while still streaming the list.

## Why

The previous code wrote `request_file(...)` to the socket from inside the loop that was concurrently reading the hash list off the same socket. Interleaving writes with the ongoing read risks a deadlock: the leader can block writing the rest of the hash list while its receive buffer fills with the follower's requests, and the follower blocks writing requests while the leader isn't draining them — both ends stuck with full socket buffers.

By collecting all needed files into `requested_files` during the comparison loop and only issuing the `request_file` writes once the list has been fully read (followed by `end_of_file_list`), reads and writes on the socket are no longer interleaved.

## Changes

- `src/lavinmq/clustering/client.cr`: defer the `request_file` calls out of the compare loop; send them in a single pass after the leader's hash list is fully consumed.
