### PR TITLE
Apply SNI changes on config reload

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -859,6 +859,30 @@ describe LavinMQ::Launcher do
       end
     end
 
+    it "serves a per-host certificate for an SNI host added on reload" do
+      with_launcher(<<-INI) do |launcher, _config, config_file|
+      [main]
+      tls_cert = spec/resources/server_certificate.pem
+      tls_key = spec/resources/server_key.pem
+      INI
+        amqp_ctx = launcher.@amqp_tls_context.not_nil!
+        served_cn(amqp_ctx, "foobar.localhost").should eq "anders" # default cert, no SNI host yet
+
+        # Add an SNI host and reload, as a SIGHUP would.
+        File.write(config_file.path, <<-INI)
+        [main]
+        tls_cert = spec/resources/server_certificate.pem
+        tls_key = spec/resources/server_key.pem
+
+        [sni:foobar.localhost]
+        tls_cert = spec/resources/foobar_localhost_certificate.pem
+        tls_key = spec/resources/foobar_localhost_key.pem
+        INI
+        launcher.reload!
+        served_cn(amqp_ctx, "foobar.localhost").should eq "foobar.localhost"
+      end
+    end
+
     it "warns that enabling TLS requires a restart" do
       with_launcher("[main]\nstats_interval = 5000\n") do |launcher, _config, config_file|
         launcher.@amqp_tls_context.should be_nil

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -889,27 +889,5 @@ describe LavinMQ::Launcher do
         end
       end
     end
-
-    it "warns that enabling SNI requires a restart" do
-      with_launcher(<<-INI) do |launcher, _config, config_file|
-      [main]
-      tls_cert = spec/resources/server_certificate.pem
-      tls_key = spec/resources/server_key.pem
-      INI
-        File.write(config_file.path, <<-INI)
-        [main]
-        tls_cert = spec/resources/server_certificate.pem
-        tls_key = spec/resources/server_key.pem
-
-        [sni:foobar.localhost]
-        tls_cert = spec/resources/foobar_localhost_certificate.pem
-        tls_key = spec/resources/foobar_localhost_key.pem
-        INI
-        Log.capture("lmq.launcher", :warn) do |logs|
-          launcher.reload!
-          logs.check(:warn, /Enabling SNI requires a restart/)
-        end
-      end
-    end
   end
 end

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -1,5 +1,14 @@
 require "./spec_helper"
 require "../src/stdlib/openssl_on_server_name"
+require "../src/lavinmq/launcher"
+
+class LavinMQ::Launcher
+  getter amqp_tls_context
+
+  def reload_for_spec
+    reload_config
+  end
+end
 
 describe LavinMQ::SNIHost do
   it "creates TLS contexts with default settings" do
@@ -453,5 +462,72 @@ describe "SNI end-to-end" do
 
     tcp_server.close
     server_done.receive
+  end
+end
+
+describe LavinMQ::Launcher do
+  it "serves a per-host certificate for an SNI host added on config reload" do
+    with_datadir do |data_dir|
+      config_file = File.join(data_dir, "lavinmq.ini")
+      File.write config_file, <<-INI
+        [main]
+        tls_cert = spec/resources/server_certificate.pem
+        tls_key = spec/resources/server_key.pem
+        INI
+
+      config = LavinMQ::Config.new
+      config.data_dir = data_dir
+      config.data_dir_lock = false
+      config.config_file = config_file
+      config.reload # initial parse, no SNI hosts configured yet
+
+      launcher = LavinMQ::Launcher.new(config)
+      amqp_ctx = launcher.amqp_tls_context.not_nil!
+
+      # Add an SNI host to the config file and reload, as a SIGHUP would.
+      File.write config_file, <<-INI
+        [main]
+        tls_cert = spec/resources/server_certificate.pem
+        tls_key = spec/resources/server_key.pem
+
+        [sni:foobar.localhost]
+        tls_cert = spec/resources/foobar_localhost_certificate.pem
+        tls_key = spec/resources/foobar_localhost_key.pem
+        INI
+      launcher.reload_for_spec
+
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      port = tcp_server.local_address.port
+      server_done = Channel(Nil).new
+
+      spawn do
+        if client = tcp_server.accept?
+          begin
+            ssl_socket = OpenSSL::SSL::Socket::Server.new(client, amqp_ctx)
+            ssl_socket.close
+          rescue
+          ensure
+            client.close
+          end
+        end
+        server_done.send(nil)
+      end
+
+      tcp_client = TCPSocket.new("127.0.0.1", port)
+      client_ctx = OpenSSL::SSL::Context::Client.new
+      client_ctx.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+      client_ctx.ca_certificates = "spec/resources/foobar_localhost_certificate.pem"
+      begin
+        # Verification against foobar's cert only succeeds if the reload-added
+        # SNI host's certificate is served, not the default [main] cert.
+        ssl_client = OpenSSL::SSL::Socket::Client.new(tcp_client, client_ctx, hostname: "foobar.localhost")
+        ssl_client.close
+      ensure
+        tcp_client.close
+      end
+
+      tcp_server.close
+      server_done.receive
+    end
   end
 end

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -1,14 +1,5 @@
 require "./spec_helper"
 require "../src/stdlib/openssl_on_server_name"
-require "../src/lavinmq/launcher"
-
-class LavinMQ::Launcher
-  getter amqp_tls_context
-
-  def reload_for_spec
-    reload_config
-  end
-end
 
 describe LavinMQ::SNIHost do
   it "creates TLS contexts with default settings" do
@@ -462,72 +453,5 @@ describe "SNI end-to-end" do
 
     tcp_server.close
     server_done.receive
-  end
-end
-
-describe LavinMQ::Launcher do
-  it "serves a per-host certificate for an SNI host added on config reload" do
-    with_datadir do |data_dir|
-      config_file = File.join(data_dir, "lavinmq.ini")
-      File.write config_file, <<-INI
-        [main]
-        tls_cert = spec/resources/server_certificate.pem
-        tls_key = spec/resources/server_key.pem
-        INI
-
-      config = LavinMQ::Config.new
-      config.data_dir = data_dir
-      config.data_dir_lock = false
-      config.config_file = config_file
-      config.reload # initial parse, no SNI hosts configured yet
-
-      launcher = LavinMQ::Launcher.new(config)
-      amqp_ctx = launcher.amqp_tls_context.not_nil!
-
-      # Add an SNI host to the config file and reload, as a SIGHUP would.
-      File.write config_file, <<-INI
-        [main]
-        tls_cert = spec/resources/server_certificate.pem
-        tls_key = spec/resources/server_key.pem
-
-        [sni:foobar.localhost]
-        tls_cert = spec/resources/foobar_localhost_certificate.pem
-        tls_key = spec/resources/foobar_localhost_key.pem
-        INI
-      launcher.reload_for_spec
-
-      tcp_server = TCPServer.new("127.0.0.1", 0)
-      port = tcp_server.local_address.port
-      server_done = Channel(Nil).new
-
-      spawn do
-        if client = tcp_server.accept?
-          begin
-            ssl_socket = OpenSSL::SSL::Socket::Server.new(client, amqp_ctx)
-            ssl_socket.close
-          rescue
-          ensure
-            client.close
-          end
-        end
-        server_done.send(nil)
-      end
-
-      tcp_client = TCPSocket.new("127.0.0.1", port)
-      client_ctx = OpenSSL::SSL::Context::Client.new
-      client_ctx.verify_mode = OpenSSL::SSL::VerifyMode::PEER
-      client_ctx.ca_certificates = "spec/resources/foobar_localhost_certificate.pem"
-      begin
-        # Verification against foobar's cert only succeeds if the reload-added
-        # SNI host's certificate is served, not the default [main] cert.
-        ssl_client = OpenSSL::SSL::Socket::Client.new(tcp_client, client_ctx, hostname: "foobar.localhost")
-        ssl_client.close
-      ensure
-        tcp_client.close
-      end
-
-      tcp_server.close
-      server_done.receive
-    end
   end
 end

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -327,19 +327,12 @@ module LavinMQ
     end
 
     private def reload_tls_context
-      # Enabling TLS or SNI needs listeners/callbacks set up at boot, so it
-      # requires a restart. Cert rotation and updates to existing SNI hosts
-      # are applied below.
       if @config.tls_configured? && @amqp_tls_context.nil?
         Log.warn { "Enabling TLS requires a restart to take effect" }
         return
       end
       if !@config.tls_configured? && @amqp_tls_context
         Log.warn { "Disabling TLS requires a restart to take effect" }
-        return
-      end
-      if (amqp_ctx = @amqp_tls_context) && !amqp_ctx.sni_callback? && !@config.sni_manager.empty?
-        Log.warn { "Enabling SNI requires a restart to take effect" }
         return
       end
       {@amqp_tls_context, @mqtt_tls_context, @http_tls_context}.each do |ctx|
@@ -387,12 +380,7 @@ module LavinMQ
       end
     end
 
-    # Registers the SNI callbacks once at boot, only when SNI hosts exist. The
-    # callbacks read `@config.sni_manager` dynamically so reloads that update
-    # existing hosts are picked up without re-registering.
     private def setup_sni_callbacks
-      return if @config.sni_manager.empty?
-
       # Set up SNI callback for AMQP TLS context
       if amqp_tls = @amqp_tls_context
         amqp_tls.on_server_name do |hostname|

--- a/src/stdlib/openssl_on_server_name.cr
+++ b/src/stdlib/openssl_on_server_name.cr
@@ -19,13 +19,6 @@ lib LibSSL
 end
 
 class OpenSSL::SSL::Context::Server
-  # Whether an SNI callback has been registered on this context. The ivar is a
-  # Pointer(Void) that Crystal zero-initialises to null until on_server_name
-  # sets it, so test for a null pointer rather than nil.
-  def sni_callback? : Bool
-    !@sni_callback_box.null?
-  end
-
   @[Experimental]
   def on_server_name(&block : String -> OpenSSL::SSL::Context::Server?)
     c_callback = Proc(LibSSL::SSL, LibC::Int*, Void*, LibC::Int).new do |ssl, alert_ptr, arg|


### PR DESCRIPTION
### WHAT is this pull request doing?

setup_sni_callbacks has an early return if the sni_manager is empty. This is the case when you bootstrap a lavinmq server with no sni-sections in the lavinmq.ini, which is fine. However, if a user wishes to add an sni-section, they have to restart lavinmq for that change to take effect.

On reload, reload_tls_context will reload the sni managers hosts and exist in memory, but since the callback is not installed for the listeners, they will still serve the default certificate.

I added https://github.com/cloudamqp/lavinmq/pull/2033 first but was cleaner to create a new PR rather than rebasing this to main.

Dropped the refactoring of reloading sni contexts, as that changed the dynamic behavior.

### HOW can this pull request be tested?
Specs.

Manually:

create a certificate and key,
boot lavinmq with no sni host section, 
send SIGHUP to the lavinmq process after adding an sni host section, for example this config

```
[main]
log_level = debug
data_dir = ./tmp/data
tls_cert = /tmp/default.pem
tls_key  = /tmp/default.key

[amqp]
tls_port = 5671

[mgmt]
tls_port = 15671

[sni:broker-a.local]
tls_cert = ./tmp/a.pem
tls_key  = ./tmp/a.key
```

and this should be the result of the openssl command:
`echo | openssl s_client -connect localhost:15671 -servername broker-a.local 2>/dev/null | openssl x509 -noout -subject subject=CN=broker-a.local
`

before this change it shows the default certificate.
