### PR TITLE
Normalize IPv4-mapped peer addresses

### DIFF
--- a/spec/connection_info_spec.cr
+++ b/spec/connection_info_spec.cr
@@ -1,6 +1,28 @@
-require "./spec_helper"
+require "spec"
+require "../src/lavinmq/connection_info"
 
 describe LavinMQ::ConnectionInfo::IPAddress do
+  describe "#address" do
+    it "unmaps IPv4-mapped IPv6 addresses" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::ffff:127.0.0.1", 1234))
+
+      addr.address.should eq "127.0.0.1"
+      addr.to_s.should eq "127.0.0.1:1234"
+    end
+
+    it "preserves plain IPv4 addresses" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("10.1.2.3", 1234))
+
+      addr.address.should eq "10.1.2.3"
+    end
+
+    it "preserves native IPv6 addresses" do
+      addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::1", 1234))
+
+      addr.address.should eq "::1"
+    end
+  end
+
   describe "#loopback?" do
     it "recognizes IPv4-mapped IPv6 loopback as loopback" do
       addr = LavinMQ::ConnectionInfo::IPAddress.new(Socket::IPAddress.new("::ffff:127.0.0.1", 0))

--- a/src/lavinmq/connection_info.cr
+++ b/src/lavinmq/connection_info.cr
@@ -26,18 +26,26 @@ module LavinMQ
 
     # Suspecting memory problem with Socket::IPAddress in Crystal 1.15.0
     struct IPAddress
+      private IPV4_MAPPED_IPV6_PREFIX = "::ffff:"
+
       getter address : String
       getter port : UInt16
       getter? loopback : Bool
 
       def initialize(ip_address : Socket::IPAddress)
-        @address = ip_address.address
+        @address = unmap_ipv6(ip_address.address)
         @port = ip_address.port.to_u16!
         @loopback = ip_address.loopback?
       end
 
       def to_s(io)
         io << @address << ':' << @port
+      end
+
+      private def unmap_ipv6(address : String) : String
+        return address unless address.starts_with?(IPV4_MAPPED_IPV6_PREFIX)
+
+        address.byte_slice(IPV4_MAPPED_IPV6_PREFIX.bytesize)
       end
     end
   end


### PR DESCRIPTION
Dual-stack listeners expose IPv4 clients as IPv4-mapped IPv6 addresses such as `::ffff:127.0.0.1`. Leaving that raw form in connection metadata makes logs, API fields, and exact-address consumers inconsistent.

Normalize once in `ConnectionInfo` so downstream code sees the same peer identity regardless of listener family.

We get this

<img width="2560" height="2646" alt="localhost-20260625-222308" src="https://github.com/user-attachments/assets/0eaec485-f49f-4a53-982f-da262b2200a0" />

Instead of this

<img width="2560" height="2646" alt="localhost-20260625-222430" src="https://github.com/user-attachments/assets/3e49af43-347b-4e28-8766-cd82b7b3398f" />
