### PR TITLE
[CSS] Remove zIndex of table links

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1173,7 +1173,7 @@ footer .logo {
       margin-top: 1rem;
       border-top: 1px solid var(--color-border-separator);
       a {
-        background-image: var(--icon-http-api); 
+        background-image: var(--icon-http-api);
         margin-top: 0.5rem;
       }
     }
@@ -1287,7 +1287,7 @@ footer .logo {
         }
 
         li:not(.menu-group) a {
-          justify-content: center; 
+          justify-content: center;
           background-position: center center;
           padding: 1.25rem;
         }
@@ -1547,7 +1547,6 @@ th.group.last {
   background-color: inherit;
   position: relative;
   padding-right: 10px;
-  z-index: 1000;
   color: var(--color-text-muted);
 
   &:hover {
@@ -1964,7 +1963,7 @@ fieldset.inline {
   text-decoration: none;
   text-align: center;
   font-weight: bold;
-} 
+}
 
 .pagination .page-item.disabled a {
   cursor: default;


### PR DESCRIPTION
### WHAT is this pull request doing?
Removes zIndex of `table tbody a` as it overlaps other UI elements:
<img width="410" height="911" alt="image" src="https://github.com/user-attachments/assets/026a4528-dae1-46c6-b1ee-77b7f0c251de" />


### HOW can this pull request be tested?
:eyes:

<img width="410" height="915" alt="image" src="https://github.com/user-attachments/assets/40d0cf29-6ef6-4256-a4be-8c1159d05237" />

