### PR TITLE
Make management UI OAuth2 scope configurable

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -68,6 +68,7 @@ jwks_cache_ttl = 3600
 | `issuer` | (required) | OIDC issuer URL. Used to discover JWKS endpoint. |
 | `client_id` | (none) | OAuth2 client ID. Required to enable management UI SSO (see below) |
 | `mgmt_base_url` | (none) | Public base URL of the management UI. Enables SSO login when set together with `issuer` and `client_id` |
+| `mgmt_scopes` | `openid profile` | Space-separated scopes requested in the management UI SSO authorization request. Override to match the requirements of your identity provider |
 | `resource_server_id` | (none) | Resource server identifier |
 | `preferred_username_claims` | `sub,client_id` | JWT claims to extract the username from (tried in order) |
 | `additional_scopes_keys` | `[]` | Additional JWT claims to check for scope strings |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `issuer` | URI | (none) | OAuth2/OIDC issuer URL |
 | `client_id` | String | (none) | OAuth2 client ID. Required to enable management UI SSO login |
 | `mgmt_base_url` | URI | (none) | Public base URL of the management UI. Setting it together with `issuer` and `client_id` enables the SSO login button. Must use `https://`, or `http://` with a `localhost`, `127.0.0.1`, or `[::1]` host. When `verify_aud` is true, SSO tokens must match `audience` or `resource_server_id` |
+| `mgmt_scopes` | String | `openid profile` | Space-separated scopes requested in the management UI SSO authorization request. Override to match the requirements of your identity provider |
 | `resource_server_id` | String | (none) | Resource server identifier |
 | `preferred_username_claims` | Array | `["sub", "client_id"]` | JWT claims for username extraction |
 | `additional_scopes_keys` | Array | `[]` | Additional JWT claims to check for scopes |

--- a/spec/http/oauth_spec.cr
+++ b/spec/http/oauth_spec.cr
@@ -531,6 +531,49 @@ describe "OAuth2" do
       end
     end
 
+    it "requests the default \"openid profile\" scope when oauth_mgmt_scopes is not configured" do
+      LavinMQ::Config.instance.oauth_client_id = "test-client"
+      LavinMQ::Config.instance.oauth_issuer_url = URI.parse("https://idp.example.com")
+      LavinMQ::Config.instance.oauth_mgmt_base_url = URI.parse("https://localhost:15672")
+
+      oidc = LavinMQ::Auth::JWT::JWKSFetcher::OIDCConfiguration.new(
+        issuer: "https://idp.example.com",
+        jwks_uri: "https://idp.example.com/jwks",
+        authorization_endpoint: "https://idp.example.com/authorize",
+        token_endpoint: "https://idp.example.com/token")
+      chain = build_oauth_chain(oidc)
+
+      with_http_server(authenticator: chain) do |http, _|
+        response = ::HTTP::Client.get(http.test_uri("/oauth/authorize"), headers: ::HTTP::Headers.new)
+        response.status_code.should eq 200
+        authorize_url = JSON.parse(response.body)["authorize_url"].as_s
+        URI.parse(authorize_url).query_params["scope"].should eq "openid profile"
+      end
+    end
+
+    it "requests the configured scope when oauth_mgmt_scopes is set" do
+      LavinMQ::Config.instance.oauth_client_id = "test-client"
+      LavinMQ::Config.instance.oauth_issuer_url = URI.parse("https://idp.example.com")
+      LavinMQ::Config.instance.oauth_mgmt_base_url = URI.parse("https://localhost:15672")
+      LavinMQ::Config.instance.oauth_mgmt_scopes = "openid email"
+
+      oidc = LavinMQ::Auth::JWT::JWKSFetcher::OIDCConfiguration.new(
+        issuer: "https://idp.example.com",
+        jwks_uri: "https://idp.example.com/jwks",
+        authorization_endpoint: "https://idp.example.com/authorize",
+        token_endpoint: "https://idp.example.com/token")
+      chain = build_oauth_chain(oidc)
+
+      with_http_server(authenticator: chain) do |http, _|
+        response = ::HTTP::Client.get(http.test_uri("/oauth/authorize"), headers: ::HTTP::Headers.new)
+        response.status_code.should eq 200
+        authorize_url = JSON.parse(response.body)["authorize_url"].as_s
+        URI.parse(authorize_url).query_params["scope"].should eq "openid email"
+      end
+    ensure
+      LavinMQ::Config.instance.oauth_mgmt_scopes = "openid profile"
+    end
+
     it "includes the audience parameter when oauth_audience is configured" do
       LavinMQ::Config.instance.oauth_client_id = "test-client"
       LavinMQ::Config.instance.oauth_issuer_url = URI.parse("https://idp.example.com")

--- a/spec/oauth_config_spec.cr
+++ b/spec/oauth_config_spec.cr
@@ -36,6 +36,11 @@ describe LavinMQ::Config do
       config = LavinMQ::Config.new
       config.oauth_resource_server_id.should be_nil
     end
+
+    it "sets default oauth_mgmt_scopes to \"openid profile\"" do
+      config = LavinMQ::Config.new
+      config.oauth_mgmt_scopes.should eq("openid profile")
+    end
   end
 
   describe "OAuth configuration parsing" do
@@ -120,6 +125,20 @@ describe LavinMQ::Config do
       config = LavinMQ::Config.new
       config.parse(["-c", config_file.path])
       config.oauth_scope_prefix.should eq("mq.")
+    end
+
+    it "parses mgmt_scopes" do
+      config_file = File.tempfile do |file|
+        file.print <<-CONFIG
+        [oauth]
+        issuer = https://auth.example.com
+        mgmt_scopes = openid email offline_access
+        CONFIG
+      end
+
+      config = LavinMQ::Config.new
+      config.parse(["-c", config_file.path])
+      config.oauth_mgmt_scopes.should eq("openid email offline_access")
     end
 
     it "parses verify_aud as boolean" do

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -514,6 +514,8 @@ module LavinMQ
       property oauth_client_id : String? = nil
       @[IniOpt(section: "oauth", ini_name: mgmt_base_url)]
       property oauth_mgmt_base_url : URI? = nil
+      @[IniOpt(section: "oauth", ini_name: mgmt_scopes)]
+      property oauth_mgmt_scopes : String = "openid profile"
 
       # Internal: not exposed as configurable, only used for testing
       property deliver_loop_idle_timeout : Time::Span = 30.seconds

--- a/src/lavinmq/http/controller/oauth.cr
+++ b/src/lavinmq/http/controller/oauth.cr
@@ -82,7 +82,7 @@ module LavinMQ
           p.add "client_id", client_id
           p.add "redirect_uri", build_redirect_uri
           p.add "response_type", "code"
-          p.add "scope", "openid profile"
+          p.add "scope", config.oauth_mgmt_scopes
           p.add "code_challenge", challenge
           p.add "code_challenge_method", "S256"
           p.add "state", state


### PR DESCRIPTION
The scope requested during the management UI OAuth2/OIDC login flow was hardcoded to "openid profile" in the authorize controller, which does not work for every identity provider (Entra ID, for example, is stricter about requested scopes).

This adds an [oauth] mgmt_scopes setting that replaces the requested scope verbatim. It defaults to "openid profile" so existing deployments are unaffected, and operators can set it to whatever their IdP requires. The name avoids confusion with the existing additional_scopes_keys and scope_prefix settings, which apply to parsing scopes out of a received token rather than the outbound authorization request.

Closes #2125
