### PR TITLE
Advertise UI version via LavinMQ-Version header instead of build-time injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ CTL_SOURCES := $(shell find src/lavinmqctl -name '*.cr' 2> /dev/null)
 VIEW_SOURCES := $(wildcard views/*.shtml)
 VIEW_TARGETS := $(patsubst views/%.shtml,static/%.html,$(VIEW_SOURCES))
 VIEW_PARTIALS := $(wildcard views/partials/*.shtml)
-VERSION := $(patsubst v%,%,$(or $(version),$(shell git describe --tags 2>/dev/null || shards version)))
 JS := static/js/lib/chunks/helpers.segment.js static/js/lib/chart.js static/js/lib/luxon.js static/js/lib/chartjs-adapter-luxon.esm.js static/js/lib/elements-8.2.0.js static/js/lib/elements-8.2.0.css $(wildcard static/js/*.js)
 CRYSTAL_FLAGS := --release
 override CRYSTAL_FLAGS += --stats -Dpreview_mt -Dexecution_context --link-flags="$(LDFLAGS)"
@@ -173,7 +172,7 @@ watch-views:
 	while true; do $(MAKE) -q -s views || $(MAKE) views; sleep 0.5; done
 
 static/%.html: views/%.shtml $(VIEW_PARTIALS) views/render.sh
-	views/render.sh $< "$(VERSION)" > $@
+	views/render.sh $< > $@
 
 .PHONY: clean-views
 clean-views:

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -1,6 +1,22 @@
 require "../spec_helper"
 
 describe LavinMQ::HTTP::Server do
+  describe "LavinMQ-Version header" do
+    it "advertises the server version on API responses" do
+      with_http_server do |http, _|
+        response = http.get("/api/whoami")
+        response.headers["LavinMQ-Version"].should eq LavinMQ::VERSION
+      end
+    end
+
+    it "is not set on static/HTML responses" do
+      with_http_server do |http, _|
+        response = ::HTTP::Client.get("#{http.addr}/login")
+        response.headers["LavinMQ-Version"]?.should be_nil
+      end
+    end
+  end
+
   describe "GET /api/overview" do
     it "should refuse access if no basic auth header" do
       with_http_server do |http, _|

--- a/spec/frontend/layout.spec.js
+++ b/spec/frontend/layout.spec.js
@@ -76,6 +76,38 @@ test.describe('theme switcher', _ => {
   })
 })
 
+test.describe('version', _ => {
+  // The version is advertised via the `LavinMQ-Version` header on API responses
+  // and picked up by http.js. The queues page is used because the nodes page
+  // deliberately overwrites #version from /api/nodes (nodes.js). /api/queues is
+  // read (not /api/vhosts, which the loadVhosts fixture mocks without the header).
+  test('is shown from the LavinMQ-Version header', async ({ page }) => {
+    const apiResponse = page.waitForResponse(r => r.url().includes('/api/queues'))
+    await page.goto('/queues')
+    const expected = (await apiResponse).headers()['lavinmq-version']
+    expect(expected).toBeTruthy()
+    await expect(page.locator('#version')).toHaveText(expected)
+  })
+
+  test('is cached in sessionStorage', async ({ page }) => {
+    await page.goto('/queues')
+    await expect(page.locator('#version')).not.toBeEmpty()
+    const shown = await page.locator('#version').textContent()
+    const stored = await page.evaluate(() => window.sessionStorage.getItem('lavinmq_version'))
+    expect(stored).toBe(shown)
+  })
+
+  // The header partial has an inline script that paints the cached version
+  // during parsing (before first paint) to avoid flicker. With all API calls
+  // aborted, http.js never updates #version, so only the inline paint is seen.
+  test('paints the cached version without any API response', async ({ page }) => {
+    await page.addInitScript(() => window.sessionStorage.setItem('lavinmq_version', '1.2.3-cached'))
+    await page.route(url => url.pathname.startsWith('/api/'), route => route.abort())
+    await page.goto('/queues')
+    await expect(page.locator('#version')).toHaveText('1.2.3-cached')
+  })
+})
+
 test.describe('vhosts', _ => {
   test('are loaded', async ({ page, vhosts }) => {
     await page.goto('/')

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -10,7 +10,8 @@ module LavinMQ
 
       LAYOUT_INLINE_JS_SHA    = "sha256-xCBzVV2TewAz4Dk/CrTquSJ4NTH48Y5fckwTF8Lg5bE="
       LOGIN_INLINE_JS_SHA     = "sha256-3bUZcnRc7hbNc+igS1dxqJNEEypKXCvZ9ozHwAxXIvc="
-      CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; script-src 'self' '#{LAYOUT_INLINE_JS_SHA}' '#{LOGIN_INLINE_JS_SHA}'"
+      VERSION_INLINE_JS_SHA   = "sha256-GgZA/DYl7oCp6n7XdT+Bi2RHOQdZ/onfVRmY6d8/Jow="
+      CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'self'; font-src 'self'; img-src 'self'; connect-src 'self'; script-src 'self' '#{LAYOUT_INLINE_JS_SHA}' '#{LOGIN_INLINE_JS_SHA}' '#{VERSION_INLINE_JS_SHA}'"
 
       # HTML views reachable without a session
       PUBLIC_HTML = {"/login.html", "/401.html", "/404.html"}

--- a/src/lavinmq/http/handler/defaults_handler.cr
+++ b/src/lavinmq/http/handler/defaults_handler.cr
@@ -1,4 +1,5 @@
 require "http/server/handler"
+require "../../version"
 
 module LavinMQ
   module HTTP
@@ -8,6 +9,10 @@ module LavinMQ
 
       def call(context)
         context.response.content_type = "application/json"
+        # Advertise the server version on API responses; the management UI reads
+        # it off any API response (see static/js/http.js) to show the version
+        # without an extra request.
+        context.response.headers["LavinMQ-Version"] = LavinMQ::VERSION
         {% if flag?(:release) %}
           call_next(context)
         {% else %}

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -14,6 +14,7 @@ function request (method, path, options = {}) {
   }
   return window.fetch(path, opts)
     .then(response => {
+      updateVersionFromResponse(response)
       if (!response.ok) {
         const error = { status: response.status, reason: response.statusText, is_error: true }
         return response.json()
@@ -21,6 +22,17 @@ function request (method, path, options = {}) {
           .finally(() => { standardErrorHandler(error) })
       } else { return response.json().catch(() => null) }
     })
+}
+
+// The server advertises its version via the `LavinMQ-Version` header on every
+// response. Pick it up here so the UI shows the current version (cached in
+// sessionStorage, displayed by inline script in header.shtml) without an extra request.
+function updateVersionFromResponse (response) {
+  const version = response.headers.get('LavinMQ-Version')
+  if (!version) return
+  window.sessionStorage.setItem('lavinmq_version', version)
+  const el = document.getElementById('version')
+  if (el) el.textContent = version
 }
 
 function alertErrorHandler (e) {

--- a/static/js/http.js
+++ b/static/js/http.js
@@ -32,7 +32,13 @@ function updateVersionFromResponse (response) {
   if (!version) return
   window.sessionStorage.setItem('lavinmq_version', version)
   const el = document.getElementById('version')
-  if (el) el.textContent = version
+  if (el) {
+    if (el.textContent === "") {
+      el.textContent = version
+    } else if (el.textContent !== version) {
+      window.location.reload() // if new version then html/js might have changed too
+    }
+  }
 }
 
 function alertErrorHandler (e) {

--- a/views/partials/header.shtml
+++ b/views/partials/header.shtml
@@ -13,7 +13,13 @@
       <img alt="LavinMQ logo" class="dark" id="logo" src="img/logo-lavinmq-all-white.svg" width="120" height="24">
       <img alt="LavinMQ logo" class="light" id="logo-light" src="img/logo-lavinmq-all-dark.svg" width="120" height="24">
     </a>
-    <span class="version-tab" id="version"><!--#echo var="VERSION" --></span>
+    <span class="version-tab" id="version"></span>
+    <script>
+      try {
+        const v = window.sessionStorage.getItem('lavinmq_version')
+        if (v) document.getElementById('version').textContent = v
+      } catch (e) {}
+    </script>
   </div>
   <button id="usermenu-button"></button>
   <nav id="user-menu">

--- a/views/render.sh
+++ b/views/render.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Processes SHTML (SSI) directives and outputs HTML.
-# Usage: views/render.sh views/page.shtml "1.2.3" > static/page.html
+# Usage: views/render.sh views/page.shtml > static/page.html
 #
 # Supported directives:
 #   <!--#set var="NAME" value="..." -->   Store a variable
@@ -10,7 +10,6 @@ set -eu
 
 VIEWS_DIR="$(cd "$(dirname "$0")" && pwd)"
 INPUT="$1"
-VERSION="${2:-dev}"
 
 process() {
   local line rest out before directive tag after varname value file
@@ -61,5 +60,4 @@ process() {
   done
 }
 
-VAR_VERSION="$VERSION"
 process < "$INPUT"


### PR DESCRIPTION
## Why

The web UI showed the server version in the header by **baking it into the static HTML at build time**: the Makefile computed `VERSION` and passed it to `views/render.sh`, which replaced an SSI `#echo var="VERSION"` directive in the header partial. The compiled value was shipped in every `static/*.html` and went stale unless rebuilt — coupling the front-end build to git/version state.

## What

Advertise the version at runtime **with no extra request**:

- **`ApiDefaultsHandler`** sets a `LavinMQ-Version: <version>` header on every API response. (That handler only sees `/api/*` requests — HTML/static are served upstream — so the header is scoped to API responses.) A custom header is used rather than `Server` because proxies (nginx, …) commonly rewrite or strip `Server`.
- **`static/js/http.js`** reads it off each API response, caches it in `sessionStorage`, and updates the `#version` span. Since every authenticated page makes API calls through `http.js`, the version refreshes on each page load (a rebuilt/upgraded server's version shows up without a hard refresh).
- **`static/js/layout.js`** paints the last-known cached value on load for instant display.
- **Removed the VERSION plumbing** from the `Makefile` and `views/render.sh`, and emptied the header span. `render.sh` still handles `TITLE` and `#include` directives.

Reading a header off the page's own HTML navigation isn't possible from JS, but reading it from a same-origin `fetch()` response is — and works in every browser.

## Tests

- `spec/api/http_api_spec.cr`: the `LavinMQ-Version` header is present on API responses (`/api/whoami`) and absent on static/HTML responses (`/login`).
- `spec/frontend/layout.spec.js`: the version from the header is shown in `#version`, and cached in `sessionStorage`. Uses the `/queues` page (because `nodes.js` overwrites `#version` from `/api/nodes`) and reads `/api/queues` (not `/api/vhosts`, which the test fixture mocks without the header).

Verified locally: `npx standard` clean on changed files, `http_api_spec` green, full `layout.spec.js` green and stable on **chromium and firefox**, and `curl` confirms the `LavinMQ-Version` header on `/api/*` responses and its absence on HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)