### PR TITLE
Return 404 instead of 403 for non-existent vhosts when user is admin

### DIFF
--- a/.github/rabbit-hole.patch
+++ b/.github/rabbit-hole.patch
@@ -187,7 +187,7 @@ index 6aea41d..02190a4 100644
  			x2, err := rmqc.GetVhost(vh)
  			Ω(x2).Should(BeNil())
 -			Ω(err).Should(Equal(ErrorResponse{404, "Object Not Found", "Not Found"}))
-+			Ω(err).Should(Equal(ErrorResponse{403, "access_refused", "Access refused"}))
++			Ω(err).Should(Equal(ErrorResponse{404, "Object Not Found", "Vhost rabbit/hole2 does not exist"}))
  		})
  	})
  

--- a/spec/api/connections_spec.cr
+++ b/spec/api/connections_spec.cr
@@ -57,9 +57,18 @@ describe LavinMQ::HTTP::ConnectionsController do
       end
     end
 
-    it "should return 403 if vhosts does not exist" do
+    it "should return 404 if vhosts does not exist and user is admin" do
       with_http_server do |http, _|
         response = http.get("/api/vhosts/vhost/connections")
+        response.status_code.should eq 404
+      end
+    end
+
+    it "should return 403 if vhosts does not exist and user is not admin" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/vhosts/nonexisting", headers: hdrs)
         response.status_code.should eq 403
       end
     end

--- a/spec/api/vhosts_spec.cr
+++ b/spec/api/vhosts_spec.cr
@@ -46,9 +46,18 @@ describe LavinMQ::HTTP::VHostsController do
       end
     end
 
-    it "should return 403 if vhost does not exist" do
+    it "should return 404 if vhost does not exist" do
       with_http_server do |http, _|
-        response = http.get("/api/vhosts/403")
+        response = http.get("/api/vhosts/404")
+        response.status_code.should eq 404
+      end
+    end
+
+    it "should return 403 if vhost does not exist and user is not an administrator" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.get("/api/vhosts/nonexisting", headers: hdrs)
         response.status_code.should eq 403
       end
     end
@@ -105,10 +114,10 @@ describe LavinMQ::HTTP::VHostsController do
       end
     end
 
-    it "should return 403 when trying to delete non existing vhost" do
+    it "should return 404 when trying to delete non existing vhost" do
       with_http_server do |http, _|
         response = http.delete("/api/vhosts/nonexisting")
-        response.status_code.should eq 403
+        response.status_code.should eq 404
       end
     end
 
@@ -117,6 +126,15 @@ describe LavinMQ::HTTP::VHostsController do
         s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
         hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
         response = http.delete("/api/vhosts/test", headers: hdrs)
+        response.status_code.should eq 403
+      end
+    end
+
+    it "should return 403 when a non-administrator tries to delete a non existing vhost" do
+      with_http_server do |http, s|
+        s.users.create("arnold", "pw", [LavinMQ::Tag::PolicyMaker])
+        hdrs = ::HTTP::Headers{"Authorization" => "Basic YXJub2xkOnB3"}
+        response = http.delete("/api/vhosts/nonexisting", headers: hdrs)
         response.status_code.should eq 403
       end
     end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -202,9 +202,12 @@ module LavinMQ
       end
 
       private def with_vhost(context, params, *, vhost_key = "vhost", &)
-        if (name = params[vhost_key]?) && (vhost = @server.vhosts[name]?)
+        name = params[vhost_key]?
+        if name && (vhost = @server.vhosts[name]?)
           refuse_unless_vhost_access(context, user(context), vhost)
           yield vhost
+        elsif user(context).tags.any? &.administrator?
+          not_found(context, "Vhost #{name} does not exist")
         else
           access_refused(context)
         end


### PR DESCRIPTION
### WHAT is this pull request doing?
`GET`/`DELETE /api/vhosts/:vhost` returned 403 for a non-existent vhost regardless of the requesting user's role. For administrators this is misleading.
- Administrators now get 404 for a non-existent vhost. Non-administrators still get 403.

### HOW can this pull request be tested?
Specs.

Manually build & run then
```
curl -XDELETE -u guest:guest localhost:15672/api/vhosts/nonexistingvhost

{"error":"Object Not Found","reason":"Vhost nonexistingvhost does not exist"}
```
