### PR TITLE
Fix clustering follower wedge during full_sync

### DIFF
--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -119,10 +119,58 @@ module FollowerSpec
         client_socket.try &.close
       end
     end
+
+    # A syncing follower isn't in the ISR, so the aggressive streaming-phase
+    # write timeout must not apply during the bulk transfer — otherwise a
+    # follower that's merely slow at hashing or persisting files gets dropped
+    # mid-sync. full_sync relaxes it; ack_loop tightens it again.
+    it "relaxes the write timeout during full_sync and restores it for ack_loop" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        client_lz4 = Compress::LZ4::Reader.new(client_socket)
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+        follower_socket.write_timeout.should eq 3.seconds # initialize default
+
+        done = Channel(Nil).new
+        spawn do
+          follower.full_sync
+          done.send nil
+        end
+
+        # Drain the file list and request no files so full_sync completes.
+        loop do
+          len = client_lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
+          break if len == 0
+          hash = Bytes.new(20)
+          client_lz4.read_string len
+          client_lz4.read_fully hash
+        end
+        client_socket.write_bytes 0, IO::ByteFormat::LittleEndian # request no files
+
+        select
+        when done.receive
+        when timeout(2.seconds)
+          fail "full_sync did not complete"
+        end
+        follower_socket.write_timeout.should eq LavinMQ::Clustering::Follower::SYNC_WRITE_TIMEOUT
+
+        spawn { follower.ack_loop }
+        # ack_loop tightens the write timeout to ACK_TIMEOUT when it starts.
+        10.times do
+          break if follower_socket.write_timeout == LavinMQ::Clustering::Follower::ACK_TIMEOUT
+          sleep 20.milliseconds
+        end
+        follower_socket.write_timeout.should eq LavinMQ::Clustering::Follower::ACK_TIMEOUT
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
   end
 
   describe "#stream changes" do
-    it "should fully sync on graceful shutdown" do
+    it "delivers and acks outstanding data, then shuts down cleanly" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
@@ -138,31 +186,28 @@ module FollowerSpec
           # socket closed
         end
 
+        spawn { follower.ack_loop }
         10.times do
           follower.append("#{data_dir}/file", "hello world".to_slice)
         end
-        spawn do
-          follower.ack_loop
+        target = follower.lag_in_bytes
+
+        # Ack the outstanding bytes and wait until the follower has registered
+        # them, so the lag-0 assertion is deterministic (close no longer flushes
+        # or waits for acks itself).
+        client_socket.write_bytes target, IO::ByteFormat::LittleEndian
+        confirmed = Channel(Bool).new
+        spawn { confirmed.send follower.wait_for_confirm }
+        select
+        when confirmed.receive
+        when timeout(2.seconds)
+          fail "follower never acked outstanding data"
         end
-
-        closed = false
-        wg = WaitGroup.new
-        wg.add(1)
-        spawn do
-          follower.close
-          closed = true
-          wg.done
-        end
-
-        # Send an ack back to satisfy lag check if needed,
-        # though close doesn't strictly depend on it now.
-        # But let's verify lag reaches 0.
-        client_socket.write_bytes follower.lag_in_bytes.to_i64, IO::ByteFormat::LittleEndian
-
-        # Wait for closing fiber to finish
-        wg.wait
-        closed.should be_true
         follower.lag_in_bytes.should eq 0
+
+        # A clean shutdown closes the socket and marks the follower dead.
+        follower.close
+        follower.dead?.should be_true
       ensure
         follower_socket.try &.close
         client_socket.try &.close
@@ -179,11 +224,11 @@ module FollowerSpec
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        lag_ch = Channel(Int64).new(1)
-        spawn do
-          lag_ch.send follower.replace("file1")
-          follower.close
-        end
+        # close no longer flushes buffered data, so drive the flush via ack_loop
+        # + request_flush (see the #request_flush test) to read it off the wire.
+        spawn { follower.ack_loop }
+        lag = follower.replace("file1")
+        follower.request_flush
 
         client_lz4 = Compress::LZ4::Reader.new(client_socket)
         read_filename(client_lz4).should eq "file1"
@@ -193,7 +238,7 @@ module FollowerSpec
         client_lz4.read_fully(buf)
         String.new(buf).should eq "foo"
 
-        lag_ch.receive.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64) + 3)
+        lag.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64) + 3)
       ensure
         follower_socket.try &.close
         client_socket.try &.close
@@ -233,11 +278,9 @@ module FollowerSpec
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        lag_ch = Channel(Int64).new(1)
-        spawn do
-          lag_ch.send follower.append("bar", "foo".to_slice)
-          follower.close
-        end
+        spawn { follower.ack_loop }
+        lag = follower.append("bar", "foo".to_slice)
+        follower.request_flush
 
         client_lz4 = Compress::LZ4::Reader.new(client_socket)
         read_filename(client_lz4).should eq "bar"
@@ -247,7 +290,7 @@ module FollowerSpec
         client_lz4.read_fully(buf)
         String.new(buf).should eq "foo"
 
-        lag_ch.receive.should eq(sizeof(Int32) + "bar".bytesize + sizeof(Int64) + 3)
+        lag.should eq(sizeof(Int32) + "bar".bytesize + sizeof(Int64) + 3)
       ensure
         follower_socket.try &.close
         client_socket.try &.close
@@ -260,18 +303,16 @@ module FollowerSpec
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        lag_ch = Channel(Int64).new(1)
-        spawn do
-          lag_ch.send follower.append("file1", 123i32)
-          follower.close
-        end
+        spawn { follower.ack_loop }
+        lag = follower.append("file1", 123i32)
+        follower.request_flush
 
         client_lz4 = Compress::LZ4::Reader.new(client_socket)
         read_filename(client_lz4).should eq "file1"
         read_data_size(client_lz4).should eq(-4i64)
         client_lz4.read_bytes(Int32, IO::ByteFormat::LittleEndian).should eq 123i32
 
-        lag_ch.receive.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64) + sizeof(Int32))
+        lag.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64) + sizeof(Int32))
       ensure
         follower_socket.try &.close
         client_socket.try &.close
@@ -284,18 +325,16 @@ module FollowerSpec
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        lag_ch = Channel(Int64).new(1)
-        spawn do
-          lag_ch.send follower.append("file1", 123u32)
-          follower.close
-        end
+        spawn { follower.ack_loop }
+        lag = follower.append("file1", 123u32)
+        follower.request_flush
 
         client_lz4 = Compress::LZ4::Reader.new(client_socket)
         read_filename(client_lz4).should eq "file1"
         read_data_size(client_lz4).should eq(-4i64)
         client_lz4.read_bytes(UInt32, IO::ByteFormat::LittleEndian).should eq 123u32
 
-        lag_ch.receive.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64) + sizeof(UInt32))
+        lag.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64) + sizeof(UInt32))
       ensure
         follower_socket.try &.close
         client_socket.try &.close
@@ -638,6 +677,39 @@ module FollowerSpec
         client_socket.try &.close
       end
     end
+
+    # Regression: when a follower stopped reading (e.g. slow hashing during
+    # full_sync) the send buffer fills. close() used to call @lz4.close first,
+    # whose flush re-blocked on the full buffer until the write timeout and
+    # raised — skipping @socket.close, so the socket stayed open. The follower
+    # then never saw a disconnect and never reconnected. close must always
+    # close the socket.
+    it "closes the socket even when the send buffer is full" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+        # Fail a blocked write fast instead of after the production timeout.
+        follower_socket.write_timeout = 200.milliseconds
+
+        # Buffered data that a (now removed) flush-on-close would try to send.
+        follower.append("#{data_dir}/file", "hello world".to_slice)
+
+        # Fill the socket send buffer; the client never reads, so any further
+        # write blocks until the write timeout.
+        junk = Bytes.new(65536)
+        begin
+          loop { follower_socket.write junk }
+        rescue IO::TimeoutError
+        end
+
+        follower.close
+        follower_socket.closed?.should be_true
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
   end
 
   describe "#already_synced" do
@@ -722,17 +794,15 @@ module FollowerSpec
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        lag_ch = Channel(Int64).new(1)
-        spawn do
-          lag_ch.send follower.delete("file1")
-          follower.close
-        end
+        spawn { follower.ack_loop }
+        lag = follower.delete("file1")
+        follower.request_flush
 
         client_lz4 = Compress::LZ4::Reader.new(client_socket)
         read_filename(client_lz4).should eq "file1"
         read_data_size(client_lz4).should eq 0i64
 
-        lag_ch.receive.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64))
+        lag.should eq(sizeof(Int32) + "file1".bytesize + sizeof(Int64))
       ensure
         follower_socket.try &.close
         client_socket.try &.close

--- a/spec/support/fake_follower.cr
+++ b/spec/support/fake_follower.cr
@@ -59,6 +59,12 @@ class FakeSocket < TCPSocket
     @io.write_timeout = timeout
   end
 
+  # Expose the backing socket's write_timeout so specs can assert the follower
+  # relaxes it during full_sync and tightens it for the streaming phase.
+  def write_timeout
+    @io.write_timeout
+  end
+
   def remote_address : Socket::IPAddress
     Socket::IPAddress.parse("tcp://127.0.0.1:1234")
   end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -172,18 +172,34 @@ module LavinMQ
       private def sync_files(socket, lz4)
         Log.info { "Waiting for list of files" }
         sha1 = Digest::SHA1.new
-        remote_hash = Bytes.new(sha1.digest_size)
-        files_to_delete, dirs_to_delete = ls_r(@data_dir)
-        requested_files = Array(String).new
-        file_count = 0
-        Log.info { "Calculating checksums and comparing files" }
-        log_limiter = RateLimiter.new(2.seconds)
+
+        # Drain the entire file list from the socket FIRST, doing no hashing in
+        # this loop. Computing local checksums is CPU-bound and would otherwise
+        # block reading between entries, so the leader's file-list flush can't
+        # complete within its write timeout and it disconnects us mid-sync. By
+        # reading the list back-to-back we let the leader's flush finish; it then
+        # blocks reading our file requests (below) while we hash, so it never
+        # write-times-out during the comparison.
+        remote_files = Array({String, Bytes}).new
         loop do
           filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
           break if filename_len.zero?
 
           filename = lz4.read_string(filename_len)
+          remote_hash = Bytes.new(sha1.digest_size)
           lz4.read_fully(remote_hash)
+          remote_files << {filename, remote_hash}
+        end
+        Log.info { "Received list of #{remote_files.size} files" }
+
+        # Now compare against local files (CPU-bound hashing) with the socket
+        # already drained.
+        files_to_delete, dirs_to_delete = ls_r(@data_dir)
+        requested_files = Array(String).new
+        file_count = 0
+        Log.info { "Calculating checksums and comparing files" }
+        log_limiter = RateLimiter.new(2.seconds)
+        remote_files.each do |filename, remote_hash|
           path = File.join(@data_dir, filename)
           files_to_delete.delete(path)
           # Walk up the path to remove all ancestors from dirs_to_delete

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -19,6 +19,15 @@ module LavinMQ
       # still-connected follower can't stall publish confirms indefinitely.
       ACK_TIMEOUT = 3.seconds
 
+      # Write timeout used during full_sync. A syncing follower isn't in the ISR
+      # yet, so its slowness can't stall publish confirms, and the bulk transfer
+      # legitimately blocks the leader's writes while the follower hashes its
+      # local files or persists received ones. The aggressive ACK_TIMEOUT is for
+      # the steady-state streaming phase; using it during full_sync wrongly drops
+      # a merely-slow follower. Still bounded so a genuinely wedged follower can't
+      # hold the sync lock forever.
+      SYNC_WRITE_TIMEOUT = 60.seconds
+
       @acked_bytes = Atomic(Int64).new(0)
       @sent_bytes = Atomic(Int64).new(0)
       # Wakes the publish-confirm waiter on each ack; closed (never replaced)
@@ -67,6 +76,9 @@ module LavinMQ
       # count recorded as that follower's synced baseline, so the snapshot and
       # the baseline agree and in-flight writes aren't duplicated.
       def full_sync(caps : Hash(String, Int64)? = nil) : Nil
+        # Relax the write timeout for the bulk transfer; ack_loop restores the
+        # tight ACK_TIMEOUT when the follower enters the streaming phase.
+        @socket.write_timeout = SYNC_WRITE_TIMEOUT
         send_file_list(caps: caps)
         send_requested_files(caps: caps)
       end
@@ -74,6 +86,9 @@ module LavinMQ
       def ack_loop(ack_timeout : Time::Span = ACK_TIMEOUT)
         @running.add
         @running.spawn(name: "Clustering follower flush loop") { flush_loop }
+        # Tighten the write timeout for the streaming phase; full_sync relaxed it
+        # to SYNC_WRITE_TIMEOUT for the bulk transfer.
+        @socket.write_timeout = ACK_TIMEOUT
         @socket.read_timeout = 100.milliseconds # Wait for an ack max this time, otherwise flush the buffer to trigger acks
         # When data is outstanding and unacked, the time we first noticed it.
         # Reset to nil on any ack (progress) or when fully caught up, so the
@@ -339,8 +354,17 @@ module LavinMQ
 
       def close
         begin
+          # Don't @lz4.close here: it writes the end-of-frame and flushes to
+          # the socket, which blocks (and re-raises the write timeout) when the
+          # follower stopped reading and the send buffer is full — the exact
+          # case that drops a follower mid full_sync. That used to skip the
+          # @socket.close below, leaving the socket open so the follower never
+          # saw a disconnect and never reconnected. close always means the
+          # follower is being dropped and will reconnect + re-sync, so a clean
+          # frame-end has no value and any buffered (hence unacked, non-durable)
+          # data is safely discarded. Just close the socket; the LZ4 writer's
+          # context is freed by its finalizer.
           @write_lock.synchronize do
-            @lz4.close
             @socket.close
           end
         rescue IO::Error


### PR DESCRIPTION
## Problem

A clustering follower could wedge during `full_sync` (observed with ~7000 queues, ~2 GiB of messages, fairly high throughput): the leader-side `Clustering::Follower` got a write timeout during `full_sync`, but the follower-side `Clustering::Client` never noticed and never reconnected.

### Root cause

1. **Client drained the file list slowly.** `Client#sync_files` hashed each local file (`sha1.file`) **inline between reads** of the leader's file list. Hashing gigabytes is CPU-bound and blocks the read loop, so the leader's `send_file_list` flush couldn't complete within the 3s `@socket.write_timeout` → `IO::TimeoutError`.
2. **Leader left the socket open.** On dropping the follower, `Follower#close` ran `@write_lock.synchronize { @lz4.close; @socket.close }`. `@lz4.close` writes the end-of-frame and flushes to the **still-full** socket → re-blocked → re-raised `IO::TimeoutError` → `@socket.close` was **skipped** (swallowed by `rescue IO::Error`). No FIN reached the client, which has no read timeout during sync, so it hung forever on an ESTABLISHED connection and never hit its reconnect path.

## Fix

Three complementary changes, each for a distinct failure mode:

- **`follower.cr` `close`** — drop `@lz4.close`; just close the socket. Teardown always means the follower is being dropped and will reconnect + re-sync, so a graceful LZ4 frame-end has no value and a buffered (unacked, non-durable) tail is safely discarded. The LZ4 writer's context is freed by its finalizer.
- **`client.cr` `sync_files`** — read the **entire** file list into memory first (no hashing), then hash/compare. The socket drains promptly; the leader then blocks *reading* our file requests while we hash, so it can't write-time-out during the comparison. The persisted `@checksums` cache makes any retry converge.
- **`follower.cr` `SYNC_WRITE_TIMEOUT = 60s`** — a syncing follower isn't in the ISR, so the aggressive 3s `ACK_TIMEOUT`/streaming write timeout is wrong for the bulk transfer. `full_sync` relaxes the write timeout; `ack_loop` restores `ACK_TIMEOUT` for the streaming phase. This covers a slow follower disk during the receive phase, which we deliberately keep as one continuous LZ4 stream (better compression of many small files + a known total-byte count for progress logging).

## Tests

- New regression test: `Follower#close` disconnects a follower whose send buffer is full (verified it **fails** without the close fix).
- New timeout-policy test: the write timeout relaxes during `full_sync` and tightens for `ack_loop`.
- Updated the wire-format (`#append`/`#replace`/`#delete`) and graceful-shutdown tests that previously relied on `close` flushing — switched to the existing `ack_loop` + `request_flush` pattern.
- Full suite green (2002 examples, 0 failures); `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)