### PR TITLE
Pre-calculate and persist follower checksums incrementally during full sync

### DIFF
--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -11,6 +11,23 @@ module ClientSyncSpec
       stream_changes(socket, lz4)
     end
 
+    def hash_local_files_public
+      hash_local_files
+    end
+
+    # Counts hashed local files, so specs can assert that no CPU-bound hashing
+    # happens while the leader is connected and waiting.
+    getter files_hashed = 0
+    # Simulates an unreadable file (can't be done with permissions: specs may
+    # run as root).
+    property fail_hash_for : String? = nil
+
+    private def hash_file(filename : String, path : String) : Bytes
+      @files_hashed += 1
+      raise File::Error.new("Permission denied", file: path) if filename == @fail_hash_for
+      super
+    end
+
     # Instrumentation for the close/ack-loop fd race spec: slow each sync down
     # and record whether one ever ran against a closed data dir fd — the real
     # implementation would Log.fatal and exit 1 there.
@@ -73,6 +90,7 @@ module ClientSyncSpec
       lz4.write content.to_slice
       lz4.flush
     end
+    requested
   end
 
   describe LavinMQ::Clustering::Client do
@@ -341,6 +359,137 @@ module ClientSyncSpec
             leader_io.read_bytes(Int64, IO::ByteFormat::LittleEndian)
           end
           client_socket.close
+        end
+      end
+    end
+
+    # Local hashing is CPU bound and the leader holds its sync lock (and, for
+    # the second sync pass, its replication lock) while it waits for the
+    # follower's file requests. So all local files are hashed before the
+    # follower even connects, not while comparing the leader's file list.
+    describe "hash_local_files" do
+      it "hashes every local file, including files the leader doesn't have" do
+        with_datadir do |data_dir|
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          File.write File.join(data_dir, "queue1", "messages.dat"), "a"
+          File.write File.join(data_dir, "definitions.amqp"), "b"
+
+          client = make_client(data_dir)
+          client.hash_local_files_public
+
+          client.@checksums["queue1/messages.dat"]?.should eq Digest::SHA1.digest("a")
+          client.@checksums["definitions.amqp"]?.should eq Digest::SHA1.digest("b")
+          # Persisted too, so a crash before the sync doesn't waste the work.
+          checksums_file = File.read(File.join(data_dir, "checksums.sha1"))
+          checksums_file.should contain "#{Digest::SHA1.digest("a").hexstring} *queue1/messages.dat"
+          checksums_file.should contain "#{Digest::SHA1.digest("b").hexstring} *definitions.amqp"
+        end
+      end
+
+      it "skips local-only files the leader never sends" do
+        with_datadir do |data_dir|
+          File.write File.join(data_dir, ".clustering_id"), "id"
+
+          client = make_client(data_dir)
+          client.hash_local_files_public
+
+          client.@checksums[".clustering_id"]?.should be_nil
+          client.@checksums[".lock"]?.should be_nil
+          client.@checksums["checksums.sha1"]?.should be_nil
+        end
+      end
+
+      it "skips files already in the checksum cache" do
+        with_datadir do |data_dir|
+          File.write File.join(data_dir, "cached.dat"), "original"
+          client = make_client(data_dir)
+          cached = Digest::SHA1.digest("cached")
+          client.@checksums.append("cached.dat", cached)
+
+          client.hash_local_files_public
+
+          client.files_hashed.should eq 0
+          client.@checksums["cached.dat"]?.should eq cached
+        end
+      end
+
+      # This pass also hashes files the leader doesn't have, which the compare
+      # loop never did, so a single unreadable file must not abort it — that
+      # would wedge the follower in the connect/retry loop before it even dials.
+      it "keeps hashing after a file it can't read" do
+        with_datadir do |data_dir|
+          File.write File.join(data_dir, "unreadable.dat"), "nope"
+          File.write File.join(data_dir, "readable.dat"), "yep"
+
+          client = make_client(data_dir)
+          client.fail_hash_for = "unreadable.dat"
+          client.hash_local_files_public
+
+          client.@checksums["unreadable.dat"]?.should be_nil
+          client.@checksums["readable.dat"]?.should eq Digest::SHA1.digest("yep")
+        end
+      end
+
+      # Regression: the compare loop used to hash local files while the leader
+      # waited for our file requests, stalling it (and every other follower
+      # waiting for its sync lock) for as long as hashing took.
+      it "leaves no hashing to do while the leader is connected" do
+        with_datadir do |data_dir|
+          content = "hello"
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          File.write File.join(data_dir, "queue1", "messages.dat"), content
+
+          client = make_client(data_dir)
+          client.hash_local_files_public
+          client.files_hashed.should eq 1
+
+          server_io, client_io = UNIXSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_io)
+          requested = Channel(Array(String)).new
+          spawn do
+            requested.send simulate_leader(server_io, {"queue1/messages.dat" => content})
+          end
+
+          client.sync_files_public(client_io, lz4_reader)
+
+          select
+          when files = requested.receive
+            files.should be_empty # matching hash, nothing to re-fetch
+          when timeout(1.second)
+            fail "leader fiber timed out"
+          end
+          client.files_hashed.should eq 1 # nothing hashed while connected
+        end
+      end
+
+      # hash_local_files hashes files the leader doesn't have, and those get
+      # deleted during the sync; their entries must go with them or the
+      # checksum map grows with dead paths on every sync.
+      it "drops checksums of files deleted because the leader lacks them" do
+        with_datadir do |data_dir|
+          File.write File.join(data_dir, "orphan.dat"), "gone tomorrow"
+          client = make_client(data_dir)
+          client.hash_local_files_public
+          client.@checksums["orphan.dat"]?.should_not be_nil
+
+          server_io, client_io = UNIXSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_io)
+          done = Channel(Nil).new
+          spawn do
+            simulate_leader(server_io, {} of String => String)
+            done.send nil
+          end
+
+          client.sync_files_public(client_io, lz4_reader)
+
+          select
+          when done.receive
+          when timeout(1.second)
+            fail "leader fiber timed out"
+          end
+
+          File.exists?(File.join(data_dir, "orphan.dat")).should be_false
+          client.@checksums["orphan.dat"]?.should be_nil
         end
       end
     end

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -15,11 +15,9 @@ module ClientSyncSpec
       hash_local_files
     end
 
-    # Counts hashed local files, so specs can assert that no CPU-bound hashing
-    # happens while the leader is connected and waiting.
+    # Lets specs assert that nothing is hashed while the leader is connected.
     getter files_hashed = 0
-    # Simulates an unreadable file (can't be done with permissions: specs may
-    # run as root).
+    # Simulates an unreadable file; permissions can't, specs may run as root.
     property fail_hash_for : String? = nil
 
     private def hash_file(filename : String, path : String) : Bytes
@@ -363,10 +361,8 @@ module ClientSyncSpec
       end
     end
 
-    # Local hashing is CPU bound and the leader holds its sync lock (and, for
-    # the second sync pass, its replication lock) while it waits for the
-    # follower's file requests. So all local files are hashed before the
-    # follower even connects, not while comparing the leader's file list.
+    # Hashing is CPU bound and the leader waits, holding its sync lock, for our
+    # file requests. So it all happens before the follower connects.
     describe "hash_local_files" do
       it "hashes every local file, including files the leader doesn't have" do
         with_datadir do |data_dir|
@@ -413,9 +409,8 @@ module ClientSyncSpec
         end
       end
 
-      # This pass also hashes files the leader doesn't have, which the compare
-      # loop never did, so a single unreadable file must not abort it — that
-      # would wedge the follower in the connect/retry loop before it even dials.
+      # This pass hashes files the leader doesn't have, so an unreadable file
+      # must not abort it and wedge the follower before it even dials.
       it "keeps hashing after a file it can't read" do
         with_datadir do |data_dir|
           File.write File.join(data_dir, "unreadable.dat"), "nope"
@@ -430,9 +425,8 @@ module ClientSyncSpec
         end
       end
 
-      # Regression: the compare loop used to hash local files while the leader
-      # waited for our file requests, stalling it (and every other follower
-      # waiting for its sync lock) for as long as hashing took.
+      # Regression: the compare loop used to hash while the leader waited for
+      # our file requests, stalling it for as long as hashing took.
       it "leaves no hashing to do while the leader is connected" do
         with_datadir do |data_dir|
           content = "hello"
@@ -462,9 +456,8 @@ module ClientSyncSpec
         end
       end
 
-      # hash_local_files hashes files the leader doesn't have, and those get
-      # deleted during the sync; their entries must go with them or the
-      # checksum map grows with dead paths on every sync.
+      # Files the leader lacks are hashed but then deleted, so their checksums
+      # must go too or the map grows dead paths on every sync.
       it "drops checksums of files deleted because the leader lacks them" do
         with_datadir do |data_dir|
           File.write File.join(data_dir, "orphan.dat"), "gone tomorrow"

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -121,6 +121,7 @@ module LavinMQ
         end
         loop do
           hash_local_files
+          return if @closed
           @socket = socket = TCPSocket.new(host, port)
           socket.sync = true
           socket.read_buffering = false # use lz4 buffering

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -16,11 +16,8 @@ module LavinMQ
       # LZ4::Reader's internal 64 KiB buffer.
       BUFFER_SIZE = 64 * 1024
 
-      # How many files #hash_local_files hashes between Fiber.yields. Hashing is
-      # CPU bound, and although it runs before we connect, the proxies are
-      # already forwarding clients to the leader, so it can't hog the scheduler.
-      # Yielding per file would add a scheduler round trip per (often small)
-      # file; a batch amortizes that without starving anyone.
+      # Files #hash_local_files hashes between Fiber.yields. Hashing is CPU
+      # bound, but a yield per (often tiny) file costs more than it gives back.
       HASH_YIELD_INTERVAL = 32
 
       # Capacity of the channel buffering acks from the stream-reading fiber to
@@ -195,15 +192,11 @@ module LavinMQ
         Log.info { "Waiting for list of files" }
         hash_size = Digest::SHA1.new.digest_size
 
-        # Drain the entire file list from the socket FIRST, doing no hashing in
-        # this loop. Local checksums are normally all computed before we even
-        # connect (see #hash_local_files), but the comparison below can still
-        # fall back to hashing a file that appeared since. Hashing is CPU-bound
-        # and would block reading between entries, so the leader's file-list
-        # flush couldn't complete within its write timeout and it would
-        # disconnect us mid-sync. By reading the list back-to-back we let the
-        # leader's flush finish; it then blocks reading our file requests
-        # (below), so it never write-times-out during the comparison.
+        # Drain the entire file list FIRST, doing no hashing in this loop. Any
+        # CPU-bound work between entries stalls the leader's file-list flush
+        # until its write timeout fires and it disconnects us. Once the list is
+        # read the leader blocks reading our file requests, so the comparison
+        # below is free to hash.
         remote_files = Array({String, Bytes}).new
         loop do
           filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
@@ -232,9 +225,8 @@ module LavinMQ
             dir = File.dirname(dir)
           end
           if File.exists? path
-            # Normally pre-computed by #hash_local_files before we connected;
-            # hashing here only happens for a file that appeared since, which
-            # is why the file list is drained up front (see above).
+            # Pre-computed by #hash_local_files, except for files that appeared
+            # after that pass.
             unless local_hash = @checksums[filename]?
               local_hash = hash_file(filename, path)
               Fiber.yield # CPU bound, so allow other fibers to run
@@ -261,9 +253,8 @@ module LavinMQ
         files_to_delete.each do |path|
           Log.debug { "File not on leader: #{path}" }
           File.delete path
-          # #hash_local_files hashes every local file, including ones the leader
-          # doesn't have; drop the entry with the file so the checksum map (and
-          # every snapshot written from it) doesn't accumulate dead paths.
+          # #hash_local_files hashed this file too, drop it or the checksum map
+          # accumulates dead paths.
           @checksums.delete(relative_path(path))
         rescue ex : File::Error
           Log.warn(exception: ex) { "Failed to delete #{path}" }
@@ -291,13 +282,10 @@ module LavinMQ
         Log.info { "Received all #{requested_files.size} files" } unless requested_files.empty?
       end
 
-      # Hash every local file before connecting to the leader. Comparing our
-      # files against the leader's file list is CPU-bound, and doing it while
-      # connected stalls the leader: it holds its sync lock (and, during the
-      # second sync pass, its replication lock) until we answer, and only
-      # relaxes its write timeout so much. Hashing here costs the leader
-      # nothing. Files already in @checksums (restored from disk, or hashed in
-      # an earlier pass) are skipped.
+      # Hash every local file before connecting to the leader. Hashing while
+      # connected stalls the leader, which holds its sync lock (and, in the
+      # second sync pass, its replication lock) until we answer. Files already
+      # in @checksums (from disk or an earlier pass) are skipped.
       private def hash_local_files : Nil
         computed = 0
         files, _dirs = ls_r(@data_dir)
@@ -315,23 +303,20 @@ module LavinMQ
           rescue ex : File::NotFoundError
             Log.debug(exception: ex) { "#{path} disappeared while hashing" }
           rescue ex : File::Error
-            # Unlike the compare loop, this pass also hashes files the leader
-            # doesn't have (they're about to be deleted), so one unreadable file
-            # must not abort the pass and wedge us in the reconnect loop. Left
-            # uncached: if the leader does have the file, the compare loop retries
-            # the hash and fails the sync there, as it always did.
+            # This pass also hashes files the leader doesn't have, so one
+            # unreadable file must not wedge us in the reconnect loop. Left
+            # uncached, so the compare loop still fails if the leader has it.
             Log.warn(exception: ex) { "Failed to calculate checksum for #{path}" }
           end
-          # #restore truncates checksums.sha1, so until something rewrites it a
-          # crash would throw away hashes that were on disk at boot. Snapshot the
-          # full set now, while we're not holding up the leader.
+          # #restore truncated checksums.sha1, so snapshot the full set or a
+          # crash loses the hashes that were on disk at boot.
           @checksums.store if computed > 0
         end
         Log.info { "Calculated #{computed} checksums (#{files.size} local files) in #{time.total_seconds} seconds" }
       end
 
-      # Hash one local file and persist the hash immediately (see
-      # Checksums#append), so hashing progress survives a crash.
+      # Hash one local file, persisting the hash right away so progress
+      # survives a crash.
       private def hash_file(filename : String, path : String) : Bytes
         Log.debug { "Calculating checksum for #{filename}" }
         sha1 = Digest::SHA1.new

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -172,10 +172,13 @@ module LavinMQ
         authenticate(socket)
         Log.info { "Authenticated" }
         set_socket_opts(socket)
-        sync_files(socket, lz4)
-        Log.info { "Bulk synchronised" }
-        sync_files(socket, lz4)
-        Log.info { "Fully synchronised" }
+        full_sync_time = Time.measure do
+          bulk_time = Time.measure { sync_files(socket, lz4) }
+          Log.info { "Bulk synchronised in #{bulk_time.total_seconds} seconds" }
+          rest_time = Time.measure { sync_files(socket, lz4) }
+          Log.info { "Changes since bulk synchronized in #{rest_time.total_seconds} seconds" }
+        end
+        Log.info { "Fully synchronised in #{full_sync_time.total_seconds} seconds" }
       end
 
       private def set_socket_opts(socket)
@@ -295,33 +298,35 @@ module LavinMQ
       # nothing. Files already in @checksums (restored from disk, or hashed in
       # an earlier pass) are skipped.
       private def hash_local_files : Nil
-        files, _dirs = ls_r(@data_dir)
-        Log.info { "Calculating checksums for #{files.size} local files" }
         computed = 0
-        log_limiter = RateLimiter.new(2.seconds)
-        files.each do |path|
-          break if @closed
-          filename = relative_path(path)
-          next if @checksums[filename]?
-          hash_file(filename, path)
-          computed &+= 1
-          Fiber.yield if computed % HASH_YIELD_INTERVAL == 0 # CPU bound, so let other fibers run
-          log_limiter.do { Log.info { "Calculated #{computed} checksums" } }
-        rescue ex : File::NotFoundError
-          Log.debug(exception: ex) { "#{path} disappeared while hashing" }
-        rescue ex : File::Error
-          # Unlike the compare loop, this pass also hashes files the leader
-          # doesn't have (they're about to be deleted), so one unreadable file
-          # must not abort the pass and wedge us in the reconnect loop. Left
-          # uncached: if the leader does have the file, the compare loop retries
-          # the hash and fails the sync there, as it always did.
-          Log.warn(exception: ex) { "Failed to calculate checksum for #{path}" }
+        files, _dirs = ls_r(@data_dir)
+        time = Time.measure do
+          Log.info { "Calculating checksums for #{files.size} local files" }
+          log_limiter = RateLimiter.new(2.seconds)
+          files.each do |path|
+            break if @closed
+            filename = relative_path(path)
+            next if @checksums[filename]?
+            hash_file(filename, path)
+            computed &+= 1
+            Fiber.yield if computed % HASH_YIELD_INTERVAL == 0 # CPU bound, so let other fibers run
+            log_limiter.do { Log.info { "Calculated #{computed} checksums" } }
+          rescue ex : File::NotFoundError
+            Log.debug(exception: ex) { "#{path} disappeared while hashing" }
+          rescue ex : File::Error
+            # Unlike the compare loop, this pass also hashes files the leader
+            # doesn't have (they're about to be deleted), so one unreadable file
+            # must not abort the pass and wedge us in the reconnect loop. Left
+            # uncached: if the leader does have the file, the compare loop retries
+            # the hash and fails the sync there, as it always did.
+            Log.warn(exception: ex) { "Failed to calculate checksum for #{path}" }
+          end
+          # #restore truncates checksums.sha1, so until something rewrites it a
+          # crash would throw away hashes that were on disk at boot. Snapshot the
+          # full set now, while we're not holding up the leader.
+          @checksums.store if computed > 0
         end
-        # #restore truncates checksums.sha1, so until something rewrites it a
-        # crash would throw away hashes that were on disk at boot. Snapshot the
-        # full set now, while we're not holding up the leader.
-        @checksums.store if computed > 0
-        Log.info { "Calculated #{computed} checksums (#{files.size} local files)" }
+        Log.info { "Calculated #{computed} checksums (#{files.size} local files) in #{time.total_seconds} seconds" }
       end
 
       # Hash one local file and persist the hash immediately (see

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -16,6 +16,13 @@ module LavinMQ
       # LZ4::Reader's internal 64 KiB buffer.
       BUFFER_SIZE = 64 * 1024
 
+      # How many files #hash_local_files hashes between Fiber.yields. Hashing is
+      # CPU bound, and although it runs before we connect, the proxies are
+      # already forwarding clients to the leader, so it can't hog the scheduler.
+      # Yielding per file would add a scheduler round trip per (often small)
+      # file; a batch amortizes that without starving anyone.
+      HASH_YIELD_INTERVAL = 32
+
       # Capacity of the channel buffering acks from the stream-reading fiber to
       # the ack-sending fiber. Only bounds an in-process queue (send_ack_loop
       # drains and coalesces it continuously), so a fixed size is fine; the
@@ -113,6 +120,7 @@ module LavinMQ
           spawn unix_mqtt_proxy.forward_to(host, @config.mqtt_port), name: "MQTT proxy"
         end
         loop do
+          hash_local_files
           @socket = socket = TCPSocket.new(host, port)
           socket.sync = true
           socket.read_buffering = false # use lz4 buffering
@@ -181,34 +189,35 @@ module LavinMQ
 
       private def sync_files(socket, lz4)
         Log.info { "Waiting for list of files" }
-        sha1 = Digest::SHA1.new
+        hash_size = Digest::SHA1.new.digest_size
 
         # Drain the entire file list from the socket FIRST, doing no hashing in
-        # this loop. Computing local checksums is CPU-bound and would otherwise
-        # block reading between entries, so the leader's file-list flush can't
-        # complete within its write timeout and it disconnects us mid-sync. By
-        # reading the list back-to-back we let the leader's flush finish; it then
-        # blocks reading our file requests (below) while we hash, so it never
-        # write-times-out during the comparison.
+        # this loop. Local checksums are normally all computed before we even
+        # connect (see #hash_local_files), but the comparison below can still
+        # fall back to hashing a file that appeared since. Hashing is CPU-bound
+        # and would block reading between entries, so the leader's file-list
+        # flush couldn't complete within its write timeout and it would
+        # disconnect us mid-sync. By reading the list back-to-back we let the
+        # leader's flush finish; it then blocks reading our file requests
+        # (below), so it never write-times-out during the comparison.
         remote_files = Array({String, Bytes}).new
         loop do
           filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
           break if filename_len.zero?
 
           filename = lz4.read_string(filename_len)
-          remote_hash = Bytes.new(sha1.digest_size)
+          remote_hash = Bytes.new(hash_size)
           lz4.read_fully(remote_hash)
           remote_files << {filename, remote_hash}
         end
         Log.info { "Received list of #{remote_files.size} files" }
 
-        # Now compare against local files (CPU-bound hashing) with the socket
-        # already drained.
+        # Now compare against local files, with the socket already drained.
         files_to_delete, dirs_to_delete = ls_r(@data_dir)
         requested_files = Array(String).new
         file_count = 0
         files_total = remote_files.size
-        Log.info { "Calculating checksums and comparing files" }
+        Log.info { "Comparing files" }
         log_limiter = RateLimiter.new(2.seconds)
         remote_files.each do |filename, remote_hash|
           path = File.join(@data_dir, filename)
@@ -219,12 +228,11 @@ module LavinMQ
             dir = File.dirname(dir)
           end
           if File.exists? path
+            # Normally pre-computed by #hash_local_files before we connected;
+            # hashing here only happens for a file that appeared since, which
+            # is why the file list is drained up front (see above).
             unless local_hash = @checksums[filename]?
-              Log.debug { "Calculating checksum for #{filename}" }
-              sha1.file(path)
-              local_hash = sha1.final
-              @checksums.append(filename, local_hash)
-              sha1.reset
+              local_hash = hash_file(filename, path)
               Fiber.yield # CPU bound, so allow other fibers to run
             end
             if local_hash != remote_hash
@@ -249,6 +257,10 @@ module LavinMQ
         files_to_delete.each do |path|
           Log.debug { "File not on leader: #{path}" }
           File.delete path
+          # #hash_local_files hashes every local file, including ones the leader
+          # doesn't have; drop the entry with the file so the checksum map (and
+          # every snapshot written from it) doesn't accumulate dead paths.
+          @checksums.delete(relative_path(path))
         rescue ex : File::Error
           Log.warn(exception: ex) { "Failed to delete #{path}" }
         end
@@ -273,6 +285,59 @@ module LavinMQ
           log_limiter.do { Log.info { "Received #{received_count}/#{requested_files.size} files" } }
         end
         Log.info { "Received all #{requested_files.size} files" } unless requested_files.empty?
+      end
+
+      # Hash every local file before connecting to the leader. Comparing our
+      # files against the leader's file list is CPU-bound, and doing it while
+      # connected stalls the leader: it holds its sync lock (and, during the
+      # second sync pass, its replication lock) until we answer, and only
+      # relaxes its write timeout so much. Hashing here costs the leader
+      # nothing. Files already in @checksums (restored from disk, or hashed in
+      # an earlier pass) are skipped.
+      private def hash_local_files : Nil
+        files, _dirs = ls_r(@data_dir)
+        Log.info { "Calculating checksums for #{files.size} local files" }
+        computed = 0
+        log_limiter = RateLimiter.new(2.seconds)
+        files.each do |path|
+          break if @closed
+          filename = relative_path(path)
+          next if @checksums[filename]?
+          hash_file(filename, path)
+          computed &+= 1
+          Fiber.yield if computed % HASH_YIELD_INTERVAL == 0 # CPU bound, so let other fibers run
+          log_limiter.do { Log.info { "Calculated #{computed} checksums" } }
+        rescue ex : File::NotFoundError
+          Log.debug(exception: ex) { "#{path} disappeared while hashing" }
+        rescue ex : File::Error
+          # Unlike the compare loop, this pass also hashes files the leader
+          # doesn't have (they're about to be deleted), so one unreadable file
+          # must not abort the pass and wedge us in the reconnect loop. Left
+          # uncached: if the leader does have the file, the compare loop retries
+          # the hash and fails the sync there, as it always did.
+          Log.warn(exception: ex) { "Failed to calculate checksum for #{path}" }
+        end
+        # #restore truncates checksums.sha1, so until something rewrites it a
+        # crash would throw away hashes that were on disk at boot. Snapshot the
+        # full set now, while we're not holding up the leader.
+        @checksums.store if computed > 0
+        Log.info { "Calculated #{computed} checksums (#{files.size} local files)" }
+      end
+
+      # Hash one local file and persist the hash immediately (see
+      # Checksums#append), so hashing progress survives a crash.
+      private def hash_file(filename : String, path : String) : Bytes
+        Log.debug { "Calculating checksum for #{filename}" }
+        sha1 = Digest::SHA1.new
+        sha1.file(path)
+        hash = sha1.final
+        @checksums.append(filename, hash)
+        hash
+      end
+
+      # Path relative to the data dir, i.e. the name the leader knows a file by.
+      private def relative_path(path : String) : String
+        path.lchop(@data_dir).lchop('/')
       end
 
       private def ls_r(dir) : {Array(String), Array(String)}

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -21,8 +21,9 @@ module LavinMQ
 
       # Write timeout used during full_sync. A syncing follower isn't in the ISR
       # yet, so its slowness can't stall publish confirms, and the bulk transfer
-      # legitimately blocks the leader's writes while the follower hashes its
-      # local files or persists received ones. The aggressive ACK_TIMEOUT is for
+      # legitimately blocks the leader's writes while the follower persists the
+      # files it receives. (Hashing its local files no longer blocks us here;
+      # the follower does that before it connects.) The aggressive ACK_TIMEOUT is for
       # the steady-state streaming phase; using it during full_sync wrongly drops
       # a merely-slow follower. Still bounded so a genuinely wedged follower can't
       # hold the sync lock forever.

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -22,11 +22,10 @@ module LavinMQ
       # Write timeout used during full_sync. A syncing follower isn't in the ISR
       # yet, so its slowness can't stall publish confirms, and the bulk transfer
       # legitimately blocks the leader's writes while the follower persists the
-      # files it receives. (Hashing its local files no longer blocks us here;
-      # the follower does that before it connects.) The aggressive ACK_TIMEOUT is for
-      # the steady-state streaming phase; using it during full_sync wrongly drops
-      # a merely-slow follower. Still bounded so a genuinely wedged follower can't
-      # hold the sync lock forever.
+      # files it receives. The aggressive ACK_TIMEOUT is for the steady-state
+      # streaming phase; using it during full_sync wrongly drops a merely-slow
+      # follower. Still bounded so a genuinely wedged follower can't hold the
+      # sync lock forever.
       SYNC_WRITE_TIMEOUT = 60.seconds
 
       @acked_bytes = Atomic(Int64).new(0)


### PR DESCRIPTION
A follower hashed its local files *while* comparing them against the leader's file list. This means that the lock the leader holds during full sync is held even for all hash calculations. 

By pre-calculating all hashes before connecting to the leader the time the lock is held is shorten. However, the follower will now calculate hashes for all its local files, even files that should be deleted, which means that the connection to the leader is delayed.