### PR TITLE
Docs: mention MQTT 3.1.0 support in docs/mqtt.md

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -1,6 +1,6 @@
 # MQTT
 
-LavinMQ implements MQTT 3.1.1 natively. MQTT clients connect directly to the dedicated MQTT port and use the protocol as-is; no plugin or external proxy is required. Internally, LavinMQ maps MQTT concepts onto its AMQP infrastructure (sessions become queues, subscriptions become bindings), but this is invisible to MQTT clients.
+LavinMQ implements MQTT 3.1.0 and 3.1.1 natively. MQTT clients connect directly to the dedicated MQTT port and use the protocol as-is; no plugin or external proxy is required. Internally, LavinMQ maps MQTT concepts onto its AMQP infrastructure (sessions become queues, subscriptions become bindings), but this is invisible to MQTT clients.
 
 ## Ports
 
@@ -122,7 +122,7 @@ Note that connecting with a client_id already in use takes over that session, so
 
 ## Limitations
 
-- Only MQTT 3.1.1 is supported. MQTT 5 features (session expiry interval, shared subscriptions, topic aliases, message expiry, user properties, response topics) are not available.
+- Only MQTT 3.1.0 and 3.1.1 are supported. MQTT 5 features (session expiry interval, shared subscriptions, topic aliases, message expiry, user properties, response topics) are not available.
 - QoS 2 is downgraded to QoS 1 — the full four-step QoS 2 handshake (PUBREC/PUBREL/PUBCOMP) is not implemented.
 - Federation and shovels operate at the AMQP layer. There is no MQTT-level bridging between brokers.
 - AMQP and MQTT components cannot be cross-connected. Exchange-to-exchange bindings between the MQTT exchange and AMQP exchanges are not supported, so an AMQP publisher cannot reach MQTT subscribers (or vice versa) within the same broker.


### PR DESCRIPTION
## What

`docs/mqtt.md` described the broker as implementing only MQTT 3.1.1, though MQTT 3.1.0 (protocol level 3, `MQIsdp`) is also supported. This updates the intro and the Limitations section to list both versions.

## Notes

- The README feature list already links a separate "MQTT 3.1.0 protocol support" entry, so no README change is needed.
- Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)