### PR TITLE
Bugfix: sessions' bindings are lost on restart

### DIFF
--- a/.github/rabbit-hole.patch
+++ b/.github/rabbit-hole.patch
@@ -90,13 +90,25 @@ index c3130ee..1888a2f 100644
  
  	return res, nil
 diff --git a/rabbithole_test.go b/rabbithole_test.go
-index 6aea41d..02190a4 100644
+index 6aea41d..47f02f6 100644
 --- a/rabbithole_test.go
 +++ b/rabbithole_test.go
-@@ -112,6 +112,18 @@ func mediumSleep() {
+@@ -112,6 +112,30 @@ func mediumSleep() {
  	time.Sleep(time.Duration(1100) * time.Millisecond)
  }
  
++// LavinMQ has an mqtt exchange in every vhost that RabbitMQ doesn't have, and it
++// is listed before the default exchange.
++func withoutMQTTExchanges(xs []ExchangeInfo) []ExchangeInfo {
++	res := make([]ExchangeInfo, 0, len(xs))
++	for _, x := range xs {
++		if x.Type != "mqtt" {
++			res = append(res, x)
++		}
++	}
++	return res
++}
++
 +func ensureTestVhost(rmqc *Client) {
 +	_, err := rmqc.GetVhost("rabbit/hole")
 +	if err != nil {
@@ -112,7 +124,7 @@ index 6aea41d..02190a4 100644
  type portTestStruct struct {
  	Port Port `json:"port"`
  }
-@@ -128,6 +140,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -128,6 +152,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  
  	BeforeEach(func() {
  		rmqc, _ = NewClient("http://127.0.0.1:15672", "guest", "guest")
@@ -120,7 +132,7 @@ index 6aea41d..02190a4 100644
  	})
  
  	Context("GET /overview", func() {
-@@ -404,7 +417,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -404,7 +429,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -129,8 +141,11 @@ index 6aea41d..02190a4 100644
  		It("Set cluster name", func() {
  			previousClusterName, err := rmqc.GetClusterName()
  			Ω(err).Should(BeNil())
-@@ -722,7 +735,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -720,9 +745,10 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+ 		It("returns decoded response", func() {
+ 			xs, err := rmqc.ListExchanges()
  			Ω(err).Should(BeNil())
++			xs = withoutMQTTExchanges(xs)
  
  			x := xs[0]
 -			Ω(x.Name).Should(Equal(""))
@@ -138,8 +153,11 @@ index 6aea41d..02190a4 100644
  			Ω(x.Durable).Should(Equal(true))
  		})
  	})
-@@ -733,7 +746,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -731,9 +757,10 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+ 		It("returns decoded response", func() {
+ 			xs, err := rmqc.ListExchangesIn("/")
  			Ω(err).Should(BeNil())
++			xs = withoutMQTTExchanges(xs)
  
  			x := xs[0]
 -			Ω(x.Name).Should(Equal(""))
@@ -147,7 +165,7 @@ index 6aea41d..02190a4 100644
  			Ω(x.Durable).Should(Equal(true))
  		})
  	})
-@@ -836,9 +849,9 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -836,9 +863,9 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			Ω(q.Name).ShouldNot(Equal(""))
  			Ω(q.Node).ShouldNot(BeNil())
  			Ω(q.Durable).ShouldNot(BeNil())
@@ -160,7 +178,7 @@ index 6aea41d..02190a4 100644
  		})
  	})
  
-@@ -883,9 +896,9 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -883,9 +910,9 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			Ω(q.Node).ShouldNot(BeNil())
  			Ω(q.Vhost).Should(Equal(vh))
  			Ω(q.Durable).ShouldNot(BeNil())
@@ -173,7 +191,7 @@ index 6aea41d..02190a4 100644
  
  			rmqc.DeleteQueue(vh, qn)
  		})
-@@ -1463,7 +1476,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -1463,7 +1490,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  
  				Ω(x.Name).Should(BeEquivalentTo(vh))
  				Ω(x.Description).Should(BeEquivalentTo("rabbit/hole3 vhost"))
@@ -182,7 +200,7 @@ index 6aea41d..02190a4 100644
  				Ω(x.Tags).Should(Equal(tags))
  				Ω(x.Tracing).Should(Equal(false))
  
-@@ -1497,7 +1510,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -1497,7 +1524,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  
  			x2, err := rmqc.GetVhost(vh)
  			Ω(x2).Should(BeNil())
@@ -191,7 +209,7 @@ index 6aea41d..02190a4 100644
  		})
  	})
  
-@@ -1585,7 +1598,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -1585,7 +1612,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -200,7 +218,7 @@ index 6aea41d..02190a4 100644
  		maxConnections := 1
  		maxChannels := 2
  
-@@ -1758,11 +1771,11 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -1758,11 +1785,11 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				},
  			}
  
@@ -214,7 +232,7 @@ index 6aea41d..02190a4 100644
  
  			Eventually(func(g Gomega) []BindingInfo {
  				xs, _ := rmqc.ListQueueBindings(vh, qn)
-@@ -1781,7 +1794,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -1781,7 +1808,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			Ω(b.Destination).Should(Equal(info.Destination))
  			Ω(b.DestinationType).Should(Equal(info.DestinationType))
  			Ω(b.RoutingKey).Should(Equal(info.RoutingKey))
@@ -223,7 +241,7 @@ index 6aea41d..02190a4 100644
  
  			_, err = rmqc.DeleteBinding(vh, b)
  			Ω(err).Should(BeNil())
-@@ -1964,7 +1977,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -1964,7 +1991,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -232,7 +250,7 @@ index 6aea41d..02190a4 100644
  		It("adds a binding to an exchange", func() {
  			vh := "rabbit/hole"
  			xn := "test.bindings.post.exchange"
-@@ -2016,7 +2029,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2016,7 +2043,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -241,7 +259,7 @@ index 6aea41d..02190a4 100644
  		It("deletes an individual exchange binding", func() {
  			vh := "rabbit/hole"
  			xn := "test.bindings.post.exchange"
-@@ -2173,7 +2186,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2173,7 +2200,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -250,7 +268,7 @@ index 6aea41d..02190a4 100644
  		It("returns decoded response", func() {
  			u := "temporary"
  
-@@ -2207,7 +2220,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2207,7 +2234,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -259,7 +277,7 @@ index 6aea41d..02190a4 100644
  		It("returns decoded response", func() {
  			u := "temporary"
  
-@@ -2241,7 +2254,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2241,7 +2268,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -268,7 +286,7 @@ index 6aea41d..02190a4 100644
  		It("updates topic permissions", func() {
  			u := "temporary"
  
-@@ -2271,7 +2284,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2271,7 +2298,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -277,7 +295,7 @@ index 6aea41d..02190a4 100644
  		It("clears topic permissions", func() {
  			u := "temporary"
  
-@@ -2306,7 +2319,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2306,7 +2333,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -286,7 +304,7 @@ index 6aea41d..02190a4 100644
  		It("deletes one topic permissions", func() {
  			u := "temporary"
  
-@@ -2853,14 +2866,14 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2853,14 +2880,14 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				policy1 := OperatorPolicy{
  					Pattern:    "abc",
  					ApplyTo:    "queues",
@@ -303,7 +321,7 @@ index 6aea41d..02190a4 100644
  					Priority:   0,
  				}
  
-@@ -2912,14 +2925,14 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2912,14 +2939,14 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				policy1 := OperatorPolicy{
  					Pattern:    "abc",
  					ApplyTo:    "queues",
@@ -320,7 +338,7 @@ index 6aea41d..02190a4 100644
  					Priority:   0,
  				}
  
-@@ -2983,7 +2996,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -2983,7 +3010,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				policy := OperatorPolicy{
  					Pattern:    ".*",
  					ApplyTo:    "queues",
@@ -329,7 +347,7 @@ index 6aea41d..02190a4 100644
  					Priority:   0,
  				}
  
-@@ -3009,7 +3022,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3009,7 +3036,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				Ω(pol.Priority).Should(BeEquivalentTo(0))
  				Ω(pol.Definition).Should(BeAssignableToTypeOf(PolicyDefinition{}))
  				Ω(pol.Definition["expires"]).Should(BeEquivalentTo(100))
@@ -337,7 +355,7 @@ index 6aea41d..02190a4 100644
  
  				_, err = rmqc.DeleteOperatorPolicy(vh, name)
  				Ω(err).Should(BeNil())
-@@ -3037,7 +3049,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3037,7 +3063,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			policy := OperatorPolicy{
  				Pattern:    ".*",
  				ApplyTo:    "queues",
@@ -346,7 +364,7 @@ index 6aea41d..02190a4 100644
  				Priority:   0,
  			}
  
-@@ -3073,7 +3085,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3073,7 +3099,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				ApplyTo: "all",
  				Definition: PolicyDefinition{
  					"expires":          100,
@@ -354,7 +372,7 @@ index 6aea41d..02190a4 100644
  					"max-length-bytes": 100000,
  				},
  				Priority: 0,
-@@ -3101,7 +3112,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3101,7 +3126,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			policy := OperatorPolicy{
  				Pattern:    ".*",
  				ApplyTo:    "queues",
@@ -363,7 +381,7 @@ index 6aea41d..02190a4 100644
  			}
  
  			vh := "rabbit/hole"
-@@ -3127,7 +3138,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3127,7 +3152,6 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			Ω(pol.ApplyTo).Should(Equal("queues"))
  			Ω(pol.Priority).Should(BeEquivalentTo(0))
  			Ω(pol.Definition).Should(BeAssignableToTypeOf(PolicyDefinition{}))
@@ -371,7 +389,7 @@ index 6aea41d..02190a4 100644
  			Ω(pol.Definition["expires"]).Should(BeEquivalentTo(100))
  
  			// update the policy
-@@ -3178,7 +3188,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3178,7 +3202,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -380,7 +398,7 @@ index 6aea41d..02190a4 100644
  		Context("when there are no upstreams", func() {
  			It("returns an empty response", func() {
  				Eventually(func(g Gomega) []FederationUpstream {
-@@ -3244,7 +3254,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3244,7 +3268,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -389,7 +407,7 @@ index 6aea41d..02190a4 100644
  		Context("when there are no upstreams", func() {
  			It("returns an empty response", func() {
  				vh := "rabbit/hole"
-@@ -3316,7 +3326,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3316,7 +3340,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -398,7 +416,7 @@ index 6aea41d..02190a4 100644
  		Context("when the upstream does not exist", func() {
  			It("returns a 404 error", func() {
  				vh := "rabbit/hole"
-@@ -3375,7 +3385,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3375,7 +3399,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -407,7 +425,7 @@ index 6aea41d..02190a4 100644
  		Context("when the upstream does not exist", func() {
  			It("creates the upstream", func() {
  				vh := "rabbit/hole"
-@@ -3540,7 +3550,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3540,7 +3564,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -416,7 +434,7 @@ index 6aea41d..02190a4 100644
  		Context("when the upstream does not exist", func() {
  			It("returns a 404 error response", func() {
  				vh := "rabbit/hole"
-@@ -3600,7 +3610,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3600,7 +3624,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -425,7 +443,7 @@ index 6aea41d..02190a4 100644
  		Context("when there are no links", func() {
  			It("returns an empty response", func() {
  				list, err := rmqc.ListFederationLinksIn("rabbit/hole")
-@@ -3677,7 +3687,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -3677,7 +3701,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -434,7 +452,7 @@ index 6aea41d..02190a4 100644
  		It("declares a shovel using AMQP 1.0 protocol", func() {
  			vh := "rabbit/hole"
  			sn := "temporary"
-@@ -4035,7 +4045,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -4035,7 +4059,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  		})
  	})
  
@@ -443,7 +461,7 @@ index 6aea41d..02190a4 100644
  		It("lists and enables feature flags", func() {
  			By("GET /feature-flags")
  			featureFlags, err := rmqc.ListFeatureFlags()
-@@ -4131,19 +4141,27 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -4131,19 +4155,27 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  			Ω(*defs.Policies).ShouldNot(BeNil())
  		})
  
@@ -472,7 +490,7 @@ index 6aea41d..02190a4 100644
  		})
  	})
  
-@@ -4206,10 +4224,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -4206,10 +4238,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  				list, err := rmqc.ListGlobalParameters()
  				Ω(err).Should(BeNil())
  				Ω(list).To(SatisfyAll(
@@ -484,7 +502,7 @@ index 6aea41d..02190a4 100644
  					ContainElements(
  						GlobalRuntimeParameter{
  							Name:  "a-name",
-@@ -4232,10 +4247,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
+@@ -4232,10 +4261,7 @@ var _ = Describe("RabbitMQ HTTP API client", func() {
  					Ω(err).Should(BeNil())
  
  					return len(xs)

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -91,6 +91,32 @@ describe LavinMQ::GlobalDefinitions do
       end
     end
 
+    it "imports bindings with the mqtt exchange as source" do
+      defs = {
+        "queues" => [
+          {"name" => "mqtt.sub", "vhost" => "/", "durable" => true, "auto_delete" => false,
+           "arguments" => {"x-queue-type" => "mqtt"}},
+        ],
+        "bindings" => [
+          {"source" => "mqtt.default", "vhost" => "/", "destination" => "mqtt.sub",
+           "destination_type" => "queue", "routing_key" => "a/b", "arguments" => {} of String => String},
+        ],
+      }
+      tmpfile = File.tempname("lavinmq-defs", ".json")
+      File.write(tmpfile, defs.to_json)
+      begin
+        with_amqp_server do |s|
+          # Nothing has created an MQTT broker at this point, just like in
+          # Launcher#start where definitions are loaded before MQTT::Server
+          LavinMQ::GlobalDefinitions.import_from_file(tmpfile, s)
+          exchange = s.vhosts["/"].mqtt_exchange
+          exchange.bindings_details.map(&.binding_key.routing_key).should eq ["a/b"]
+        end
+      ensure
+        File.delete?(tmpfile)
+      end
+    end
+
     it "raises if definitions file not found" do
       with_amqp_server do |s|
         expect_raises(File::NotFoundError) do

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -262,11 +262,12 @@ describe LavinMQ::Clustering::Client, tags: %w[etcd slow] do
       # written to socket, meaning that the lag_size has changed.
       wait_for { replicator.followers.first?.try &.lag_in_bytes == 0 }
 
-      props = LavinMQ::AMQP::Properties.new
-      msg1 = LavinMQ::Message.new(100, "test", "rk", props, 5, IO::Memory.new("body1"))
-      msg2 = LavinMQ::Message.new(100, "test", "rk", props, 5, IO::Memory.new("body2"))
-      retain_store.retain("topic1", msg1.body_io, msg1.bodysize)
-      retain_store.retain("topic2", msg2.body_io, msg2.bodysize)
+      pub1 = MQTT::Protocol::Publish.new(topic: "topic1", payload: "body1".to_slice,
+        packet_id: nil, dup: false, qos: 0u8, retain: true)
+      pub2 = MQTT::Protocol::Publish.new(topic: "topic2", payload: "body2".to_slice,
+        packet_id: nil, dup: false, qos: 0u8, retain: true)
+      retain_store.retain(pub1)
+      retain_store.retain(pub2)
 
       wait_for { replicator.followers.first?.try &.lag_in_bytes == 0 }
       cluster.stop

--- a/spec/message_routing_spec.cr
+++ b/spec/message_routing_spec.cr
@@ -535,14 +535,11 @@ module MessageRoutingSpec
         vhost = s.vhosts.create("x")
         q1 = LavinMQ::QueueFactory.make(vhost, "q1")
         s1 = LavinMQ::QueueFactory.make(vhost, "q1", arguments: LavinMQ::AMQP::Table.new({"x-queue-type": "mqtt"}))
-        index = LavinMQ::MQTT::TopicTree(String).new
-        store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        x = LavinMQ::MQTT::Exchange.new(vhost, "", store)
+        x = LavinMQ::MQTT::Exchange.new(vhost, "")
         x.bind(s1, "s1", LavinMQ::AMQP::Table.new)
         expect_raises(LavinMQ::Exchange::AccessRefused) do
           x.bind(q1, "q1", LavinMQ::AMQP::Table.new)
         end
-        store.close
       end
     end
   end

--- a/spec/mqtt/consts_spec.cr
+++ b/spec/mqtt/consts_spec.cr
@@ -19,4 +19,35 @@ describe LavinMQ::MQTT do
       LavinMQ::MQTT.qos_arguments(1u8)[LavinMQ::MQTT::QOS_HEADER].should eq 1u8
     end
   end
+
+  describe ".qos" do
+    it "reads the QoS back from the arguments of qos_arguments" do
+      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(0u8)).should eq 0u8
+      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(1u8)).should eq 1u8
+      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(2u8)).should eq 1u8
+    end
+
+    it "grants QoS 2 as QoS 1" do
+      arguments = LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2u8})
+      LavinMQ::MQTT.qos(arguments).should eq 1u8
+    end
+
+    it "accepts any integer type, not just UInt8" do
+      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 1})).should eq 1u8
+      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2i64})).should eq 1u8
+    end
+
+    it "is QoS 0 without arguments" do
+      LavinMQ::MQTT.qos(nil).should eq 0u8
+      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new).should eq 0u8
+    end
+
+    it "is QoS 0 for a non-integer value" do
+      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => "1"})).should eq 0u8
+    end
+
+    it "is QoS 0 for a negative value" do
+      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => -1})).should eq 0u8
+    end
+  end
 end

--- a/spec/mqtt/exchange_spec.cr
+++ b/spec/mqtt/exchange_spec.cr
@@ -22,6 +22,30 @@ module MqttSpecs
       end
     end
 
+    it "grants a QoS 2 subscription bound from outside the MQTT protocol as QoS 1" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        exchange = vhost.mqtt_exchange
+        vhost.declare_queue("mqtt.sub", true, false,
+          LavinMQ::AMQP::Table.new({"x-queue-type" => "mqtt"}))
+
+        # Bindings made over the HTTP API or imported from a definitions file don't
+        # pass through the MQTT parser, so the QoS header is any integer here.
+        vhost.bind_queue("mqtt.sub", LavinMQ::MQTT::EXCHANGE, "a/b",
+          LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2}))
+
+        binding = exchange.bindings_details.first
+        binding.binding_key.qos.should eq 1u8
+        binding.arguments.should eq LavinMQ::MQTT::QOS1_ARGUMENTS
+
+        # bind and unbind must read the QoS the same way, or the unbind wouldn't
+        # match the binding it's meant to remove
+        vhost.unbind_queue("mqtt.sub", LavinMQ::MQTT::EXCHANGE, "a/b",
+          LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2}))
+        exchange.bindings_details.should be_empty
+      end
+    end
+
     it "exposes subscriptions as MQTT::SubscriptionDetails sharing the binding details interface" do
       with_server do |server|
         exchange = server.vhosts["/"].exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)

--- a/spec/mqtt/integrations/retain_store_spec.cr
+++ b/spec/mqtt/integrations/retain_store_spec.cr
@@ -14,9 +14,7 @@ module MqttSpecs
       it "adds to index and writes msg file" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        props = LavinMQ::AMQP::Properties.new
-        msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
-        store.retain("a", msg.body_io, msg.bodysize)
+        store.retain(publish_packet(topic: "a", payload: "body".to_slice, retain: true))
 
         index.size.should eq(1)
         index.@leafs.has_key?("a").should be_true
@@ -30,14 +28,12 @@ module MqttSpecs
       it "empty body deletes" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        props = LavinMQ::AMQP::Properties.new
-        msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
 
-        store.retain("a", msg.body_io, msg.bodysize)
+        store.retain(publish_packet(topic: "a", payload: "body".to_slice, retain: true))
         index.size.should eq(1)
         entry = index["a"]?.should be_a String
 
-        store.retain("a", msg.body_io, 0)
+        store.retain(publish_packet(topic: "a", payload: Bytes.empty, retain: true))
         index.size.should eq(0)
         File.exists?(File.join("tmp/retain_store", entry)).should be_false
       ensure
@@ -49,9 +45,7 @@ module MqttSpecs
       it "can be called multiple times" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        props = LavinMQ::AMQP::Properties.new
-        msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
-        store.retain("a", msg.body_io, msg.bodysize)
+        store.retain(publish_packet(topic: "a", payload: "body".to_slice, retain: true))
         10.times do
           store.each("a") do |_topic, body_io, body_bytesize|
             body = Bytes.new(body_bytesize)
@@ -66,11 +60,8 @@ module MqttSpecs
       it "calls block with correct arguments" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        props = LavinMQ::AMQP::Properties.new
-        msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
-        store.retain("a", msg.body_io, msg.bodysize)
-        msg.body_io.rewind
-        store.retain("b", msg.body_io, msg.bodysize)
+        store.retain(publish_packet(topic: "a", payload: "body".to_slice, retain: true))
+        store.retain(publish_packet(topic: "b", payload: "body".to_slice, retain: true))
 
         called = [] of Tuple(String, Bytes)
         store.each("a") do |topic, body_io, body_bytesize|
@@ -89,11 +80,8 @@ module MqttSpecs
       it "handles multiple subscriptions" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        props = LavinMQ::AMQP::Properties.new
-        msg1 = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
-        msg2 = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
-        store.retain("a", msg1.body_io, msg1.bodysize)
-        store.retain("b", msg2.body_io, msg2.bodysize)
+        store.retain(publish_packet(topic: "a", payload: "body".to_slice, retain: true))
+        store.retain(publish_packet(topic: "b", payload: "body".to_slice, retain: true))
 
         called = [] of Tuple(String, Bytes)
         store.each("a") do |topic, body_io, body_bytesize|
@@ -121,10 +109,8 @@ module MqttSpecs
       it "restores the index from a file" do
         index = IndexTree.new
         store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-        props = LavinMQ::AMQP::Properties.new
-        msg = LavinMQ::Message.new(100, "test", "rk", props, 4, IO::Memory.new("body"))
 
-        store.retain("a", msg.body_io, msg.bodysize)
+        store.retain(publish_packet(topic: "a", payload: "body".to_slice, retain: true))
         store.close
 
         new_index = IndexTree.new
@@ -138,10 +124,8 @@ module MqttSpecs
     it "survives a restart" do
       index = IndexTree.new
       store = LavinMQ::MQTT::RetainStore.new("tmp/retain_store", nil, index)
-      props = LavinMQ::AMQP::Properties.new
-      msg = LavinMQ::Message.new(100, "test", "topic", props, 4, IO::Memory.new("body"))
 
-      store.retain("topic", msg.body_io, msg.bodysize)
+      store.retain(publish_packet(topic: "topic", payload: "body".to_slice, retain: true))
       store.close
 
       # Reopen

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -198,5 +198,20 @@ module MqttSpecs
         exchange.bindings_details.map(&.binding_key.routing_key).should eq ["a/b"]
       end
     end
+
+    it "does not restore an unsubscribed topic after a restart" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "sub", clean_session: false)
+          subscribe(io, topic_filters: [subtopic("a/b", 0u8)])
+          unsubscribe(io, ["a/b"])
+          disconnect(io)
+        end
+
+        restart_server(server)
+
+        server.vhosts["/"].mqtt_exchange.bindings_details.should be_empty
+      end
+    end
   end
 end

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -181,5 +181,22 @@ module MqttSpecs
         end
       end
     end
+
+    it "keeps the subscriptions of a persistent session after a restart" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "sub", clean_session: false)
+          subscribe(io, topic_filters: [subtopic("a/b", 0u8)])
+          disconnect(io)
+        end
+
+        restart_server(server)
+
+        vhost = server.vhosts["/"]
+        vhost.session?("mqtt.sub").should_not be_nil
+        exchange = vhost.exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
+        exchange.bindings_details.map(&.binding_key.routing_key).should eq ["a/b"]
+      end
+    end
   end
 end

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -101,7 +101,7 @@ module MqttHelpers
     MQTT::Protocol::Subscribe::TopicFilter.new(topic, qos.to_u8)
   end
 
-  def publish(io, expect_response = true, **args)
+  def publish_packet(**args) : MQTT::Protocol::Publish
     pub_args = {
       packet_id: next_packet_id,
       payload:   "data".to_slice,
@@ -109,8 +109,13 @@ module MqttHelpers
       qos:       0u8,
       retain:    false,
     }.merge(args)
-    MQTT::Protocol::Publish.new(**pub_args).to_io(io)
-    MQTT::Protocol::PubAck.from_io(io) if pub_args[:qos].positive? && expect_response
+    MQTT::Protocol::Publish.new(**pub_args)
+  end
+
+  def publish(io, expect_response = true, **args)
+    packet = publish_packet(**args)
+    packet.to_io(io)
+    MQTT::Protocol::PubAck.from_io(io) if packet.qos.positive? && expect_response
   end
 
   def puback(io, packet_id : UInt16?)

--- a/spec/vhost_spec.cr
+++ b/spec/vhost_spec.cr
@@ -132,6 +132,25 @@ describe LavinMQ::VHost do
       s.vhosts["/"].queue?("mqtt.persist").should be_nil
     end
   end
+
+  it "should keep durable mqtt session bindings after compaction and restart" do
+    with_amqp_server do |s|
+      LavinMQ::Config.instance.max_deleted_definitions = 8
+      v = s.vhosts["/"]
+      v.declare_queue("mqtt.persist", true, false, LavinMQ::AMQP::Table.new({"x-queue-type" => "mqtt"}))
+      v.bind_queue("mqtt.persist", LavinMQ::MQTT::EXCHANGE, "a/b",
+        LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 1u8}))
+      LavinMQ::Config.instance.max_deleted_definitions.times do
+        v.declare_queue("q", true, false)
+        v.delete_queue("q")
+      end
+      restart_server(s)
+      bindings = s.vhosts["/"].mqtt_exchange.bindings_details
+      bindings.map(&.binding_key.routing_key).should eq ["a/b"]
+      bindings.first.arguments.try &.[](LavinMQ::MQTT::QOS_HEADER).should eq 1u8
+    end
+  end
+
   describe "auto add permissions" do
     it "should add permission to the user creating the vhost" do
       with_amqp_server do |s|

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -4,6 +4,7 @@ require "./event_type"
 require "./queue_factory"
 require "./amqp/exchange/*"
 require "./amqp/queue"
+require "./mqtt/exchange"
 
 module LavinMQ
   class DefinitionsStore
@@ -11,10 +12,18 @@ module LavinMQ
 
     @definitions_file : File
 
+    # The vhost's MQTT exchange. Created with the store rather than declared, so
+    # that it's always there when frames are applied — bindings with it as
+    # source would be dropped otherwise. It isn't durable, which is what keeps
+    # it out of the definitions file.
+    getter mqtt_exchange : MQTT::Exchange
+
     def initialize(@vhost : VHost, @data_dir : String, @replicator : Clustering::Replicator?, @log : Logger)
       @exchanges = Hash(String, Exchange).new
       @queues = Hash(String, AMQP::Queue).new
       @sessions = Hash(String, MQTT::Session).new
+      @mqtt_exchange = MQTT::Exchange.new(@vhost, MQTT::EXCHANGE)
+      @exchanges[MQTT::EXCHANGE] = @mqtt_exchange
       @definitions_lock = Mutex.new(:reentrant)
       @definitions_file_path = File.join(@data_dir, "definitions.amqp")
       # Unbuffered (sync) writes: replication offsets (store_definition) and a
@@ -216,16 +225,23 @@ module LavinMQ
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || @sessions[f.queue_name]? || return false
           return false unless x.bind(q, f.routing_key, f.arguments)
-          store_definition(f, fsync: fsync) if !loading && x.durable? && q.durable? && !q.exclusive?
+          store_definition(f, fsync: fsync) if !loading && persist_binding?(x, q)
         when AMQP::Frame::Queue::Unbind
           x = @exchanges[f.exchange_name]? || return false
           q = @queues[f.queue_name]? || @sessions[f.queue_name]? || return false
           return false unless x.unbind(q, f.routing_key, f.arguments)
-          store_definition(f, dirty: true) if !loading && x.durable? && q.durable? && !q.exclusive?
+          store_definition(f, dirty: true) if !loading && persist_binding?(x, q)
         else raise "Cannot apply frame #{f.class} in vhost #{@vhost.name}"
         end
         true
       end
+    end
+
+    # Bindings are stored so they can be restored on boot. The MQTT exchange is
+    # not durable — it's created with the store, never declared — but bindings
+    # from durable sessions to it must survive a restart.
+    private def persist_binding?(x : Exchange, q : Queue) : Bool
+      q.durable? && !q.exclusive? && (x.durable? || x.same?(@mqtt_exchange))
     end
 
     def queue_bindings(queue : Queue)
@@ -337,6 +353,8 @@ module LavinMQ
         # @definitions_file after the rename.
         io = File.open("#{@definitions_file_path}.tmp", "a+").tap &.sync = true
         SchemaVersion.prefix(io, :definition)
+        # Durable only, which is what keeps the MQTT exchange out: it's created
+        # with the store, and `make_exchange` can't build its type from a frame.
         @exchanges.each_value.select(&.durable?).each do |e|
           f = AMQP::Frame::Exchange::Declare.new(0_u16, 0_u16, e.name, e.type,
             false, e.durable?, e.auto_delete?, e.internal?,
@@ -353,16 +371,23 @@ module LavinMQ
             s.auto_delete?, false, s.arguments)
           io.write_bytes f
         end
-        @exchanges.each_value.select(&.durable?).each do |e|
+        # Not filtered on the source being durable: the bindings written here
+        # are the ones the incremental path in `apply` would have stored, which
+        # includes bindings from durable sessions to the (non-durable) MQTT exchange.
+        @exchanges.each_value do |e|
           e.bindings_details.each do |binding|
             args = binding.arguments || AMQP::Table.new
-            frame = case binding.destination
+            frame = case d = binding.destination
                     when Queue
-                      AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
+                      if persist_binding?(e, d)
+                        AMQP::Frame::Queue::Bind.new(0_u16, 0_u16, d.name, e.name,
+                          binding.routing_key, false, args)
+                      end
                     when Exchange
-                      AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, binding.destination.name, e.name,
-                        binding.routing_key, false, args)
+                      if e.durable? && d.durable?
+                        AMQP::Frame::Exchange::Bind.new(0_u16, 0_u16, d.name, e.name,
+                          binding.routing_key, false, args)
+                      end
                     end
             if f = frame
               io.write_bytes f

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -26,7 +26,7 @@ module LavinMQ
         @sessions = Sessions.new(@vhost)
         @clients = Hash(String, Client).new
         @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @vhost.replicator)
-        @exchange = MQTT::Exchange.new(@vhost, EXCHANGE, @retain_store)
+        @exchange = MQTT::Exchange.new(@vhost, EXCHANGE)
         @vhost.register_exchange(@exchange)
       end
 
@@ -88,6 +88,7 @@ module LavinMQ
       end
 
       def publish(packet : Protocol::Publish)
+        @retain_store.retain(packet) if packet.retain?
         @exchange.publish(packet)
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -26,8 +26,7 @@ module LavinMQ
         @sessions = Sessions.new(@vhost)
         @clients = Hash(String, Client).new
         @retain_store = RetainStore.new(File.join(@vhost.data_dir, "mqtt_retained_store"), @vhost.replicator)
-        @exchange = MQTT::Exchange.new(@vhost, EXCHANGE)
-        @vhost.register_exchange(@exchange)
+        @exchange = @vhost.mqtt_exchange
       end
 
       def session_present?(client_id : String, clean_session) : Bool

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -16,5 +16,17 @@ module LavinMQ
     def self.qos_arguments(qos : UInt8) : AMQP::Table
       qos.zero? ? QOS0_ARGUMENTS : QOS1_ARGUMENTS
     end
+
+    # The QoS carried in binding arguments, the inverse of `qos_arguments`.
+    #
+    # Any integer type is accepted: bindings made over the HTTP API or imported
+    # from a definitions file don't go through the MQTT protocol parser, so the
+    # header isn't necessarily a `UInt8`. The value is granted as the closest
+    # supported QoS, never higher than what we can deliver: QoS 2 as QoS 1
+    # [MQTT-3.9.3-1], a missing, negative or non-integer value as QoS 0.
+    def self.qos(arguments : AMQP::Table?) : UInt8
+      qos = arguments.try { |args| args[QOS_HEADER]?.as?(Int) } || 0
+      qos.clamp(0, 1).to_u8
+    end
   end
 end

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -5,7 +5,6 @@ require "./subscription_tree"
 require "./session"
 require "./subscription_key"
 require "./subscription_details"
-require "./retain_store"
 
 module LavinMQ
   module MQTT
@@ -16,10 +15,12 @@ module LavinMQ
         "mqtt"
       end
 
-      def initialize(vhost : VHost, name : String, @retain_store : MQTT::RetainStore)
+      def initialize(vhost : VHost, name : String)
         super(vhost, name, false, false, true)
       end
 
+      # Routes a packet to the subscribed sessions. Retaining the message is the
+      # `Broker`'s responsibility, it owns the retain store.
       def publish(packet : Protocol::Publish) : UInt32
         @publish_in_count.add(1, :relaxed)
         properties = AMQP::Properties.new(headers: AMQP::Table.new)
@@ -28,11 +29,6 @@ module LavinMQ
         timestamp = RoughTime.unix_ms
         bodysize = packet.payload.bytesize.to_u64
         body = ::IO::Memory.new(packet.payload, writable: false)
-
-        if packet.retain?
-          @retain_store.retain(packet.topic, body, bodysize)
-          body.rewind
-        end
 
         msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
         count = 0u32

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -19,8 +19,6 @@ module LavinMQ
         super(vhost, name, false, false, true)
       end
 
-      # Routes a packet to the subscribed sessions. Retaining the message is the
-      # `Broker`'s responsibility, it owns the retain store.
       def publish(packet : Protocol::Publish) : UInt32
         @publish_in_count.add(1, :relaxed)
         properties = AMQP::Properties.new(headers: AMQP::Table.new)

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -61,8 +61,7 @@ module LavinMQ
       end
 
       def bind(destination : MQTT::Session, routing_key : String, arguments = nil) : Bool
-        qos = arguments.try { |h| h[QOS_HEADER]?.try(&.as(UInt8)) } || 0u8
-        qos = 1u8 if qos > 1
+        qos = MQTT.qos(arguments)
         @tree.subscribe(routing_key, destination, qos)
 
         binding_key = SubscriptionKey.new(routing_key, qos)
@@ -72,8 +71,7 @@ module LavinMQ
       end
 
       def unbind(destination : MQTT::Session, routing_key, arguments = nil) : Bool
-        qos = arguments.try { |h| h[QOS_HEADER]?.try(&.as(UInt8)) } || 0u8
-        qos = 1u8 if qos > 1
+        qos = MQTT.qos(arguments)
         @tree.unsubscribe(routing_key, destination)
 
         binding_key = SubscriptionKey.new(routing_key, qos)

--- a/src/lavinmq/mqtt/retain_store.cr
+++ b/src/lavinmq/mqtt/retain_store.cr
@@ -1,4 +1,5 @@
 require "./topic_tree"
+require "./protocol"
 require "digest/md5"
 
 module LavinMQ
@@ -66,11 +67,13 @@ module LavinMQ
         Log.debug { "restoring index done, msg_count = #{msg_count}" }
       end
 
-      def retain(topic : String, body_io : ::IO, size : UInt64) : Nil
+      def retain(packet : Protocol::Publish) : Nil
         @lock.synchronize do
-          Log.debug { "retain topic=#{topic} body.bytesize=#{size}" }
+          topic = packet.topic
+          payload = packet.payload
+          Log.debug { "retain topic=#{topic} body.bytesize=#{payload.bytesize}" }
           # An empty message with retain flag means clear the topic from retained messages
-          if size.zero?
+          if payload.empty?
             delete_from_index(topic)
             return
           end
@@ -83,8 +86,9 @@ module LavinMQ
           file = File.new(File.join(@dir, "#{msg_file_name}.tmp"), "w+")
           file.sync = true
           file.read_buffering = false
-          len = ::IO.copy(body_io, file, size)
-          raise ::IO::EOFError.new("Copied only #{len} of #{size} bytes") if len != size
+          # sync = true, so this writes the payload straight to the fd, no
+          # intermediate buffer and no copy
+          file.write payload
           final_file_path = File.join(@dir, msg_file_name)
           file.rename(final_file_path)
           @replicator.try &.replace_file(final_file_path)

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -90,6 +90,10 @@ module LavinMQ
       definitions.register_exchange(exchange)
     end
 
+    def mqtt_exchange : MQTT::Exchange
+      definitions.mqtt_exchange
+    end
+
     # Queue accessors
 
     def queue?(name : String) : AMQP::Queue?


### PR DESCRIPTION
### WHAT is this pull request doing?

This pr fixes two related bugs, each with its own cause:

  - The MQTT Exchange was created AFTER definitions was loaded on startup, causing subscription (bindings) to be dropped.
  - Subscriptions (bindings) of persistent MQTT sessions was never written to definitions file because bindings from non-durable exchange isn't presisted, and the MQTT Exchange is non-durable

## Changes
  - The definition store now creates the MQTT exchange to make sure it's created before definitions are loaded
  - Add a condition when applying Bind and Unbind frames if the exchange is the MQTT exchange
  - Retained messages moved from the exchange to the broker, leaving the router to only route. 

Clean-session subscriptions are still not persisted, and the router itself is still never
  written to the definitions file.

### HOW can this pull request be tested?
Specs