### PR TITLE
Report negotiated MQTT protocol version in connections

### DIFF
--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -45,6 +45,28 @@ module MqttSpecs
       end
     end
 
+    describe "reports the negotiated protocol version" do
+      it "as MQTT 3.1.1 for protocol level 4" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, version: 0x04u8)
+            client = wait_for { server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first? }.not_nil!
+            client.details_tuple[:protocol].should eq("MQTT 3.1.1")
+          end
+        end
+      end
+
+      it "as MQTT 3.1.0 for protocol level 3" do
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, version: 0x03u8)
+            client = wait_for { server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first? }.not_nil!
+            client.details_tuple[:protocol].should eq("MQTT 3.1.0")
+          end
+        end
+      end
+    end
+
     describe "receives connack" do
       describe "with expected flags set" do
         it "no session present when reconnecting a non-clean session with a clean session [MQTT-3.1.2-6]" do

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -51,7 +51,8 @@ module LavinMQ
           packet.client_id,
           packet.clean_session?,
           packet.keepalive,
-          packet.will)
+          packet.will,
+          packet.version)
         if client.clean_session?
           sessions[client.client_id]?.try &.delete
         else

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -51,7 +51,8 @@ module LavinMQ
                      @client_id : String,
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
-                     @will : Protocol::Will? = nil)
+                     @will : Protocol::Will? = nil,
+                     @protocol_version : UInt8 = 0x04u8)
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
@@ -205,7 +206,7 @@ module LavinMQ
         {
           vhost:             @broker.vhost.name,
           user:              @user.name,
-          protocol:          "MQTT 3.1.1",
+          protocol:          protocol_name,
           client_id:         @client_id,
           name:              @name,
           timeout:           @keepalive,
@@ -216,6 +217,19 @@ module LavinMQ
           cipher:            @connection_info.ssl_cipher,
           client_properties: NamedTuple.new,
         }.merge(current_stats_details)
+      end
+
+      # Maps the CONNECT protocol level byte to a human-readable version,
+      # shown as the connection's protocol in the management API/UI.
+      # Add new protocol levels here as support is introduced
+      # (e.g. 0x05 => "MQTT 5.0").
+      PROTOCOL_NAMES = {
+        0x03u8 => "MQTT 3.1.0", # "MQIsdp"
+        0x04u8 => "MQTT 3.1.1", # "MQTT"
+      }
+
+      private def protocol_name : String
+        PROTOCOL_NAMES.fetch(@protocol_version) { "MQTT #{@protocol_version}" }
       end
 
       def to_json(json : JSON::Builder)


### PR DESCRIPTION
## What

The management API/UI hardcoded every MQTT connection's `protocol` field as `"MQTT 3.1.1"`, so MQTT 3.1.0 clients (protocol level 3, `MQIsdp`) were mislabelled.

This threads the CONNECT packet's version byte through to `MQTT::Client` and maps it to a human-readable name.

## How

- `broker.cr` passes `packet.version` when constructing the client.
- `client.cr` gains a `@protocol_version` param and an extensible `PROTOCOL_NAMES` lookup table (`0x03 => "MQTT 3.1.0"`, `0x04 => "MQTT 3.1.1"`). Adding MQTT 5.0 later is a one-line change; unknown levels fall back to `"MQTT <n>"` rather than crashing.

## Testing

- Added regression specs: a level-4 CONNECT reports `"MQTT 3.1.1"`, a level-3 CONNECT reports `"MQTT 3.1.0"`.
- `make test SPEC=spec/mqtt/integrations/connect_spec.cr` → 21 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)