### PR TITLE
Use mqtt-protocol 0.3.1 to get rid of shard version warning

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -18,7 +18,7 @@ shards:
 
   mqtt-protocol:
     git: https://github.com/84codes/mqtt-protocol.cr.git
-    version: 0.3.0
+    version: 0.3.1
 
   systemd:
     git: https://github.com/84codes/systemd.cr.git


### PR DESCRIPTION
### WHAT is this pull request doing?
Installing shards gives warning: `W: Shard "mqtt-protocol" version (0.2.0) doesn't match tag version (0.3.0)`

This is fixed in mqtt-protocol 0.3.1.

### HOW can this pull request be tested?
Specs, but this doesn't really change anything
