### PR TITLE
Report actual MQTT protocol version in connection details

### DIFF
--- a/spec/mqtt/protocol_version_spec.cr
+++ b/spec/mqtt/protocol_version_spec.cr
@@ -1,0 +1,36 @@
+require "./spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  describe "MQTT protocol version" do
+    it "reports MQTT 3.1.1 for protocol level 4" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, version: 4u8)
+          conn = wait_for { server.connections.first?.as?(LavinMQ::MQTT::Client) }
+          conn.details_tuple[:protocol].should eq "MQTT 3.1.1"
+        end
+      end
+    end
+
+    it "reports MQTT 3.1 for protocol level 3 (MQIsdp)" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, version: 3u8)
+          conn = wait_for { server.connections.first?.as?(LavinMQ::MQTT::Client) }
+          conn.details_tuple[:protocol].should eq "MQTT 3.1"
+        end
+      end
+    end
+
+    it "keeps the negotiated version when the client id is auto-assigned" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, version: 3u8, client_id: "", clean_session: true)
+          conn = wait_for { server.connections.first?.as?(LavinMQ::MQTT::Client) }
+          conn.details_tuple[:protocol].should eq "MQTT 3.1"
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -49,6 +49,7 @@ module LavinMQ
           user,
           self,
           packet.client_id,
+          ProtocolVersion.from_value(packet.version),
           packet.clean_session?,
           packet.keepalive,
           packet.will)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -11,6 +11,13 @@ require "../stats"
 
 module LavinMQ
   module MQTT
+    # Protocol level from the CONNECT packet:
+    # level 3 is MQTT 3.1 (MQIsdp), level 4 is MQTT 3.1.1 (MQTT).
+    enum ProtocolVersion : UInt8
+      V3_1   = 3
+      V3_1_1 = 4
+    end
+
     class Client < LavinMQ::Client
       include Stats
       include SortableJSON
@@ -20,6 +27,7 @@ module LavinMQ
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
       @session : MQTT::Session?
+      @protocol : String
       rate_stats({"send_oct", "recv_oct"})
       Log = LavinMQ::Log.for "mqtt.client"
 
@@ -49,9 +57,14 @@ module LavinMQ
                      @user : Auth::BaseUser,
                      @broker : MQTT::Broker,
                      @client_id : String,
+                     protocol_version : ProtocolVersion,
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
                      @will : Protocol::Will? = nil)
+        @protocol = case protocol_version
+                    in .v3_1?   then "MQTT 3.1"
+                    in .v3_1_1? then "MQTT 3.1.1"
+                    end
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
@@ -205,7 +218,7 @@ module LavinMQ
         {
           vhost:             @broker.vhost.name,
           user:              @user.name,
-          protocol:          "MQTT 3.1.1",
+          protocol:          @protocol,
           client_id:         @client_id,
           name:              @name,
           timeout:           @keepalive,

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -16,6 +16,13 @@ module LavinMQ
     enum ProtocolVersion : UInt8
       V3_1   = 3
       V3_1_1 = 4
+
+      def name
+        case self
+        in .v3_1?   then "MQTT 3.1"
+        in .v3_1_1? then "MQTT 3.1.1"
+        end
+      end
     end
 
     class Client < LavinMQ::Client
@@ -61,10 +68,7 @@ module LavinMQ
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
                      @will : Protocol::Will? = nil)
-        @protocol = case protocol_version
-                    in .v3_1?   then "MQTT 3.1"
-                    in .v3_1_1? then "MQTT 3.1.1"
-                    end
+        @protocol = protocol_version.name
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -81,7 +81,8 @@ module LavinMQ
           packet.keepalive,
           packet.username,
           packet.password,
-          packet.will)
+          packet.will,
+          packet.version)
       end
 
       private def validate_client_id!(client_id : String, username : String) : Nil


### PR DESCRIPTION
### WHAT is this pull request doing?

The MQTT CONNECT handler accepts both protocol level 3 (MQTT 3.1, "MQIsdp") and level 4 (MQTT 3.1.1, "MQTT"), but the connection details hardcoded the protocol as "MQTT 3.1.1", mislabelling 3.1 clients.

Thread the negotiated protocol version through to MQTT::Client as a ProtocolVersion enum and report "MQTT 3.1" for level 3 and "MQTT 3.1.1" for level 4. Also preserve the version when the CONNECT packet is rebuilt for an empty client id, which previously reset it to level 4.

### HOW can this pull request be tested?

Specs and manually:

```
$ mosquitto_sub -u guest -P guest -t test -V mqttv31
$ curl -s http://guest:guest@localhost:15672/api/connections | jq '.[].protocol'
"MQTT 3.1"

$ mosquitto_sub -u guest -P guest -t test -V mqttv311
$ curl -s http://guest:guest@localhost:15672/api/connections | jq '.[].protocol'
"MQTT 3.1.1"
```
