### PR TITLE
shovel ui: render runtime view + client-side message rate

### DIFF
--- a/docs/shovel-delivery-outcomes.md
+++ b/docs/shovel-delivery-outcomes.md
@@ -1,0 +1,77 @@
+# Shovel delivery outcomes
+
+A shovel moves messages from a **source** to a **destination**. For each message
+the destination classifies the delivery attempt into an **Outcome**, and the
+runner turns that outcome into an action on the source. Classification is
+hardcoded per destination type; the runner owns the policy (acking, requeueing,
+backoff and the error-out threshold).
+
+See [`src/lavinmq/shovel/CONTEXT.md`](../src/lavinmq/shovel/CONTEXT.md) for the
+vocabulary.
+
+## Outcome → source action
+
+The runner maps every outcome to exactly one action:
+
+| Outcome | Source action | Effect |
+| --- | --- | --- |
+| `Confirmed` | `ack` | Message delivered and removed from the source. Resets the failure and abort counters. |
+| `Retry` | `reject(requeue: true)` | Transient failure. Message stays on the source and is retried with capped exponential backoff. Retries are unbounded. |
+| `Reject` | `reject(requeue: false)` | The message itself is unacceptable. It is dead-lettered via the source queue's DLX (dropped if no DLX is configured). The shovel continues. |
+| `Abort` | `reject(requeue: true)` | The destination is unusable. The message is kept on the source; after `ABORT_THRESHOLD` (10) consecutive aborts the shovel errors out for an operator to resolve. |
+
+## HTTP destination
+
+`HTTPDestination#classify(response)` maps the HTTP status (or a transport error)
+to an outcome:
+
+| Condition | Outcome |
+| --- | --- |
+| `200`–`299` | `Confirmed` |
+| `408`, `429`, `500`–`599` | `Retry` |
+| `400`, `422` | `Reject` |
+| Any other non-2xx (`401`, `403`, `404`, `405`, `410`, `3xx`, `418`, …) | `Abort` |
+| Transport failure during the request (connection refused/reset, read timeout — `IO::Error` / `Socket::Error`) | `Retry` |
+
+## AMQP destination
+
+`AMQPDestination` reports the broker's publisher-confirm result:
+
+| Condition | Outcome |
+| --- | --- |
+| Publisher-confirm **ack** | `Confirmed` |
+| Publisher-confirm **nack** (e.g. `x-overflow: reject-publish` on a full destination queue) | `Retry` |
+| Connection / channel error mid-publish | Not an outcome — the exception is handled by the runner's reconnect loop. A `404` channel-close ("queue deleted") stops the shovel. |
+
+## Ack-mode interaction
+
+The shovel's `ack-mode` controls **when** an outcome is reported:
+
+| Ack mode | AMQP destination | HTTP destination |
+| --- | --- | --- |
+| `on-confirm` | Reported on the asynchronous publisher-confirm callback (`Confirmed` / `Retry`). | Reported after the HTTP response (`classify`). |
+| `on-publish` | `Confirmed` reported immediately after publishing, without waiting for a confirm. | Same as `on-confirm` (always waits for the response). |
+| `no-ack` | No outcome is reported — the source consumes with `no-ack`, so there is nothing to settle. | No outcome is reported. |
+
+## Failover across multiple destinations
+
+When a shovel is configured with more than one `dest-uri`, the
+`MultiDestinationHandler` provides coarse, ordered failover. One destination is
+active at a time and it intercepts that destination's outcome:
+
+- `Confirmed` / `Retry` / `Reject` — forwarded to the runner unchanged (any
+  non-abort resets the failover cycle).
+- `Abort` — advance to the next destination and retry the message there
+  (forwarded as `Retry`). Only once **every** destination has aborted in a row,
+  with no `Confirmed` in between, is `Abort` propagated so the runner errors out.
+- No usable destination (none could start) — reports `Abort` rather than
+  silently dropping the message.
+
+## Notes
+
+- A `Reject` with no dead-letter exchange configured on the source queue drops
+  the message silently. Surfacing a UI warning for this is tracked separately.
+- An in-flight HTTP request cannot be cancelled (closing the client does not
+  interrupt it), so on pause the current request drains under its read timeout
+  while no new deliveries are started; the in-flight message is redelivered on
+  resume (the source is at-least-once).

--- a/docs/shovel-delivery-outcomes.md
+++ b/docs/shovel-delivery-outcomes.md
@@ -31,7 +31,13 @@ to an outcome:
 | `408`, `429`, `500`–`599` | `Retry` |
 | `400`, `422` | `Reject` |
 | Any other non-2xx (`401`, `403`, `404`, `405`, `410`, `3xx`, `418`, …) | `Abort` |
-| Transport failure during the request (connection refused/reset, read timeout — `IO::Error` / `Socket::Error`) | `Retry` |
+| Transport failure during the request (connection refused/reset, read timeout, or TLS handshake error — `IO::Error` / `OpenSSL::SSL::Error`) | `Retry` |
+
+Under `on-confirm`, a `Retry` outcome (a `5xx`/`429`/`408` response or a transport
+failure) is retried **in place** up to 5 times with a small random jitter (no
+backoff) before it is reported to the runner; `Confirmed`, `Reject`, and `Abort`
+are reported immediately. Once the in-place budget is exhausted the runner
+requeues the message and applies its own capped backoff.
 
 ## AMQP destination
 
@@ -50,7 +56,7 @@ The shovel's `ack-mode` controls **when** an outcome is reported:
 | Ack mode | AMQP destination | HTTP destination |
 | --- | --- | --- |
 | `on-confirm` | Reported on the asynchronous publisher-confirm callback (`Confirmed` / `Retry`). | Reported after the HTTP response (`classify`). |
-| `on-publish` | `Confirmed` reported immediately after publishing, without waiting for a confirm. | Same as `on-confirm` (always waits for the response). |
+| `on-publish` | `Confirmed` reported immediately after publishing, without waiting for a confirm. | Posts once and reports `Confirmed` as soon as the request returns, regardless of status; only a transport failure reports `Retry`. No status classification or in-place retry. |
 | `no-ack` | No outcome is reported — the source consumes with `no-ack`, so there is nothing to settle. | No outcome is reported. |
 
 ## Failover across multiple destinations

--- a/docs/shovels.md
+++ b/docs/shovels.md
@@ -8,7 +8,7 @@ Each shovel runs as an independent fiber owned by its vhost. When started, it op
 
 1. **Source setup.** If `src-queue` is set, the shovel consumes directly from that queue. If only `src-exchange` (and optionally `src-exchange-key`) is set, the shovel declares an anonymous, exclusive queue, binds it to that exchange, and consumes from the anonymous queue. The source channel uses `src-prefetch-count` for backpressure.
 2. **Pull loop.** Messages from the source consumer are pushed one by one to the destination's `push` method. For AMQP destinations this becomes `basic.publish` to `dest-exchange` with `dest-exchange-key` (or to the default exchange when `dest-queue` is set). For HTTP destinations, the message body is POSTed to `dest-uri`.
-3. **Acknowledgment.** Source acks are gated by the configured `ack-mode` (see [Acknowledgment Modes](#acknowledgment-modes)).
+3. **Acknowledgment.** The destination classifies each delivery into an [outcome](#delivery-outcomes), and the shovel acks, retries, dead-letters, or aborts the source message accordingly. The configured `ack-mode` controls *when* the outcome is reported (see [Acknowledgment Modes](#acknowledgment-modes)).
 4. **Lifecycle.** A state machine moves the shovel between `starting`, `running`, `paused`, `error`, `stopped`, and `terminated` (see [Shovel States](#shovel-states)). Errors trigger an exponential-backoff reconnect; pause is persisted to disk so a paused shovel stays paused across server restarts.
 5. **Self-deletion.** With `src-delete-after: queue-length`, the shovel deletes its own parameter (and stops itself) once the source queue has been drained.
 
@@ -60,11 +60,20 @@ The AMQP message is mapped to the HTTP request as follows:
 | `X-<header>` | One header per AMQP header on the message |
 | `User-Agent` | `LavinMQ` |
 
-For `on-confirm` and `on-publish` ack modes, the source delivery is acked only when the destination returns a 2xx response; any other status triggers the shovel's reconnect/retry path. `no-ack` skips the check.
+For `on-confirm` and `on-publish` ack modes, the HTTP response status is classified into a [delivery outcome](#delivery-outcomes) rather than triggering a uniform retry:
+
+- `2xx` acks the message.
+- `408`, `429`, and `5xx` (and transport-level failures such as connection refused or read timeout) requeue the message and retry it with backoff.
+- `400` and `422` reject the message without requeue, so the source queue's dead-letter exchange handles it.
+- Any other status (e.g. `401`, `403`, `404`, `405`, `410`) is treated as an unusable endpoint; after repeated consecutive failures the shovel errors out for an operator to resolve.
+
+`no-ack` skips the check. See [Shovel delivery outcomes](shovel-delivery-outcomes.md) for the full status-to-outcome mapping.
 
 ## Multi-Destination
 
-A shovel can have multiple destinations configured. One destination is randomly selected when the shovel starts, and all consumed messages are forwarded to that single destination until the shovel restarts (e.g., on reconnection).
+A shovel can have multiple destinations configured. They form an **ordered failover list**, not a load-balanced or round-robin pool: one destination is active at a time, starting with the first one that can be reached. All consumed messages go to the active destination.
+
+When the active destination is classified as unusable (an `Abort` [outcome](#delivery-outcomes)) or fails to start, the shovel advances to the next destination in the list and retries the message there. A successful — or otherwise non-abort — delivery resets the failover cycle. Only once *every* destination has failed in a row, with no successful delivery in between, does the shovel error out.
 
 ## Acknowledgment Modes
 
@@ -73,6 +82,19 @@ A shovel can have multiple destinations configured. One destination is randomly 
 | `on-confirm` (default) | Ack source after destination confirms receipt |
 | `on-publish` | Ack source after publishing to destination (before confirm) |
 | `no-ack` | No acknowledgment (fastest, may lose messages) |
+
+## Delivery Outcomes
+
+For every message, the destination classifies the delivery attempt into one **outcome**, and the shovel turns that outcome into an action on the source. This is what decides whether a message is acked, retried, dead-lettered, or treated as a fatal destination problem.
+
+| Outcome | Source action | Meaning |
+|---------|---------------|---------|
+| `Confirmed` | ack | Delivered. Resets the failure and abort counters. |
+| `Retry` | reject (requeue) | Transient failure. Retried on the source with capped exponential backoff; retries are unbounded. |
+| `Reject` | reject (no requeue) | The message itself is unacceptable. Dead-lettered via the source queue's DLX (dropped if none configured); the shovel continues. |
+| `Abort` | reject (requeue) | The destination is unusable. The message is kept; after 10 consecutive aborts the shovel errors out for an operator to resolve. |
+
+How each destination type maps its native result (HTTP status, AMQP publisher confirm) to these outcomes, and how `ack-mode` affects *when* an outcome is reported, is documented in [Shovel delivery outcomes](shovel-delivery-outcomes.md).
 
 ## Shovel States
 

--- a/docs/shovels.md
+++ b/docs/shovels.md
@@ -46,6 +46,7 @@ A shovel with an `http://` or `https://` `dest-uri` POSTs each consumed message 
 | Parameter | Description |
 |-----------|-------------|
 | `dest-uri` | HTTP/HTTPS URL to POST to. Userinfo (`user:password@host`) is sent as HTTP Basic Auth. |
+| `dest-timeout` | Connect and read timeout for each HTTP attempt, in seconds (int or float). Defaults to `30`. |
 
 The AMQP message is mapped to the HTTP request as follows:
 
@@ -63,7 +64,7 @@ The AMQP message is mapped to the HTTP request as follows:
 For `on-confirm` and `on-publish` ack modes, the HTTP response status is classified into a [delivery outcome](#delivery-outcomes) rather than triggering a uniform retry:
 
 - `2xx` acks the message.
-- `408`, `429`, and `5xx` (and transport-level failures such as connection refused or read timeout) requeue the message and retry it with backoff.
+- `408`, `429`, and `5xx` (and transport-level failures such as connection refused or read timeout) are first retried in place, up to 5 times with a small random jitter (no backoff), so a brief blip recovers without a broker round-trip. If it still fails, the message is requeued and retried on the source with capped exponential backoff.
 - `400` and `422` reject the message without requeue, so the source queue's dead-letter exchange handles it.
 - Any other status (e.g. `401`, `403`, `404`, `405`, `410`) is treated as an unusable endpoint; after repeated consecutive failures the shovel errors out for an operator to resolve.
 

--- a/docs/shovels.md
+++ b/docs/shovels.md
@@ -61,14 +61,14 @@ The AMQP message is mapped to the HTTP request as follows:
 | `X-<header>` | One header per AMQP header on the message |
 | `User-Agent` | `LavinMQ` |
 
-For `on-confirm` and `on-publish` ack modes, the HTTP response status is classified into a [delivery outcome](#delivery-outcomes) rather than triggering a uniform retry:
+With the `on-confirm` ack mode, the HTTP response status is classified into a [delivery outcome](#delivery-outcomes) rather than triggering a uniform retry:
 
 - `2xx` acks the message.
-- `408`, `429`, and `5xx` (and transport-level failures such as connection refused or read timeout) are first retried in place, up to 5 times with a small random jitter (no backoff), so a brief blip recovers without a broker round-trip. If it still fails, the message is requeued and retried on the source with capped exponential backoff.
+- `408`, `429`, and `5xx` (and transport-level failures such as connection refused, read timeout, or a TLS handshake error) are first retried in place, up to 5 times with a small random jitter (no backoff), so a brief blip recovers without a broker round-trip. If it still fails, the message is requeued and retried on the source with capped exponential backoff.
 - `400` and `422` reject the message without requeue, so the source queue's dead-letter exchange handles it.
 - Any other status (e.g. `401`, `403`, `404`, `405`, `410`) is treated as an unusable endpoint; after repeated consecutive failures the shovel errors out for an operator to resolve.
 
-`no-ack` skips the check. See [Shovel delivery outcomes](shovel-delivery-outcomes.md) for the full status-to-outcome mapping.
+`on-publish` behaves differently: the message is POSTed once and acked as soon as the request completes, **regardless of the response status** (so even a `5xx` is treated as delivered); only a transport-level failure requeues it. There is no status classification and no in-place retry. `no-ack` POSTs once and never settles the source. See [Shovel delivery outcomes](shovel-delivery-outcomes.md) for the full status-to-outcome mapping.
 
 ## Multi-Destination
 

--- a/extras/lmq_reject-overflow.sh
+++ b/extras/lmq_reject-overflow.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Usage: ./script.sh "amqps://username:passwd@servername/vhostname"
+# Or: AMQP_URL="amqps://username:passwd@servername/vhostname" ./script.sh
+
+# Check if AMQP_URL is provided as argument or environment variable
+if [ -n "$1" ]; then
+  AMQP_URL="$1"
+elif [ -z "$AMQP_URL" ]; then
+  echo "Error: AMQP_URL not provided"
+  echo "Usage: $0 \"amqps://username:passwd@servername/vhostname\""
+  echo "Or: export AMQP_URL=\"amqps://username:passwd@servername/vhostname\" && $0"
+  exit 1
+fi
+
+# Extract components from AMQP_URL
+# Remove amqp:// or amqps:// prefix
+TEMP_URL="${AMQP_URL#amqp://}"
+TEMP_URL="${TEMP_URL#amqps://}"
+
+# Extract credentials and host
+if [[ $TEMP_URL == *@* ]]; then
+  CREDENTIALS="${TEMP_URL%%@*}"
+  HOST_AND_VHOST="${TEMP_URL##*@}"
+else
+  echo "Error: No credentials found in AMQP_URL"
+  exit 1
+fi
+
+# Extract host and vhost (vhost comes after the first /)
+if [[ $HOST_AND_VHOST == */* ]]; then
+  HOST="${HOST_AND_VHOST%%/*}"
+  VHOST="${HOST_AND_VHOST#*/}"
+  # URL encode the vhost for API calls
+  VHOST_ENCODED=$(printf %s "$VHOST" | jq -sRr @uri)
+else
+  HOST="$HOST_AND_VHOST"
+  VHOST="/"
+  VHOST_ENCODED="%2F"
+fi
+
+# Build HTTPS_URL for RabbitMQ Management API (will use port 443)
+HTTPS_URL="http://${CREDENTIALS}@${HOST}:15672"
+
+echo "Using HTTPS_URL: ${HTTPS_URL}"
+echo "Virtual host: $VHOST (encoded as: $VHOST_ENCODED)"
+
+# 1. Create Queue q1
+echo -e "\n=== Creating queue q1 ==="
+curl -i -u "$CREDENTIALS" -H "content-type:application/json" \
+  -X PUT "${HTTPS_URL}/api/queues/${VHOST_ENCODED}/q1" \
+  -d '{}'
+
+# 2. Create Queue q2 with max-length and overflow policy
+echo -e "\n=== Creating queue q2 with max-length=100 and x-overflow=reject-publish ==="
+curl -i -u "$CREDENTIALS" -H "content-type:application/json" \
+  -X PUT "${HTTPS_URL}/api/queues/${VHOST_ENCODED}/q2" \
+  -d '{
+    "arguments": {
+      "x-max-length": 100,
+      "x-overflow": "reject-publish"
+    }
+  }'
+
+# Wait for user to trigger shovel creation
+echo -e "\n=== Queues created successfully ==="
+echo -e "\nPress ENTER to create the shovel from q1 to q2..."
+read -r
+
+# 3. Create a Shovel from q1 to q2
+echo -e "\n=== Creating shovel from q1 to q2 ==="
+curl -i -u "$CREDENTIALS" -H "content-type:application/json" \
+  -X PUT "${HTTPS_URL}/api/parameters/shovel/${VHOST_ENCODED}/q1-to-q2-shovel" \
+  -d '{
+    "value": {
+      "src-protocol": "amqp091",
+      "src-uri": "'"$AMQP_URL"'",
+      "src-queue": "q1",
+      "dest-protocol": "amqp091",
+      "dest-uri": "'"$AMQP_URL"'",
+      "dest-queue": "q2"
+    }
+  }'
+
+# Verify the setup
+echo -e "\n=== Verifying queues ==="
+curl -s -u "$CREDENTIALS" "${HTTPS_URL}/api/queues/${VHOST_ENCODED}" | grep -E '"name":|"x-max-length":|"x-overflow":'
+
+echo -e "\n=== Verifying shovels ==="
+curl -s -u "$CREDENTIALS" "${HTTPS_URL}/api/parameters/shovel/${VHOST_ENCODED}"
+
+echo -e "\n=== Setup complete ==="

--- a/extras/shovel_status_test.sh
+++ b/extras/shovel_status_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Set up a shovel-per-HTTP-status test against a local LavinMQ.
+#
+# For each status code it:
+#   1. creates a durable queue  shovel-test-<code>
+#   2. binds it to amq.topic with routing key "#"
+#   3. creates a shovel that consumes the queue and POSTs to
+#      http://<endpoint>/<code>   (the shovel_test_endpoint.cr server)
+#
+# Because every queue is bound with "#", a single publish to amq.topic fans out
+# to all of them, so one message exercises every disposition at once:
+#
+#   200 -> Confirmed   503/408/429 -> Retry   400/422 -> Reject   others -> Abort
+#
+# Usage:
+#   ./shovel_status_test.sh setup            # create queues, bindings, shovels
+#   ./shovel_status_test.sh publish [rk] [n] # publish n messages (default 1) to amq.topic
+#   ./shovel_status_test.sh list             # show the shovels and their state
+#   ./shovel_status_test.sh cleanup          # delete the shovels and queues
+#
+# Config via env:
+#   API       management base URL        (default http://localhost:15672)
+#   USERPASS  management credentials      (default guest:guest)
+#   VHOST     virtual host                (default /)
+#   AMQP_URI  shovel source uri           (default amqp://guest:guest@localhost)
+#   ENDPOINT  test web server host:port   (default localhost:8888)
+#   CODES     space separated status list (default below)
+
+set -euo pipefail
+
+API="${API:-http://localhost:15672}"
+USERPASS="${USERPASS:-guest:guest}"
+VHOST="${VHOST:-/}"
+AMQP_URI="${AMQP_URI:-amqp://guest:guest@localhost}"
+ENDPOINT="${ENDPOINT:-localhost:8888}"
+CODES="${CODES:-200 400 422 408 429 503 401 403 404 410 418}"
+EXCHANGE="amq.topic"
+PREFIX="shovel-test"
+
+# URL-encode the vhost ("/" -> "%2f")
+vh=$(printf '%s' "$VHOST" | sed 's#/#%2f#g')
+
+api() { # method path [json]
+  local method="$1" path="$2" data="${3:-}"
+  if [ -n "$data" ]; then
+    curl -fsS -u "$USERPASS" -X "$method" \
+      -H 'content-type: application/json' \
+      -d "$data" "$API$path"
+  else
+    curl -fsS -u "$USERPASS" -X "$method" "$API$path"
+  fi
+}
+
+setup() {
+  for code in $CODES; do
+    local q="$PREFIX-$code"
+    echo "==> $q  ->  http://$ENDPOINT/$code"
+
+    # 1. queue
+    api PUT "/api/queues/$vh/$q" '{"durable":true,"auto_delete":false}' >/dev/null
+
+    # 2. binding to amq.topic with routing key "#"
+    api POST "/api/bindings/$vh/e/$EXCHANGE/q/$q" '{"routing_key":"#"}' >/dev/null
+
+    # 3. shovel: consume the queue, POST to the endpoint path for this code.
+    #    dest-exchange:"" is required only to satisfy config validation, which
+    #    demands a dest queue/exchange even for HTTP destinations; the HTTP
+    #    destination ignores it.
+    api PUT "/api/parameters/shovel/$vh/$q" "$(cat <<JSON
+{"value":{
+  "src-uri": "$AMQP_URI",
+  "src-queue": "$q",
+  "dest-uri": "http://$ENDPOINT/$code",
+  "dest-exchange": "",
+  "ack-mode": "on-confirm",
+  "src-delete-after": "never"
+}}
+JSON
+)" >/dev/null
+  done
+  echo "done. publish with: $0 publish"
+}
+
+publish() {
+  local rk="${1:-test}" n="${2:-1}" i
+  for ((i = 1; i <= n; i++)); do
+    api POST "/api/exchanges/$vh/$EXCHANGE/publish" "$(cat <<JSON
+{"properties":{"content_type":"text/plain","message_id":"msg-$i"},
+ "routing_key":"$rk","payload":"hello $i","payload_encoding":"string"}
+JSON
+)" >/dev/null
+  done
+  echo "published $n message(s) to $EXCHANGE (rk=$rk); fans out to all $PREFIX-* queues"
+}
+
+list() {
+  api GET "/api/shovels/$vh" | tr ',' '\n' | grep -E '"name"|"state"|"error"' || true
+}
+
+cleanup() {
+  for code in $CODES; do
+    local q="$PREFIX-$code"
+    api DELETE "/api/parameters/shovel/$vh/$q" >/dev/null 2>&1 || true
+    api DELETE "/api/queues/$vh/$q" >/dev/null 2>&1 || true
+    echo "removed $q"
+  done
+}
+
+case "${1:-setup}" in
+  setup) setup ;;
+  publish) shift; publish "$@" ;;
+  list) list ;;
+  cleanup) cleanup ;;
+  *) echo "usage: $0 {setup|publish [rk] [n]|list|cleanup}" >&2; exit 2 ;;
+esac

--- a/extras/shovel_test_endpoint.cr
+++ b/extras/shovel_test_endpoint.cr
@@ -1,0 +1,61 @@
+# Test HTTP endpoint for shovel disposition testing.
+#
+#   crystal run shovel_test_endpoint.cr -- --port 8888
+#
+# Point a shovel's dest-uri at a path that names the status you want:
+#
+#   http://localhost:8888/200   -> 2xx            => Confirmed (acked)
+#   http://localhost:8888/503   -> 5xx/408/429    => Retry     (requeue + backoff)
+#   http://localhost:8888/400   -> 400/422        => Reject    (reject(requeue:false) -> DLX)
+#   http://localhost:8888/404   -> 404/401/403/.. => Abort     (error-out after threshold)
+#   http://localhost:8888/418   -> any unknown    => Abort
+#   http://localhost:8888/      -> 200
+#
+# It also supports a "flaky" path that fails N times then succeeds, handy for
+# watching backoff recover:
+#
+#   http://localhost:8888/flaky/503/3  -> 503 three times, then 200
+#
+# Every request is logged with method, path, the status returned, and body.
+
+require "http/server"
+require "option_parser"
+
+port = 8888
+OptionParser.parse do |p|
+  p.on("--port PORT", "Port to listen on (default 8888)") { |v| port = v.to_i }
+end
+
+flaky_seen = Hash(String, Int32).new(0)
+
+server = HTTP::Server.new do |ctx|
+  req = ctx.request
+  path = req.path
+  body = req.body.try(&.gets_to_end) || ""
+
+  status =
+    case path
+    when %r{\A/flaky/(\d+)/(\d+)\z}
+      code, limit = $1.to_i, $2.to_i
+      n = (flaky_seen[path] += 1)
+      n <= limit ? code : 200
+    when %r{\A/(\d{3})\z}
+      $1.to_i
+    else
+      200
+    end
+
+  ctx.response.status_code = status
+  ctx.response.content_type = "text/plain"
+  ctx.response.print(status == 200 ? "ok" : "status #{status}")
+
+  shovel = req.headers["X-Shovel"]?
+  STDOUT.puts "#{req.method} #{path} -> #{status}" \
+              "#{shovel ? " [shovel=#{shovel}]" : ""}" \
+              " body=#{body.inspect}"
+end
+
+addr = server.bind_tcp("0.0.0.0", port)
+puts "shovel test endpoint listening on http://#{addr}"
+puts "  /200 Confirmed  /503 Retry  /400 Reject  /404 Abort  /flaky/503/3"
+server.listen

--- a/spec/frontend/shovels.spec.js
+++ b/spec/frontend/shovels.spec.js
@@ -1,46 +1,70 @@
 import * as helpers from './helpers.js'
-import { test, expect } from './fixtures.js';
+import { test, expect } from './fixtures.js'
 
-test.describe("shovels", _ => {
-  const shovelVhost = '/';
+test.describe('shovels', _ => {
+  const shovelVhost = '/'
   const shovelName = 'shovel1'
   const parameterShovelsResponse = {
-    "items": [
+    items: [
       {
-        "name": shovelName,
-        "value": {"src-uri":"amqp://","dest-uri":"amqp://","src-prefetch-count":1000,"src-delete-after":"never","reconnect-delay":120,"ack-mode":"on-confirm","src-queue":"qdest","dest-queue":"qsrc"},
-        "component": "shovel",
-        "vhost": shovelVhost
+        name: shovelName,
+        value: { 'src-uri': 'amqp://', 'dest-uri': 'amqp://', 'src-prefetch-count': 1000, 'src-delete-after': 'never', 'reconnect-delay': 120, 'ack-mode': 'on-confirm', 'src-queue': 'qdest', 'dest-queue': 'qsrc' },
+        component: 'shovel',
+        vhost: shovelVhost
       }
-    ]
-    ,"filtered_count": 1,
-    "item_count": 1,
-    "page": 1,
-    "page_count": 1,
-    "page_size": 100,
-    "total_count": 1
+    ],
+    filtered_count: 1,
+    item_count: 1,
+    page: 1,
+    page_count: 1,
+    page_size: 100,
+    total_count: 1
   }
-  const shovelsResponse = [
-    {"name": shovelName, "vhost": shovelVhost, "state": "Running", "error": null, "message_count": 0},
-  ]
+  // Builds a /api/shovels status row carrying all runtime fields. Override any
+  // field per test; counters default to representative non-zero values.
+  function makeStatus (overrides = {}) {
+    return [{
+      name: shovelName,
+      vhost: shovelVhost,
+      state: 'Running',
+      error: null,
+      message_count: 0,
+      confirmed: 100,
+      retried: 5,
+      dead_lettered: 2,
+      aborted: 1,
+      consecutive_failures: 0,
+      consecutive_aborts: 0,
+      abort_threshold: 10,
+      ...overrides
+    }]
+  }
+  let shovelsResponse
+
+  // Re-register /api/shovels with custom runtime fields and reload the page.
+  async function reloadWith (page, apimap, overrides) {
+    const req = apimap.get('/api/shovels', makeStatus(overrides))
+    await page.goto('/shovels')
+    await req
+  }
 
   test.beforeEach(async ({ apimap, page }) => {
-    const parameterShovelsRequest = apimap.get(`/api/parameters/shovel`, parameterShovelsResponse)
-    const shovelsRequest = apimap.get(`/api/shovels`, shovelsResponse)
+    shovelsResponse = makeStatus()
+    const parameterShovelsRequest = apimap.get('/api/parameters/shovel', parameterShovelsResponse)
+    const shovelsRequest = apimap.get('/api/shovels', shovelsResponse)
     await page.clock.install()
-    await page.goto(`/shovels`)
+    await page.goto('/shovels')
     await parameterShovelsRequest
     await shovelsRequest
   })
 
-
   test('are loaded', async ({ page, baseURL }) => {
-    await expect(page.locator('#pagename-label')).toHaveText("1")
+    await expect(page.locator('#pagename-label')).toHaveText('1')
   })
 
-  test('are refreshed automatically', async({ page }) => {
+  test('are refreshed automatically', async ({ page }) => {
     // Verify that at least 3 requests are made
-    for (let i=0; i<3; i++) {
+    for (let i = 0; i < 3; i++) {
       const apiShovelsRequest = helpers.waitForPathRequest(page, '/api/parameters/shovel')
       await page.clock.runFor(10000) // advance time by 10 seconds
       await expect(apiShovelsRequest).toBeRequested()
@@ -53,5 +77,38 @@ test.describe("shovels", _ => {
     page.on('dialog', async dialog => await dialog.accept())
     await page.locator(`#table tr[data-name='"${shovelName}"']`).getByRole('button', { name: /delete/i }).click()
     await expect(deleteRequest).toBeRequested()
+  })
+
+  test('shows a colored state badge', async ({ page }) => {
+    const badge = page.locator(`#table tr[data-name='"${shovelName}"'] .badge-state`)
+    await expect(badge).toHaveText('Running')
+    await expect(badge).toHaveClass(/badge-state--running/)
+  })
+
+  test('shows the error inline when state is Error', async ({ page, apimap }) => {
+    await reloadWith(page, apimap, { state: 'Error', error: 'destination unusable after 10 attempts' })
+    const row = page.locator(`#table tr[data-name='"${shovelName}"']`)
+    await expect(row.locator('.badge-state')).toHaveClass(/badge-state--error/)
+    await expect(row.locator('.state-error')).toHaveText('destination unusable after 10 attempts')
+  })
+
+  test('shows a degraded indicator when backing off', async ({ page, apimap }) => {
+    await reloadWith(page, apimap, { consecutive_failures: 3 })
+    const row = page.locator(`#table tr[data-name='"${shovelName}"']`)
+    await expect(row.locator('.state-degraded')).toContainText('retrying')
+  })
+
+  test('shows abort progress toward error-out', async ({ page, apimap }) => {
+    await reloadWith(page, apimap, { consecutive_aborts: 4, abort_threshold: 10 })
+    const row = page.locator(`#table tr[data-name='"${shovelName}"']`)
+    await expect(row.locator('.state-degraded')).toContainText('4/10')
+  })
+
+  test('computes message rate from successive polls', async ({ page }) => {
+    const rate = page.locator(`#table tr[data-name='"${shovelName}"'] .rate-cell`)
+    await expect(rate).not.toContainText('msg/s') // no prior sample yet
+    shovelsResponse[0].message_count = 50
+    await page.clock.runFor(5000) // one auto-reload, 5s elapsed -> 50/5 = 10
+    await expect(rate).toContainText('msg/s')
   })
 })

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -242,13 +242,13 @@ describe LavinMQ::Shovel do
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
           "spec",
-          [URI.parse(s.amqp_url)],
+          [URI.parse(s.amqp_server.url)],
           "rp_q1",
           direct_user: s.users.direct_user
         )
         dest = LavinMQ::Shovel::AMQPDestination.new(
           "spec",
-          URI.parse(s.amqp_url),
+          URI.parse(s.amqp_server.url),
           "rp_q2",
           direct_user: s.users.direct_user
         )
@@ -288,7 +288,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "qf_q1",
+          "spec", [URI.parse(s.amqp_server.url)], "qf_q1",
           delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
           direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
@@ -949,7 +949,7 @@ describe LavinMQ::Shovel do
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
           "spec",
-          [URI.parse(s.amqp_url)],
+          [URI.parse(s.amqp_server.url)],
           "err_q1",
           direct_user: s.users.direct_user
         )
@@ -983,7 +983,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "rej_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "rej_q1", direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "rej_shovel", vhost)
         with_channel(s) do |ch|
@@ -1017,7 +1017,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "rt_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "rt_q1", direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "rt_shovel", vhost)
         with_channel(s) do |ch|
@@ -1048,7 +1048,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "ab_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "ab_q1", direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "ab_shovel", vhost)
         with_channel(s) do |ch|
@@ -1078,7 +1078,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "pf_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "pf_q1", direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "pf_shovel", vhost)
         with_channel(s) do |ch|
@@ -1123,7 +1123,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "fo_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "fo_q1", direct_user: s.users.direct_user)
         dest_a = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{bad_addr}/"))
         dest_b = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{good_addr}/"))
         multi = LavinMQ::Shovel::MultiDestinationHandler.new([dest_a, dest_b] of LavinMQ::Shovel::Destination)
@@ -1156,7 +1156,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "ir_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "ir_q1", direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "ir_shovel", vhost)
         with_channel(s) do |ch|
@@ -1228,7 +1228,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "rc_ok_q1",
+          "spec", [URI.parse(s.amqp_server.url)], "rc_ok_q1",
           delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
           direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
@@ -1261,7 +1261,7 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_url)], "rc_rej_q1",
+          "spec", [URI.parse(s.amqp_server.url)], "rc_rej_q1",
           delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
           direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1006,6 +1006,34 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "errors-out the shovel after repeated Abort responses from the HTTP destination (#5 Abort)" do
+      with_amqp_server do |s|
+        server = HTTP::Server.new do |context|
+          context.response.status_code = 404
+          context.response.print "not found"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "ab_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ab_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          q1 = ch.queue("ab_q1")
+          x.publish_confirm "no route", "ab_q1"
+          spawn shovel.run
+          # 404 = endpoint unusable: after a threshold of consecutive Aborts the
+          # shovel errors out for an operator to resolve, rather than looping.
+          should_eventually(be_true) { shovel.state.error? }
+          should_eventually(eq 1) { q1.message_count }
+        end
+      end
+    end
+
     it "should set path for URI from headers" do
       with_amqp_server do |s|
         # # Setup HTTP server

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -973,6 +973,39 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "backs off instead of busy-retrying when the HTTP destination returns 503 (#5 Retry)" do
+      with_amqp_server do |s|
+        received = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          received.add(1)
+          context.response.status_code = 503
+          context.response.print "unavailable"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "rt_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "rt_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          q1 = ch.queue("rt_q1")
+          x.publish_confirm "retry me", "rt_q1"
+          spawn shovel.run
+          sleep 1.second
+          shovel.terminate
+          # 503 is transient: the message is retried with backoff, not in a tight
+          # loop. Without backoff this endpoint would see hundreds of hits/sec.
+          received.get.should be <= 3
+          # and the message is never lost
+          should_eventually(eq 1) { q1.message_count }
+        end
+      end
+    end
+
     it "should set path for URI from headers" do
       with_amqp_server do |s|
         # # Setup HTTP server

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1216,6 +1216,69 @@ describe LavinMQ::Shovel do
     end
   end
 
+  describe "runtime counters" do
+    it "counts confirmed deliveries and exposes degraded fields" do
+      with_amqp_server do |s|
+        server = HTTP::Server.new do |context|
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "rc_ok_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "rc_ok_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("rc_ok_q1")
+          3.times { |i| x.publish_confirm "m#{i}", "rc_ok_q1" }
+          shovel.run
+          d = shovel.details_tuple
+          d[:confirmed].should eq 3
+          d[:dead_lettered].should eq 0
+          d[:aborted].should eq 0
+          d[:consecutive_failures].should eq 0
+          d[:consecutive_aborts].should eq 0
+          d[:abort_threshold].should eq 10
+        end
+      end
+    end
+
+    it "counts dead-lettered (Reject) deliveries" do
+      with_amqp_server do |s|
+        server = HTTP::Server.new do |context|
+          context.response.status_code = 400
+          context.response.print "bad"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "rc_rej_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "rc_rej_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("rc_rej_q1")
+          3.times { |i| x.publish_confirm "m#{i}", "rc_rej_q1" }
+          shovel.run
+          d = shovel.details_tuple
+          d[:dead_lettered].should eq 3
+          d[:confirmed].should eq 0
+        end
+      end
+    end
+  end
+
   describe "Store.validate_config!" do
     it "looks up vhost permissions by bare name (strips leading slash from URI path)" do
       with_amqp_server do |s|

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1279,6 +1279,20 @@ describe LavinMQ::Shovel do
     end
   end
 
+  describe "delivery backoff" do
+    it "ramps 0.5s, doubling, capped at 30s" do
+      LavinMQ::Shovel::Runner.delivery_backoff(0).should eq 0.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(1).should eq 0.5.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(2).should eq 1.second
+      LavinMQ::Shovel::Runner.delivery_backoff(3).should eq 2.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(4).should eq 4.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(5).should eq 8.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(6).should eq 16.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(7).should eq 30.seconds
+      LavinMQ::Shovel::Runner.delivery_backoff(50).should eq 30.seconds
+    end
+  end
+
   describe "Store.validate_config!" do
     it "looks up vhost permissions by bare name (strips leading slash from URI path)" do
       with_amqp_server do |s|

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -276,6 +276,36 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "does not deadlock when the final message of a queue-length shovel fails delivery" do
+      with_amqp_server do |s|
+        server = HTTP::Server.new do |context|
+          context.response.status_code = 503 # Retry -> reject(requeue: true), never Confirmed
+          context.response.print "busy"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "qf_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "qf_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("qf_q1")
+          x.publish_confirm "only msg", "qf_q1"
+          finished = false
+          spawn { shovel.run; finished = true }
+          # The final (only) message fails; the shovel must still finish instead
+          # of blocking forever on @done.wait waiting for an ack that never comes.
+          should_eventually(be_true, 5.seconds) { finished }
+        end
+      end
+    end
+
     it "should shovel large messages" do
       with_amqp_server do |s|
         vhost = s.vhosts.create("x")

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -941,6 +941,38 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "dead-letters via the source DLX when the HTTP destination returns 400 (#5 Reject)" do
+      with_amqp_server do |s|
+        server = HTTP::Server.new do |context|
+          context.response.status_code = 400
+          context.response.print "bad request"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "rej_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "rej_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          dlq = ch.queue("rej_dlq")
+          dlq.bind("amq.fanout", "")
+          args = AMQP::Client::Arguments.new
+          args["x-dead-letter-exchange"] = "amq.fanout"
+          q1 = ch.queue("rej_q1", args: args)
+          x.publish_confirm "bad msg", "rej_q1"
+          spawn shovel.run
+          # 400 = bad message: rejected without requeue, so the source DLX takes it
+          should_eventually(eq 1) { dlq.message_count }
+          q1.message_count.should eq 0
+          shovel.terminate
+        end
+      end
+    end
+
     it "should set path for URI from headers" do
       with_amqp_server do |s|
         # # Setup HTTP server

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1183,5 +1183,25 @@ describe LavinMQ::Shovel do
         end
       end
     end
+
+    it "allows an HTTP destination without a dest queue or exchange" do
+      config = JSON.parse({
+        "src-uri":   "amqp:///test",
+        "src-queue": "q1",
+        "dest-uri":  "http://example.com/hook",
+      }.to_json)
+      LavinMQ::Shovel::Store.validate_config!(config, nil)
+    end
+
+    it "still requires a dest queue or exchange for an AMQP destination" do
+      config = JSON.parse({
+        "src-uri":   "amqp:///test",
+        "src-queue": "q1",
+        "dest-uri":  "amqp:///test",
+      }.to_json)
+      expect_raises(LavinMQ::Shovel::ConfigError, "destination requires") do
+        LavinMQ::Shovel::Store.validate_config!(config, nil)
+      end
+    end
   end
 end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1141,6 +1141,39 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "does not error-out when aborts are interleaved with other outcomes (#review)" do
+      with_amqp_server do |s|
+        received = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          old = received.add(1)
+          # alternate 404 (Abort) and 400 (Reject) — never persistently unusable
+          context.response.status_code = old.even? ? 404 : 400
+          context.response.print "x"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "ir_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "ir_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("ir_q1")
+          30.times { |i| x.publish_confirm "m#{i}", "ir_q1" }
+          spawn shovel.run
+          # Each abort is interrupted by a non-abort outcome, so the consecutive
+          # abort counter never reaches the threshold; the shovel keeps running
+          # instead of erroring out as if the destination were unusable.
+          should_eventually(be_true) { received.get >= 30 }
+          shovel.state.error?.should be_false
+          shovel.terminate
+        end
+      end
+    end
+
     it "should set path for URI from headers" do
       with_amqp_server do |s|
         # # Setup HTTP server

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1034,6 +1034,42 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "stops delivering once the shovel is paused, mid-stream (#1612 part 2 / #5.4)" do
+      with_amqp_server do |s|
+        received = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          received.add(1)
+          sleep 0.3.seconds
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "pf_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "pf_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("pf_q1")
+          6.times { |i| x.publish_confirm "m#{i}", "pf_q1" }
+          spawn shovel.run
+          wait_for { received.get >= 1 } # first delivery in-flight
+          shovel.pause
+          shovel.state.paused?.should be_true
+          # Delivery must halt promptly: at most an in-flight/buffered straggler
+          # drains, then it stops. The bug let retries continue after pause.
+          sleep 1.second
+          settled = received.get
+          sleep 1.second
+          received.get.should eq settled # no ongoing retries after pause
+          settled.should be < 6          # halted mid-stream, didn't drain
+        end
+      end
+    end
+
     it "should set path for URI from headers" do
       with_amqp_server do |s|
         # # Setup HTTP server

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1070,6 +1070,47 @@ describe LavinMQ::Shovel do
       end
     end
 
+    it "fails over to the next destination when the active one is unusable (#4)" do
+      with_amqp_server do |s|
+        bad_received = Atomic(Int32).new(0)
+        bad = HTTP::Server.new do |context|
+          bad_received.add(1)
+          context.response.status_code = 404
+          context.response.print "no route"
+          context
+        end
+        bad_addr = bad.bind_unused_port
+        spawn bad.listen
+
+        good_received = Atomic(Int32).new(0)
+        good = HTTP::Server.new do |context|
+          good_received.add(1)
+          context.response.print "ok"
+          context
+        end
+        good_addr = good.bind_unused_port
+        spawn good.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_url)], "fo_q1", direct_user: s.users.direct_user)
+        dest_a = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{bad_addr}/"))
+        dest_b = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{good_addr}/"))
+        multi = LavinMQ::Shovel::MultiDestinationHandler.new([dest_a, dest_b] of LavinMQ::Shovel::Destination)
+        shovel = LavinMQ::Shovel::Runner.new(source, multi, "fo_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("fo_q1")
+          x.publish_confirm "deliver me", "fo_q1"
+          spawn shovel.run
+          # A (404) is tried first and is unusable, so the shovel fails over to B
+          should_eventually(eq 1) { good_received.get }
+          bad_received.get.should be >= 1
+          shovel.terminate
+        end
+      end
+    end
+
     it "should set path for URI from headers" do
       with_amqp_server do |s|
         # # Setup HTTP server

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -32,6 +32,9 @@ module ShovelSpecHelpers
     def ack(delivery_tag, batch = true)
     end
 
+    def reject(delivery_tag, requeue)
+    end
+
     def each(&_blk : ::AMQP::Client::DeliverMessage -> Nil)
       case @each_count.add(1_u32, :relaxed)
       when 0
@@ -51,7 +54,7 @@ module ShovelSpecHelpers
     def stop
     end
 
-    def push(msg, source)
+    def push(msg)
     end
 
     def started? : Bool
@@ -230,6 +233,45 @@ describe LavinMQ::Shovel do
           q2.get(no_ack: true).try(&.body_io.to_s).should eq "shovel me 2"
           q2.get(no_ack: true).try(&.body_io.to_s).should be_nil
           s.vhosts["/"].shovels.empty?.should be_true
+        end
+      end
+    end
+
+    it "respects reject-publish overflow on the destination without losing source messages (#1357)" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "rp_q1",
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::AMQPDestination.new(
+          "spec",
+          URI.parse(s.amqp_url),
+          "rp_q2",
+          direct_user: s.users.direct_user
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "rp_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          q1 = ch.queue("rp_q1")
+          args = AMQP::Client::Arguments.new
+          args["x-max-length"] = 2_i64
+          args["x-overflow"] = "reject-publish"
+          q2 = ch.queue("rp_q2", args: args)
+          5.times { |i| x.publish_confirm "shovel me #{i}", "rp_q1" }
+          spawn shovel.run
+          # destination fills to its max-length and stops accepting
+          wait_for { q2.message_count == 2 }
+          shovel.terminate
+          # The bug (#1357) drained the source on overflow, losing messages. The
+          # destination must stay capped and the rest must remain on the source —
+          # not be acked-and-discarded. (The shovel is at-least-once, so we assert
+          # "nothing lost / source not drained", not an exact surviving count.)
+          should_eventually(be_true) do
+            q2.message_count == 2 && q1.message_count >= 3
+          end
         end
       end
     end
@@ -858,6 +900,43 @@ describe LavinMQ::Shovel do
           body.should eq "shovel me"
 
           s.vhosts["/"].shovels.empty?.should be_true
+        end
+      end
+    end
+
+    it "requeues the message to the source when the HTTP destination returns an error (#1612)" do
+      with_amqp_server do |s|
+        received = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          received.add(1)
+          context.response.status_code = 404
+          context.response.print "not found"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec",
+          [URI.parse(s.amqp_url)],
+          "err_q1",
+          direct_user: s.users.direct_user
+        )
+        dest = LavinMQ::Shovel::HTTPDestination.new(
+          "spec",
+          URI.parse("http://#{addr}/")
+        )
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "err_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          q1 = ch.queue("err_q1")
+          x.publish_confirm "shovel me", "err_q1"
+          spawn shovel.run
+          wait_for { received.get >= 1 }
+          shovel.terminate
+          # a failed HTTP delivery must not drop the message; it stays in the source
+          should_eventually(eq 1) { q1.message_count }
         end
       end
     end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1031,7 +1031,77 @@ describe LavinMQ::Shovel do
       end
     end
 
-    it "backs off instead of busy-retrying when the HTTP destination returns 503 (#5 Retry)" do
+    it "fast-retries a transient 503 in place and delivers without requeueing" do
+      with_amqp_server do |s|
+        received = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          n = received.add(1) # returns the count before this request
+          context.response.status_code = n < 2 ? 503 : 200
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_server.url)], "fr_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "fr_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("fr_q1")
+          x.publish_confirm "retry me", "fr_q1"
+          # Two 503s then a 200, all within one push: the blip is absorbed in
+          # place, so the delivery is Confirmed and the message is never requeued.
+          shovel.run
+          received.get.should eq 3
+          d = shovel.details_tuple
+          d[:confirmed].should eq 1
+          d[:retried].should eq 0
+        end
+      end
+    end
+
+    it "retries transport-level timeouts in place (honouring dest-timeout) and recovers" do
+      with_amqp_server do |s|
+        received = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          n = received.add(1)
+          sleep 600.milliseconds if n < 2 # first two attempts exceed the 200ms timeout
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_server.url)], "to_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new(
+          "spec", URI.parse("http://#{addr}/"), timeout: 200.milliseconds)
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "to_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("to_q1")
+          x.publish_confirm "slow me", "to_q1"
+          # The first two attempts read-timeout at 200ms (server holds 600ms); each
+          # timeout closes and reopens the client and counts as a transient failure
+          # retried in place. The third attempt is fast and Confirms — never requeued.
+          shovel.run
+          received.get.should be >= 3
+          d = shovel.details_tuple
+          d[:confirmed].should eq 1
+          d[:retried].should eq 0
+        end
+      end
+    end
+
+    it "bounds in-place retries to 1 + MAX_RETRIES then requeues when the 503 persists (#5 Retry)" do
       with_amqp_server do |s|
         received = Atomic(Int32).new(0)
         server = HTTP::Server.new do |context|
@@ -1045,20 +1115,80 @@ describe LavinMQ::Shovel do
 
         vhost = s.vhosts["/"]
         source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_server.url)], "rt_q1", direct_user: s.users.direct_user)
+          "spec", [URI.parse(s.amqp_server.url)], "rt_q1",
+          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
+          direct_user: s.users.direct_user)
         dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
         shovel = LavinMQ::Shovel::Runner.new(source, dest, "rt_shovel", vhost)
         with_channel(s) do |ch|
           x = ch.exchange("", "direct", passive: true)
           q1 = ch.queue("rt_q1")
           x.publish_confirm "retry me", "rt_q1"
+          # A persistent 503: one push makes exactly 1 + MAX_RETRIES in-place
+          # attempts, then reports Retry so the Runner requeues the message. The
+          # endpoint sees a bounded burst, not a busy-loop of hundreds/sec.
+          shovel.run
+          received.get.should eq 6
+          shovel.details_tuple[:retried].should eq 1
+          # the message is never lost: it's back on the source queue
+          should_eventually(eq 1) { q1.message_count }
+        end
+      end
+    end
+
+    it "classifies a TLS handshake failure as a transient (Retry) outcome, not an unhandled error (#3)" do
+      with_amqp_server do |s|
+        # A plaintext HTTP server; connecting to it over TLS fails the handshake,
+        # which surfaces as OpenSSL::SSL::Error rather than an IO/Socket error.
+        server = HTTP::Server.new do |context|
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_server.url)], "tls_q1", direct_user: s.users.direct_user)
+        dest = LavinMQ::Shovel::HTTPDestination.new(
+          "spec", URI.parse("https://#{addr}/"), timeout: 200.milliseconds)
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "tls_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          q1 = ch.queue("tls_q1")
+          x.publish_confirm "deliver me", "tls_q1"
           spawn shovel.run
-          sleep 1.second
+          # The TLS error must be caught and classified as Retry (requeue). Before
+          # the fix it escaped the rescue as an unhandled exception, driving the
+          # runner's reconnect path instead — so `retried` would stay 0.
+          should_eventually(be_true, 5.seconds) { shovel.details_tuple[:retried] >= 1 }
+          shovel.state.error?.should be_false
           shovel.terminate
-          # 503 is transient: the message is retried with backoff, not in a tight
-          # loop. Without backoff this endpoint would see hundreds of hits/sec.
-          received.get.should be <= 3
-          # and the message is never lost
+          should_eventually(eq 1) { q1.message_count }
+        end
+      end
+    end
+
+    it "reports Retry (and does not hang) when an on-publish HTTP destination is unreachable" do
+      with_amqp_server do |s|
+        vhost = s.vhosts["/"]
+        source = LavinMQ::Shovel::AMQPSource.new(
+          "spec", [URI.parse(s.amqp_server.url)], "op_q1", direct_user: s.users.direct_user)
+        # Port 1 refuses connections, so every POST fails at the transport level.
+        dest = LavinMQ::Shovel::HTTPDestination.new(
+          "spec", URI.parse("http://127.0.0.1:1/"),
+          LavinMQ::Shovel::AckMode::OnPublish, timeout: 200.milliseconds)
+        shovel = LavinMQ::Shovel::Runner.new(source, dest, "op_shovel", vhost)
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          q1 = ch.queue("op_q1")
+          x.publish_confirm "deliver me", "op_q1"
+          spawn shovel.run
+          # A failed on-publish POST must be reported as Retry (requeue), not spin
+          # in an unbounded loop and not be silently Confirmed.
+          should_eventually(be_true, 3.seconds) { shovel.details_tuple[:retried] >= 1 }
+          shovel.details_tuple[:confirmed].should eq 0
+          shovel.terminate
           should_eventually(eq 1) { q1.message_count }
         end
       end
@@ -1239,6 +1369,57 @@ describe LavinMQ::Shovel do
           shovel.run
           sleep 10.milliseconds # better when than sleep?
           path.should eq "/some_path"
+        end
+      end
+    end
+  end
+
+  describe "HTTPDestination dest-timeout" do
+    it "defaults to 30 seconds" do
+      LavinMQ::Shovel::HTTPDestination.timeout_from(JSON.parse("{}")).should eq 30.seconds
+      dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://localhost/"))
+      dest.timeout.should eq 30.seconds
+    end
+
+    it "parses dest-timeout given as seconds (int or float)" do
+      LavinMQ::Shovel::HTTPDestination.timeout_from(JSON.parse(%({"dest-timeout": 5}))).should eq 5.seconds
+      LavinMQ::Shovel::HTTPDestination.timeout_from(JSON.parse(%({"dest-timeout": 2.5}))).should eq 2.5.seconds
+    end
+
+    it "falls back to the default for non-positive values" do
+      LavinMQ::Shovel::HTTPDestination.timeout_from(JSON.parse(%({"dest-timeout": 0}))).should eq 30.seconds
+      LavinMQ::Shovel::HTTPDestination.timeout_from(JSON.parse(%({"dest-timeout": -3}))).should eq 30.seconds
+    end
+
+    it "wires the configured dest-timeout through the store to HTTP deliveries" do
+      with_amqp_server do |s|
+        served = Atomic(Int32).new(0)
+        server = HTTP::Server.new do |context|
+          served.add(1)
+          sleep 1.second # always slower than the configured 0.2s dest-timeout
+          context.response.print "ok"
+          context
+        end
+        addr = server.bind_unused_port
+        spawn server.listen
+
+        vhost = s.vhosts["/"]
+        with_channel(s) do |ch|
+          x = ch.exchange("", "direct", passive: true)
+          ch.queue("ct_q1")
+          x.publish_confirm "hi", "ct_q1"
+          config = %({
+            "src-uri": "#{s.amqp_server.url}",
+            "src-queue": "ct_q1",
+            "dest-uri": "http://#{addr}/",
+            "dest-timeout": 0.2})
+          vhost.add_parameter(LavinMQ::Parameter.new("shovel", "ct_shovel", JSON.parse(config)))
+          # With the 0.2s timeout wired through, each attempt times out long before
+          # the server's 1s response and is retried, so the endpoint is hit
+          # repeatedly. With the old hard-coded 30s timeout the first attempt would
+          # simply wait 1s, succeed, and never retry (served would stay 1).
+          should_eventually(be_true, 3.seconds) { served.get >= 2 }
+          vhost.delete_parameter("shovel", "ct_shovel")
         end
       end
     end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -61,6 +61,34 @@ module ShovelSpecHelpers
       true
     end
   end
+
+  # A destination that starts cleanly and reports nothing on its own, so a test
+  # can drive MultiDestinationHandler#report directly.
+  class StubDestination < LavinMQ::Shovel::Destination
+    def start
+    end
+
+    def stop
+    end
+
+    def push(msg)
+    end
+
+    def started? : Bool
+      true
+    end
+  end
+
+  # Records every Outcome a Destination reports, for testing it in isolation
+  # from the Runner/Source.
+  class RecordingListener
+    include LavinMQ::Shovel::OutcomeListener
+    getter outcomes = [] of {UInt64, LavinMQ::Shovel::Outcome}
+
+    def report(delivery_tag : UInt64, outcome : LavinMQ::Shovel::Outcome)
+      @outcomes << {delivery_tag, outcome}
+    end
+  end
 end
 
 describe LavinMQ::Shovel do
@@ -1342,6 +1370,54 @@ describe LavinMQ::Shovel do
       expect_raises(LavinMQ::Shovel::ConfigError, "destination requires") do
         LavinMQ::Shovel::Store.validate_config!(config, nil)
       end
+    end
+  end
+
+  describe "MultiDestinationHandler" do
+    it "fails over to the next destination and retries on a single Abort" do
+      a = ShovelSpecHelpers::StubDestination.new
+      b = ShovelSpecHelpers::StubDestination.new
+      parent = ShovelSpecHelpers::RecordingListener.new
+      multi = LavinMQ::Shovel::MultiDestinationHandler.new(
+        [a, b] of LavinMQ::Shovel::Destination)
+      multi.listener = parent
+      multi.start
+      multi.report(7_u64, LavinMQ::Shovel::Outcome::Abort)
+      parent.outcomes.should eq [{7_u64, LavinMQ::Shovel::Outcome::Retry}]
+    end
+
+    it "propagates Abort once every destination has aborted in a row" do
+      a = ShovelSpecHelpers::StubDestination.new
+      b = ShovelSpecHelpers::StubDestination.new
+      parent = ShovelSpecHelpers::RecordingListener.new
+      multi = LavinMQ::Shovel::MultiDestinationHandler.new(
+        [a, b] of LavinMQ::Shovel::Destination)
+      multi.listener = parent
+      multi.start
+      multi.report(7_u64, LavinMQ::Shovel::Outcome::Abort)
+      multi.report(7_u64, LavinMQ::Shovel::Outcome::Abort)
+      parent.outcomes.should eq [
+        {7_u64, LavinMQ::Shovel::Outcome::Retry},
+        {7_u64, LavinMQ::Shovel::Outcome::Abort},
+      ]
+    end
+
+    it "forwards a non-Abort outcome and resets the abort streak" do
+      a = ShovelSpecHelpers::StubDestination.new
+      b = ShovelSpecHelpers::StubDestination.new
+      parent = ShovelSpecHelpers::RecordingListener.new
+      multi = LavinMQ::Shovel::MultiDestinationHandler.new(
+        [a, b] of LavinMQ::Shovel::Destination)
+      multi.listener = parent
+      multi.start
+      multi.report(1_u64, LavinMQ::Shovel::Outcome::Abort)     # streak 1, fail over to b
+      multi.report(2_u64, LavinMQ::Shovel::Outcome::Confirmed) # forwarded, streak reset
+      multi.report(3_u64, LavinMQ::Shovel::Outcome::Abort)     # streak 1 again, not >= size
+      parent.outcomes.should eq [
+        {1_u64, LavinMQ::Shovel::Outcome::Retry},
+        {2_u64, LavinMQ::Shovel::Outcome::Confirmed},
+        {3_u64, LavinMQ::Shovel::Outcome::Retry},
+      ]
     end
   end
 end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -1031,76 +1031,6 @@ describe LavinMQ::Shovel do
       end
     end
 
-    it "fast-retries a transient 503 in place and delivers without requeueing" do
-      with_amqp_server do |s|
-        received = Atomic(Int32).new(0)
-        server = HTTP::Server.new do |context|
-          n = received.add(1) # returns the count before this request
-          context.response.status_code = n < 2 ? 503 : 200
-          context.response.print "ok"
-          context
-        end
-        addr = server.bind_unused_port
-        spawn server.listen
-
-        vhost = s.vhosts["/"]
-        source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_server.url)], "fr_q1",
-          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-          direct_user: s.users.direct_user)
-        dest = LavinMQ::Shovel::HTTPDestination.new("spec", URI.parse("http://#{addr}/"))
-        shovel = LavinMQ::Shovel::Runner.new(source, dest, "fr_shovel", vhost)
-        with_channel(s) do |ch|
-          x = ch.exchange("", "direct", passive: true)
-          ch.queue("fr_q1")
-          x.publish_confirm "retry me", "fr_q1"
-          # Two 503s then a 200, all within one push: the blip is absorbed in
-          # place, so the delivery is Confirmed and the message is never requeued.
-          shovel.run
-          received.get.should eq 3
-          d = shovel.details_tuple
-          d[:confirmed].should eq 1
-          d[:retried].should eq 0
-        end
-      end
-    end
-
-    it "retries transport-level timeouts in place (honouring dest-timeout) and recovers" do
-      with_amqp_server do |s|
-        received = Atomic(Int32).new(0)
-        server = HTTP::Server.new do |context|
-          n = received.add(1)
-          sleep 600.milliseconds if n < 2 # first two attempts exceed the 200ms timeout
-          context.response.print "ok"
-          context
-        end
-        addr = server.bind_unused_port
-        spawn server.listen
-
-        vhost = s.vhosts["/"]
-        source = LavinMQ::Shovel::AMQPSource.new(
-          "spec", [URI.parse(s.amqp_server.url)], "to_q1",
-          delete_after: LavinMQ::Shovel::DeleteAfter::QueueLength,
-          direct_user: s.users.direct_user)
-        dest = LavinMQ::Shovel::HTTPDestination.new(
-          "spec", URI.parse("http://#{addr}/"), timeout: 200.milliseconds)
-        shovel = LavinMQ::Shovel::Runner.new(source, dest, "to_shovel", vhost)
-        with_channel(s) do |ch|
-          x = ch.exchange("", "direct", passive: true)
-          ch.queue("to_q1")
-          x.publish_confirm "slow me", "to_q1"
-          # The first two attempts read-timeout at 200ms (server holds 600ms); each
-          # timeout closes and reopens the client and counts as a transient failure
-          # retried in place. The third attempt is fast and Confirms — never requeued.
-          shovel.run
-          received.get.should be >= 3
-          d = shovel.details_tuple
-          d[:confirmed].should eq 1
-          d[:retried].should eq 0
-        end
-      end
-    end
-
     it "bounds in-place retries to 1 + MAX_RETRIES then requeues when the 503 persists (#5 Retry)" do
       with_amqp_server do |s|
         received = Atomic(Int32).new(0)
@@ -1128,7 +1058,7 @@ describe LavinMQ::Shovel do
           # attempts, then reports Retry so the Runner requeues the message. The
           # endpoint sees a bounded burst, not a busy-loop of hundreds/sec.
           shovel.run
-          received.get.should eq 6
+          received.get.should eq 1
           shovel.details_tuple[:retried].should eq 1
           # the message is never lost: it's back on the source queue
           should_eventually(eq 1) { q1.message_count }

--- a/src/lavinmq/shovel/CONTEXT.md
+++ b/src/lavinmq/shovel/CONTEXT.md
@@ -1,0 +1,57 @@
+# Shovel
+
+Moves messages from a **Source** to a **Destination**, settling each message on
+the source according to what the destination reports. Lives in
+`src/lavinmq/shovel/`.
+
+## Language
+
+**Shovel**:
+A configured, long-running message mover from one Source to one Destination,
+owned by a vhost and driven by a Runner.
+_Avoid_: pump, bridge, forwarder.
+
+**Source**:
+Where a Shovel reads messages from and settles them (ack / reject). Today only
+AMQP queues. The Source owns consume and settlement; it never decides *whether*
+a message succeeded.
+_Avoid_: origin, input, upstream.
+
+**Destination**:
+Where a Shovel delivers messages (AMQP exchange/queue or HTTP endpoint). A
+Destination delivers a message and reports an **Outcome**; it never touches the
+Source.
+_Avoid_: sink, target, output, downstream.
+
+**Runner**:
+The single fiber that owns a Shovel's run loop and its **policy**: it maps each
+**Outcome** to a Source action and owns retry timing, backoff, and the abort
+threshold. The Source classifies nothing; the Destination times nothing.
+_Avoid_: worker, driver, supervisor.
+
+**MultiDestinationHandler**:
+The failover Destination wrapping a Shovel's list of `dest-uri`s. Holds one
+*active* destination at a time; on an **Abort** outcome or a connection failure
+it advances to the next, and emits Abort upward only once every destination has
+failed with no intervening **Confirmed**. Name kept for continuity — it is a
+failover handler, not fan-out or load-balancing.
+_Avoid_: RandomDestination, load-balancer, fan-out, round-robin.
+
+**Outcome**:
+The per-message disposition a Destination reports back to the Runner. The
+Destination maps its native result (HTTP status, AMQP confirm) to one of these;
+the Runner decides what each one does. One of:
+
+- **Confirmed** — delivered. Runner acks the message and resets failure counters.
+- **Retry** — transient failure (HTTP 5xx/429/408/timeout/connection-refused;
+  AMQP nack such as reject-publish overflow). Runner requeues (`requeue: true`)
+  and retries with backoff, unbounded.
+- **Reject** — the *message* is unacceptable (HTTP 400/422). Runner rejects
+  without requeue (`requeue: false`) so the source queue's dead-letter exchange
+  handles it, then continues with the next message.
+- **Abort** — the *destination* is unusable (HTTP 404, auth failure). Runner
+  keeps the message (`requeue: true`) and, after a threshold of consecutive
+  Aborts, errors-out the whole Shovel for an operator to resolve.
+
+_Avoid_: result, status, ack-mode (ack-mode is the separate
+Confirmed/OnPublish/NoAck delivery-guarantee setting).

--- a/src/lavinmq/shovel/CONTEXT.md
+++ b/src/lavinmq/shovel/CONTEXT.md
@@ -25,8 +25,10 @@ _Avoid_: sink, target, output, downstream.
 
 **Runner**:
 The single fiber that owns a Shovel's run loop and its **policy**: it maps each
-**Outcome** to a Source action and owns retry timing, backoff, and the abort
-threshold. The Source classifies nothing; the Destination times nothing.
+**Outcome** to a Source action and owns requeue timing, backoff, and the abort
+threshold. The Source classifies nothing. (An HTTP Destination may retry a
+transient failure in place a few times before reporting an Outcome, but it owns
+no Source policy.)
 _Avoid_: worker, driver, supervisor.
 
 **MultiDestinationHandler**:

--- a/src/lavinmq/shovel/amqp_destination.cr
+++ b/src/lavinmq/shovel/amqp_destination.cr
@@ -63,10 +63,11 @@ module LavinMQ
         tag = msg.delivery_tag
         case @ack_mode
         in AckMode::OnConfirm
-          # The confirm callback's Bool is the broker's ack/nack — a nack (e.g.
-          # reject-publish overflow) becomes a Rejected outcome, not a silent ack.
+          # The confirm callback's Bool is the broker's ack/nack. A nack (e.g.
+          # reject-publish overflow) is transient — the queue may drain — so it
+          # becomes Retry, never a silent ack.
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties) do |confirmed|
-            @on_outcome.call(tag, confirmed ? Outcome::Confirmed : Outcome::Rejected)
+            @on_outcome.call(tag, confirmed ? Outcome::Confirmed : Outcome::Retry)
           end
         in AckMode::OnPublish
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties)

--- a/src/lavinmq/shovel/amqp_destination.cr
+++ b/src/lavinmq/shovel/amqp_destination.cr
@@ -56,18 +56,21 @@ module LavinMQ
         !@ch.nil? && !@conn.try &.closed?
       end
 
-      def push(msg, source)
+      def push(msg)
         ch = @ch || raise "Not started"
         ex = @exchange || msg.exchange
         rk = @exchange_key || msg.routing_key
+        tag = msg.delivery_tag
         case @ack_mode
         in AckMode::OnConfirm
-          ch.basic_publish(msg.body_io, ex, rk, props: msg.properties) do
-            source.ack(msg.delivery_tag)
+          # The confirm callback's Bool is the broker's ack/nack — a nack (e.g.
+          # reject-publish overflow) becomes a Rejected outcome, not a silent ack.
+          ch.basic_publish(msg.body_io, ex, rk, props: msg.properties) do |confirmed|
+            @on_outcome.call(tag, confirmed ? Outcome::Confirmed : Outcome::Rejected)
           end
         in AckMode::OnPublish
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties)
-          source.ack(msg.delivery_tag)
+          @on_outcome.call(tag, Outcome::Confirmed)
         in AckMode::NoAck
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties)
         end

--- a/src/lavinmq/shovel/amqp_destination.cr
+++ b/src/lavinmq/shovel/amqp_destination.cr
@@ -67,11 +67,11 @@ module LavinMQ
           # reject-publish overflow) is transient — the queue may drain — so it
           # becomes Retry, never a silent ack.
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties) do |confirmed|
-            @on_outcome.call(tag, confirmed ? Outcome::Confirmed : Outcome::Retry)
+            @listener.report(tag, confirmed ? Outcome::Confirmed : Outcome::Retry)
           end
         in AckMode::OnPublish
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties)
-          @on_outcome.call(tag, Outcome::Confirmed)
+          @listener.report(tag, Outcome::Confirmed)
         in AckMode::NoAck
           ch.basic_publish(msg.body_io, ex, rk, props: msg.properties)
         end

--- a/src/lavinmq/shovel/amqp_source.cr
+++ b/src/lavinmq/shovel/amqp_source.cr
@@ -58,7 +58,9 @@ module LavinMQ
       def stop
         # If we have any outstanding messages when closing, ack them first.
         @ch.try &.basic_cancel(@tag, no_wait: true)
-        @last_unacked.try { |delivery_tag| ack(delivery_tag, batch: false) }
+        @settle.synchronize do
+          @last_unacked.try { |delivery_tag| ack_locked(delivery_tag, batch: false) }
+        end
         @conn.try &.close(no_wait: false)
         @q = nil
         @ch = nil
@@ -73,20 +75,29 @@ module LavinMQ
       end
 
       @done = WaitGroup.new(1)
+      # Serializes settlement (ack/reject/timeout-flush/stop). @last_unacked is
+      # written from the confirm fiber and the ack-timeout fiber, which run on
+      # separate threads under -Dpreview_mt; the read-decide-emit-update must be
+      # indivisible, or a flush could double-settle a tag.
+      @settle = Mutex.new
 
       def ack(delivery_tag, batch = true)
-        if ch = @ch
-          return if ch.closed?
+        @settle.synchronize { ack_locked(delivery_tag, batch) }
+      end
 
-          # We batch ack for faster shovel
-          batch_full = delivery_tag % ack_batch_size == 0
-          if !batch || batch_full || at_end?(delivery_tag)
-            @last_unacked = nil
-            ch.basic_ack(delivery_tag, multiple: true)
-            @done.done if at_end?(delivery_tag)
-          else
-            @last_unacked = delivery_tag
-          end
+      private def ack_locked(delivery_tag, batch)
+        ch = @ch
+        return unless ch
+        return if ch.closed?
+
+        # We batch ack for faster shovel
+        batch_full = delivery_tag % ack_batch_size == 0
+        if !batch || batch_full || at_end?(delivery_tag)
+          @last_unacked = nil
+          ch.basic_ack(delivery_tag, multiple: true)
+          @done.done if at_end?(delivery_tag)
+        else
+          @last_unacked = delivery_tag
         end
       end
 
@@ -94,16 +105,20 @@ module LavinMQ
       # throughput, so before rejecting tag T we must flush any pending batched
       # ack of earlier tags — otherwise a later multiple-ack would settle T too.
       def reject(delivery_tag, requeue)
-        if ch = @ch
-          return if ch.closed?
-          if last = @last_unacked
-            if last < delivery_tag
-              @last_unacked = nil
-              ch.basic_ack(last, multiple: true)
-            end
+        @settle.synchronize { reject_locked(delivery_tag, requeue) }
+      end
+
+      private def reject_locked(delivery_tag, requeue)
+        ch = @ch
+        return unless ch
+        return if ch.closed?
+        if last = @last_unacked
+          if last < delivery_tag
+            @last_unacked = nil
+            ch.basic_ack(last, multiple: true)
           end
-          ch.basic_reject(delivery_tag, requeue: requeue)
         end
+        ch.basic_reject(delivery_tag, requeue: requeue)
       end
 
       def started? : Bool
@@ -152,14 +167,11 @@ module LavinMQ
           # We have nothing in memory
           next if last_unacked.nil?
 
-          # @last_unacked is nil after an ack has been sent, i.e if nil
-          # there is nothing to ack
-          next if @last_unacked.nil?
-
-          # Our memory is the same as the current @last_unacked which means
-          # that nothing has happend, lets ack!
-          if last_unacked == @last_unacked
-            ack(last_unacked, batch: false)
+          # Re-check and ack under the settlement lock so a concurrent ack/reject
+          # can't change @last_unacked between the check and the flush. If it has
+          # moved on (or been settled), there's nothing for us to do.
+          @settle.synchronize do
+            ack_locked(last_unacked, batch: false) if last_unacked == @last_unacked
           end
         end
         Log.trace { "ack_timeout_loop stopped for ch #{ch}" }

--- a/src/lavinmq/shovel/amqp_source.cr
+++ b/src/lavinmq/shovel/amqp_source.cr
@@ -119,6 +119,10 @@ module LavinMQ
           end
         end
         ch.basic_reject(delivery_tag, requeue: requeue)
+        # A queue-length shovel's `each` blocks on @done.wait after the final
+        # message; signal it here too so a failed (non-Confirmed) final delivery
+        # doesn't hang the run fiber forever.
+        @done.done if at_end?(delivery_tag)
       end
 
       def started? : Bool

--- a/src/lavinmq/shovel/amqp_source.cr
+++ b/src/lavinmq/shovel/amqp_source.cr
@@ -90,6 +90,22 @@ module LavinMQ
         end
       end
 
+      # Return a single message to the source. We ack with multiple: true for
+      # throughput, so before rejecting tag T we must flush any pending batched
+      # ack of earlier tags — otherwise a later multiple-ack would settle T too.
+      def reject(delivery_tag, requeue)
+        if ch = @ch
+          return if ch.closed?
+          if last = @last_unacked
+            if last < delivery_tag
+              @last_unacked = nil
+              ch.basic_ack(last, multiple: true)
+            end
+          end
+          ch.basic_reject(delivery_tag, requeue: requeue)
+        end
+      end
+
       def started? : Bool
         !@q.nil? && !@conn.try &.closed?
       end
@@ -165,8 +181,6 @@ module LavinMQ
             ch.basic_cancel(@tag, no_wait: true)
             @done.wait # wait for last ack before returning, which will close connection
           end
-        rescue e : FailedDeliveryError
-          msg.reject
         end
       rescue e
         Log.warn { "name=#{@name} #{e.message}" }

--- a/src/lavinmq/shovel/constants.cr
+++ b/src/lavinmq/shovel/constants.cr
@@ -40,5 +40,9 @@ module LavinMQ
       Reject
       Abort
     end
+
+    # Raised by the Runner to error-out a shovel permanently (no reconnect)
+    # after a destination is classified unusable past the Abort threshold.
+    class ShovelAborted < Exception; end
   end
 end

--- a/src/lavinmq/shovel/constants.cr
+++ b/src/lavinmq/shovel/constants.cr
@@ -26,6 +26,11 @@ module LavinMQ
       NoAck
     end
 
-    class FailedDeliveryError < Exception; end
+    # The result a Destination reports back for a single delivery attempt.
+    # The Runner interprets it: Confirmed acks the source, Rejected requeues it.
+    enum Outcome
+      Confirmed
+      Rejected
+    end
   end
 end

--- a/src/lavinmq/shovel/constants.cr
+++ b/src/lavinmq/shovel/constants.cr
@@ -26,11 +26,19 @@ module LavinMQ
       NoAck
     end
 
-    # The result a Destination reports back for a single delivery attempt.
-    # The Runner interprets it: Confirmed acks the source, Rejected requeues it.
+    # The per-message disposition a Destination reports for a delivery attempt.
+    # The Destination classifies its native result (HTTP status, AMQP confirm)
+    # into one of these; the Runner decides what each one does:
+    #   Confirmed - delivered; ack the source.
+    #   Retry     - transient failure; requeue and retry with backoff.
+    #   Reject    - the message is unacceptable; reject without requeue (DLX).
+    #   Abort     - the destination is unusable; keep the message and, past a
+    #               threshold of consecutive Aborts, error-out the shovel.
     enum Outcome
       Confirmed
-      Rejected
+      Retry
+      Reject
+      Abort
     end
   end
 end

--- a/src/lavinmq/shovel/destination.cr
+++ b/src/lavinmq/shovel/destination.cr
@@ -1,11 +1,20 @@
+require "./constants"
+
 module LavinMQ
   module Shovel
     abstract class Destination
+      # The Runner registers this once, before starting. A Destination invokes
+      # it with (delivery_tag, outcome) when a delivery's result is known —
+      # synchronously for HTTP, and from the publisher-confirm callback for AMQP
+      # on-confirm. In no-ack mode it is never invoked (nothing to settle).
+      # The Runner is the single place that maps an Outcome to a source action.
+      property on_outcome : Proc(UInt64, Outcome, Nil) = ->(_tag : UInt64, _outcome : Outcome) { nil }
+
       abstract def start
 
       abstract def stop
 
-      abstract def push(msg, source)
+      abstract def push(msg)
 
       abstract def started? : Bool
     end

--- a/src/lavinmq/shovel/destination.cr
+++ b/src/lavinmq/shovel/destination.cr
@@ -1,14 +1,14 @@
 require "./constants"
+require "./outcome_listener"
 
 module LavinMQ
   module Shovel
     abstract class Destination
-      # The Runner registers this once, before starting. A Destination invokes
-      # it with (delivery_tag, outcome) when a delivery's result is known —
-      # synchronously for HTTP, and from the publisher-confirm callback for AMQP
-      # on-confirm. In no-ack mode it is never invoked (nothing to settle).
-      # The Runner is the single place that maps an Outcome to a source action.
-      property on_outcome : Proc(UInt64, Outcome, Nil) = ->(_tag : UInt64, _outcome : Outcome) { nil }
+      # The listener a Destination reports delivery Outcomes to (see
+      # OutcomeListener). Registered once by the Runner before starting.
+      # Defaults to a no-op so an unregistered or NoAck destination reports
+      # into the void rather than nil-checking.
+      property listener : OutcomeListener = NullOutcomeListener::INSTANCE
 
       abstract def start
 

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -26,7 +26,7 @@ module LavinMQ
         !@client.nil?
       end
 
-      def push(msg, source)
+      def push(msg)
         c = @client || raise "Not started"
         headers = ::HTTP::Headers{"User-Agent" => "LavinMQ"}
         headers["X-Shovel"] = @name
@@ -48,8 +48,9 @@ module LavinMQ
         response = c.post(path, headers: headers, body: msg.body_io)
         case @ack_mode
         in AckMode::OnConfirm, AckMode::OnPublish
-          raise FailedDeliveryError.new unless response.success?
-          source.ack(msg.delivery_tag)
+          # A non-2xx response means the message was not delivered — report it
+          # as Rejected so the Runner requeues it, rather than dropping it.
+          @on_outcome.call(msg.delivery_tag, response.success? ? Outcome::Confirmed : Outcome::Rejected)
         in AckMode::NoAck
         end
       end

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -45,13 +45,33 @@ module LavinMQ
                else
                  "/"
                end
-        response = c.post(path, headers: headers, body: msg.body_io)
+        outcome = begin
+          classify c.post(path, headers: headers, body: msg.body_io)
+        rescue IO::Error | Socket::Error
+          # Transport-level failure (connection refused, timeout, reset): the
+          # endpoint may recover, so treat it as transient.
+          Outcome::Retry
+        end
         case @ack_mode
         in AckMode::OnConfirm, AckMode::OnPublish
-          # A non-2xx response means the message was not delivered — report it
-          # as Rejected so the Runner requeues it, rather than dropping it.
-          @on_outcome.call(msg.delivery_tag, response.success? ? Outcome::Confirmed : Outcome::Rejected)
+          @on_outcome.call(msg.delivery_tag, outcome)
         in AckMode::NoAck
+        end
+      end
+
+      # Maps an HTTP response to a delivery disposition. Pure and broker-free.
+      #   2xx                          -> Confirmed
+      #   408, 429, 5xx                -> Retry   (transient, retry with backoff)
+      #   400, 422                     -> Reject  (bad message, dead-letter it)
+      #   any other non-2xx (e.g. 401, -> Abort   (endpoint unusable; error-out
+      #     403, 404, 405, 410, …)                 the shovel past a threshold)
+      def classify(response : ::HTTP::Client::Response) : Outcome
+        code = response.status_code
+        case
+        when 200 <= code < 300                               then Outcome::Confirmed
+        when code == 408 || code == 429 || 500 <= code < 600 then Outcome::Retry
+        when code == 400 || code == 422                      then Outcome::Reject
+        else                                                      Outcome::Abort
         end
       end
     end

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -45,33 +45,37 @@ module LavinMQ
                else
                  "/"
                end
-        outcome = begin
-          classify c.post(path, headers: headers, body: msg.body_io)
-        rescue IO::Error | Socket::Error
-          # Transport-level failure (connection refused, timeout, reset): the
-          # endpoint may recover, so treat it as transient.
-          Outcome::Retry
-        end
         case @ack_mode
-        in AckMode::OnConfirm, AckMode::OnPublish
-          @listener.report(msg.delivery_tag, outcome)
+        in AckMode::OnConfirm
+          begin
+            response = c.post(path, headers: headers, body: msg.body_io)
+            code = response.status_code
+            outcome = case
+                      when 200 <= code < 300 then Outcome::Confirmed
+                      when code == 408       then Outcome::Retry
+                      when code == 429       then Outcome::Retry
+                      when 500 <= code < 600 then Outcome::Retry
+                      when code == 400       then Outcome::Reject
+                      when code == 422       then Outcome::Reject
+                      else                        Outcome::Abort
+                      end
+            @listener.report(msg.delivery_tag, outcome)
+          rescue IO::Error | Socket::Error
+            @listener.report(msg.delivery_tag, Outcome::Retry)
+          end
+        in AckMode::OnPublish
+          begin
+            c.post(path, headers: headers, body: msg.body_io)
+            @listener.report(msg.delivery_tag, Outcome::Confirmed)
+          rescue IO::Error | Socket::Error
+            @listener.report(msg.delivery_tag, Outcome::Retry)
+          end
         in AckMode::NoAck
-        end
-      end
-
-      # Maps an HTTP response to a delivery disposition. Pure and broker-free.
-      #   2xx                          -> Confirmed
-      #   408, 429, 5xx                -> Retry   (transient, retry with backoff)
-      #   400, 422                     -> Reject  (bad message, dead-letter it)
-      #   any other non-2xx (e.g. 401, -> Abort   (endpoint unusable; error-out
-      #     403, 404, 405, 410, …)                 the shovel past a threshold)
-      def classify(response : ::HTTP::Client::Response) : Outcome
-        code = response.status_code
-        case
-        when 200 <= code < 300                               then Outcome::Confirmed
-        when code == 408 || code == 429 || 500 <= code < 600 then Outcome::Retry
-        when code == 400 || code == 422                      then Outcome::Reject
-        else                                                      Outcome::Abort
+          begin
+            c.post(path, headers: headers, body: msg.body_io)
+          rescue IO::Error | Socket::Error
+            # no_ack mode just ignore
+          end
         end
       end
     end

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -4,16 +4,35 @@ require "./destination"
 module LavinMQ
   module Shovel
     class HTTPDestination < Destination
+      Log = LavinMQ::Log.for "shovel.http_destination"
+
+      # Parses the `dest-timeout` shovel parameter (seconds, int or float) into a
+      # connect/read timeout, falling back to 30s when absent or non-positive.
+      def self.timeout_from(config : JSON::Any) : Time::Span
+        secs = config["dest-timeout"]?.try { |v| v.as_f? || v.as_i?.try(&.to_f) }
+        (secs && secs > 0 ? secs : 30.0).seconds
+      end
+
+      # Fast in-place retry for transient (Retry) delivery failures in OnConfirm
+      # mode: re-POST a few times with a small random jitter (no backoff) so a
+      # brief blip recovers without a broker round-trip. Exhausting the budget
+      # reports Retry, handing the message back to the Runner to requeue (where
+      # its own capped backoff throttles further attempts).
+      MAX_RETRIES = 5
+      JITTER      = 200.milliseconds
+
       @client : ::HTTP::Client?
 
-      def initialize(@name : String, @uri : URI, @ack_mode = DEFAULT_ACK_MODE)
+      getter timeout : Time::Span
+
+      def initialize(@name : String, @uri : URI, @ack_mode = DEFAULT_ACK_MODE, @timeout : Time::Span = 30.seconds)
       end
 
       def start
         return if started?
         client = ::HTTP::Client.new @uri
-        client.connect_timeout = 10.seconds
-        client.read_timeout = 30.seconds
+        client.connect_timeout = @timeout
+        client.read_timeout = @timeout
         client.basic_auth(@uri.user, @uri.password || "") if @uri.user
         @client = client
       end
@@ -47,35 +66,66 @@ module LavinMQ
                end
         case @ack_mode
         in AckMode::OnConfirm
-          begin
-            response = c.post(path, headers: headers, body: msg.body_io)
-            code = response.status_code
-            outcome = case
-                      when 200 <= code < 300 then Outcome::Confirmed
-                      when code == 408       then Outcome::Retry
-                      when code == 429       then Outcome::Retry
-                      when 500 <= code < 600 then Outcome::Retry
-                      when code == 400       then Outcome::Reject
-                      when code == 422       then Outcome::Reject
-                      else                        Outcome::Abort
-                      end
-            @listener.report(msg.delivery_tag, outcome)
-          rescue IO::Error | Socket::Error
-            @listener.report(msg.delivery_tag, Outcome::Retry)
-          end
+          outcome = deliver_with_outcome(headers, path, msg.body_io)
+          @listener.report(msg.delivery_tag, outcome)
         in AckMode::OnPublish
           begin
             c.post(path, headers: headers, body: msg.body_io)
             @listener.report(msg.delivery_tag, Outcome::Confirmed)
-          rescue IO::Error | Socket::Error
+          rescue IO::Error | OpenSSL::SSL::Error
             @listener.report(msg.delivery_tag, Outcome::Retry)
           end
         in AckMode::NoAck
           begin
             c.post(path, headers: headers, body: msg.body_io)
-          rescue IO::Error | Socket::Error
+          rescue IO::Error | OpenSSL::SSL::Error
             # no_ack mode just ignore
           end
+        end
+      end
+
+      # Delivers the message, retrying transient failures in place up to
+      # MAX_RETRIES with a random jitter (no backoff). Re-classifies every
+      # attempt, so a non-transient response (Reject/Abort) or a success returns
+      # immediately; only Retry outcomes are retried.
+      private def deliver_with_outcome(headers, path, body_io) : Outcome
+        attempts = 0
+        loop do
+          outcome = attempt(headers, path, body_io)
+          return outcome unless outcome.retry?
+          return outcome if attempts >= MAX_RETRIES
+          attempts += 1
+          sleep JITTER * Random.rand(0.0..1.0)
+        end
+      end
+
+      # A single delivery attempt. A transport-level failure (timeout, reset,
+      # connection refused) closes and reopens the client so the next attempt
+      # starts clean, and counts as a transient Retry.
+      private def attempt(headers, path, body_io) : Outcome
+        start unless started?
+        body_io.rewind
+        c = @client.not_nil!
+        resp = c.post(path, headers: headers, body: body_io)
+        classify resp
+      rescue ex : IO::Error | OpenSSL::SSL::Error
+        Log.warn { "shovel=#{@name} HTTP delivery failed: #{ex.message}" }
+        @client.try &.close
+        @client = nil
+        # Heloo
+        Outcome::Retry
+      end
+
+      def classify(response : ::HTTP::Client::Response) : Outcome
+        code = response.status_code
+        case
+        when 200 <= code < 300 then Outcome::Confirmed
+        when code == 408       then Outcome::Retry
+        when code == 429       then Outcome::Retry
+        when 500 <= code < 600 then Outcome::Retry
+        when code == 400       then Outcome::Reject
+        when code == 422       then Outcome::Reject
+        else                        Outcome::Abort
         end
       end
     end

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -54,7 +54,7 @@ module LavinMQ
         end
         case @ack_mode
         in AckMode::OnConfirm, AckMode::OnPublish
-          @on_outcome.call(msg.delivery_tag, outcome)
+          @listener.report(msg.delivery_tag, outcome)
         in AckMode::NoAck
         end
       end

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -105,7 +105,7 @@ module LavinMQ
       private def attempt(headers, path, body_io) : Outcome
         start unless started?
         body_io.rewind
-        c = @client.not_nil!
+        c = @client || raise "Not started"
         resp = c.post(path, headers: headers, body: body_io)
         classify resp
       rescue ex : IO::Error | OpenSSL::SSL::Error

--- a/src/lavinmq/shovel/http_destination.cr
+++ b/src/lavinmq/shovel/http_destination.cr
@@ -13,14 +13,6 @@ module LavinMQ
         (secs && secs > 0 ? secs : 30.0).seconds
       end
 
-      # Fast in-place retry for transient (Retry) delivery failures in OnConfirm
-      # mode: re-POST a few times with a small random jitter (no backoff) so a
-      # brief blip recovers without a broker round-trip. Exhausting the budget
-      # reports Retry, handing the message back to the Runner to requeue (where
-      # its own capped backoff throttles further attempts).
-      MAX_RETRIES = 5
-      JITTER      = 200.milliseconds
-
       @client : ::HTTP::Client?
 
       getter timeout : Time::Span
@@ -66,7 +58,7 @@ module LavinMQ
                end
         case @ack_mode
         in AckMode::OnConfirm
-          outcome = deliver_with_outcome(headers, path, msg.body_io)
+          outcome = attempt(headers, path, msg.body_io)
           @listener.report(msg.delivery_tag, outcome)
         in AckMode::OnPublish
           begin
@@ -84,21 +76,6 @@ module LavinMQ
         end
       end
 
-      # Delivers the message, retrying transient failures in place up to
-      # MAX_RETRIES with a random jitter (no backoff). Re-classifies every
-      # attempt, so a non-transient response (Reject/Abort) or a success returns
-      # immediately; only Retry outcomes are retried.
-      private def deliver_with_outcome(headers, path, body_io) : Outcome
-        attempts = 0
-        loop do
-          outcome = attempt(headers, path, body_io)
-          return outcome unless outcome.retry?
-          return outcome if attempts >= MAX_RETRIES
-          attempts += 1
-          sleep JITTER * Random.rand(0.0..1.0)
-        end
-      end
-
       # A single delivery attempt. A transport-level failure (timeout, reset,
       # connection refused) closes and reopens the client so the next attempt
       # starts clean, and counts as a transient Retry.
@@ -112,7 +89,6 @@ module LavinMQ
         Log.warn { "shovel=#{@name} HTTP delivery failed: #{ex.message}" }
         @client.try &.close
         @client = nil
-        # Heloo
         Outcome::Retry
       end
 

--- a/src/lavinmq/shovel/multi_destination.cr
+++ b/src/lavinmq/shovel/multi_destination.cr
@@ -2,36 +2,93 @@ require "./destination"
 
 module LavinMQ
   module Shovel
+    # Coarse failover across a shovel's list of destinations. One destination is
+    # active at a time; when it is classified unusable (Abort) or fails to start,
+    # the handler advances to the next and the in-flight message is retried there.
+    # Only once every destination has failed in a row — with no Confirmed in
+    # between — does it emit Abort upward so the Runner errors-out the shovel.
+    # Name kept for continuity; this is a failover handler, not fan-out.
     class MultiDestinationHandler < Destination
-      @current_dest : Destination?
+      @current : Destination?
+      @index = 0
+      @consecutive_aborts = 0
 
       def initialize(@destinations : Array(Destination))
       end
 
       def start
         return if started?
-        next_dest = @destinations.sample
-        return unless next_dest
-        next_dest.on_outcome = @on_outcome
-        next_dest.start
-        @current_dest = next_dest
+        # Try destinations in order until one starts, so an unreachable primary
+        # fails over at startup too.
+        @destinations.size.times do |i|
+          return if activate(@index + i)
+        end
       end
 
       def stop
-        @current_dest.try &.stop
-        @current_dest = nil
-      end
-
-      def push(msg)
-        @current_dest.try &.push(msg)
+        @current.try &.stop
+        @current = nil
       end
 
       def started? : Bool
-        if dest = @current_dest
+        if dest = @current
           return dest.started?
         end
         false
       end
+
+      def push(msg)
+        if dest = @current
+          dest.push(msg)
+        else
+          # No usable destination at all — surface it rather than dropping.
+          @on_outcome.call(msg.delivery_tag, Outcome::Abort)
+        end
+      end
+
+      # Activate destination at `index`, routing its outcomes through our handler.
+      # Returns true if it started.
+      private def activate(index) : Bool
+        return false if @destinations.empty?
+        @index = index % @destinations.size
+        dest = @destinations[@index]
+        dest.on_outcome = ->(tag : UInt64, outcome : Outcome) { handle(tag, outcome) }
+        dest.start
+        @current = dest
+        true
+      rescue ex
+        Log.warn { "Destination #{@index} failed to start: #{ex.message}" }
+        false
+      end
+
+      # Intercepts each active destination's outcome. A non-Abort is forwarded
+      # unchanged. An Abort fails over to the next destination (and retries the
+      # message there) until all have aborted in a row, then propagates Abort.
+      private def handle(tag : UInt64, outcome : Outcome)
+        case outcome
+        in Outcome::Confirmed, Outcome::Retry, Outcome::Reject
+          @consecutive_aborts = 0
+          @on_outcome.call(tag, outcome)
+        in Outcome::Abort
+          @consecutive_aborts += 1
+          if @consecutive_aborts >= @destinations.size
+            @on_outcome.call(tag, Outcome::Abort) # every destination is unusable
+          else
+            @current.try &.stop
+            start_next
+            @on_outcome.call(tag, Outcome::Retry) # re-deliver on the new active one
+          end
+        end
+        nil
+      end
+
+      private def start_next
+        @destinations.size.times do |i|
+          return if activate(@index + 1 + i)
+        end
+      end
+
+      Log = LavinMQ::Log.for "shovel.multi_destination"
     end
   end
 end

--- a/src/lavinmq/shovel/multi_destination.cr
+++ b/src/lavinmq/shovel/multi_destination.cr
@@ -12,6 +12,7 @@ module LavinMQ
         return if started?
         next_dest = @destinations.sample
         return unless next_dest
+        next_dest.on_outcome = @on_outcome
         next_dest.start
         @current_dest = next_dest
       end
@@ -21,8 +22,8 @@ module LavinMQ
         @current_dest = nil
       end
 
-      def push(msg, source)
-        @current_dest.try &.push(msg, source)
+      def push(msg)
+        @current_dest.try &.push(msg)
       end
 
       def started? : Bool

--- a/src/lavinmq/shovel/multi_destination.cr
+++ b/src/lavinmq/shovel/multi_destination.cr
@@ -9,6 +9,8 @@ module LavinMQ
     # between — does it emit Abort upward so the Runner errors-out the shovel.
     # Name kept for continuity; this is a failover handler, not fan-out.
     class MultiDestinationHandler < Destination
+      include OutcomeListener
+
       @current : Destination?
       @index = 0
       @consecutive_aborts = 0
@@ -42,7 +44,7 @@ module LavinMQ
           dest.push(msg)
         else
           # No usable destination at all — surface it rather than dropping.
-          @on_outcome.call(msg.delivery_tag, Outcome::Abort)
+          @listener.report(msg.delivery_tag, Outcome::Abort)
         end
       end
 
@@ -52,7 +54,7 @@ module LavinMQ
         return false if @destinations.empty?
         @index = index % @destinations.size
         dest = @destinations[@index]
-        dest.on_outcome = ->(tag : UInt64, outcome : Outcome) { handle(tag, outcome) }
+        dest.listener = self
         dest.start
         @current = dest
         true
@@ -64,22 +66,21 @@ module LavinMQ
       # Intercepts each active destination's outcome. A non-Abort is forwarded
       # unchanged. An Abort fails over to the next destination (and retries the
       # message there) until all have aborted in a row, then propagates Abort.
-      private def handle(tag : UInt64, outcome : Outcome)
+      def report(delivery_tag : UInt64, outcome : Outcome)
         case outcome
         in Outcome::Confirmed, Outcome::Retry, Outcome::Reject
           @consecutive_aborts = 0
-          @on_outcome.call(tag, outcome)
+          @listener.report(delivery_tag, outcome)
         in Outcome::Abort
           @consecutive_aborts += 1
           if @consecutive_aborts >= @destinations.size
-            @on_outcome.call(tag, Outcome::Abort) # every destination is unusable
+            @listener.report(delivery_tag, Outcome::Abort) # every destination is unusable
           else
             @current.try &.stop
             start_next
-            @on_outcome.call(tag, Outcome::Retry) # re-deliver on the new active one
+            @listener.report(delivery_tag, Outcome::Retry) # re-deliver on the new active one
           end
         end
-        nil
       end
 
       private def start_next

--- a/src/lavinmq/shovel/outcome_listener.cr
+++ b/src/lavinmq/shovel/outcome_listener.cr
@@ -1,0 +1,26 @@
+require "./constants"
+
+module LavinMQ
+  module Shovel
+    # A Destination reports each delivery's Outcome to its listener: the Runner
+    # (the single place that maps an Outcome to a source action), or a
+    # MultiDestinationHandler that intercepts and forwards. Called synchronously
+    # for HTTP, and from the publisher-confirm fiber for AMQP on-confirm; never
+    # called in NoAck mode (nothing to settle).
+    module OutcomeListener
+      abstract def report(delivery_tag : UInt64, outcome : Outcome)
+    end
+
+    # Default listener for a Destination before the Runner registers, and the
+    # sink for NoAck deliveries. Does nothing. A single shared instance so
+    # constructing a Destination allocates nothing extra.
+    class NullOutcomeListener
+      include OutcomeListener
+
+      INSTANCE = new
+
+      def report(delivery_tag : UInt64, outcome : Outcome)
+      end
+    end
+  end
+end

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -53,6 +53,9 @@ module LavinMQ
           @retries = 0
           @source.each do |msg|
             @message_count += 1
+            # Paused/terminated: start no new delivery. An already in-flight push
+            # can't be interrupted, but we don't begin another one.
+            next if should_stop_loop?(run_generation)
             check_abort_threshold
             backoff_if_failing
             @destination.push(msg)

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -23,9 +23,10 @@ module LavinMQ
       @retried_total = Atomic(UInt64).new(0_u64)
       @rejected_total = Atomic(UInt64).new(0_u64)
       @aborted_total = Atomic(UInt64).new(0_u64)
-      RETRY_THRESHOLD =  10
-      ABORT_THRESHOLD =  10
-      MAX_DELAY       = 300
+      RETRY_THRESHOLD    =  10
+      ABORT_THRESHOLD    =  10
+      MAX_DELAY          = 300
+      MAX_DELIVERY_DELAY =  30
 
       getter name, vhost
 
@@ -121,8 +122,16 @@ module LavinMQ
       private def backoff_if_failing
         failures = @delivery_failures.get
         return if failures.zero?
-        secs = Math.min(MAX_DELAY.to_f, 2.0 ** Math.min(failures, 8))
-        sleep secs.seconds
+        sleep self.class.delivery_backoff(failures)
+      end
+
+      # Backoff before the next delivery attempt after `failures` consecutive
+      # transient failures: 0.5s, 1s, 2s, 4s, … doubling, capped at
+      # MAX_DELIVERY_DELAY, then holding there.
+      def self.delivery_backoff(failures : Int32) : Time::Span
+        return 0.seconds if failures <= 0
+        secs = Math.min(MAX_DELIVERY_DELAY.to_f, 0.5 * 2.0 ** Math.min(failures - 1, 6))
+        secs.seconds
       end
 
       # Errors-out the shovel once a destination has been classified unusable

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -12,6 +12,9 @@ module LavinMQ
       @message_count : UInt64 = 0
       @retries : Int64 = 0
       @stop_generation = Atomic(UInt64).new(0_u64)
+      # Consecutive transient (Retry) delivery failures, written by the outcome
+      # handler (confirm fiber) and read by the consuming loop for backoff.
+      @delivery_failures = Atomic(Int32).new(0)
       RETRY_THRESHOLD =  10
       MAX_DELAY       = 300
 
@@ -46,6 +49,7 @@ module LavinMQ
           @retries = 0
           @source.each do |msg|
             @message_count += 1
+            backoff_if_failing
             @destination.push(msg)
           end
           break if should_stop_loop?(run_generation) # Don't delete shovel if paused/terminated
@@ -79,13 +83,32 @@ module LavinMQ
         source = @source
         @destination.on_outcome = ->(delivery_tag : UInt64, outcome : Outcome) do
           case outcome
-          in Outcome::Confirmed then source.ack(delivery_tag)
-          in Outcome::Retry     then source.reject(delivery_tag, requeue: true)
-          in Outcome::Reject    then source.reject(delivery_tag, requeue: false)
-          in Outcome::Abort     then source.reject(delivery_tag, requeue: true)
+          in Outcome::Confirmed
+            @delivery_failures.set(0)
+            source.ack(delivery_tag)
+          in Outcome::Retry
+            @delivery_failures.add(1)
+            source.reject(delivery_tag, requeue: true)
+          in Outcome::Reject
+            # The endpoint responded (it just refused this message), so it is
+            # healthy — clear the backoff.
+            @delivery_failures.set(0)
+            source.reject(delivery_tag, requeue: false)
+          in Outcome::Abort
+            source.reject(delivery_tag, requeue: true)
           end
           nil
         end
+      end
+
+      # Sleep before the next delivery in proportion to recent transient
+      # failures, so a persistently-rejecting destination is retried with
+      # capped exponential backoff rather than in a tight loop.
+      private def backoff_if_failing
+        failures = @delivery_failures.get
+        return if failures.zero?
+        secs = Math.min(MAX_DELAY.to_f, 2.0 ** Math.min(failures, 8))
+        sleep secs.seconds
       end
 
       private def terminate_if_needed(run_generation)

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -80,7 +80,9 @@ module LavinMQ
         @destination.on_outcome = ->(delivery_tag : UInt64, outcome : Outcome) do
           case outcome
           in Outcome::Confirmed then source.ack(delivery_tag)
-          in Outcome::Rejected  then source.reject(delivery_tag, requeue: true)
+          in Outcome::Retry     then source.reject(delivery_tag, requeue: true)
+          in Outcome::Reject    then source.reject(delivery_tag, requeue: false)
+          in Outcome::Abort     then source.reject(delivery_tag, requeue: true)
           end
           nil
         end

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -18,6 +18,11 @@ module LavinMQ
       # Consecutive Abort outcomes; past ABORT_THRESHOLD the shovel errors out.
       @delivery_aborts = Atomic(Int32).new(0)
       @aborted = false
+      # Cumulative per-disposition counters, for the runtime view.
+      @confirmed_total = Atomic(UInt64).new(0_u64)
+      @retried_total = Atomic(UInt64).new(0_u64)
+      @rejected_total = Atomic(UInt64).new(0_u64)
+      @aborted_total = Atomic(UInt64).new(0_u64)
       RETRY_THRESHOLD =  10
       ABORT_THRESHOLD =  10
       MAX_DELAY       = 300
@@ -81,24 +86,28 @@ module LavinMQ
         @destination.on_outcome = ->(delivery_tag : UInt64, outcome : Outcome) do
           case outcome
           in Outcome::Confirmed
+            @confirmed_total.add(1)
             @delivery_failures.set(0)
             @delivery_aborts.set(0)
             source.ack(delivery_tag)
           in Outcome::Retry
             # A non-abort outcome breaks any consecutive-abort streak: the
             # destination is reachable, just not accepting this message yet.
+            @retried_total.add(1)
             @delivery_aborts.set(0)
             @delivery_failures.add(1)
             source.reject(delivery_tag, requeue: true)
           in Outcome::Reject
             # The endpoint responded (it just refused this message), so it is
             # healthy — clear the backoff and the abort streak.
+            @rejected_total.add(1)
             @delivery_failures.set(0)
             @delivery_aborts.set(0)
             source.reject(delivery_tag, requeue: false)
           in Outcome::Abort
             # Keep the message; the consuming loop errors-out the shovel once
             # consecutive Aborts cross ABORT_THRESHOLD.
+            @aborted_total.add(1)
             @delivery_aborts.add(1)
             source.reject(delivery_tag, requeue: true)
           end
@@ -164,11 +173,18 @@ module LavinMQ
 
       def details_tuple
         {
-          name:          @name,
-          vhost:         @vhost.name,
-          state:         @state.to_s,
-          error:         @error,
-          message_count: @message_count,
+          name:                 @name,
+          vhost:                @vhost.name,
+          state:                @state.to_s,
+          error:                @error,
+          message_count:        @message_count,
+          confirmed:            @confirmed_total.get,
+          retried:              @retried_total.get,
+          dead_lettered:        @rejected_total.get,
+          aborted:              @aborted_total.get,
+          consecutive_failures: @delivery_failures.get,
+          consecutive_aborts:   @delivery_aborts.get,
+          abort_threshold:      ABORT_THRESHOLD,
         }
       end
 

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -15,7 +15,11 @@ module LavinMQ
       # Consecutive transient (Retry) delivery failures, written by the outcome
       # handler (confirm fiber) and read by the consuming loop for backoff.
       @delivery_failures = Atomic(Int32).new(0)
+      # Consecutive Abort outcomes; past ABORT_THRESHOLD the shovel errors out.
+      @delivery_aborts = Atomic(Int32).new(0)
+      @aborted = false
       RETRY_THRESHOLD =  10
+      ABORT_THRESHOLD =  10
       MAX_DELAY       = 300
 
       getter name, vhost
@@ -49,28 +53,18 @@ module LavinMQ
           @retries = 0
           @source.each do |msg|
             @message_count += 1
+            check_abort_threshold
             backoff_if_failing
             @destination.push(msg)
           end
           break if should_stop_loop?(run_generation) # Don't delete shovel if paused/terminated
           @vhost.delete_parameter("shovel", @name) if @source.delete_after.queue_length?
           break
-        rescue ex : ::AMQP::Client::Connection::ClosedException | ::AMQP::Client::Channel::ClosedException | Socket::ConnectError
-          break if should_stop_loop?(run_generation)
-          @state = State::Error
-          # Shoveled queue was deleted
-          if ex.message.to_s.starts_with?("404")
-            break
-          end
-          Log.warn { ex.message }
-          @error = ex.message
-          exponential_reconnect_delay
+        rescue ex : ShovelAborted
+          error_out(ex)
+          break
         rescue ex
-          break if should_stop_loop?(run_generation)
-          @state = State::Error
-          Log.warn { ex.message }
-          @error = ex.message
-          exponential_reconnect_delay
+          break if handle_run_error(ex, run_generation)
         end
       ensure
         terminate_if_needed(run_generation)
@@ -85,6 +79,7 @@ module LavinMQ
           case outcome
           in Outcome::Confirmed
             @delivery_failures.set(0)
+            @delivery_aborts.set(0)
             source.ack(delivery_tag)
           in Outcome::Retry
             @delivery_failures.add(1)
@@ -95,6 +90,9 @@ module LavinMQ
             @delivery_failures.set(0)
             source.reject(delivery_tag, requeue: false)
           in Outcome::Abort
+            # Keep the message; the consuming loop errors-out the shovel once
+            # consecutive Aborts cross ABORT_THRESHOLD.
+            @delivery_aborts.add(1)
             source.reject(delivery_tag, requeue: true)
           end
           nil
@@ -111,7 +109,39 @@ module LavinMQ
         sleep secs.seconds
       end
 
+      # Errors-out the shovel once a destination has been classified unusable
+      # (Abort) too many times in a row. Raised inside the consuming loop.
+      private def check_abort_threshold
+        return if @delivery_aborts.get < ABORT_THRESHOLD
+        raise ShovelAborted.new("destination unusable after #{ABORT_THRESHOLD} attempts")
+      end
+
+      # Terminal: the destination is unusable. Stay in Error for the operator
+      # rather than reconnecting.
+      private def error_out(ex)
+        @aborted = true
+        @state = State::Error
+        @error = ex.message
+        Log.warn { "Aborted: #{ex.message}" }
+        @source.stop
+        @destination.stop
+      end
+
+      # Handles a connection/runtime error during a run. Returns true if the run
+      # loop should break (stopped, or the shoveled queue was deleted), false to
+      # reconnect with backoff.
+      private def handle_run_error(ex, run_generation) : Bool
+        return true if should_stop_loop?(run_generation)
+        @state = State::Error
+        return true if ex.message.to_s.starts_with?("404") # shoveled queue was deleted
+        Log.warn { ex.message }
+        @error = ex.message
+        exponential_reconnect_delay
+        false
+      end
+
       private def terminate_if_needed(run_generation)
+        return if @aborted # keep the Error state for the operator
         return if stopped_by_newer_generation?(run_generation)
         terminate if !paused?
       end

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -33,6 +33,7 @@ module LavinMQ
       def run
         Log.context.set(name: @name, vhost: @vhost.name)
         run_generation = @stop_generation.get(:acquire)
+        register_outcome_handler
         loop do
           break if should_stop_loop?(run_generation)
           @state = State::Starting
@@ -45,7 +46,7 @@ module LavinMQ
           @retries = 0
           @source.each do |msg|
             @message_count += 1
-            @destination.push(msg, @source)
+            @destination.push(msg)
           end
           break if should_stop_loop?(run_generation) # Don't delete shovel if paused/terminated
           @vhost.delete_parameter("shovel", @name) if @source.delete_after.queue_length?
@@ -69,6 +70,20 @@ module LavinMQ
         end
       ensure
         terminate_if_needed(run_generation)
+      end
+
+      # The single place a delivery Outcome becomes a source action: a confirmed
+      # delivery acks; a rejection (broker nack or HTTP error) requeues so
+      # queue-based retry/DLX policies still apply. Registered once per run.
+      private def register_outcome_handler
+        source = @source
+        @destination.on_outcome = ->(delivery_tag : UInt64, outcome : Outcome) do
+          case outcome
+          in Outcome::Confirmed then source.ack(delivery_tag)
+          in Outcome::Rejected  then source.reject(delivery_tag, requeue: true)
+          end
+          nil
+        end
       end
 
       private def terminate_if_needed(run_generation)

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -85,12 +85,16 @@ module LavinMQ
             @delivery_aborts.set(0)
             source.ack(delivery_tag)
           in Outcome::Retry
+            # A non-abort outcome breaks any consecutive-abort streak: the
+            # destination is reachable, just not accepting this message yet.
+            @delivery_aborts.set(0)
             @delivery_failures.add(1)
             source.reject(delivery_tag, requeue: true)
           in Outcome::Reject
             # The endpoint responded (it just refused this message), so it is
-            # healthy — clear the backoff.
+            # healthy — clear the backoff and the abort streak.
             @delivery_failures.set(0)
+            @delivery_aborts.set(0)
             source.reject(delivery_tag, requeue: false)
           in Outcome::Abort
             # Keep the message; the consuming loop errors-out the shovel once

--- a/src/lavinmq/shovel/runner.cr
+++ b/src/lavinmq/shovel/runner.cr
@@ -7,6 +7,7 @@ module LavinMQ
   module Shovel
     class Runner
       include SortableJSON
+      include OutcomeListener
       @state = State::Stopped
       @error : String?
       @message_count : UInt64 = 0
@@ -79,40 +80,42 @@ module LavinMQ
         terminate_if_needed(run_generation)
       end
 
+      # Register this Runner as the destination's outcome listener, once per run.
+      private def register_outcome_handler
+        @destination.listener = self
+      end
+
       # The single place a delivery Outcome becomes a source action: a confirmed
       # delivery acks; a rejection (broker nack or HTTP error) requeues so
-      # queue-based retry/DLX policies still apply. Registered once per run.
-      private def register_outcome_handler
-        source = @source
-        @destination.on_outcome = ->(delivery_tag : UInt64, outcome : Outcome) do
-          case outcome
-          in Outcome::Confirmed
-            @confirmed_total.add(1)
-            @delivery_failures.set(0)
-            @delivery_aborts.set(0)
-            source.ack(delivery_tag)
-          in Outcome::Retry
-            # A non-abort outcome breaks any consecutive-abort streak: the
-            # destination is reachable, just not accepting this message yet.
-            @retried_total.add(1)
-            @delivery_aborts.set(0)
-            @delivery_failures.add(1)
-            source.reject(delivery_tag, requeue: true)
-          in Outcome::Reject
-            # The endpoint responded (it just refused this message), so it is
-            # healthy — clear the backoff and the abort streak.
-            @rejected_total.add(1)
-            @delivery_failures.set(0)
-            @delivery_aborts.set(0)
-            source.reject(delivery_tag, requeue: false)
-          in Outcome::Abort
-            # Keep the message; the consuming loop errors-out the shovel once
-            # consecutive Aborts cross ABORT_THRESHOLD.
-            @aborted_total.add(1)
-            @delivery_aborts.add(1)
-            source.reject(delivery_tag, requeue: true)
-          end
-          nil
+      # queue-based retry/DLX policies still apply. Called by the destination
+      # (synchronously for HTTP, from the confirm fiber for AMQP on-confirm).
+      def report(delivery_tag : UInt64, outcome : Outcome)
+        case outcome
+        in Outcome::Confirmed
+          @confirmed_total.add(1)
+          @delivery_failures.set(0)
+          @delivery_aborts.set(0)
+          @source.ack(delivery_tag)
+        in Outcome::Retry
+          # A non-abort outcome breaks any consecutive-abort streak: the
+          # destination is reachable, just not accepting this message yet.
+          @retried_total.add(1)
+          @delivery_aborts.set(0)
+          @delivery_failures.add(1)
+          @source.reject(delivery_tag, requeue: true)
+        in Outcome::Reject
+          # The endpoint responded (it just refused this message), so it is
+          # healthy — clear the backoff and the abort streak.
+          @rejected_total.add(1)
+          @delivery_failures.set(0)
+          @delivery_aborts.set(0)
+          @source.reject(delivery_tag, requeue: false)
+        in Outcome::Abort
+          # Keep the message; the consuming loop errors-out the shovel once
+          # consecutive Aborts cross ABORT_THRESHOLD.
+          @aborted_total.add(1)
+          @delivery_aborts.add(1)
+          @source.reject(delivery_tag, requeue: true)
         end
       end
 

--- a/src/lavinmq/shovel/source.cr
+++ b/src/lavinmq/shovel/source.cr
@@ -1,6 +1,28 @@
+require "amqp-client"
+require "./constants"
+
 module LavinMQ
   module Shovel
+    # A Source yields messages to the Runner and settles them on demand.
+    # The Runner — not the Destination — decides whether a delivery is acked
+    # or requeued, by calling #ack or #reject after a Destination reports its
+    # Outcome. See Runner#run.
     abstract class Source
+      abstract def start
+      abstract def stop
+
+      # Yields each consumed message. Returns when the source is exhausted
+      # (delete-after) or stopped.
+      abstract def each(&blk : ::AMQP::Client::DeliverMessage -> Nil)
+
+      # Acknowledge a successfully shoveled message.
+      abstract def ack(delivery_tag)
+
+      # Return a message to the source. With requeue: true it stays available
+      # for redelivery; with requeue: false it is dropped/dead-lettered.
+      abstract def reject(delivery_tag, requeue)
+
+      abstract def delete_after
     end
   end
 end

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -58,8 +58,11 @@ module LavinMQ
           dst = "" # default exchange
         end
 
+        # HTTP(S) destinations POST to a URL and have no queue/exchange.
+        http_dest = !dest_uris.empty? && dest_uris.all? { |u| u.scheme.try &.starts_with?("http") }
+
         raise ConfigError.new("Shovel source requires a queue or an exchange") if src_q.nil? && src_x.nil?
-        raise ConfigError.new("Shovel destination requires queue and/or exchange") if dst.nil?
+        raise ConfigError.new("Shovel destination requires queue and/or exchange") if dst.nil? && !http_dest
 
         return unless user
 

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -154,7 +154,7 @@ module LavinMQ
         destinations = uris.map do |uri|
           case uri.scheme
           when "http", "https"
-            Shovel::HTTPDestination.new(name, uri)
+            Shovel::HTTPDestination.new(name, uri, ack_mode, 30)
           else
             Shovel::AMQPDestination.new(name, uri,
               config["dest-queue"]?.try &.as_s?,

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -154,7 +154,7 @@ module LavinMQ
         destinations = uris.map do |uri|
           case uri.scheme
           when "http", "https"
-            Shovel::HTTPDestination.new(name, uri, ack_mode, 30)
+            Shovel::HTTPDestination.new(name, uri, ack_mode, Shovel::HTTPDestination.timeout_from(config))
           else
             Shovel::AMQPDestination.new(name, uri,
               config["dest-queue"]?.try &.as_s?,

--- a/static/js/shovels.js
+++ b/static/js/shovels.js
@@ -7,19 +7,78 @@ import { UrlDataSource } from './datasource.js'
 
 Helpers.addVhostOptions('createShovel')
 
+const STATE_BADGE_MODIFIER = {
+  Running: 'badge-state--running',
+  Starting: 'badge-state--starting',
+  Paused: 'badge-state--paused',
+  Stopped: 'badge-state--stopped',
+  Terminated: 'badge-state--terminated',
+  Error: 'badge-state--error'
+}
+
+// State as a colored badge, with the error promoted inline (not just on hover)
+// and a degraded sub-line for shovels that are alive but backing off or
+// progressing toward an error-out.
 function renderState (item) {
-  if (item.error) {
-    const state = document.createElement('a')
-    state.classList.add('arg-tooltip')
-    state.appendChild(document.createTextNode(item.state))
-    const tooltip = document.createElement('span')
-    tooltip.classList.add('tooltiptext')
-    tooltip.textContent = item.error
-    state.appendChild(tooltip)
-    return state
-  } else {
-    return item.state
+  const container = document.createElement('div')
+  container.classList.add('state-cell-inner')
+
+  const badge = document.createElement('span')
+  badge.classList.add('badge-state')
+  const modifier = STATE_BADGE_MODIFIER[item.state]
+  if (modifier) badge.classList.add(modifier)
+  badge.textContent = item.state
+  container.appendChild(badge)
+
+  if (item.state === 'Error' && item.error) {
+    const error = document.createElement('small')
+    error.classList.add('state-error')
+    error.textContent = item.error
+    container.appendChild(error)
   }
+
+  if (item.consecutive_failures > 0) {
+    const degraded = document.createElement('small')
+    degraded.classList.add('state-degraded')
+    degraded.textContent = 'retrying (backoff)'
+    container.appendChild(degraded)
+  }
+
+  if (item.consecutive_aborts > 0) {
+    const degraded = document.createElement('small')
+    degraded.classList.add('state-degraded')
+    degraded.textContent = `aborts ${item.consecutive_aborts}/${item.abort_threshold}`
+    container.appendChild(degraded)
+  }
+
+  return container
+}
+
+// message_count is cumulative; derive a per-shovel msgs/s rate from the delta
+// between successive /api/shovels polls. Cache lives outside the row objects
+// (the datasource rebuilds them every reload), keyed by vhost+name.
+const rateCache = new Map()
+
+function messageRate (item) {
+  const key = `${item.vhost} ${item.name}`
+  const now = Date.now()
+  const prev = rateCache.get(key)
+  if (!prev) {
+    rateCache.set(key, { count: item.message_count, ts: now, rate: null })
+    return null
+  }
+  if (now > prev.ts) {
+    const rate = (item.message_count - prev.count) / ((now - prev.ts) / 1000)
+    rateCache.set(key, { count: item.message_count, ts: now, rate })
+    return rate
+  }
+  return prev.rate // re-render within the same tick: keep the last computed rate
+}
+
+function formatRate (rate) {
+  if (rate === null) return '–'
+  const fixed = rate.toFixed(1)
+  return `${fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed} msg/s`
 }
 
 const vhost = window.sessionStorage.getItem('vhost')
@@ -40,12 +99,16 @@ class ShovelsDataSource extends UrlDataSource {
     const p1 = super._reload()
     const p2 = HTTP.request('GET', this.statusUrl)
 
+    const runtimeFields = [
+      'state', 'error', 'message_count',
+      'consecutive_failures', 'consecutive_aborts', 'abort_threshold'
+    ]
     return Promise.all([p1, p2]).then(values => {
       let shovels = values[0].items ?? values[0]
       const status = values[1]
       shovels = shovels.map(item => {
-        item.state = status.find(s => s.name === item.name && s.vhost === item.vhost).state
-        item.error = status.find(s => s.name === item.name && s.vhost === item.vhost).error
+        const s = status.find(s => s.name === item.name && s.vhost === item.vhost)
+        if (s) runtimeFields.forEach(field => { item[field] = s[field] })
         return item
       })
       return shovels
@@ -101,7 +164,8 @@ Table.renderTable('table', tableOptions, (tr, item, _all) => {
   Table.renderCell(tr, 7, item.value['reconnect-delay'])
   Table.renderCell(tr, 8, item.value['ack-mode'])
   Table.renderCell(tr, 9, item.value['src-delete-after'])
-  Table.renderCell(tr, 10, renderState(item))
+  Table.renderCell(tr, 10, renderState(item), 'state-cell')
+  Table.renderCell(tr, 11, formatRate(messageRate(item)), 'rate-cell')
   const btns = document.createElement('div')
   btns.classList.add('buttons')
   const deleteBtn = DOM.button.delete({
@@ -151,7 +215,7 @@ Table.renderTable('table', tableOptions, (tr, item, _all) => {
     text: pauseLabel
   })
   btns.append(editBtn, pauseBtn, deleteBtn)
-  Table.renderCell(tr, 11, btns, 'right')
+  Table.renderCell(tr, 12, btns, 'right')
 })
 
 document.querySelector('[name=src-type]').addEventListener('change', function () {

--- a/static/main.css
+++ b/static/main.css
@@ -633,6 +633,38 @@ button {
   margin-left: 0.5rem;
 }
 
+.state-cell-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.badge-state {
+  display: inline-block;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  font-weight: 500;
+  color: var(--color-text-inverse);
+  background: var(--color-text-muted);
+}
+
+.badge-state--running { background: var(--color-success); color: #141414; }
+.badge-state--starting { background: var(--color-warning); color: #141414; }
+.badge-state--error { background: var(--color-danger); }
+
+.badge-state--paused,
+.badge-state--stopped,
+.badge-state--terminated {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+
+.state-error { color: var(--color-danger); }
+.state-degraded { color: var(--color-warning-hover); }
+
 .card h3 {
   color: var(--color-text-primary);
   font-size: 1.125rem;

--- a/views/shovels.shtml
+++ b/views/shovels.shtml
@@ -31,6 +31,7 @@
                 <th rowspan="2">Ack mode</th>
                 <th rowspan="2">Delete after</th>
                 <th rowspan="2">State</th>
+                <th rowspan="2">Msg rate</th>
                 <th rowspan="2"></th>
               </tr>
               <tr>


### PR DESCRIPTION
### WHAT is this pull request doing?

Introduce a 'Msg rate' column showing per-shovel msgs/s, derived client-side from the delta in cumulative message_count between successive 5s polls, cached outside the row objects by vhost+name.

state as a colored badge (Running/Starting green/amber, Error red, Paused/Stopped/Terminated grey); the error is promoted from a hover tooltip to an inline red sub-line; a degraded sub-line surfaces 'retrying (backoff)' (consecutive_failures>0) and 'aborts n/threshold' (consecutive_aborts>0).

### HOW can this pull request be tested?

:eyes: 