### PR TITLE
Fix in documentation: OAuth scope use glob, not regex syntax

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -167,12 +167,12 @@ A token with these filtered scopes:
 
 ```
 tag:management
-read:%2F/.*
-write:%2F/orders
-configure:staging/temp.*
+read:%2F/*
+write:%2F/orders*
+configure:staging/temp*
 ```
 
-Grants the user the `management` tag, full read access on the `/` vhost, write access only to resources starting with `orders` on `/`, and configure access to resources matching `temp*` on the `staging` vhost.
+Grants the user the `management` tag, full read access on the `/` vhost, write access only to resources starting with `orders` on `/`, and configure access to resources starting with `temp` on the `staging` vhost.
 
 ### Token Refresh
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Tweak in documentation. The docs show permissions for regular users logging in with username/password. But oauth is different since we convert from glob to regex: https://github.com/cloudamqp/lavinmq/blob/cdc9b2a8f5fa3c7f28a87bcfa93d7756c6e5838c/src/lavinmq/auth/jwt/token_claim.cr#L166-L171