### PR TITLE
Mqtt exchange to amqp exchange

### DIFF
--- a/spec/exchange_spec.cr
+++ b/spec/exchange_spec.cr
@@ -222,7 +222,7 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchange("test")
+          ex = s.vhosts["/"].exchange("test").as(LavinMQ::AMQP::Exchange)
           q = s.vhosts["/"].queues.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "x-deduplication-header" => "msg1",
@@ -251,7 +251,7 @@ describe LavinMQ::Exchange do
           })
           ch.exchange("test", "topic", args: args)
           ch.queue.bind("test", "#")
-          ex = s.vhosts["/"].exchange("test")
+          ex = s.vhosts["/"].exchange("test").as(LavinMQ::AMQP::Exchange)
           q = s.vhosts["/"].queues.first
           props = LavinMQ::AMQP::Properties.new(headers: LavinMQ::AMQP::Table.new({
             "custom" => "msg1",

--- a/spec/mqtt/cross_protocol_binding_spec.cr
+++ b/spec/mqtt/cross_protocol_binding_spec.cr
@@ -1,0 +1,128 @@
+require "./spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+
+  describe "MQTT exchange to AMQP exchange binding (#1136)" do
+    it "routes an MQTT publish into a bound AMQP topic exchange with a translated routing key" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.dest", "topic", false, false)
+        vhost.declare_queue("dest-q", false, false)
+        vhost.bind_queue("dest-q", "amq.dest", "sensors.#")
+        # Bind the MQTT exchange -> AMQP exchange using an MQTT-syntax filter.
+        vhost.bind_exchange("amq.dest", LavinMQ::MQTT::EXCHANGE, "sensors/+/temp")
+
+        with_client_io(server) do |io|
+          connect(io)
+          publish(io, topic: "sensors/dev1/temp", payload: "25".to_slice, qos: 0u8)
+        end
+
+        q = vhost.queue("dest-q")
+        wait_for { q.message_count == 1 }
+        q.message_count.should eq 1
+        q.basic_get(true) do |env|
+          env.message.routing_key.should eq "sensors.dev1.temp"
+          String.new(env.message.body).should eq "25"
+        end.should be_true
+      end
+    end
+
+    it "maps MQTT QoS>=1 to a persistent AMQP delivery_mode" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.persist", "topic", true, false)
+        vhost.declare_queue("persist-q", true, false)
+        vhost.bind_queue("persist-q", "amq.persist", "#")
+        vhost.bind_exchange("amq.persist", LavinMQ::MQTT::EXCHANGE, "sensors/+/temp")
+
+        with_client_io(server) do |io|
+          connect(io)
+          publish(io, topic: "sensors/dev1/temp", payload: "25".to_slice, qos: 1u8)
+        end
+
+        q = vhost.queue("persist-q")
+        wait_for { q.message_count == 1 }
+        q.basic_get(true) do |env|
+          env.message.properties.delivery_mode.should eq 2u8
+        end.should be_true
+      end
+    end
+
+    it "maps MQTT QoS 0 to a transient AMQP delivery_mode" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.transient-dm", "topic", true, false)
+        vhost.declare_queue("transient-dm-q", true, false)
+        vhost.bind_queue("transient-dm-q", "amq.transient-dm", "#")
+        vhost.bind_exchange("amq.transient-dm", LavinMQ::MQTT::EXCHANGE, "sensors/+/temp")
+
+        with_client_io(server) do |io|
+          connect(io)
+          publish(io, topic: "sensors/dev1/temp", payload: "25".to_slice, qos: 0u8)
+        end
+
+        q = vhost.queue("transient-dm-q")
+        wait_for { q.message_count == 1 }
+        q.basic_get(true) do |env|
+          env.message.properties.delivery_mode.should eq 1u8
+        end.should be_true
+      end
+    end
+
+    it "does not route an MQTT publish that doesn't match the binding filter" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.dest2", "topic", false, false)
+        vhost.declare_queue("dest-q2", false, false)
+        vhost.bind_queue("dest-q2", "amq.dest2", "#")
+        vhost.bind_exchange("amq.dest2", LavinMQ::MQTT::EXCHANGE, "sensors/+/temp")
+
+        with_client_io(server) do |io|
+          connect(io)
+          publish(io, topic: "other/topic", payload: "x".to_slice, qos: 0u8)
+        end
+
+        q = vhost.queue("dest-q2")
+        sleep 50.milliseconds
+        q.message_count.should eq 0
+      end
+    end
+
+    it "reports the bound AMQP exchange as the binding destination" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.dest3", "topic", false, false)
+        vhost.bind_exchange("amq.dest3", LavinMQ::MQTT::EXCHANGE, "a/b")
+        exchange = vhost.exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
+        bindings = exchange.bindings_details
+        bindings.size.should eq 1
+        bindings.first.destination.name.should eq "amq.dest3"
+        bindings.first.routing_key.should eq "a/b"
+      end
+    end
+
+    it "preserves binding arguments on a cross-protocol binding" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.args", "topic", false, false)
+        args = LavinMQ::AMQP::Table.new({"x-foo" => "bar"})
+        vhost.bind_exchange("amq.args", LavinMQ::MQTT::EXCHANGE, "a/b", args)
+        exchange = vhost.exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
+        exchange.bindings_details.first.arguments.should eq args
+      end
+    end
+
+    it "removes the binding when unbound" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.dest4", "topic", false, false)
+        vhost.bind_exchange("amq.dest4", LavinMQ::MQTT::EXCHANGE, "a/b")
+        exchange = vhost.exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
+        exchange.bindings_details.size.should eq 1
+        vhost.unbind_exchange("amq.dest4", LavinMQ::MQTT::EXCHANGE, "a/b")
+        exchange.bindings_details.should be_empty
+      end
+    end
+  end
+end

--- a/spec/mqtt/cross_protocol_binding_spec.cr
+++ b/spec/mqtt/cross_protocol_binding_spec.cr
@@ -113,6 +113,27 @@ module MqttSpecs
       end
     end
 
+    it "persists only durable cross-protocol bindings, not sessions or transient destinations" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        vhost.declare_exchange("amq.durable-dest", "topic", true, false)
+        vhost.declare_exchange("amq.transient-dest", "topic", false, false)
+        vhost.bind_exchange("amq.durable-dest", LavinMQ::MQTT::EXCHANGE, "a/b")
+        vhost.bind_exchange("amq.transient-dest", LavinMQ::MQTT::EXCHANGE, "c/d")
+        exchange = vhost.exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "sub", clean_session: true)
+          subscribe(io, topic_filters: [subtopic("x/y", 0u8), subtopic("z/#", 0u8)])
+          # tree: 2 cross-protocol bindings + 2 session subscriptions
+          exchange.bindings_details.size.should eq 4
+          # only the durable cross-protocol destination is persisted
+          exchange.bindings_to_persist.map(&.destination.name).should eq ["amq.durable-dest"]
+          disconnect(io)
+        end
+      end
+    end
+
     it "removes the binding when unbound" do
       with_server do |server|
         vhost = server.vhosts["/"]

--- a/spec/mqtt/exchange_spec.cr
+++ b/spec/mqtt/exchange_spec.cr
@@ -4,6 +4,11 @@ module MqttSpecs
   extend MqttHelpers
 
   describe LavinMQ::MQTT::Exchange do
+    it "does not inherit from AMQP::Exchange (protocol decoupling, #1136)" do
+      {{ LavinMQ::MQTT::Exchange.ancestors.includes?(LavinMQ::Exchange) }}.should be_true
+      {{ LavinMQ::MQTT::Exchange.ancestors.includes?(LavinMQ::AMQP::Exchange) }}.should be_false
+    end
+
     it "removes all subscriptions from the subscription tree when a session is removed" do
       with_server do |server|
         exchange = server.vhosts["/"].exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)

--- a/spec/mqtt/topic_translator_spec.cr
+++ b/spec/mqtt/topic_translator_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+require "../../src/lavinmq/mqtt/topic_translator"
+
+describe LavinMQ::MQTT::TopicTranslator do
+  describe ".mqtt_to_amqp" do
+    # { mqtt topic, expected amqp routing key }
+    [
+      {"a", "a"},
+      {"a/b/c", "a.b.c"},
+      {"sensors/device1/temp", "sensors.device1.temp"},
+      {"a//c", "a..c"},           # empty level preserved
+      {"/a", ".a"},               # leading separator preserved
+      {"a/", "a."},               # trailing separator preserved
+      {"v1.2/data", "v1.2.data"}, # documented caveat: literal '.' collapses into a level
+    ].each do |(topic, expected)|
+      it "translates #{topic.inspect} to #{expected.inspect}" do
+        LavinMQ::MQTT::TopicTranslator.mqtt_to_amqp(topic).should eq expected
+      end
+    end
+
+    it "is byte-length preserving" do
+      topic = "a/bb/ccc/dddd"
+      LavinMQ::MQTT::TopicTranslator.mqtt_to_amqp(topic).bytesize.should eq topic.bytesize
+    end
+  end
+end

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -34,6 +34,43 @@ describe LavinMQ::VHost do
     end
   end
 
+  it "persists an MQTT exchange to AMQP exchange binding across restart (#1136)" do
+    with_amqp_server do |s|
+      v = s.vhosts["/"]
+      v.declare_exchange("amq.dest", "topic", true, false)
+      v.bind_exchange("amq.dest", LavinMQ::MQTT::EXCHANGE, "sensors/+/temp")
+      v.exchange(LavinMQ::MQTT::EXCHANGE).bindings_details
+        .map(&.destination.name).should contain("amq.dest")
+      s.restart
+      v = s.vhosts["/"]
+      v.exchange(LavinMQ::MQTT::EXCHANGE).bindings_details
+        .map(&.destination.name).should contain("amq.dest")
+    end
+  end
+
+  it "does not persist a cross-protocol binding to a non-durable AMQP exchange (#1136)" do
+    with_amqp_server do |s|
+      v = s.vhosts["/"]
+      v.declare_exchange("amq.transient", "topic", false, false)
+      v.bind_exchange("amq.transient", LavinMQ::MQTT::EXCHANGE, "a/b")
+      s.restart
+      v = s.vhosts["/"]
+      v.exchange(LavinMQ::MQTT::EXCHANGE).bindings_details.should be_empty
+    end
+  end
+
+  it "removes the cross-protocol binding when the downstream exchange is deleted (#1136)" do
+    with_amqp_server do |s|
+      v = s.vhosts["/"]
+      v.declare_exchange("amq.dest", "topic", true, false)
+      v.bind_exchange("amq.dest", LavinMQ::MQTT::EXCHANGE, "a/b")
+      mqtt_ex = v.exchange(LavinMQ::MQTT::EXCHANGE)
+      mqtt_ex.bindings_details.size.should eq 1
+      v.delete_exchange("amq.dest")
+      mqtt_ex.bindings_details.should be_empty
+    end
+  end
+
   it "should be able to persist durable delayed exchanges when type = x-delayed-message" do
     config = LavinMQ::Config.new
     with_amqp_server do |s|

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -131,6 +131,10 @@ module LavinMQ
           @arguments == frame_args
       end
 
+      def persistent? : Bool
+        durable?
+      end
+
       def in_use?
         return true unless bindings_details.empty?
         @vhost.exchanges_any? do |_, x|

--- a/src/lavinmq/amqp/exchange/exchange.cr
+++ b/src/lavinmq/amqp/exchange/exchange.cr
@@ -135,6 +135,13 @@ module LavinMQ
         durable?
       end
 
+      # Bindings that definitions compaction should write to the dump. AMQP
+      # exchanges persist all of their bindings (as the live bind path does for
+      # durable sources); see MQTT::Exchange for the cross-protocol override.
+      def bindings_to_persist : Array(BindingDetails)
+        bindings_details
+      end
+
       def in_use?
         return true unless bindings_details.empty?
         @vhost.exchanges_any? do |_, x|

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -179,12 +179,12 @@ module LavinMQ
           src = @exchanges[f.source]? || return false
           dst = @exchanges[f.destination]? || return false
           return false unless src.bind(dst, f.routing_key, f.arguments)
-          store_definition(f, fsync: fsync) if !loading && src.durable? && dst.durable?
+          store_definition(f, fsync: fsync) if !loading && src.persistent? && dst.durable?
         when AMQP::Frame::Exchange::Unbind
           src = @exchanges[f.source]? || return false
           dst = @exchanges[f.destination]? || return false
           return false unless src.unbind(dst, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && src.durable? && dst.durable?
+          store_definition(f, dirty: true) if !loading && src.persistent? && dst.durable?
         when AMQP::Frame::Queue::Declare
           return false if @queues.has_key?(f.queue_name) || @sessions.has_key?(f.queue_name)
           q = QueueFactory.make(@vhost, f)
@@ -353,15 +353,22 @@ module LavinMQ
             s.auto_delete?, false, s.arguments)
           io.write_bytes f
         end
-        @exchanges.each_value.select(&.durable?).each do |e|
+        @exchanges.each_value.select(&.persistent?).each do |e|
           e.bindings_details.each do |binding|
+            dest = binding.destination
+            # A persistent-but-not-durable exchange (the MQTT exchange) only
+            # persists its exchange-to-exchange bindings to durable
+            # destinations; its session subscriptions stay transient (#1136).
+            unless e.durable?
+              next unless dest.is_a?(Exchange) && dest.durable?
+            end
             args = binding.arguments || AMQP::Table.new
-            frame = case binding.destination
+            frame = case dest
                     when Queue
-                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
+                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, dest.name, e.name,
                         binding.routing_key, false, args)
                     when Exchange
-                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
+                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, dest.name, e.name,
                         binding.routing_key, false, args)
                     end
             if f = frame

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -354,14 +354,10 @@ module LavinMQ
           io.write_bytes f
         end
         @exchanges.each_value.select(&.persistent?).each do |e|
-          e.bindings_details.each do |binding|
+          # Each exchange decides which of its bindings survive a restart; the
+          # MQTT exchange yields only its durable cross-protocol bindings (#1136).
+          e.bindings_to_persist.each do |binding|
             dest = binding.destination
-            # A persistent-but-not-durable exchange (the MQTT exchange) only
-            # persists its exchange-to-exchange bindings to durable
-            # destinations; its session subscriptions stay transient (#1136).
-            unless e.durable?
-              next unless dest.is_a?(Exchange) && dest.durable?
-            end
             args = binding.arguments || AMQP::Table.new
             frame = case dest
                     when Queue

--- a/src/lavinmq/exchange.cr
+++ b/src/lavinmq/exchange.cr
@@ -6,6 +6,12 @@ module LavinMQ
     include SortableJSON
     @name = ""
 
+    # Whether bindings whose source is this exchange should survive a restart.
+    # Tracks durability for AMQP exchanges; the MQTT exchange overrides it to
+    # true because it is always recreated at boot, so cross-protocol bindings
+    # from it can be persisted and replayed (#1136).
+    abstract def persistent? : Bool
+
     class AccessRefused < Error
       def initialize(@exchange : Exchange)
         super("Access refused to #{@exchange.name}")

--- a/src/lavinmq/mqtt/amqp_destination.cr
+++ b/src/lavinmq/mqtt/amqp_destination.cr
@@ -1,0 +1,40 @@
+require "../message"
+require "../amqp/exchange"
+require "./topic_translator"
+
+module LavinMQ
+  module MQTT
+    # Adapts a downstream `AMQP::Exchange` so it can be held in the MQTT
+    # `SubscriptionTree` alongside sessions. When an MQTT message matches the
+    # binding filter, the wrapper translates the topic into an AMQP routing key
+    # and routes the message into the wrapped exchange — enabling MQTT
+    # exchange-to-AMQP-exchange bindings (#1136).
+    #
+    # Equality is defined on the wrapped exchange so bind/unbind can create
+    # fresh wrappers: two wrappers over the same downstream exchange are
+    # interchangeable as tree entries.
+    class AMQPDestination
+      getter exchange : LavinMQ::AMQP::Exchange
+      getter arguments : AMQP::Table?
+
+      def initialize(@exchange : LavinMQ::AMQP::Exchange, @arguments : AMQP::Table? = nil)
+      end
+
+      # Equality is intentionally on the wrapped exchange only (not arguments),
+      # so unbind can match with a fresh wrapper regardless of arguments.
+      def_equals_and_hash @exchange
+
+      # Translates the MQTT topic to an AMQP routing key and routes the message
+      # into the wrapped exchange via its full publish path (so downstream
+      # dedup/delayed/alternate-exchange semantics apply). Returns whether the
+      # message was routed to at least one downstream queue. The new `Message`
+      # shares the original body IO; the downstream routing rewinds it.
+      def publish(msg : Message) : Bool
+        routing_key = TopicTranslator.mqtt_to_amqp(msg.routing_key)
+        translated = Message.new(msg.timestamp, @exchange.name, routing_key,
+          msg.properties, msg.bodysize, msg.body_io)
+        @exchange.publish(translated, false).routed?
+      end
+    end
+  end
+end

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -25,9 +25,10 @@ module LavinMQ
       def initialize(@vhost : VHost, @replicator : Clustering::Replicator?)
         @sessions = Sessions.new(@vhost)
         @clients = Hash(String, Client).new
-        @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @replicator)
-        @exchange = MQTT::Exchange.new(@vhost, EXCHANGE, @retain_store)
-        @vhost.register_exchange(@exchange)
+        # The exchange and retain store are owned by the VHost (created before
+        # definitions replay); the broker attaches to them. (#1136)
+        @retain_store = @vhost.mqtt_retain_store
+        @exchange = @vhost.mqtt_exchange
       end
 
       def session_present?(client_id : String, clean_session) : Bool
@@ -102,7 +103,7 @@ module LavinMQ
       end
 
       def close
-        @retain_store.close
+        # The retain store is owned and closed by the VHost.
       end
     end
   end

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -134,6 +134,21 @@ module LavinMQ
         @tree.size
       end
 
+      # Only the cross-protocol exchange-to-exchange bindings (to durable
+      # destinations) are persisted; session subscriptions stay transient.
+      # Built lazily so compaction never materializes a BindingDetails per MQTT
+      # session subscription (#1136).
+      def bindings_to_persist : Array(BindingDetails)
+        result = Array(BindingDetails).new
+        @tree.each_entry do |entry, _qos, filter|
+          next unless entry.is_a?(MQTT::AMQPDestination)
+          dest = entry.exchange
+          next unless dest.durable?
+          result << BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(filter, entry.arguments), dest)
+        end
+        result
+      end
+
       # The internal MQTT exchange is never (re)declarable by an AMQP client, so
       # it never matches a declare frame.
       def match?(frame : AMQP::Frame) : Bool

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -1,21 +1,54 @@
+require "../exchange"
 require "../amqp/exchange"
+require "../stats"
+require "../observable"
+require "../policy"
+require "../sortable_json"
 require "./consts"
 require "../destination"
 require "./subscription_tree"
 require "./session"
+require "./amqp_destination"
 require "./retain_store"
 
 module LavinMQ
   module MQTT
-    class Exchange < AMQP::Exchange
-      @tree = MQTT::SubscriptionTree(MQTT::Session).new
+    # Entries held in the MQTT SubscriptionTree: either an MQTT session or a
+    # wrapper routing into a downstream AMQP exchange (#1136).
+    alias Subscriber = Session | AMQPDestination
+
+    # The MQTT routing exchange. It deliberately does NOT inherit from
+    # `AMQP::Exchange`: MQTT routing has its own topic semantics (slash
+    # separated levels, '+'/'#' wildcards) and its own message ingress
+    # (`broker.publish(packet)`), so it only implements the protocol-agnostic
+    # `LavinMQ::Exchange` contract plus the MQTT-specific routing.
+    class Exchange < LavinMQ::Exchange
+      include Stats
+      include PolicyTarget
+      include SortableJSON
+      include Observable(ExchangeEvent)
+
+      Log = ::LavinMQ::Log.for "mqtt.exchange"
+
+      getter name : String
+      getter vhost : VHost
+      getter arguments = AMQP::Table.new
+      getter? durable = false
+      getter? auto_delete = false
+      getter? internal = true
+
+      # Match the AMQP exchange stat surface so polymorphic consumers (the
+      # Prometheus exporter, management UI) work; "dedup" stays 0 for MQTT.
+      rate_stats({"publish_in", "publish_out", "unroutable", "dedup"})
+
+      @tree = MQTT::SubscriptionTree(MQTT::Subscriber).new
+      @deleted = false
 
       def type : String
         "mqtt"
       end
 
-      def initialize(vhost : VHost, name : String, @retain_store : MQTT::RetainStore)
-        super(vhost, name, false, false, true)
+      def initialize(@vhost : VHost, @name : String, @retain_store : MQTT::RetainStore)
       end
 
       def publish(packet : Protocol::Publish) : UInt32
@@ -34,9 +67,20 @@ module LavinMQ
 
         msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
         count = 0u32
-        @tree.each_entry(packet.topic) do |queue, qos, _filter|
-          msg.properties.delivery_mode = qos
-          if queue.publish(msg)
+        @tree.each_entry(packet.topic) do |entry, qos, _filter|
+          # Sessions carry the per-subscription QoS in delivery_mode; for an AMQP
+          # destination, map the publish QoS to AMQP persistence semantics
+          # (QoS>=1 -> persistent) so durable downstream queues persist it (#1136).
+          routed =
+            case entry
+            in MQTT::Session
+              msg.properties.delivery_mode = qos
+              entry.publish(msg)
+            in MQTT::AMQPDestination
+              msg.properties.delivery_mode = packet.qos >= 1 ? 2u8 : 1u8
+              entry.publish(msg)
+            end
+          if routed
             count += 1
             msg.body_io.rewind
           end
@@ -46,12 +90,42 @@ module LavinMQ
         count
       end
 
+      # The MQTT exchange is not a valid target for AMQP-side publishing; the
+      # only ingress is `publish(packet)`. Satisfies the `LavinMQ::Exchange`
+      # contract used by `VHost#publish`.
+      def publish(msg : Message, immediate : Bool,
+                  queues : Set(AMQP::Queue) = Set(AMQP::Queue).new,
+                  exchanges : Set(LavinMQ::Exchange) = Set(LavinMQ::Exchange).new) : AMQP::Exchange::PublishResult
+        AMQP::Exchange::PublishResult::None
+      end
+
+      # No-op: the MQTT exchange never contributes AMQP queues when reached as a
+      # destination of an AMQP exchange. Exists so the virtual `find_queues`
+      # dispatch over `LavinMQ::Exchange` compiles.
+      def find_queues(routing_key : String, headers : AMQP::Table?,
+                      queues : Set(AMQP::Queue) = Set(AMQP::Queue).new,
+                      exchanges : Set(LavinMQ::Exchange) = Set(LavinMQ::Exchange).new) : Nil
+      end
+
+      # Not a valid AMQP routing target; satisfies the virtual `route_msg`
+      # dispatch over `LavinMQ::Exchange`.
+      def route_msg(msg : Message) : AMQP::Exchange::PublishResult
+        AMQP::Exchange::PublishResult::None
+      end
+
       def bindings_details : Array(BindingDetails)
         result = Array(BindingDetails).new
-        @tree.each_entry do |session, qos, filter|
-          arguments = AMQP::Table.new
-          arguments[QOS_HEADER] = qos
-          result << BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(filter, arguments), session)
+        @tree.each_entry do |entry, qos, filter|
+          case entry
+          in MQTT::Session
+            arguments = AMQP::Table.new
+            arguments[QOS_HEADER] = qos
+            result << BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(filter, arguments), entry)
+          in MQTT::AMQPDestination
+            # Report the wrapped downstream exchange as the binding destination,
+            # preserving the arguments supplied at bind time.
+            result << BindingDetails.new(name, vhost.name, LavinMQ::BindingKey.new(filter, entry.arguments), entry.exchange)
+          end
         end
         result
       end
@@ -60,8 +134,14 @@ module LavinMQ
         @tree.size
       end
 
-      # Only here to make superclass happy
-      protected def each_destination(routing_key : String, headers : AMQP::Table?, & : LavinMQ::Destination ->)
+      # The internal MQTT exchange is never (re)declarable by an AMQP client, so
+      # it never matches a declare frame.
+      def match?(frame : AMQP::Frame) : Bool
+        false
+      end
+
+      def match?(type, durable, auto_delete, internal, arguments) : Bool
+        false
       end
 
       def bind(destination : MQTT::Session, routing_key : String, arguments = nil) : Bool
@@ -85,6 +165,27 @@ module LavinMQ
         true
       end
 
+      # Bind a downstream AMQP exchange so MQTT publishes matching the filter
+      # are routed into it (cross-protocol exchange-to-exchange, #1136). The
+      # routing key is an MQTT-syntax topic filter, matched against MQTT topics.
+      def bind(destination : LavinMQ::AMQP::Exchange, routing_key : String, arguments = nil) : Bool
+        @tree.subscribe(routing_key, AMQPDestination.new(destination, arguments), 0u8)
+
+        binding_key = LavinMQ::BindingKey.new(routing_key, arguments)
+        data = BindingDetails.new(name, vhost.name, binding_key, destination)
+        notify_observers(ExchangeEvent::Bind, data)
+        true
+      end
+
+      def unbind(destination : LavinMQ::AMQP::Exchange, routing_key, arguments = nil) : Bool
+        @tree.unsubscribe(routing_key, AMQPDestination.new(destination))
+
+        binding_key = LavinMQ::BindingKey.new(routing_key, arguments)
+        data = BindingDetails.new(name, vhost.name, binding_key, destination)
+        notify_observers(ExchangeEvent::Unbind, data)
+        true
+      end
+
       def bind(destination : Destination, routing_key : String, arguments = nil) : Bool
         raise LavinMQ::Exchange::AccessRefused.new(self)
       end
@@ -93,8 +194,55 @@ module LavinMQ
         raise LavinMQ::Exchange::AccessRefused.new(self)
       end
 
-      private def apply_policy_argument(key : String, value : JSON::Any)
+      # The MQTT exchange is always recreated at boot, so bindings from it can
+      # be persisted and replayed even though it isn't durable (#1136).
+      def persistent? : Bool
+        true
+      end
+
+      def in_use? : Bool
+        !@tree.empty?
+      end
+
+      # No-op: the retain store is owned and closed by the `Broker`.
+      def close : Nil
+      end
+
+      def delete : Nil
+        return if @deleted
+        @deleted = true
+        @vhost.delete_exchange(@name)
+        notify_observers(ExchangeEvent::Deleted)
+      end
+
+      def details_tuple
+        {
+          name:                        @name,
+          type:                        type,
+          durable:                     durable?,
+          auto_delete:                 auto_delete?,
+          internal:                    internal?,
+          arguments:                   @arguments,
+          vhost:                       @vhost.name,
+          policy:                      policy.try &.name,
+          operator_policy:             operator_policy.try &.name,
+          effective_policy_definition: Policy.merge_definitions(policy, operator_policy),
+          message_stats:               current_stats_details,
+          effective_arguments:         Array(String).new,
+        }
+      end
+
+      def to_json(json : JSON::Builder)
+        json.object do
+          details_tuple.merge(message_stats: stats_details).each do |k, v|
+            json.field(k, v) unless v.nil?
+          end
+        end
+      end
+
+      private def apply_policy_argument(key : String, value : JSON::Any) : Bool
         # mqtt exchange doesn't support policies, make this a noop
+        false
       end
 
       private def clear_policy_arguments

--- a/src/lavinmq/mqtt/subscription_tree.cr
+++ b/src/lavinmq/mqtt/subscription_tree.cr
@@ -16,17 +16,20 @@ module LavinMQ
       # Non wildcards may be an unnecessary "optimization". We store all subscriptions without
       # wildcard in the first level. No need to make a tree out of them.
       @non_wildcards = Hash(String, Hash(T, UInt8)).new do |h, k|
-        h[k] = Hash(T, UInt8).new.compare_by_identity
+        h[k] = Hash(T, UInt8).new
       end
       # Keyed by owned Bytes copies of each level. Bytes hash and compare by
       # content, so matching can look up with zero-allocation views into the
       # published topic.
       @sublevels = Hash(Bytes, SubscriptionTree(T)).new
 
-      def initialize
-        @wildcard_rest.compare_by_identity
-        @leafs.compare_by_identity
-      end
+      # NOTE: the T-keyed hashes (@leafs, @wildcard_rest, @non_wildcards) do not
+      # use compare_by_identity. Sessions fall back to Reference identity
+      # equality (unchanged behaviour), while wrapper entries like
+      # MQTT::AMQPDestination can define value equality so bind/unbind may
+      # create fresh, interchangeable wrappers (#1136). These hashes are only
+      # mutated on (un)subscribe (cold path); the publish hot path iterates via
+      # #each_entry and never hashes by T.
 
       def subscribe(filter : String, session : T, qos : UInt8)
         if filter.index('#').nil? && filter.index('+').nil?

--- a/src/lavinmq/mqtt/topic_translator.cr
+++ b/src/lavinmq/mqtt/topic_translator.cr
@@ -1,0 +1,22 @@
+module LavinMQ
+  module MQTT
+    # Encapsulates the conversion between MQTT topic syntax and AMQP routing
+    # key syntax for cross-protocol routing (see issue #1136).
+    #
+    # MQTT separates topic levels with '/', AMQP with '.'. The translation is a
+    # length-preserving 1:1 character substitution. This is intentionally naive
+    # and matches the behaviour of other brokers (e.g. RabbitMQ's MQTT plugin):
+    # a literal '.' inside an MQTT topic level collapses into an extra AMQP
+    # level (e.g. "v1.2/data" => "v1.2.data"). This is a documented limitation;
+    # it keeps MQTT levels lined up with AMQP levels so that AMQP wildcard
+    # bindings ('*'/'#') match as a user would expect.
+    module TopicTranslator
+      # Translates a concrete (wildcard-free) MQTT topic into an AMQP routing
+      # key. Published MQTT topics never contain '+'/'#', so only the level
+      # separator is rewritten.
+      def self.mqtt_to_amqp(topic : String) : String
+        topic.tr("/", ".")
+      end
+    end
+  end
+end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -16,6 +16,8 @@ require "./event_type"
 require "./stats"
 require "./queue_factory"
 require "./mqtt/session"
+require "./mqtt/exchange"
+require "./mqtt/retain_store"
 require "./connection_store"
 require "./direct_reply_consumer_store"
 require "./definitions_store"
@@ -206,6 +208,15 @@ module LavinMQ
 
     Log = LavinMQ::Log.for "vhost"
 
+    # The MQTT routing exchange and its retain store are owned by the VHost (not
+    # the per-vhost MQTT::Broker) so they exist before definitions are replayed.
+    # This lets persisted cross-protocol bindings whose source is the MQTT
+    # exchange be re-applied during load! (#1136). The Broker attaches to these.
+    # Declared nilable to satisfy initialization ordering (assigned in
+    # #initialize before any use), exposed via non-nil accessors below.
+    @mqtt_exchange : MQTT::Exchange?
+    @mqtt_retain_store : MQTT::RetainStore?
+
     def initialize(@name : String, @server_data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @persister : Persister, @description = "", @tags = Array(String).new(0))
       @log = Logger.new(Log, vhost: @name)
       @dir = Digest::SHA1.hexdigest(@name)
@@ -220,6 +231,13 @@ module LavinMQ
       @shovels = Shovel::Store.new(self)
       @upstreams = Federation::UpstreamStore.new(self)
       @definitions = DefinitionsStore.new(self, @data_dir, @replicator, @log)
+      # Register the MQTT exchange before load! so persisted cross-protocol
+      # bindings (source = the MQTT exchange) can be re-applied during replay.
+      retain_store = MQTT::RetainStore.new(File.join(@data_dir, "mqtt_retained_store"), @replicator)
+      @mqtt_retain_store = retain_store
+      mqtt_exchange = MQTT::Exchange.new(self, MQTT::EXCHANGE, retain_store)
+      @mqtt_exchange = mqtt_exchange
+      register_exchange(mqtt_exchange)
       load!
       spawn check_consumer_timeouts_loop, name: "Consumer timeouts loop"
     end
@@ -530,6 +548,7 @@ module LavinMQ
       each_queue &.close
       each_session &.close
       each_exchange &.close
+      @mqtt_retain_store.try &.close
       Fiber.yield
       definitions.close
       FileUtils.rm_rf File.join(@data_dir, "transient")
@@ -644,6 +663,14 @@ module LavinMQ
 
     private def definitions : DefinitionsStore
       @definitions.not_nil!
+    end
+
+    def mqtt_exchange : MQTT::Exchange
+      @mqtt_exchange.not_nil!
+    end
+
+    def mqtt_retain_store : MQTT::RetainStore
+      @mqtt_retain_store.not_nil!
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes #1136 

Introduces a `MQTT::AMQPDestination` that wraps a AMQP::Exchange and allows it to fit into the mqtt subscription tree. 

### HOW can this pull request be tested?

Specs 