### PR TITLE
Allow keys with no alg parameter when fetching jwks

### DIFF
--- a/spec/jwks_fetcher_spec.cr
+++ b/spec/jwks_fetcher_spec.cr
@@ -1,0 +1,62 @@
+require "./spec_helper"
+
+# Stub IdP serving OIDC discovery and a JWKS built from the given key entries.
+# Each entry is a Hash representing a single JWK as served on the /jwks endpoint.
+private def with_jwks_idp_server(keys : Array, & : Socket::IPAddress ->)
+  bound = [] of Socket::IPAddress
+  server = ::HTTP::Server.new do |ctx|
+    base = "http://#{bound.first}"
+    if ctx.request.path == "/.well-known/openid-configuration"
+      ctx.response.content_type = "application/json"
+      {issuer: base, jwks_uri: "#{base}/jwks"}.to_json(ctx.response)
+    elsif ctx.request.path == "/jwks"
+      ctx.response.content_type = "application/json"
+      {keys: keys}.to_json(ctx.response)
+    else
+      ctx.response.status_code = 404
+    end
+  end
+  bound << server.bind_tcp("127.0.0.1", 0)
+  spawn { server.listen }
+  Fiber.yield
+  yield bound.first
+ensure
+  server.try &.close
+end
+
+# A valid base64url-encoded RSA modulus so to_pem succeeds.
+private def rsa_modulus : String
+  Base64.urlsafe_encode(Random::Secure.random_bytes(256), padding: false)
+end
+
+private def fetcher_for(addr) : LavinMQ::Auth::JWT::JWKSFetcher
+  LavinMQ::Auth::JWT::JWKSFetcher.new(URI.parse("http://#{addr}"), 1.hour)
+end
+
+describe LavinMQ::Auth::JWT::JWKSFetcher do
+  describe "#fetch_jwks alg filtering" do
+    it "includes RSA signing keys with no alg param" do
+      keys = [{kty: "RSA", use: "sig", kid: "no-alg", n: rsa_modulus, e: "AQAB"}]
+      with_jwks_idp_server(keys) do |addr|
+        result = fetcher_for(addr).fetch_jwks
+        result.keys.keys.should eq ["no-alg"]
+      end
+    end
+
+    it "includes RSA signing keys with alg RS256" do
+      keys = [{kty: "RSA", use: "sig", alg: "RS256", kid: "rs256", n: rsa_modulus, e: "AQAB"}]
+      with_jwks_idp_server(keys) do |addr|
+        result = fetcher_for(addr).fetch_jwks
+        result.keys.keys.should eq ["rs256"]
+      end
+    end
+
+    it "excludes RSA signing keys with a non-RS256 alg" do
+      keys = [{kty: "RSA", use: "sig", alg: "RS512", kid: "rs512", n: rsa_modulus, e: "AQAB"}]
+      with_jwks_idp_server(keys) do |addr|
+        result = fetcher_for(addr).fetch_jwks
+        result.keys.should be_empty
+      end
+    end
+  end
+end

--- a/src/lavinmq/auth/jwt/jwks_fetcher.cr
+++ b/src/lavinmq/auth/jwt/jwks_fetcher.cr
@@ -163,8 +163,8 @@ module LavinMQ
             next unless key.kty == "RSA"
             # Skip keys not intended for signatures (RFC 7517 Section 4.2)
             next if key.use != "sig"
-            # Skip keys for other algorithms (RFC 7517 Section 4.4)
-            next if key.alg != "RS256"
+            # skip keys with unsupported algorithms, but allow keys with no alg (RFC 7517 Section 4.4)
+            next if (alg = key.alg) && alg != "RS256"
             next unless (n = key.n) && (e = key.e)
             kid = key.kid || "unknown-#{idx}"
             public_keys[kid] = to_pem(n, e)

--- a/src/lavinmq/auth/jwt/jwks_fetcher.cr
+++ b/src/lavinmq/auth/jwt/jwks_fetcher.cr
@@ -164,7 +164,7 @@ module LavinMQ
             # Skip keys not intended for signatures (RFC 7517 Section 4.2)
             next if key.use != "sig"
             # skip keys with unsupported algorithms, but allow keys with no alg (RFC 7517 Section 4.4)
-            next if (alg = key.alg) && alg != "RS256"
+            next if key.alg.try { |alg| alg != "RS256" }
             next unless (n = key.n) && (e = key.e)
             kid = key.kid || "unknown-#{idx}"
             public_keys[kid] = to_pem(n, e)


### PR DESCRIPTION
[RFC 7517 4.4](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4) states that this parameter is optional. Notice that we still must ensure its in the header. But we do that here:
https://github.com/cloudamqp/lavinmq/blob/01e9b7aea634f0abc8759cbb066ceb73e5af581a/src/lavinmq/auth/jwt/token_verifier.cr#L65-L66

### HOW can this pull request be tested?
Compiled and tested with entra, logs:
`Jun 26 06:49:57 dev-cold-kiwi-01 lavinmq[21671]:  lmq.jwks_fetcher Refreshed JWKS with 6 key(s), TTL=1.00:00:00`

Compiling main it outputs 0 key(s)