### PR TITLE
Add non-destructive peek endpoint for queue messages

### DIFF
--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -664,6 +664,27 @@ describe LavinMQ::HTTP::QueuesController do
       end
     end
 
+    it "should peek unacked messages held by basic_get" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q9")
+          server_q = s.vhosts["/"].queue("peek_q9")
+          q.publish "taken"
+          wait_for { server_q.message_count == 1 }
+          q.get(no_ack: false).not_nil!
+          wait_for { server_q.unacked_count == 1 }
+
+          body = %({"count": 10, "state": "unacked"})
+          response = http.post("/api/queues/%2f/peek_q9/peek", body: body)
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.size.should eq 1
+          messages[0]["payload"].as_s.should eq "taken"
+          server_q.unacked_count.should eq 1
+        end
+      end
+    end
+
     it "should show requeued messages as redelivered ready messages" do
       with_http_server do |http, s|
         with_channel(s) do |ch|

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -664,6 +664,26 @@ describe LavinMQ::HTTP::QueuesController do
       end
     end
 
+    it "should refuse peeking queues that are not running, but allow paused" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q10")
+          server_q = s.vhosts["/"].queue("peek_q10")
+          q.publish "m1"
+          wait_for { server_q.message_count == 1 }
+
+          server_q.pause!
+          response = http.post("/api/queues/%2f/peek_q10/peek", body: %({"count": 1}))
+          response.status_code.should eq 200
+          JSON.parse(response.body).as_a.size.should eq 1
+
+          server_q.close
+          response = http.post("/api/queues/%2f/peek_q10/peek", body: %({"count": 1}))
+          response.status_code.should eq 403
+        end
+      end
+    end
+
     it "should peek unacked messages held by basic_get" do
       with_http_server do |http, s|
         with_channel(s) do |ch|

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -553,6 +553,181 @@ describe LavinMQ::HTTP::QueuesController do
     end
   end
 
+  describe "POST /api/queues/vhost/name/peek" do
+    it "should peek messages without consuming them" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q1")
+          server_q = s.vhosts["/"].queue("peek_q1")
+          q.publish "m1"
+          q.publish "m2"
+          q.publish "m3"
+          wait_for { server_q.message_count == 3 }
+          body = %({ "offset": 0, "count": 10, "encoding": "auto" })
+          response = http.post("/api/queues/%2f/peek_q1/peek", body: body)
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.size.should eq 3
+          messages.map(&.["payload"].as_s).should eq ["m1", "m2", "m3"]
+          messages.each(&.["state"].as_s.should(eq("ready")))
+          server_q.message_count.should eq 3
+        end
+      end
+    end
+
+    it "should support offset and count windowing" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q2")
+          server_q = s.vhosts["/"].queue("peek_q2")
+          5.times { |i| q.publish "m#{i}" }
+          wait_for { server_q.message_count == 5 }
+          body = %({ "offset": 1, "count": 2, "encoding": "auto" })
+          response = http.post("/api/queues/%2f/peek_q2/peek", body: body)
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.map(&.["payload"].as_s).should eq ["m1", "m2"]
+          server_q.message_count.should eq 5
+        end
+      end
+    end
+
+    it "should peek unacked messages when state is unacked" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q3")
+          server_q = s.vhosts["/"].queue("peek_q3")
+          3.times { |i| q.publish "m#{i}" }
+          wait_for { server_q.message_count == 3 }
+          # Consume but do not ack, leaving the messages unacked.
+          ch.prefetch 10
+          q.subscribe(no_ack: false) { }
+          wait_for { server_q.unacked_count == 3 }
+
+          # Default state is ready: no ready messages, returns []
+          body = %({ "offset": 0, "count": 10, "encoding": "auto" })
+          response = http.post("/api/queues/%2f/peek_q3/peek", body: body)
+          response.status_code.should eq 200
+          JSON.parse(response.body).as_a.size.should eq 0
+
+          # state unacked: returns the 3 unacked messages from offset 0
+          body = %({ "offset": 0, "count": 10, "state": "unacked", "encoding": "auto" })
+          response = http.post("/api/queues/%2f/peek_q3/peek", body: body)
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.size.should eq 3
+          messages.each(&.["state"].as_s.should(eq("unacked")))
+          messages.map(&.["payload"].as_s).sort!.should eq ["m0", "m1", "m2"]
+
+          # offset applies within the unacked set
+          body = %({ "offset": 2, "count": 10, "state": "unacked" })
+          response = http.post("/api/queues/%2f/peek_q3/peek", body: body)
+          JSON.parse(response.body).as_a.size.should eq 1
+        end
+      end
+    end
+
+    it "should return empty array for empty queue" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          ch.queue("peek_q4")
+          body = %({ "offset": 0, "count": 1, "encoding": "auto" })
+          response = http.post("/api/queues/%2f/peek_q4/peek", body: body)
+          response.status_code.should eq 200
+          JSON.parse(response.body).as_a.should be_empty
+        end
+      end
+    end
+
+    it "should validate count and offset" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          ch.queue("peek_q5")
+          response = http.post("/api/queues/%2f/peek_q5/peek", body: %({"offset": -1, "count": 1}))
+          response.status_code.should eq 400
+          response = http.post("/api/queues/%2f/peek_q5/peek", body: %({"offset": 0, "count": 0}))
+          response.status_code.should eq 400
+          response = http.post("/api/queues/%2f/peek_q5/peek", body: %({"offset": 0, "count": 1001}))
+          response.status_code.should eq 400
+          response = http.post("/api/queues/%2f/peek_q5/peek", body: %({"count": 1, "state": "acked"}))
+          response.status_code.should eq 400
+          response = http.post("/api/queues/%2f/peek_q5/peek", body: %({"count": 1, "truncate": -1}))
+          response.status_code.should eq 400
+        end
+      end
+    end
+
+    it "should return 404 for unknown queue" do
+      with_http_server do |http, _s|
+        response = http.post("/api/queues/%2f/peek_gone/peek", body: %({"count": 1}))
+        response.status_code.should eq 404
+      end
+    end
+
+    it "should show requeued messages as redelivered ready messages" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q6")
+          server_q = s.vhosts["/"].queue("peek_q6")
+          q.publish "m1"
+          wait_for { server_q.message_count == 1 }
+          msg = q.get(no_ack: false).not_nil!
+          msg.reject(requeue: true)
+          wait_for { server_q.message_count == 1 }
+          response = http.post("/api/queues/%2f/peek_q6/peek", body: %({"count": 10}))
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.size.should eq 1
+          messages[0]["state"].as_s.should eq "ready"
+          messages[0]["redelivered"].as_bool.should be_true
+          server_q.message_count.should eq 1
+        end
+      end
+    end
+
+    it "should peek priority queues, highest priority first" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          args = AMQP::Client::Arguments.new({"x-max-priority" => 5})
+          q = ch.queue("peek_q8", args: args)
+          server_q = s.vhosts["/"].queue("peek_q8")
+          q.publish_confirm "low", props: AMQP::Client::Properties.new(priority: 1_u8)
+          q.publish_confirm "high", props: AMQP::Client::Properties.new(priority: 5_u8)
+          wait_for { server_q.message_count == 2 }
+
+          # empty peek first, this segfaulted when peek_step ran on the
+          # composite store whose @rfile is uninitialized
+          response = http.post("/api/queues/%2f/peek_q8/peek", body: %({"count": 10, "offset": 2}))
+          response.status_code.should eq 200
+          JSON.parse(response.body).as_a.should be_empty
+
+          response = http.post("/api/queues/%2f/peek_q8/peek", body: %({"count": 10}))
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.map(&.["payload"].as_s).should eq ["high", "low"]
+          server_q.message_count.should eq 2
+        end
+      end
+    end
+
+    it "should truncate payload but report full payload size" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("peek_q7")
+          server_q = s.vhosts["/"].queue("peek_q7")
+          q.publish "abcdefghij"
+          wait_for { server_q.message_count == 1 }
+          body = %({"count": 1, "truncate": 4})
+          response = http.post("/api/queues/%2f/peek_q7/peek", body: body)
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages[0]["payload"].as_s.should eq "abcd"
+          messages[0]["payload_bytes"].as_i.should eq 10
+        end
+      end
+    end
+  end
+
   describe "PUT /api/queues/vhost/name/pause" do
     it "should pause the queue" do
       with_http_server do |http, s|

--- a/spec/mqtt/integrations/peek_spec.cr
+++ b/spec/mqtt/integrations/peek_spec.cr
@@ -1,0 +1,81 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  def self.with_http(server, &)
+    h = server.http_server
+    addr = h.bind_tcp("::1", 0)
+    spawn(name: "http listen") { h.listen }
+    Fiber.yield
+    yield HTTPSpecHelper.new(addr)
+  end
+
+  describe "POST /api/queues/vhost/name/peek on MQTT sessions" do
+    it "peeks ready messages without consuming them" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, clean_session: false)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+          disconnect(io)
+        end
+
+        with_client_io(server) do |pub_io|
+          connect(pub_io, client_id: "publisher")
+          publish(pub_io, topic: "a/b", qos: 1u8, payload: "m1".to_slice)
+          publish(pub_io, topic: "a/b", qos: 1u8, payload: "m2".to_slice)
+          disconnect(pub_io)
+        end
+
+        session = server.vhosts["/"].session("mqtt.client_id")
+        wait_for { session.message_count == 2 }
+
+        with_http(server) do |http|
+          response = http.post("/api/queues/%2f/mqtt.client_id/peek", body: %({"count": 10}))
+          response.status_code.should eq 200
+          messages = JSON.parse(response.body).as_a
+          messages.map(&.["payload"].as_s).should eq ["m1", "m2"]
+          messages.each(&.["state"].as_s.should(eq("ready")))
+          session.message_count.should eq 2
+        end
+      end
+    end
+
+    it "peeks unacked messages" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, clean_session: false)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+          with_client_io(server) do |pub_io|
+            connect(pub_io, client_id: "publisher")
+            publish(pub_io, topic: "a/b", qos: 1u8, payload: "inflight".to_slice)
+            disconnect(pub_io)
+          end
+
+          # Receive the QoS 1 delivery but do not send PubAck
+          read_packet(io).should be_a(MQTT::Protocol::Publish)
+          session = server.vhosts["/"].session("mqtt.client_id")
+          wait_for { session.@unacked.size == 1 }
+
+          with_http(server) do |http|
+            response = http.post("/api/queues/%2f/mqtt.client_id/peek", body: %({"count": 10}))
+            response.status_code.should eq 200
+            JSON.parse(response.body).as_a.should be_empty
+
+            body = %({"count": 10, "state": "unacked"})
+            response = http.post("/api/queues/%2f/mqtt.client_id/peek", body: body)
+            response.status_code.should eq 200
+            messages = JSON.parse(response.body).as_a
+            messages.size.should eq 1
+            messages[0]["payload"].as_s.should eq "inflight"
+            messages[0]["state"].as_s.should eq "unacked"
+            session.@unacked.size.should eq 1
+          end
+          disconnect(io)
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -753,6 +753,13 @@ module LavinMQ
         tag
       end
 
+      # Safe traversal from other fibers, @unacked is mutated under the lock
+      def each_unacked(& : Unack -> Nil) : Nil
+        @unack_lock.synchronize do
+          @unacked.each { |u| yield u }
+        end
+      end
+
       # Iterate over all unacked messages and see if any has been unacked longer than the queue's consumer timeout
       def check_consumer_timeout
         @unack_lock.synchronize do

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue/delayed_requeued_store.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue/delayed_requeued_store.cr
@@ -54,6 +54,10 @@ module LavinMQ::AMQP
         def clear : Nil
           @segment_positions = Deque(DelayedSegmentPosition).new
         end
+
+        def each(& : SegmentPosition -> Nil) : Nil
+          @segment_positions.each { |dsp| yield dsp.sp }
+        end
       end
     end
   end

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -167,6 +167,33 @@ module LavinMQ::AMQP
         store_for sp, &.[sp]
       end
 
+      def peek_requeued(offset : Int32, max : Int32) : {Array(SegmentPosition), Int32}
+        raise ClosedError.new if @closed
+        sps = Array(SegmentPosition).new
+        total = 0
+        @stores.reverse_each do |s|
+          s_sps, s_count = s.peek_requeued(Math.max(0, offset - total), max - sps.size)
+          sps.concat s_sps
+          total += s_count
+        end
+        {sps, total}
+      end
+
+      # PeekStep#store tracks which substore the cursor is in,
+      # in reverse order since substores are peeked highest priority first
+      def peek_step(prev : PeekStep?, skip : Int32, max_body : Int32) : PeekStep
+        raise ClosedError.new if @closed
+        store = prev.try(&.store) || 0
+        i = @stores.size - 1 - store
+        return PeekStep.new(nil, 0_u32, 0, nil, true, store) if i < 0
+        step = @stores[i].peek_step(prev.try(&.seg) ? prev : nil, skip, max_body)
+        if step.done && i > 0
+          PeekStep.new(nil, 0_u32, step.skipped, step.message, false, store + 1)
+        else
+          step.copy_with(store: store)
+        end
+      end
+
       def delete(sp) : Nil
         raise ClosedError.new if @closed
         store_for sp, &.delete(sp)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -903,7 +903,7 @@ module LavinMQ::AMQP
       @vhost.connections.each do |client|
         next unless client.is_a?(Client)
         client.channels.each do |ch|
-          ch.unacked.each { |u| sps << u.sp if u.queue == self }
+          ch.each_unacked { |u| sps << u.sp if u.queue == self }
         end
       end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -892,6 +892,73 @@ module LavinMQ::AMQP
       result.concat(@basic_get_unacked.to_a)
     end
 
+    # Non-destructive peek at the ready messages, in delivery order (requeued
+    # first, then from the read head forward), yielding up to `count`
+    # PeekedMessages from logical `offset`. The store lock is only held while
+    # copying one message at a time.
+    def peek(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
+      return if @closed || count <= 0
+
+      requeued_sps, requeued_count = @msg_store_lock.synchronize do
+        @msg_store.peek_requeued(offset, count)
+      end
+
+      yielded = 0
+      requeued_sps.each do |sp|
+        if message = peek_copy(sp, redelivered: true, max_body: max_body)
+          block.call(message)
+          yielded += 1
+        end
+      end
+
+      peek_segments(Math.max(0, offset - requeued_count), count, yielded, max_body, block)
+    rescue ClosedError | MessageStore::ClosedError
+      # queue was deleted/closed mid peek, end the result list early
+    end
+
+    # Non-destructive peek at messages delivered to consumers but not yet acked.
+    def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
+      return if @closed || count <= 0
+
+      sps = [] of SegmentPosition
+      consumers.select(AMQP::Consumer).map(&.channel).uniq!.each do |ch|
+        ch.unacked.each { |u| sps << u.sp if u.queue == self }
+      end
+
+      yielded = 0
+      sps.each.skip(offset).each do |sp|
+        break if yielded >= count
+        if message = peek_copy(sp, redelivered: false, max_body: max_body)
+          block.call(message)
+          yielded += 1
+        end
+      end
+    end
+
+    private def peek_copy(sp : SegmentPosition, redelivered : Bool, max_body : Int32) : PeekedMessage?
+      message = @msg_store_lock.synchronize do
+        PeekedMessage.new(@msg_store[sp], max_body, redelivered: redelivered) rescue nil
+      end
+      # without this the peek fiber can reacquire the lock before waiters run
+      Fiber.yield
+      message
+    end
+
+    private def peek_segments(skip : Int32, count : Int32, yielded : Int32, max_body : Int32,
+                              block : Proc(PeekedMessage, Nil)) : Nil
+      step = nil.as(MessageStore::PeekStep?)
+      while yielded < count
+        step = @msg_store_lock.synchronize { @msg_store.peek_step(step, skip, max_body) }
+        Fiber.yield
+        skip -= step.skipped
+        if message = step.message
+          block.call(message)
+          yielded += 1
+        end
+        break if step.done
+      end
+    end
+
     private def with_delivery_count_header(env) : Envelope?
       if @delivery_limit
         sp = env.segment_position

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -10,6 +10,7 @@ require "../../error"
 require "./state"
 require "./event"
 require "../../message_store"
+require "../../peekable"
 require "../../unacked_message"
 require "../../deduplication"
 require "../../bool_channel"
@@ -24,6 +25,7 @@ module LavinMQ::AMQP
     include Observable(QueueEvent)
     include SortableJSON
     include QueueStats
+    include Peekable
 
     include ArgumentTarget
     include Argument::DeadLettering
@@ -892,30 +894,6 @@ module LavinMQ::AMQP
       result.concat(@basic_get_unacked.to_a)
     end
 
-    # Non-destructive peek at the ready messages, in delivery order (requeued
-    # first, then from the read head forward), yielding up to `count`
-    # PeekedMessages from logical `offset`. The store lock is only held while
-    # copying one message at a time.
-    def peek(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
-      return if @closed || count <= 0
-
-      requeued_sps, requeued_count = @msg_store_lock.synchronize do
-        @msg_store.peek_requeued(offset, count)
-      end
-
-      yielded = 0
-      requeued_sps.each do |sp|
-        if message = peek_copy(sp, redelivered: true, max_body: max_body)
-          block.call(message)
-          yielded += 1
-        end
-      end
-
-      peek_segments(Math.max(0, offset - requeued_count), count, yielded, max_body, block)
-    rescue ClosedError | MessageStore::ClosedError
-      # queue was deleted/closed mid peek, end the result list early
-    end
-
     # Non-destructive peek at messages delivered to consumers but not yet acked.
     def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
       return if @closed || count <= 0
@@ -932,30 +910,6 @@ module LavinMQ::AMQP
           block.call(message)
           yielded += 1
         end
-      end
-    end
-
-    private def peek_copy(sp : SegmentPosition, redelivered : Bool, max_body : Int32) : PeekedMessage?
-      message = @msg_store_lock.synchronize do
-        PeekedMessage.new(@msg_store[sp], max_body, redelivered: redelivered) rescue nil
-      end
-      # without this the peek fiber can reacquire the lock before waiters run
-      Fiber.yield
-      message
-    end
-
-    private def peek_segments(skip : Int32, count : Int32, yielded : Int32, max_body : Int32,
-                              block : Proc(PeekedMessage, Nil)) : Nil
-      step = nil.as(MessageStore::PeekStep?)
-      while yielded < count
-        step = @msg_store_lock.synchronize { @msg_store.peek_step(step, skip, max_body) }
-        Fiber.yield
-        skip -= step.skipped
-        if message = step.message
-          block.call(message)
-          yielded += 1
-        end
-        break if step.done
       end
     end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -894,13 +894,17 @@ module LavinMQ::AMQP
       result.concat(@basic_get_unacked.to_a)
     end
 
-    # Non-destructive peek at messages delivered to consumers but not yet acked.
+    # Non-destructive peek at messages delivered to clients but not yet acked,
+    # both consumer deliveries and basic_get:s.
     def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
       return if @closed || count <= 0
 
       sps = [] of SegmentPosition
-      consumers.select(AMQP::Consumer).map(&.channel).uniq!.each do |ch|
-        ch.unacked.each { |u| sps << u.sp if u.queue == self }
+      @vhost.connections.each do |client|
+        next unless client.is_a?(Client)
+        client.channels.each do |ch|
+          ch.unacked.each { |u| sps << u.sp if u.queue == self }
+        end
       end
 
       yielded = 0

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -899,12 +899,18 @@ module LavinMQ::AMQP
     def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
       return if @closed || count <= 0
 
+      max = offset.to_i64 + count
       sps = [] of SegmentPosition
       @vhost.connections.each do |client|
         next unless client.is_a?(Client)
         client.channels.each do |ch|
-          ch.each_unacked { |u| sps << u.sp if u.queue == self }
+          break if sps.size >= max
+          ch.each_unacked do |u|
+            break if sps.size >= max
+            sps << u.sp if u.queue == self
+          end
         end
+        break if sps.size >= max
       end
 
       yielded = 0

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -26,6 +26,9 @@ module LavinMQ
       include BindingHelpers
       include QueueHelpers
 
+      # Caps the payload bytes peek copies under the store lock per message
+      PEEK_MAX_BODY = 1024 * 1024
+
       # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/api/queues" do |context, _|
@@ -236,6 +239,48 @@ module LavinMQ
           end
         end
 
+        post "/api/queues/:vhost/:name/peek" do |context, params|
+          with_vhost(context, params) do |vhost|
+            user = user(context)
+            refuse_unless_management(context, user, vhost)
+            q = find_queue(context, params, vhost)
+            unless q.is_a?(AMQP::Queue)
+              forbidden(context, "Only supported by AMQP queues")
+            end
+            unless user.can_read?(q.vhost.name, q.name)
+              access_refused(context, "User doesn't have permissions to read queue '#{q.name}'")
+            end
+            if q.is_a?(LavinMQ::AMQP::Stream)
+              bad_request(context, "Use /stream for stream queues")
+            end
+            body = parse_body(context)
+            offset = body["offset"]?.try(&.as_i?) || 0
+            count = body["count"]?.try(&.as_i?) || 1
+            state = body["state"]?.try(&.as_s) || "ready"
+            encoding = body["encoding"]?.try(&.as_s) || "auto"
+            truncate = body["truncate"]?.try(&.as_i?)
+            bad_request(context, "offset must be >= 0") if offset < 0
+            bad_request(context, "count must be > 0") if count <= 0
+            bad_request(context, "count must be <= 1000") if count > 1000
+            bad_request(context, "state must be 'ready' or 'unacked'") unless state.in?("ready", "unacked")
+            bad_request(context, "truncate must be >= 0") if truncate && truncate < 0
+            max_body = truncate ? Math.min(truncate, PEEK_MAX_BODY) : PEEK_MAX_BODY
+            JSON.build(context.response) do |j|
+              j.array do
+                if state == "unacked"
+                  q.peek_unacked(offset, count, max_body) do |message|
+                    peeked_message_json(j, q, message, state, encoding, max_body)
+                  end
+                else
+                  q.peek(offset, count, max_body) do |message|
+                    peeked_message_json(j, q, message, state, encoding, max_body)
+                  end
+                end
+              end
+            end
+          end
+        end
+
         post "/api/queues/:vhost/:name/stream" do |context, params|
           with_vhost(context, params) do |vhost|
             user = user(context)
@@ -281,6 +326,25 @@ module LavinMQ
           rescue e : LavinMQ::AMQP::StreamMessageStore::OffsetError
             bad_request(context, e.message)
           end
+        end
+      end
+
+      private def peeked_message_json(j, q, message, state, encoding, max_body) : Nil
+        j.object do
+          payload_encoding = "string"
+          j.field("payload_bytes", message.bodysize)
+          j.field("redelivered", message.redelivered?)
+          j.field("exchange", message.exchange_name)
+          j.field("routing_key", message.routing_key)
+          j.field("message_count", q.message_count)
+          j.field("properties", message.properties)
+          j.field("state", state)
+          j.field("payload") do
+            j.string do |io|
+              payload_encoding = encode_body(message, max_body, encoding, io)
+            end
+          end
+          j.field("payload_encoding", payload_encoding)
         end
       end
 

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -250,6 +250,9 @@ module LavinMQ
             if q.is_a?(LavinMQ::AMQP::Stream)
               bad_request(context, "Use /stream for stream queues")
             end
+            if q.state != QueueState::Running && q.state != QueueState::Paused
+              forbidden(context, "Can't peek queue that is not in running state")
+            end
             body = parse_body(context)
             offset = body["offset"]?.try(&.as_i?) || 0
             count = body["count"]?.try(&.as_i?) || 1

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -244,9 +244,6 @@ module LavinMQ
             user = user(context)
             refuse_unless_management(context, user, vhost)
             q = find_queue(context, params, vhost)
-            unless q.is_a?(AMQP::Queue)
-              forbidden(context, "Only supported by AMQP queues")
-            end
             unless user.can_read?(q.vhost.name, q.name)
               access_refused(context, "User doesn't have permissions to read queue '#{q.name}'")
             end

--- a/src/lavinmq/message.cr
+++ b/src/lavinmq/message.cr
@@ -108,4 +108,25 @@ module LavinMQ
                    @redelivered = false)
     end
   end
+
+  # Heap-only copy of a BytesMessage, whose body and headers table are slices
+  # into a mmap:ed segment that can be unmapped at any time. Must be created
+  # while holding the message store lock; safe to use after releasing it.
+  struct PeekedMessage
+    getter exchange_name : String
+    getter routing_key : String
+    getter properties : AMQ::Protocol::Properties
+    getter bodysize : UInt64
+    getter body : Bytes
+    getter? redelivered : Bool
+
+    def initialize(msg : BytesMessage, max_body : Int32, @redelivered : Bool)
+      @exchange_name = msg.exchange_name
+      @routing_key = msg.routing_key
+      @properties = msg.properties
+      @properties.headers = @properties.headers.try &.clone
+      @bodysize = msg.bodysize
+      @body = msg.body[0, Math.min(msg.body.size, max_body)].dup
+    end
+  end
 end

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -173,6 +173,71 @@ module LavinMQ
       end
     end
 
+    PEEK_SCAN_LIMIT = 100
+
+    record PeekStep, seg : UInt32?, pos : UInt32, skipped : Int32, message : PeekedMessage?, done : Bool, store : Int32 = 0
+
+    def peek_requeued(offset : Int32, max : Int32) : {Array(SegmentPosition), Int32}
+      raise ClosedError.new if @closed
+      sps = Array(SegmentPosition).new
+      i = 0
+      @requeued.each do |sp|
+        break if sps.size >= max
+        sps << sp if i >= offset
+        i += 1
+      end
+      {sps, @requeued.size.to_i32}
+    end
+
+    # One bounded scan step (max PEEK_SCAN_LIMIT messages) from the previous
+    # step's cursor, or the read head when `prev` is nil, so the caller can
+    # release the store lock between steps. Skips acked positions and up to
+    # `skip` live messages, returning a copy of the next live message and the
+    # new cursor.
+    def peek_step(prev : PeekStep?, skip : Int32, max_body : Int32) : PeekStep # ameba:disable Metrics/CyclomaticComplexity
+      raise ClosedError.new if @closed
+      if prev && (prev_seg = prev.seg)
+        cur_seg, cur_pos = prev_seg, prev.pos
+      else
+        cur_seg, cur_pos = @rfile_id, @rfile.pos.to_u32
+      end
+      skipped = 0
+      scanned = 0
+      loop do
+        if mfile = @segments[cur_seg]?
+          slice = mfile.to_slice
+          file_size = slice.size.to_u32
+          while cur_pos + 8 <= file_size
+            return PeekStep.new(cur_seg, cur_pos, skipped, nil, false) if scanned >= PEEK_SCAN_LIMIT
+            ts = IO::ByteFormat::SystemEndian.decode(Int64, slice[cur_pos, 8])
+            break if ts.zero? # rest of the segment is preallocated space
+            begin
+              msg = BytesMessage.from_bytes(slice + cur_pos)
+            rescue
+              break
+            end
+            scanned += 1
+            bytesize = msg.bytesize.to_u32
+            unless deleted?(cur_seg, cur_pos)
+              if skipped < skip
+                skipped += 1
+              else
+                message = PeekedMessage.new(msg, max_body, redelivered: false)
+                return PeekStep.new(cur_seg, cur_pos + bytesize, skipped, message, false)
+              end
+            end
+            cur_pos += bytesize
+          end
+        end
+        if next_seg = @segments.each_key.find { |id| id > cur_seg }
+          cur_seg = next_seg
+          cur_pos = 4_u32
+        else
+          return PeekStep.new(cur_seg, cur_pos, skipped, nil, true)
+        end
+      end
+    end
+
     def delete(sp) : Nil
       raise ClosedError.new if @closed
       afile = @acks[sp.segment]

--- a/src/lavinmq/message_store/requeued_store.cr
+++ b/src/lavinmq/message_store/requeued_store.cr
@@ -9,6 +9,7 @@ module LavinMQ
       abstract def insert(sp : SegmentPosition) : Nil
       abstract def size
       abstract def clear : Nil
+      abstract def each(& : SegmentPosition -> Nil) : Nil
     end
 
     class PublishOrderedRequeuedStore < RequeuedStore
@@ -36,6 +37,10 @@ module LavinMQ
 
       def clear : Nil
         @segment_positions = Deque(SegmentPosition).new
+      end
+
+      def each(& : SegmentPosition -> Nil) : Nil
+        @segment_positions.each { |sp| yield sp }
       end
     end
   end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -377,7 +377,15 @@ module LavinMQ
       def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
         return if count <= 0
 
-        sps = @msg_store_lock.synchronize { @unacked.values }
+        max = offset.to_i64 + count
+        sps = Array(SegmentPosition).new
+        @msg_store_lock.synchronize do
+          @unacked.each_value do |sp|
+            break if sps.size >= max
+            sps << sp
+          end
+        end
+
         yielded = 0
         sps.each.skip(offset).each do |sp|
           break if yielded >= count

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -136,15 +136,14 @@ module LavinMQ
         return if closed?
         @last_get_time = RoughTime.instant
 
-        unless clean_session?
-          @msg_store_lock.synchronize do
+        @msg_store_lock.synchronize do
+          unless clean_session?
             @unacked.values.each do |sp|
               @msg_store.requeue(sp)
             end
           end
+          @unacked.clear
         end
-
-        @unacked.clear
         @unacked_count.set(0, :release)
         @unacked_bytesize.set(0, :release)
         @has_capacity.set(true)
@@ -236,7 +235,7 @@ module LavinMQ
                 @deliver_count.add(1, :relaxed)
                 @deliver_get_count.add(1, :relaxed)
               end
-              @unacked[id] = sp
+              @msg_store_lock.synchronize { @unacked[id] = sp }
               @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
@@ -293,7 +292,7 @@ module LavinMQ
 
       def ack(packet : Protocol::PubAck) : Nil
         id = packet.packet_id
-        if sp = @unacked.delete(id)
+        if sp = @msg_store_lock.synchronize { @unacked.delete(id) }
           begin
             @ack_count.add(1, :relaxed)
             @unacked_count.sub(1, :relaxed)
@@ -378,8 +377,9 @@ module LavinMQ
       def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
         return if count <= 0
 
+        sps = @msg_store_lock.synchronize { @unacked.values }
         yielded = 0
-        @unacked.values.each.skip(offset).each do |sp|
+        sps.each.skip(offset).each do |sp|
           break if yielded >= count
           if message = peek_copy(sp, redelivered: false, max_body: max_body)
             block.call(message)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -3,6 +3,7 @@ require "./protocol"
 require "../mqtt"
 require "../amqp/queue/queue"
 require "../error"
+require "../peekable"
 require "../sortable_json"
 require "./client"
 require "../policy"
@@ -18,6 +19,7 @@ module LavinMQ
       include SortableJSON
       include PolicyTarget
       include AMQP::QueueStats
+      include Peekable
       Log = ::LavinMQ::Log.for "mqtt.session"
 
       ARGUMENTS      = AMQP::Table.new({"x-queue-type" => "mqtt"})
@@ -370,6 +372,20 @@ module LavinMQ
         count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
         @log.info { "Purged #{count} messages" }
         count
+      end
+
+      # Non-destructive peek at messages delivered to the client but not yet acked.
+      def peek_unacked(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
+        return if count <= 0
+
+        yielded = 0
+        @unacked.values.each.skip(offset).each do |sp|
+          break if yielded >= count
+          if message = peek_copy(sp, redelivered: false, max_body: max_body)
+            block.call(message)
+            yielded += 1
+          end
+        end
       end
 
       def in_use? : Bool

--- a/src/lavinmq/peekable.cr
+++ b/src/lavinmq/peekable.cr
@@ -1,0 +1,55 @@
+require "./message_store"
+
+module LavinMQ
+  # Non-destructive peek at the ready messages of a message store, shared by
+  # AMQP queues and MQTT sessions. Includers must have a `@msg_store` and
+  # guard it with `@msg_store_lock`.
+  module Peekable
+    # Yields up to `count` PeekedMessages from logical `offset`, in delivery
+    # order (requeued first, then from the read head forward). The store lock
+    # is only held while copying one message at a time.
+    def peek(offset : Int32, count : Int32, max_body : Int32, &block : PeekedMessage -> Nil) : Nil
+      return if count <= 0
+
+      requeued_sps, requeued_count = @msg_store_lock.synchronize do
+        @msg_store.peek_requeued(offset, count)
+      end
+
+      yielded = 0
+      requeued_sps.each do |sp|
+        if message = peek_copy(sp, redelivered: true, max_body: max_body)
+          block.call(message)
+          yielded += 1
+        end
+      end
+
+      peek_segments(Math.max(0, offset - requeued_count), count, yielded, max_body, block)
+    rescue MessageStore::ClosedError
+      # queue was deleted/closed mid peek, end the result list early
+    end
+
+    private def peek_copy(sp : SegmentPosition, redelivered : Bool, max_body : Int32) : PeekedMessage?
+      message = @msg_store_lock.synchronize do
+        PeekedMessage.new(@msg_store[sp], max_body, redelivered: redelivered) rescue nil
+      end
+      # without this the peek fiber can reacquire the lock before waiters run
+      Fiber.yield
+      message
+    end
+
+    private def peek_segments(skip : Int32, count : Int32, yielded : Int32, max_body : Int32,
+                              block : Proc(PeekedMessage, Nil)) : Nil
+      step = nil.as(MessageStore::PeekStep?)
+      while yielded < count
+        step = @msg_store_lock.synchronize { @msg_store.peek_step(step, skip, max_body) }
+        Fiber.yield
+        skip -= step.skipped
+        if message = step.message
+          block.call(message)
+          yielded += 1
+        end
+        break if step.done
+      end
+    end
+  end
+end

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -251,23 +251,43 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
     })
 })
 
-document.querySelector('#getMessages').addEventListener('submit', function (evt) {
+const getMessagesForm = document.querySelector('#getMessages')
+getMessagesForm.querySelector('[name=mode]').addEventListener('change', function () {
+  const peek = this.value === 'peek'
+  getMessagesForm.querySelectorAll('.peek-only').forEach(el => el.classList.toggle('hide', !peek))
+})
+getMessagesForm.addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)
-  const url = HTTP.url`api/queues/${vhost}/${queue}/get`
-  const body = {
-    count: parseInt(data.get('messages')),
-    ack_mode: data.get('mode'),
-    encoding: data.get('encoding'),
-    truncate: 50000
+  const peek = data.get('mode') === 'peek'
+  const count = parseInt(data.get('messages')) || 1
+  const offset = peek ? parseInt(data.get('offset')) || 0 : 0
+  let url, body
+  if (peek) {
+    url = HTTP.url`api/queues/${vhost}/${queue}/peek`
+    body = {
+      offset,
+      count,
+      state: data.get('peek_state'),
+      encoding: data.get('encoding'),
+      truncate: 50000
+    }
+  } else {
+    url = HTTP.url`api/queues/${vhost}/${queue}/get`
+    body = {
+      count,
+      ack_mode: data.get('mode'),
+      encoding: data.get('encoding'),
+      truncate: 50000
+    }
   }
   HTTP.request('POST', url, { body })
     .then(messages => {
       if (messages.length === 0) {
-        window.alert('No messages in queue')
+        window.alert(peek ? 'No messages to peek at this offset' : 'No messages in queue')
         return
       }
-      updateQueue(false)
+      if (!peek) updateQueue(false)
       const messagesContainer = document.getElementById('messages')
       messagesContainer.textContent = ''
       const template = document.getElementById('message-template')
@@ -275,8 +295,12 @@ document.querySelector('#getMessages').addEventListener('submit', function (evt)
         const message = messages[i]
         const msgNode = template.cloneNode(true)
         msgNode.removeAttribute('id')
-        msgNode.querySelector('.message-number').textContent = i + 1
+        msgNode.querySelector('.message-number').textContent = i + 1 + offset
         msgNode.querySelector('.messages-remaining').textContent = message.message_count
+        if (message.state) {
+          msgNode.querySelector('.message-state-row').classList.remove('hide')
+          msgNode.querySelector('.message-state').textContent = message.state
+        }
         const exchange = message.exchange === '' ? '(AMQP default)' : message.exchange
         msgNode.querySelector('.message-exchange').textContent = exchange
         msgNode.querySelector('.message-routing-key').textContent = message.routing_key

--- a/static/js/queue.js
+++ b/static/js/queue.js
@@ -252,10 +252,13 @@ document.querySelector('#publishMessage').addEventListener('submit', function (e
 })
 
 const getMessagesForm = document.querySelector('#getMessages')
-getMessagesForm.querySelector('[name=mode]').addEventListener('change', function () {
-  const peek = this.value === 'peek'
+const getModeSelect = getMessagesForm.querySelector('[name=mode]')
+const togglePeekFields = () => {
+  const peek = getModeSelect.value === 'peek'
   getMessagesForm.querySelectorAll('.peek-only').forEach(el => el.classList.toggle('hide', !peek))
-})
+}
+getModeSelect.addEventListener('change', togglePeekFields)
+togglePeekFields()
 getMessagesForm.addEventListener('submit', function (evt) {
   evt.preventDefault()
   const data = new window.FormData(this)

--- a/static/main.css
+++ b/static/main.css
@@ -1723,6 +1723,12 @@ a[data-tag] {
   margin: 0.5em 0;
 }
 
+.form .form-help {
+  display: block;
+  margin-left: 155px;
+  color: var(--color-text-secondary);
+}
+
 .form legend {
   margin-bottom: 20px;
   padding: 0 0.25rem;
@@ -2487,6 +2493,10 @@ pre.arguments .inactive-argument:before {
   #dataTags {
     margin-left: 0;
     padding-left: 0;
+  }
+
+  .form .form-help {
+    margin-left: 0;
   }
 
   textarea {

--- a/views/queue.shtml
+++ b/views/queue.shtml
@@ -269,6 +269,7 @@
                 <option value="get">Get Ack</option>
                 <option value="reject_requeue_true" selected>Reject and Requeue</option>
                 <option value="reject_requeue_false">Reject</option>
+                <option value="peek">Peek (non-destructive)</option>
               </select>
             </label>
             <label>
@@ -281,7 +282,18 @@
             <label>
               <span>Messages</span>
               <input type="number" name="messages" value=1 min="1" max="1000">
-              <small id="dataTags">Maximum 1000 messages</small>
+              <small class="form-help">Maximum 1000 messages</small>
+            </label>
+            <label class="peek-only hide">
+              <span>Offset</span>
+              <input type="number" name="offset" value="0" min="0">
+            </label>
+            <label class="peek-only hide">
+              <span>State</span>
+              <select class="dropdown" name="peek_state">
+                <option value="ready">Ready</option>
+                <option value="unacked">Unacked</option>
+              </select>
             </label>
             <button type="submit" class="btn btn-outlined">Get message(s)</button>
           </form>
@@ -300,6 +312,10 @@
           <h4 class="message-header">Message <span class="message-number"></span></h4>
           <p>The server reported <span class="messages-remaining"></span> messages remaining.</p>
           <table>
+            <tr class="message-state-row hide">
+              <th>State</th>
+              <td class="message-state"></td>
+            </tr>
             <tr>
               <th>Exchange</th>
               <td class="message-exchange"></td>


### PR DESCRIPTION
Adds POST /api/queues/:vhost/:name/peek that reads messages directly from disk without consuming them via AMQP. Supports offset/count windowing and a state parameter selecting either the ready messages (requeued first, then from the read head, in delivery order) or the unacked messages currently held by clients. Works for both AMQP queues (including priority queues) and MQTT sessions.

The message store lock is only held while copying one message at a time (PeekedMessage, a heap-only copy of body and headers, which otherwise are slices into the mmap:ed segments that can be unmapped by a concurrent ack). Serialization to the HTTP response happens outside the lock, so a slow client cannot stall publishes or deliveries on the queue.

- MessageStore#peek_requeued snapshots requeued SegmentPositions, MessageStore#peek_step scans segments from the read head in bounded steps (max 100 positions per lock hold), skipping acked positions, mirroring shift? order.
- The ready-message walk lives in the Peekable module, shared by AMQP::Queue and MQTT::Session (which stores messages in the same MessageStore). It walks requeued then segments with a cursor, yielding the store lock between copies.
- Queue#peek_unacked discovers channels through the vhost's connections, so it covers both consumer deliveries and basic_get:s. Session#peek_unacked snapshots the packet-id => SegmentPosition map of in-flight QoS 1 messages. (QoS 0 messages to a connected client never touch the store, so peek only shows pending/in-flight messages.)
- Payload copies are capped at 1 MiB per message (client truncate can lower it; the UI sends 50 kB).
- PriorityMessageStore delegates peek to its substores, highest priority first, tracked by the store index in the PeekStep cursor.
- Stream queues are rejected (they have /stream already)
- In the UI, peek is a mode in the existing Get messages card; the peek-specific fields (offset, state) appear when the Peek mode is selected. Results show a state badge (ready / unacked).

<img width="2188" height="1756" alt="localhost_15672_queue (4)" src="https://github.com/user-attachments/assets/756daefe-56b6-4d2c-83eb-8e5e341595a3" />
