### PR TITLE
Fix message_stats over-count and counter resets on queue/vhost deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The management UI version is advertised via the `LavinMQ-Version` response header instead of being injected at build time [#2123](https://github.com/cloudamqp/lavinmq/pull/2123)
 - CC and BCC headers are removed from dead-lettered messages when `x-dead-letter-routing-key` is set, instead of being preserved, matching RabbitMQ [#1993](https://github.com/cloudamqp/lavinmq/pull/1993)
 
+### Fixed
+
+- Per-vhost `message_stats` no longer over-counts published messages by the fan-out factor; cumulative message counters are read from the vhost's own counters instead of summing per-queue [#2092](https://github.com/cloudamqp/lavinmq/issues/2092)
+- Prometheus and HTTP API counters (`global_messages_*`, churn `*_total`, `/api/overview`, `/api/nodes`) no longer decrease when a queue or vhost is deleted, which previously made `rate()`/`increase()` fabricate spikes [#2093](https://github.com/cloudamqp/lavinmq/issues/2093)
+
 ## [2.9.1] - 2026-07-01
 
 ### Fixed

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -387,6 +387,51 @@ describe LavinMQ::HTTP::PrometheusController do
   end
 end
 
+describe "LavinMQ::HTTP::PrometheusController counter monotonicity" do
+  # Counter series must never decrease: rate()/increase() read a drop as a reset
+  # and fabricate a spike. These exercise the queue/vhost churn that caused it.
+
+  it "keeps global_messages_delivered_total monotonic when a queue is deleted" do
+    with_metrics_server do |http, s|
+      vhost = s.vhosts.create("mono_qdel")
+      s.users.add_permission("guest", vhost.name, /.*/, /.*/, /.*/)
+      with_channel(s, vhost: vhost.name) do |ch|
+        q = ch.queue("doomed", durable: true)
+        3.times { q.publish_confirm "m" }
+        3.times { q.get(no_ack: true).should_not be_nil }
+      end
+
+      before = prometheus_counter(http, "lavinmq_global_messages_delivered_total")
+      before.should be >= 3
+
+      # Deleting the queue must not drop the global counter.
+      vhost.delete_queue("doomed")
+
+      after = prometheus_counter(http, "lavinmq_global_messages_delivered_total")
+      after.should be >= before
+    end
+  end
+
+  it "counts a fan-out publish once, not once per bound queue" do
+    with_metrics_server do |_, s|
+      vhost = s.vhosts.create("fanout_publish")
+      s.users.add_permission("guest", vhost.name, /.*/, /.*/, /.*/)
+      vhost.declare_exchange("fx", "fanout", false, false)
+      %w[q1 q2 q3].each do |q|
+        vhost.declare_queue(q, false, false)
+        vhost.bind_queue(q, "fx", "")
+      end
+
+      with_channel(s, vhost: vhost.name) do |ch|
+        ch.basic_publish_confirm("m", "fx", "")
+      end
+
+      # One publish fanned out to 3 queues must still count as 1.
+      vhost.message_details[:message_stats][:publish].should eq 1
+    end
+  end
+end
+
 describe LavinMQ::HTTP::FollowerPrometheusController do
   it "returns gc metrics on /metrics" do
     with_follower_metrics_server do |http|
@@ -406,6 +451,12 @@ describe LavinMQ::HTTP::FollowerPrometheusController do
       response.body.lines.any?(&.starts_with? "lavinmq_detailed_queue_messages_ready").should be_false
     end
   end
+end
+
+# Scrape /metrics and return the value of a single (unlabeled) counter series.
+def prometheus_counter(http, key : String) : Float64
+  raw = http.get("/metrics").body
+  PrometheusSpecHelper.parse_prometheus(raw).find! { |m| m[:key] == key }[:value]
 end
 
 class PrometheusSpecHelper

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -467,6 +467,42 @@ describe "LavinMQ::HTTP::PrometheusController counter monotonicity" do
       vhost.message_details[:message_stats][:publish].should eq 1
     end
   end
+
+  it "keeps /api/overview message_stats monotonic when a vhost is deleted" do
+    with_http_server do |http, s|
+      vhost = s.vhosts.create("ov_mono")
+      s.users.add_permission("guest", vhost.name, /.*/, /.*/, /.*/)
+      with_channel(s, vhost: vhost.name) do |ch|
+        q = ch.queue("q", durable: true)
+        3.times { q.publish_confirm "m" }
+        3.times { q.get(no_ack: true).should_not be_nil }
+      end
+
+      before = JSON.parse(http.get("/api/overview").body).dig("message_stats", "deliver_get").as_i64
+      before.should be >= 3
+
+      s.vhosts.delete("ov_mono")
+
+      after = JSON.parse(http.get("/api/overview").body).dig("message_stats", "deliver_get").as_i64
+      after.should be >= before
+    end
+  end
+
+  it "keeps /api/nodes queue_declared monotonic when a vhost is deleted" do
+    with_http_server do |http, s|
+      vhost = s.vhosts.create("node_mono")
+      vhost.declare_queue("q1", true, false)
+      vhost.declare_queue("q2", true, false)
+
+      before = JSON.parse(http.get("/api/nodes").body)[0]["queue_declared"].as_i64
+      before.should be >= 2
+
+      s.vhosts.delete("node_mono")
+
+      after = JSON.parse(http.get("/api/nodes").body)[0]["queue_declared"].as_i64
+      after.should be >= before
+    end
+  end
 end
 
 describe LavinMQ::HTTP::FollowerPrometheusController do

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -412,6 +412,43 @@ describe "LavinMQ::HTTP::PrometheusController counter monotonicity" do
     end
   end
 
+  it "keeps queues_declared_total monotonic when a vhost is deleted" do
+    with_metrics_server do |http, s|
+      vhost = s.vhosts.create("mono_vdel")
+      vhost.declare_queue("q1", true, false)
+      vhost.declare_queue("q2", true, false)
+
+      before = prometheus_counter(http, "lavinmq_queues_declared_total")
+      before.should be >= 2
+
+      s.vhosts.delete("mono_vdel")
+
+      after = prometheus_counter(http, "lavinmq_queues_declared_total")
+      after.should be >= before
+    end
+  end
+
+  it "keeps global_messages_delivered_total monotonic when a vhost is deleted via the store" do
+    with_metrics_server do |http, s|
+      vhost = s.vhosts.create("mono_vdel_msg")
+      s.users.add_permission("guest", vhost.name, /.*/, /.*/, /.*/)
+      with_channel(s, vhost: vhost.name) do |ch|
+        q = ch.queue("q", durable: true)
+        3.times { q.publish_confirm "m" }
+        3.times { q.get(no_ack: true).should_not be_nil }
+      end
+
+      before = prometheus_counter(http, "lavinmq_global_messages_delivered_total")
+      before.should be >= 3
+
+      # Must survive the canonical VHostStore#delete path, not just HTTP DELETE.
+      s.vhosts.delete("mono_vdel_msg")
+
+      after = prometheus_counter(http, "lavinmq_global_messages_delivered_total")
+      after.should be >= before
+    end
+  end
+
   it "counts a fan-out publish once, not once per bound queue" do
     with_metrics_server do |_, s|
       vhost = s.vhosts.create("fanout_publish")

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -42,6 +42,16 @@ module LavinMQ
           {{ name.id }}_rate = 0_f64
           {% end %}
 
+          unless x_vhost
+            deleted_stats = @server.vhosts.deleted_stats
+            {% for name in OVERVIEW_STATS %}
+            {{ name.id }}_count += deleted_stats.{{ name.id }}
+            {% end %}
+            {% for name in CHURN_STATS %}
+            {{ name.id }} += deleted_stats.{{ name.id }}
+            {% end %}
+          end
+
           vhosts(user(context)).each do |vhost|
             next if x_vhost && vhost.name != x_vhost
             vhost.each_connection do |c|

--- a/src/lavinmq/http/controller/nodes.cr
+++ b/src/lavinmq/http/controller/nodes.cr
@@ -13,8 +13,9 @@ module LavinMQ
         messages_unacknowledged = 0_u64
         messages_ready = 0_u64
 
+        deleted_stats = @server.vhosts.deleted_stats
         {% for sm in SERVER_METRICS %}
-          {{ sm.id }} = 0_u64
+          {{ sm.id }} = deleted_stats.{{ sm.id }}
           {{ sm.id }}_rate = 0_f64
           {{ sm.id }}_log = Deque(Float64).new(LavinMQ::Config.instance.stats_log_size)
         {% end %}

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -340,29 +340,30 @@ module LavinMQ
       end
 
       private def global_metrics(writer)
+        deleted_stats = @server.vhosts.deleted_stats
         message_stats = @server.vhosts.map { |_, v| v.message_details[:message_stats] }
         writer.write({name:  "global_messages_delivered_total",
-                      value: @server.deleted_vhosts_messages_delivered_total +
+                      value: deleted_stats.deliver_get +
                              message_stats.sum { |ms| ms[:deliver_get] },
                       type: "counter",
                       help: "Total number of messaged delivered to consumers"})
         writer.write({name:  "global_messages_redelivered_total",
-                      value: @server.deleted_vhosts_messages_redelivered_total +
+                      value: deleted_stats.redeliver +
                              message_stats.sum { |ms| ms[:redeliver] },
                       type: "counter",
                       help: "Total number of messages redelivered to consumers"})
         writer.write({name:  "global_messages_acknowledged_total",
-                      value: @server.deleted_vhosts_messages_acknowledged_total +
+                      value: deleted_stats.ack +
                              message_stats.sum { |ms| ms[:ack] },
                       type: "counter",
                       help: "Total number of messages acknowledged by consumers"})
         writer.write({name:  "global_messages_confirmed_total",
-                      value: @server.deleted_vhosts_messages_confirmed_total +
+                      value: deleted_stats.confirm +
                              message_stats.sum { |ms| ms[:confirm] },
                       type: "counter",
                       help: "Total number of messages confirmed to publishers"})
         writer.write({name:  "global_messages_unroutable_returned_total",
-                      value: @server.deleted_vhosts_messages_unroutable_returned_total +
+                      value: deleted_stats.return_unroutable +
                              message_stats.sum { |ms| ms[:return_unroutable] },
                       type: "counter",
                       help: "Total number of unroutable messages returned to publishers"})
@@ -473,8 +474,9 @@ module LavinMQ
                         :queue_declared, :queue_deleted, :consumer_added, :consumer_removed}
 
       private def vhost_stats(vhosts)
+        deleted_stats = @server.vhosts.deleted_stats
         {% for sm in SERVER_METRICS %}
-          {{ sm.id }} = 0_u64
+          {{ sm.id }} = deleted_stats.{{ sm.id }}
         {% end %}
         vhosts.each do |vhost|
           stats_details = vhost.stats_details

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -54,14 +54,7 @@ module LavinMQ
         delete "/api/vhosts/:name" do |context, params|
           refuse_unless_administrator(context, user(context))
           with_vhost(context, params, vhost_key: "name") do |vhost|
-            if deleted_vhost = @server.vhosts.delete(vhost.name)
-              message_stats = deleted_vhost.message_details[:message_stats]
-              # Add stats to global stats for accurate prometheus metrics counters
-              @server.deleted_vhosts_messages_delivered_total += message_stats[:deliver_get]
-              @server.deleted_vhosts_messages_redelivered_total += message_stats[:redeliver]
-              @server.deleted_vhosts_messages_acknowledged_total += message_stats[:ack]
-              @server.deleted_vhosts_messages_confirmed_total += message_stats[:confirm]
-              @server.deleted_vhosts_messages_unroutable_returned_total += message_stats[:return_unroutable]
+            if @server.vhosts.delete(vhost.name)
               context.response.status_code = 204
             else
               context.response.status_code = 404

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -299,13 +299,6 @@ module LavinMQ
     getter stats_system_collection_duration_seconds = Time::Span.new
     getter gc_stats = GC.prof_stats
 
-    # Message stats for deleted vhosts, required to keep accurate global counters
-    property deleted_vhosts_messages_delivered_total = 0_u64
-    property deleted_vhosts_messages_redelivered_total = 0_u64
-    property deleted_vhosts_messages_acknowledged_total = 0_u64
-    property deleted_vhosts_messages_confirmed_total = 0_u64
-    property deleted_vhosts_messages_unroutable_returned_total = 0_u64
-
     private def control_flow!
       if disk_full?
         if flow?

--- a/src/lavinmq/stats.cr
+++ b/src/lavinmq/stats.cr
@@ -1,6 +1,7 @@
 module LavinMQ
   module Stats
     macro rate_stats(stats_keys, log_keys = %w[])
+      {% stats_keys = stats_keys.resolve if stats_keys.is_a?(Path) %}
       {% for name in stats_keys %}
         @{{ name.id }}_count = Atomic(UInt64).new(0_u64)
         @{{ name.id }}_count_prev = 0_u64

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -323,32 +323,13 @@ module LavinMQ
 
     def message_details
       ready = unacked = 0_u64
-      ack = confirm = deliver = deliver_no_ack = get = get_no_ack = publish = redeliver = deliver_get = 0_u64
       each_queue do |q|
         ready += q.message_count
         unacked += q.unacked_count
-        ack += q.ack_count
-        confirm += q.confirm_count
-        deliver += q.deliver_count
-        deliver_no_ack += q.deliver_no_ack_count
-        deliver_get += q.deliver_get_count
-        get += q.get_count
-        get_no_ack += q.get_no_ack_count
-        publish += q.publish_count
-        redeliver += q.redeliver_count
       end
       each_session do |s|
         ready += s.message_count
         unacked += s.unacked_count
-        ack += s.ack_count
-        confirm += s.confirm_count
-        deliver += s.deliver_count
-        deliver_no_ack += s.deliver_no_ack_count
-        deliver_get += s.deliver_get_count
-        get += s.get_count
-        get_no_ack += s.get_no_ack_count
-        publish += s.publish_count
-        redeliver += s.redeliver_count
       end
 
       {
@@ -356,15 +337,15 @@ module LavinMQ
         messages_unacknowledged: unacked,
         messages_ready:          ready,
         message_stats:           {
-          ack:               ack,
-          confirm:           confirm,
-          deliver:           deliver,
-          deliver_no_ack:    deliver_no_ack,
-          get:               get,
-          get_no_ack:        get_no_ack,
-          deliver_get:       deliver_get,
-          publish:           publish,
-          redeliver:         redeliver,
+          ack:               ack_count,
+          confirm:           confirm_count,
+          deliver:           deliver_count,
+          deliver_no_ack:    deliver_no_ack_count,
+          get:               get_count,
+          get_no_ack:        get_no_ack_count,
+          deliver_get:       deliver_get_count,
+          publish:           publish_count,
+          redeliver:         redeliver_count,
           return_unroutable: return_unroutable_count,
         },
       }

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -27,9 +27,10 @@ module LavinMQ
     include SortableJSON
     include Stats
 
-    rate_stats({"channel_closed", "channel_created", "connection_closed", "connection_created",
-                "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
-                "redeliver", "reject", "return_unroutable", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
+    STATS_KEYS = {"channel_closed", "channel_created", "connection_closed", "connection_created",
+                  "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
+                  "redeliver", "reject", "return_unroutable", "consumer_added", "consumer_removed", "recv_oct", "send_oct"}
+    rate_stats(STATS_KEYS)
 
     getter name, data_dir, operator_policies, policies, parameters, shovels, dir, users, replicator
     getter closed = BoolChannel.new(true)

--- a/src/lavinmq/vhost_store.cr
+++ b/src/lavinmq/vhost_store.cr
@@ -4,6 +4,22 @@ require "./auth/base_user"
 require "./observable"
 
 module LavinMQ
+  class DeletedVHostStats
+    {% for m in VHost::STATS_KEYS %}
+      @{{ m.id }} = Atomic(UInt64).new(0_u64)
+
+      def {{ m.id }} : UInt64
+        @{{ m.id }}.get(:relaxed)
+      end
+    {% end %}
+
+    def add(vhost : VHost) : Nil
+      {% for m in VHost::STATS_KEYS %}
+        @{{ m.id }}.add(vhost.{{ m.id }}_count, :relaxed)
+      {% end %}
+    end
+  end
+
   class VHostStore
     enum Event
       Added
@@ -14,6 +30,8 @@ module LavinMQ
     include Observable(Event)
 
     Log = LavinMQ::Log.for "vhost_store"
+
+    getter deleted_stats = DeletedVHostStats.new
 
     def initialize(@data_dir : String, @users : Auth::UserStore, @replicator : Clustering::Replicator?, @persister : Persister)
       @vhosts = Hash(String, VHost).new
@@ -78,6 +96,7 @@ module LavinMQ
     def delete(name) : VHost?
       if vhost = @vhosts.delete name
         Log.info { "Deleting vhost #{name}" }
+        @deleted_stats.add(vhost)
         @users.rm_vhost_permissions_for_all(name)
         vhost.delete
         notify_observers(Event::Deleted, name)


### PR DESCRIPTION
### WHAT is this pull request doing?

- Per-vhost `message_stats` now reads the vhost's own cumulative counters instead of summing per queue, so a fan-out publish is counted once and the value survives queue deletion (#2092).
- Server-wide counters (`global_messages_*`, churn `*_total`, `/api/overview`, `/api/nodes`) stay monotonic across queue/vhost deletion. 
 
A `DeletedVHostStats` accumulator, folded in the canonical `VHostStore#delete`, keeps the totals from dropping, previously a delete made the sum go backwards and Prometheus read it as a counter reset (#2093). It derives from `VHost::STATS_KEYS` (single source) and uses atomic counters.

Closes #2092, #2093.

### HOW can this pull request be tested?

- `make test SPEC=spec/api/prometheus_spec.cr` New regression specs: fan-out counted once; counters monotonic across queue delete and vhost delete (via the store path); `/api/overview` and `/api/nodes` monotonic.
- Manual: Curl as described in #2092 and we'll now get the correct result