### PR TITLE
docs: document sync/--no-sync option and disk-durable publisher confirms

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `tcp_recv_buffer_size` | — | — | Int | (system) | TCP receive buffer size |
 | `tcp_send_buffer_size` | — | — | Int | (system) | TCP send buffer size |
 | `segment_size` | — | — | Int | `8388608` | Message store segment size (bytes, 8MB) |
+| `sync` | `--no-sync` | `LAVINMQ_SYNC` | Bool | `true` | Flush pending writes to the data directory with `syncfs(2)` before acking publisher confirms (`Basic.Ack`) and transaction commits, so confirmed messages survive sudden power loss or a kernel crash. Disabling (`--no-sync` / `sync = false`) leaves durability to the OS — unsafe for production, but speeds up CI and local development. See [Publisher Confirms](publisher-confirms.md#disk-durable-confirms). |
 | `free_disk_min` | — | — | Int | `0` | Minimum free disk space (bytes). Publishing is blocked when free space drops below this value. |
 | `free_disk_warn` | — | — | Int | `0` | Free disk space warning threshold (bytes) |
 | `max_deleted_definitions` | — | — | Int | `8192` | Deleted definitions before compaction |

--- a/docs/publisher-confirms.md
+++ b/docs/publisher-confirms.md
@@ -16,6 +16,17 @@ After `confirm.select`, every message published on the channel is assigned a mon
 - `basic.ack` with `multiple=true` — confirms all messages up to and including the delivery tag
 - `basic.nack` — the server failed to process the message (e.g., internal error). The publisher should handle this and potentially retry.
 
+## Disk-durable confirms
+
+Since LavinMQ 2.9.0, a confirmed message is guaranteed to be on disk: the broker flushes pending writes with `syncfs(2)` before emitting `Basic.Ack`, so any confirmed message survives a sudden power loss or kernel crash.
+
+- Concurrent in-flight confirms coalesce into a single `syncfs` call, keeping throughput high without an artificial flush delay.
+- The blocking syscall runs on a dedicated isolated thread, so it never stalls client connection handling.
+- If `syncfs` fails, the broker logs fatal and exits with status 1, so a follower in a clustered deployment can take over before any acked-but-unpersisted data is at risk.
+- In a clustered deployment a publish is confirmed once every in-sync follower has the data; the local `syncfs` flush is used as a fallback when there are no in-sync followers or the node is standalone.
+
+The flush can be turned off with the [`sync`](configuration.md) setting (`sync = false`, the `--no-sync` flag, or `LAVINMQ_SYNC=false`), which leaves durability to the OS. This is faster but unsafe — a confirmed message can be lost on crash or power loss — and is intended for CI and local development only.
+
 ## Mutual Exclusivity with Transactions
 
 Publisher confirms and transactions (`tx.select`) are mutually exclusive on a channel. Enabling one after the other results in a channel error.


### PR DESCRIPTION
## Summary

Documents two related 2.9.0 durability features that are not yet in `docs/`:

- **`configuration.md`** — adds the `sync` row to the `[main]` table: INI key `sync` (default `true`), CLI flag `--no-sync`, env var `LAVINMQ_SYNC`. ([#1987](https://github.com/cloudamqp/lavinmq/pull/1987))
- **`publisher-confirms.md`** — adds a *Disk-durable confirms* section: `Basic.Ack` is emitted only after `syncfs(2)` flushes pending writes; concurrent confirms coalesce into one `syncfs`; the blocking call runs on a dedicated isolated thread; `syncfs` failure logs fatal and exits 1; and in a cluster a confirm waits for in-sync followers with local `syncfs` as the standalone/fallback path. ([#1891](https://github.com/cloudamqp/lavinmq/pull/1891), [#2002](https://github.com/cloudamqp/lavinmq/pull/2002))

The two pages cross-link each other.

## Why

These shipped in **v2.9.0** but weren't documented. Verified against `src/lavinmq/config/options.cr` (the `property? sync : Bool = true` with `--no-sync` / `LAVINMQ_SYNC`), `src/lavinmq/persister.cr`, and the 2.9.0 CHANGELOG. The website pulls these pages in via its docs sync, so documenting them here surfaces them on lavinmq.com automatically.

Content adapted from the website docs PRs [84codes/lavinmq-website#229](https://github.com/84codes/lavinmq-website/pull/229) and [84codes/lavinmq-website#226](https://github.com/84codes/lavinmq-website/pull/226), with the clustered-confirm nuance from #2002 added for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)