### PR TITLE
Add policymaker role checks to ShovelsController endpoints

### DIFF
--- a/spec/api/shovels_spec.cr
+++ b/spec/api/shovels_spec.cr
@@ -22,6 +22,71 @@ def create_shovel(server, name = "spec-shovel", config = NamedTuple.new, paused 
 end
 
 describe LavinMQ::HTTP::ShovelsController do
+  describe "access control" do
+    it "should refuse management users from listing all shovels" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/shovels", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+
+    it "should allow policymaker to list shovels in a vhost" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        s.users.add_permission("arnold", "/", /.*/, /.*/, /.*/)
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.get("/api/shovels/#{vhost_url_encoded}", headers: hdrs)
+        response.status_code.should eq 200
+      end
+    end
+
+    it "should refuse management and monitoring users from listing shovels" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management, LavinMQ::Tag::Monitoring])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.get("/api/shovels/#{vhost_url_encoded}", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+
+    it "should refuse management users from getting a shovel" do
+      with_http_server do |http, s|
+        create_shovel(s)
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.get("/api/shovels/#{vhost_url_encoded}/spec-shovel", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+
+    it "should refuse management users from pausing a shovel" do
+      with_http_server do |http, s|
+        create_shovel(s)
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.put("/api/shovels/#{vhost_url_encoded}/spec-shovel/pause", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+
+    it "should refuse management users from resuming a shovel" do
+      with_http_server do |http, s|
+        create_shovel(s, paused: true)
+        s.users.create("arnold", "pw", [LavinMQ::Tag::Management])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        vhost_url_encoded = URI.encode_path_segment("/")
+        response = http.put("/api/shovels/#{vhost_url_encoded}/spec-shovel/resume", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+  end
+
   describe "PUT api/shovels/:vhost/:name/pause" do
     it "should return 404 for non-existing shovel" do
       with_http_server do |http, _s|

--- a/src/lavinmq/http/controller/shovels.cr
+++ b/src/lavinmq/http/controller/shovels.cr
@@ -8,6 +8,7 @@ module LavinMQ
 
       private def register_routes
         get "/api/shovels" do |context, _params|
+          refuse_unless_policymaker(context, user(context))
           arr = vhosts(user(context)).flat_map do |v|
             v.shovels.values
           end
@@ -16,12 +17,14 @@ module LavinMQ
 
         get "/api/shovels/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
             page(context, vhost.shovels.values)
           end
         end
 
         get "/api/shovels/:vhost/:name" do |context, params|
           with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
             shovel_name = params["name"]
             if shovel = vhost.shovels[shovel_name]?
               shovel.to_json(context.response)
@@ -33,6 +36,7 @@ module LavinMQ
 
         put "/api/shovels/:vhost/:name/pause" do |context, params|
           with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
             shovel_name = params["name"]
             if current_shovel = vhost.shovels[shovel_name]?
               if !current_shovel.running?
@@ -49,6 +53,7 @@ module LavinMQ
 
         put "/api/shovels/:vhost/:name/resume" do |context, params|
           with_vhost(context, params) do |vhost|
+            refuse_unless_policymaker(context, user(context), vhost)
             shovel_name = params["name"]
             if current_shovel = vhost.shovels[shovel_name]?
               if !current_shovel.paused?


### PR DESCRIPTION
The shovel endpoints didn't enforce role checks, unlike the parameters
and policies controllers which already require policymaker access.

This aligns ShovelsController with those controllers: listing, viewing,
pausing, and resuming shovels now go through `refuse_unless_policymaker`,
consistent with how shovels (dynamic parameters) are managed elsewhere.

Specs added for the role checks on each endpoint.
