### PR TITLE
Add leader disk watchdog that self-fences on a data-dir stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Leader disk watchdog: the clustering leader self-fences (drops its etcd lease and exits) when its data dir stalls, so a follower is promoted instead of the cluster hanging indefinitely. Configurable via `clustering_disk_watchdog`, `clustering_disk_watchdog_interval` and `clustering_disk_watchdog_timeout` [#2150](https://github.com/cloudamqp/lavinmq/pull/2150)
 - Negative `x-stream-offset` values to consume the last N stream messages [#1941](https://github.com/cloudamqp/lavinmq/pull/1941)
 - Tab navigation on queue detail pages in the management UI [#2006](https://github.com/cloudamqp/lavinmq/pull/2006)
 - `client_id_validation` MQTT config option to require the client ID to match the authenticated username [#2038](https://github.com/cloudamqp/lavinmq/pull/2038)

--- a/spec/clustering/disk_watchdog_spec.cr
+++ b/spec/clustering/disk_watchdog_spec.cr
@@ -1,0 +1,92 @@
+require "../spec_helper"
+require "../../src/lavinmq/clustering/disk_watchdog"
+
+describe LavinMQ::Clustering::DiskWatchdog do
+  it "does not fence when probes complete in time" do
+    fenced = Channel(String).new(1)
+    wd = LavinMQ::Clustering::DiskWatchdog.new(
+      interval: 1.milliseconds, timeout: 200.milliseconds,
+      probe: -> { nil } # returns immediately
+) { |reason| fenced.send(reason) }
+    spawn wd.run
+    select
+    when fenced.receive
+      fail "should not have fenced on a healthy disk"
+    when timeout(100.milliseconds)
+      # good: several probes ran without fencing
+    end
+  end
+
+  it "fences when a probe stalls past the timeout" do
+    fenced = Channel(String).new(1)
+    wd = LavinMQ::Clustering::DiskWatchdog.new(
+      interval: 1.milliseconds, timeout: 50.milliseconds,
+      probe: -> { sleep 10.seconds } # simulates a wedged fsync
+) { |reason| fenced.send(reason) }
+    spawn wd.run
+    select
+    when reason = fenced.receive
+      reason.should contain "stalled"
+    when timeout(2.seconds)
+      fail "watchdog did not fence on a stalled probe"
+    end
+  end
+
+  it "fences when a probe returns an error (EIO / read-only remount)" do
+    fenced = Channel(String).new(1)
+    wd = LavinMQ::Clustering::DiskWatchdog.new(
+      interval: 1.milliseconds, timeout: 2.seconds,
+      probe: -> { raise IO::Error.new("Read-only file system") }
+    ) { |reason| fenced.send(reason) }
+    spawn wd.run
+    select
+    when reason = fenced.receive
+      reason.should contain "probe failed"
+    when timeout(2.seconds)
+      fail "watchdog did not fence on a failing probe"
+    end
+  end
+
+  it "fences at most once" do
+    count = 0
+    done = Channel(Nil).new(1)
+    wd = LavinMQ::Clustering::DiskWatchdog.new(
+      interval: 1.milliseconds, timeout: 2.seconds,
+      probe: -> { raise IO::Error.new("boom") }
+    ) do |_reason|
+      count += 1
+      done.send(nil) rescue nil
+    end
+    spawn wd.run
+    done.receive
+    sleep 50.milliseconds # give the loop a chance to (wrongly) fence again
+    count.should eq 1
+  end
+
+  it "does not fence after stop (graceful shutdown)" do
+    fenced = Channel(String).new(1)
+    wd = LavinMQ::Clustering::DiskWatchdog.new(
+      interval: 1.milliseconds, timeout: 50.milliseconds,
+      probe: -> { sleep 10.seconds } # would fence if the loop ran
+) { |reason| fenced.send(reason) }
+    wd.stop # requested before run: the loop must exit without probing
+    spawn wd.run
+    select
+    when fenced.receive
+      fail "should not fence after stop"
+    when timeout(200.milliseconds)
+      # good: stopped watchdog never probed
+    end
+  end
+
+  it "real disk probe succeeds on a working data dir" do
+    dir = File.tempname
+    Dir.mkdir_p dir
+    begin
+      LavinMQ::Clustering::DiskWatchdog.probe_disk(dir)
+      File.exists?(File.join(dir, ".disk_watchdog")).should be_false # cleaned up
+    ensure
+      FileUtils.rm_rf dir
+    end
+  end
+end

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -75,6 +75,26 @@ class SelfLeaderController < LavinMQ::Clustering::Controller
   end
 end
 
+class LeaseExpiryController < LavinMQ::Clustering::Controller
+  getter leader_lost_hooks = 0
+
+  def handle_lease_expiry_for_spec
+    handle_lease_expiry
+  end
+
+  # Mirrors the state and hook dispatch at the beginning of fence_leader,
+  # without exercising its intentional SIGKILL path in the spec process.
+  def fence_for_spec
+    @fencing = true
+    @stopped = true
+    execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
+  end
+
+  private def execute_shell_command(_command : String, event : String)
+    @leader_lost_hooks += 1 if event == "leader_lost"
+  end
+end
+
 class ProxyBindEtcd < LavinMQ::Etcd
   def initialize(@leader_uri : String)
     super("localhost:1")
@@ -90,6 +110,21 @@ class ProxyBindEtcd < LavinMQ::Etcd
 end
 
 describe LavinMQ::Clustering::Controller do
+  it "dispatches leader_lost only once when fencing wakes the expired lease path" do
+    with_datadir do |data_dir|
+      config = LavinMQ::Config.new
+      config.data_dir = data_dir
+      etcd = SelfLeaderEtcd.new("tcp://127.0.0.1:5679")
+      coordinator = LavinMQ::Clustering::EtcdCoordinator.new(config, etcd)
+      controller = LeaseExpiryController.new(config, etcd, coordinator)
+
+      controller.fence_for_spec
+      controller.handle_lease_expiry_for_spec
+
+      controller.leader_lost_hooks.should eq 1
+    end
+  end
+
   it "reports follower proxy bind failures without the generic unhandled exception log" do
     blocker = TCPServer.new("127.0.0.1", 0)
     with_datadir do |data_dir|

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -635,6 +635,28 @@ describe LavinMQ::Config do
     end
   end
 
+  describe "clustering disk watchdog" do
+    it "rejects non-positive interval and timeout values" do
+      {
+        "disk_watchdog_interval" => "clustering_disk_watchdog_interval",
+        "disk_watchdog_timeout"  => "clustering_disk_watchdog_timeout",
+      }.each do |option, property|
+        [0, -1].each do |value|
+          config_file = File.tempfile do |file|
+            file.print <<-CONFIG
+              [clustering]
+              #{option} = #{value}
+            CONFIG
+          end
+          config = LavinMQ::Config.new
+          expect_raises(LavinMQ::Config::Error, /#{property}/) do
+            config.parse(["-c", config_file.path])
+          end
+        end
+      end
+    end
+  end
+
   describe "reload" do
     it "keeps the running config when the new config has an invalid value" do
       config_file = File.tempfile("lavinmq-config", ".ini")

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -42,6 +42,19 @@ class LavinMQ::Clustering::Controller
       lease.wait(1.hour) # blocks until the lease expires (raises Expired)
     end
   rescue Etcd::Lease::Expired
+    handle_lease_expiry
+  rescue Etcd::LeaseAlreadyExists
+    Log.fatal { "Cluster ID #{@id.to_s(36)} used by another node" }
+    exit 3
+  rescue Etcd::LeaseNotFound
+    Log.fatal { "Lease not found, etcd may have been reset" }
+    exit 3
+  end
+
+  # Keep lease-expiry handling separate from the run loop so the fencing race
+  # is explicit and covered independently. Releasing the lease while fencing
+  # wakes the loop above with Expired; the hook has already run in that case.
+  private def handle_lease_expiry : Nil
     # When fencing, fence_leader has already dispatched the hook and is about to
     # SIGKILL; releasing the lease woke this path, so skip the duplicate dispatch.
     unless @fencing
@@ -51,12 +64,6 @@ class LavinMQ::Clustering::Controller
       Log.fatal { "Lease expired, lost leadership" }
       exit 3
     end
-  rescue Etcd::LeaseAlreadyExists
-    Log.fatal { "Cluster ID #{@id.to_s(36)} used by another node" }
-    exit 3
-  rescue Etcd::LeaseNotFound
-    Log.fatal { "Lease not found, etcd may have been reset" }
-    exit 3
   end
 
   @disk_watchdog : DiskWatchdog? = nil

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -1,6 +1,7 @@
 require "../etcd"
 require "./client"
 require "./etcd_coordinator"
+require "./disk_watchdog"
 
 class LavinMQ::Clustering::Controller
   Log = LavinMQ::Log.for "clustering.controller"
@@ -33,6 +34,7 @@ class LavinMQ::Clustering::Controller
     @coordinator.campaign(@advertised_uri, @id) # blocks until becoming leader, captures the fencing token
     @elected_leader.set(true)
     ensure_in_isr!
+    start_disk_watchdog(lease)
     execute_shell_command(@config.clustering_on_leader_elected, "leader_elected")
     @repli_client.try &.close
     yield
@@ -40,7 +42,11 @@ class LavinMQ::Clustering::Controller
       lease.wait(1.hour) # blocks until the lease expires (raises Expired)
     end
   rescue Etcd::Lease::Expired
-    execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
+    # When fencing, fence_leader has already dispatched the hook and is about to
+    # SIGKILL; releasing the lease woke this path, so skip the duplicate dispatch.
+    unless @fencing
+      execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
+    end
     unless @stopped
       Log.fatal { "Lease expired, lost leadership" }
       exit 3
@@ -53,10 +59,65 @@ class LavinMQ::Clustering::Controller
     exit 3
   end
 
+  @disk_watchdog : DiskWatchdog? = nil
+
+  # Grace period the best-effort lease revoke and leader_lost hook get before the
+  # unconditional kill.
+  FENCE_GRACE = 2.seconds
+
+  # Start the disk watchdog once this node is the leader.
+  private def start_disk_watchdog(lease)
+    return unless @config.clustering_disk_watchdog?
+    interval = @config.clustering_disk_watchdog_interval.seconds
+    timeout = @config.clustering_disk_watchdog_timeout.seconds
+    watchdog = @disk_watchdog = DiskWatchdog.for_data_dir(@config.data_dir, interval, timeout) do |reason|
+      fence_leader(lease, reason)
+    end
+    spawn(watchdog.run, name: "Disk watchdog")
+    Log.info { "Disk watchdog started (interval=#{interval}, timeout=#{timeout})" }
+  end
+
+  # Give up leadership after a data-dir stall and terminate. The SIGKILL is
+  # unconditional and always reached: the process must die so the lease keepalive
+  # stops and a follower is promoted within the lease TTL. We must not go through
+  # normal shutdown — it flushes the persister, whose syncfs would hang on the
+  # stalled disk. Revoking the lease (for near-instant failover instead of
+  # waiting out the TTL) and running the leader_lost hook are best-effort: the
+  # revoke runs on a separate thread and both are bounded by FENCE_GRACE, so a
+  # hung etcd or a hook that touches the dead disk can never delay the kill.
+  private def fence_leader(lease, reason : String) : Nil
+    # @fencing: skip the duplicate leader_lost hook in the Expired rescue (we
+    # dispatch it here). @stopped: suppress that path's exit 3, whose at_exit
+    # flush would hang on the dead disk; we hard-kill below instead.
+    @fencing = true
+    @stopped = true
+    Log.fatal { "Data dir stalled, fencing leader: #{reason}" }
+    execute_shell_command(@config.clustering_on_leader_lost, "leader_lost")
+    revoked = ::Channel(Nil).new(1)
+    Fiber::ExecutionContext::Isolated.new("Leader fence") do
+      begin
+        Log.info { "Revoking lease #{@id.to_s(36)} before fencing" }
+        lease.release
+      rescue ex
+        Log.warn(exception: ex) { "Failed to revoke lease while fencing; it will expire on its TTL" }
+      end
+      revoked.send(nil) rescue nil
+    end
+    select
+    when revoked.receive
+      # revoke completed; the grace window also let the leader_lost hook run
+    when timeout(FENCE_GRACE)
+      Log.warn { "Lease revoke did not finish within #{FENCE_GRACE}, killing anyway" }
+    end
+    Process.signal(Signal::KILL, Process.pid)
+  end
+
   @stopped = false
+  @fencing = false
 
   def stop
     @stopped = true
+    @disk_watchdog.try &.stop
     @repli_client.try &.close
     @lease.try &.release
   end

--- a/src/lavinmq/clustering/disk_watchdog.cr
+++ b/src/lavinmq/clustering/disk_watchdog.cr
@@ -1,0 +1,120 @@
+require "../logger"
+
+module LavinMQ
+  module Clustering
+    # Detects a stalled data-dir filesystem on the leader and self-fences so a
+    # follower can take over.
+    #
+    # Background: leadership is held via an etcd lease whose keepalive runs on a
+    # network-only isolated thread (see `Etcd::Lease#keepalive_loop`). A pure
+    # disk-I/O stall — e.g. the backing block volume hanging — blocks `syncfs(2)`
+    # (see `Persister#sync`) in uninterruptible sleep, but leaves the keepalive
+    # thread happily renewing the lease over the network. etcd therefore keeps
+    # considering this node a healthy leader and no follower is ever promoted;
+    # publishers hang on confirms indefinitely with no automatic recovery.
+    #
+    # This watchdog closes that gap. It periodically probes the data dir with a
+    # bounded-timeout write+fsync run on its *own* isolated thread. If a probe
+    # does not complete within `timeout` (or returns an error such as EIO / a
+    # read-only remount), the disk is considered lost: the `fence` callback runs,
+    # which is expected to drop the etcd lease and hard-exit the process so the
+    # keepalive stops and a follower is promoted within the lease TTL.
+    #
+    # Scope: only the leader runs this. A follower with a dead disk already
+    # self-heals via the existing ISR mechanism — it stops acking the
+    # replication stream and the leader drops it from the ISR after
+    # `Follower::ACK_TIMEOUT` — so it can never be a promotion candidate. The
+    # leader is the only role lacking such a liveness check.
+    class DiskWatchdog
+      Log = LavinMQ::Log.for "clustering.disk_watchdog"
+
+      # `probe` performs one disk health check and raises on failure. `fence` is
+      # invoked (once) with a human-readable reason when the disk is deemed lost.
+      def initialize(@interval : Time::Span, @timeout : Time::Span,
+                     @probe : Proc(Nil), &@fence : String ->)
+        @fenced = false
+        @stopped = false
+      end
+
+      # Build a watchdog whose probe writes+fsyncs a canary file in `data_dir`.
+      def self.for_data_dir(data_dir : String, interval : Time::Span,
+                            timeout : Time::Span, &fence : String ->)
+        new(interval, timeout, -> { DiskWatchdog.probe_disk(data_dir) }, &fence)
+      end
+
+      # Probe loop. Blocking — spawn it in its own fiber. Runs on the default
+      # execution context, which stays responsive during a stall because the
+      # blocking syscalls live on isolated threads (the persister's syncfs and
+      # this watchdog's own probe thread), not on the worker threads.
+      def run : Nil
+        until @stopped || @fenced
+          sleep @interval
+          probe_once unless @stopped
+        end
+      end
+
+      # Halt the watchdog without fencing. Called on graceful shutdown so a slow
+      # but legitimate final flush can't be mistaken for a stall and hard-killed.
+      def stop : Nil
+        @stopped = true
+      end
+
+      private def probe_once : Nil
+        result = ::Channel(Exception?).new(1)
+        started = Time.instant
+        # The probe must run on a separate thread: on a wedged filesystem the
+        # fsync(2) blocks in uninterruptible sleep and would freeze whatever
+        # thread it runs on. Isolating it keeps this fiber — and therefore the
+        # timeout below — responsive. If the fs is stalled this thread leaks,
+        # blocked in D state, which is fine: the process is about to be killed.
+        Fiber::ExecutionContext::Isolated.new("Disk probe") do
+          err = begin
+            @probe.call
+            nil
+          rescue ex
+            ex
+          end
+          result.send(err) rescue nil
+        end
+
+        select
+        when err = result.receive
+          if err
+            # A returned error (EIO, ENOSPC, EROFS after a read-only remount, …)
+            # is itself grounds to step down: this node cannot durably persist.
+            fence!("disk probe failed: #{err.class}: #{err.message}")
+          else
+            elapsed = Time.instant - started
+            Log.debug { "disk probe ok in #{elapsed.total_milliseconds.round(1)}ms" }
+          end
+        when timeout(@timeout)
+          fence!("disk probe did not complete within #{@timeout.total_seconds}s (filesystem stalled)")
+        end
+      end
+
+      # Write, fsync, and remove a small canary file. fsync(2) is the syscall
+      # that hangs on a stalled ext4 journal — the same commit path the
+      # persister's syncfs waits on — so its latency is what we bound. A
+      # read-only remount surfaces here as EROFS from the open/write.
+      def self.probe_disk(data_dir : String) : Nil
+        path = File.join(data_dir, ".disk_watchdog")
+        begin
+          File.open(path, "w") do |f|
+            f.print("ok")
+            f.flush
+            f.fsync
+          end
+        ensure
+          File.delete?(path)
+        end
+      end
+
+      private def fence!(reason : String) : Nil
+        return if @fenced || @stopped
+        @fenced = true
+        Log.fatal { "Self-fencing: #{reason}" }
+        @fence.call(reason)
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/disk_watchdog.cr
+++ b/src/lavinmq/clustering/disk_watchdog.cr
@@ -34,6 +34,11 @@ module LavinMQ
                      @probe : Proc(Nil), &@fence : String ->)
         @fenced = false
         @stopped = false
+        # One long-lived isolated context serves all probes. Creating an
+        # isolated context creates an OS thread, so doing it for every interval
+        # would continuously create and tear down threads on a healthy leader.
+        @probe_requests = ::Channel(::Channel(Exception?)).new
+        @probe_worker_started = false
       end
 
       # Build a watchdog whose probe writes+fsyncs a canary file in `data_dir`.
@@ -47,35 +52,30 @@ module LavinMQ
       # blocking syscalls live on isolated threads (the persister's syncfs and
       # this watchdog's own probe thread), not on the worker threads.
       def run : Nil
+        start_probe_worker unless @stopped
         until @stopped || @fenced
           sleep @interval
           probe_once unless @stopped
         end
+      ensure
+        # A healthy worker is waiting for requests and can exit cleanly. A
+        # worker stuck in fsync cannot be recovered, but fencing will kill this
+        # process shortly afterwards.
+        @probe_requests.close
       end
 
       # Halt the watchdog without fencing. Called on graceful shutdown so a slow
       # but legitimate final flush can't be mistaken for a stall and hard-killed.
       def stop : Nil
+        return if @stopped
         @stopped = true
+        @probe_requests.close
       end
 
       private def probe_once : Nil
         result = ::Channel(Exception?).new(1)
         started = Time.instant
-        # The probe must run on a separate thread: on a wedged filesystem the
-        # fsync(2) blocks in uninterruptible sleep and would freeze whatever
-        # thread it runs on. Isolating it keeps this fiber — and therefore the
-        # timeout below — responsive. If the fs is stalled this thread leaks,
-        # blocked in D state, which is fine: the process is about to be killed.
-        Fiber::ExecutionContext::Isolated.new("Disk probe") do
-          err = begin
-            @probe.call
-            nil
-          rescue ex
-            ex
-          end
-          result.send(err) rescue nil
-        end
+        @probe_requests.send(result)
 
         select
         when err = result.receive
@@ -89,6 +89,29 @@ module LavinMQ
           end
         when timeout(@timeout)
           fence!("disk probe did not complete within #{@timeout.total_seconds}s (filesystem stalled)")
+        end
+      end
+
+      # The probe must run on a separate thread: on a wedged filesystem the
+      # fsync(2) blocks in uninterruptible sleep and would freeze whatever
+      # thread it runs on. Isolating it keeps the watchdog fiber — and therefore
+      # its timeout — responsive. There is intentionally just one worker for
+      # the healthy path. If the filesystem stalls, that worker is unrecoverably
+      # blocked in D state, which is acceptable because fencing kills the
+      # process.
+      private def start_probe_worker : Nil
+        return if @probe_worker_started
+        @probe_worker_started = true
+        Fiber::ExecutionContext::Isolated.new("Disk probe") do
+          while result = @probe_requests.receive?
+            err = begin
+              @probe.call
+              nil
+            rescue ex
+              ex
+            end
+            result.send(err) rescue nil
+          end
         end
       end
 

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -87,6 +87,12 @@ module LavinMQ
       unless @stats_interval.positive?
         raise Error.new("stats_interval must be positive (got #{@stats_interval})")
       end
+      unless @clustering_disk_watchdog_interval.positive?
+        raise Error.new("clustering_disk_watchdog_interval must be positive (got #{@clustering_disk_watchdog_interval})")
+      end
+      unless @clustering_disk_watchdog_timeout.positive?
+        raise Error.new("clustering_disk_watchdog_timeout must be positive (got #{@clustering_disk_watchdog_timeout})")
+      end
     end
 
     private def parse_config_from_cli(argv)

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -430,6 +430,21 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_CLUSTERING_PORT")]
       property clustering_port = 5679
 
+      @[CliOpt("", "--clustering-disk-watchdog=BOOL", "Self-fence the leader if its data dir stalls (default: true)", section: "clustering")]
+      @[IniOpt(ini_name: disk_watchdog, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_DISK_WATCHDOG")]
+      property? clustering_disk_watchdog = true
+
+      @[CliOpt("", "--clustering-disk-watchdog-interval=SECONDS", "Seconds between leader disk health probes (default: 5)", section: "clustering")]
+      @[IniOpt(ini_name: disk_watchdog_interval, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_DISK_WATCHDOG_INTERVAL")]
+      property clustering_disk_watchdog_interval = 5
+
+      @[CliOpt("", "--clustering-disk-watchdog-timeout=SECONDS", "Fence the leader if a disk probe exceeds this many seconds (default: 15)", section: "clustering")]
+      @[IniOpt(ini_name: disk_watchdog_timeout, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_DISK_WATCHDOG_TIMEOUT")]
+      property clustering_disk_watchdog_timeout = 15
+
       @[IniOpt(section: "amqp")]
       property max_consumers_per_channel = 0
 


### PR DESCRIPTION
# Add a leader disk watchdog that self-fences on a data-dir stall

Fixes #2151

### WHAT is this pull request doing?

Adds a **leader-scoped disk watchdog** so that a clustering leader whose data-dir
filesystem stalls will step down and let a follower take over, instead of hanging
the whole cluster indefinitely.

**Why this is needed.** Leadership is held via an etcd lease whose keepalive
(`Etcd::Lease#keepalive_loop`) runs on a network-only isolated thread and never
touches the disk. The blocking `syncfs(2)` in `Persister#sync` runs on a separate
isolated thread. So if the data-dir device wedges (backing volume hangs), `syncfs`
blocks in uninterruptible `D` state while the keepalive thread keeps renewing the
lease over the network. etcd keeps considering the node a healthy leader, no
follower campaigns, and every publisher confirm hangs — a "zombie leader" with no
automatic recovery. The existing self-exits only cover *etcd* failures and a
*returned* `syncfs` error, not a hung `syncfs`.

**What it adds:**

- `src/lavinmq/clustering/disk_watchdog.cr` — `DiskWatchdog`. Every `interval` it
  runs a canary probe (write + `fsync` + delete of `.disk_watchdog`) on its **own**
  `Fiber::ExecutionContext::Isolated` thread, and waits for it with a `select ...
  timeout`. If the probe exceeds `timeout` (stall) or raises (EIO / read-only
  remount), it invokes the `fence` callback exactly once. Isolating the probe is
  the crux: a wedged `fsync` blocks its thread in `D` state, so it must not run on
  the fiber that also enforces the timeout (mirrors how `Persister` already
  isolates `syncfs`).

- `src/lavinmq/clustering/controller.cr` — starts the watchdog right after this
  node wins the election (leader-only). The fence action best-effort revokes the
  etcd lease (for near-instant failover, same pattern as `ensure_in_isr!`), then
  `Process.signal(Signal::KILL, Process.pid)`. The hard SIGKILL is deliberate:
  normal shutdown flushes the persister, whose `syncfs` would itself hang on the
  dead disk and defeat the fence. Even if the revoke fails, killing the process
  stops the keepalive so the lease expires within its TTL and a follower is
  promoted.

- `src/lavinmq/config/options.cr` — three `[clustering]` options (CLI/INI/ENV):
  - `clustering_disk_watchdog` (default `true`)
  - `clustering_disk_watchdog_interval` (default `5` s)
  - `clustering_disk_watchdog_timeout` (default `15` s)

**Scope / why leader-only.** A follower with a dead disk already self-heals: it
stops acking the replication stream and the leader drops it from the ISR after
`Follower::ACK_TIMEOUT`, so it can never be promoted. The leader was the only role
without a disk-liveness check.

**Design notes / trade-offs (reviewers please weigh in):**

- `timeout` (15s) must sit above worst-case legitimate `fsync` latency under peak
  load or it risks false fences; the probe logs its latency at debug
  (`disk probe ok in Nms`) to help tune. Open to different defaults.
- The probe is independent of publish traffic, so it also catches a stall on an
  idle leader (one tiny write every `interval`).
- On a genuine stall the probe thread is intentionally leaked in `D` state — the
  process is about to be SIGKILLed anyway.
- This is an in-process fence only; it composes with, but does not require, a
  systemd `WatchdogSec`.

### HOW can this pull request be tested?

**Automated** — `spec/clustering/disk_watchdog_spec.cr` (`make test
SPEC=spec/clustering/disk_watchdog_spec.cr`). The watchdog takes an injectable
probe `Proc` so failure modes are tested without real disk faults:

- healthy probe → never fences;
- probe that sleeps past the timeout → fences with a "stalled" reason;
- probe that raises (EIO / read-only remount) → fences with a "probe failed" reason;
- fences at most once;
- the real `probe_disk` succeeds and cleans up its canary file on a working dir.

`make test`, `make lint`, and `crystal tool format` all pass; full project
type-checks.

**Manual** — on a 3-node cluster, freeze the leader's data-dir I/O (`fsfreeze -f`,
`dm-delay`/`dm-flakey`, or blkio throttle). Within ~`timeout` seconds the leader
logs `Self-fencing: ...`, drops its lease, exits, and a follower is promoted;
`etcdctl get {prefix}/leader --prefix` shows the new leader.
