### PR TITLE
Reuse cached checksums in the capped full_sync pass

### DIFF
--- a/spec/clustering/checksums_spec.cr
+++ b/spec/clustering/checksums_spec.cr
@@ -6,11 +6,11 @@ describe LavinMQ::Clustering::Checksums do
     with_datadir do |data_dir|
       checksums = LavinMQ::Clustering::Checksums.new(data_dir)
       hash = Digest::SHA1.digest("hello")
-      checksums.append("queue1/msgs.0000000001", hash)
+      checksums.append("queue1/msgs.0000000001", hash, 5i64)
 
       path = File.join(data_dir, "checksums.sha1")
       File.exists?(path).should be_true
-      File.read(path).should eq "#{hash.hexstring} *queue1/msgs.0000000001\n"
+      File.read(path).should eq "#{hash.hexstring} 5 *queue1/msgs.0000000001\n"
     end
   end
 
@@ -18,11 +18,11 @@ describe LavinMQ::Clustering::Checksums do
     with_datadir do |data_dir|
       hash = Digest::SHA1.digest("hello")
       written = LavinMQ::Clustering::Checksums.new(data_dir)
-      written.append("queue1/msgs.0000000001", hash)
+      written.append("queue1/msgs.0000000001", hash, 5i64)
 
       restored = LavinMQ::Clustering::Checksums.new(data_dir)
       restored.restore
-      restored["queue1/msgs.0000000001"]?.should eq hash
+      restored["queue1/msgs.0000000001"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(hash, 5i64)
 
       # one-shot: the on-disk copy is discarded after restore, so a stale hash
       # can't outlive a 2nd crash before a clean store rewrites it.
@@ -36,13 +36,13 @@ describe LavinMQ::Clustering::Checksums do
   it "rewrites a clean snapshot on store" do
     with_datadir do |data_dir|
       checksums = LavinMQ::Clustering::Checksums.new(data_dir)
-      checksums.append("a", Digest::SHA1.digest("a"))
-      checksums.append("b", Digest::SHA1.digest("b"))
+      checksums.append("a", Digest::SHA1.digest("a"), 1i64)
+      checksums.append("b", Digest::SHA1.digest("b"), 1i64)
       checksums.store
 
       lines = File.read(File.join(data_dir, "checksums.sha1")).lines
       lines.size.should eq checksums.size
-      lines.each(&.should(match(/^[0-9a-f]{40} \*/)))
+      lines.each(&.should(match(/^[0-9a-f]{40} \d+ \*/)))
       # No torn temp file left behind by the atomic rename.
       File.exists?(File.join(data_dir, "checksums.sha1.tmp")).should be_false
     end
@@ -51,14 +51,14 @@ describe LavinMQ::Clustering::Checksums do
   it "keeps persisting via append after a store rewrite" do
     with_datadir do |data_dir|
       checksums = LavinMQ::Clustering::Checksums.new(data_dir)
-      checksums.append("a", Digest::SHA1.digest("a"))
+      checksums.append("a", Digest::SHA1.digest("a"), 1i64)
       checksums.store # rewrites and adopts the new handle
-      checksums.append("b", Digest::SHA1.digest("b"))
+      checksums.append("b", Digest::SHA1.digest("b"), 1i64)
 
       restored = LavinMQ::Clustering::Checksums.new(data_dir)
       restored.restore
-      restored["a"]?.should eq Digest::SHA1.digest("a")
-      restored["b"]?.should eq Digest::SHA1.digest("b")
+      restored["a"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(Digest::SHA1.digest("a"), 1i64)
+      restored["b"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(Digest::SHA1.digest("b"), 1i64)
     end
   end
 
@@ -70,9 +70,7 @@ describe LavinMQ::Clustering::Checksums do
 
       restored = LavinMQ::Clustering::Checksums.new(data_dir)
       restored.restore
-      restored["q/msgs.0000000001"]?.should eq hash
-      restored.hash_for?("q/msgs.0000000001", 5i64).should eq hash
-      restored.hash_for?("q/msgs.0000000001", 4i64).should be_nil
+      restored["q/msgs.0000000001"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(hash, 5i64)
     end
   end
 
@@ -85,19 +83,18 @@ describe LavinMQ::Clustering::Checksums do
 
       restored = LavinMQ::Clustering::Checksums.new(data_dir)
       restored.restore
-      restored.hash_for?("q/msgs.0000000001", 5i64).should eq hash
+      restored["q/msgs.0000000001"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(hash, 5i64)
     end
   end
 
-  it "restores sizeless entries and never serves them for a sized lookup" do
+  it "restores old-format entries without a covered size" do
     with_datadir do |data_dir|
       hash = Digest::SHA1.digest("hello")
       File.write File.join(data_dir, "checksums.sha1"), "#{hash.hexstring} *q/msgs.0000000001\n"
 
       checksums = LavinMQ::Clustering::Checksums.new(data_dir)
       checksums.restore
-      checksums["q/msgs.0000000001"]?.should eq hash
-      checksums.hash_for?("q/msgs.0000000001", 5i64).should be_nil
+      checksums["q/msgs.0000000001"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(hash, nil)
     end
   end
 end

--- a/spec/clustering/checksums_spec.cr
+++ b/spec/clustering/checksums_spec.cr
@@ -87,14 +87,14 @@ describe LavinMQ::Clustering::Checksums do
     end
   end
 
-  it "restores old-format entries without a covered size" do
+  it "drops old-format entries without a covered size on restore" do
     with_datadir do |data_dir|
       hash = Digest::SHA1.digest("hello")
       File.write File.join(data_dir, "checksums.sha1"), "#{hash.hexstring} *q/msgs.0000000001\n"
 
       checksums = LavinMQ::Clustering::Checksums.new(data_dir)
       checksums.restore
-      checksums["q/msgs.0000000001"]?.should eq LavinMQ::Clustering::Checksums::Entry.new(hash, nil)
+      checksums["q/msgs.0000000001"]?.should be_nil
     end
   end
 end

--- a/spec/clustering/checksums_spec.cr
+++ b/spec/clustering/checksums_spec.cr
@@ -61,4 +61,43 @@ describe LavinMQ::Clustering::Checksums do
       restored["b"]?.should eq Digest::SHA1.digest("b")
     end
   end
+
+  it "persists and restores the covered size" do
+    with_datadir do |data_dir|
+      hash = Digest::SHA1.digest("hello")
+      written = LavinMQ::Clustering::Checksums.new(data_dir)
+      written.append("q/msgs.0000000001", hash, 5i64)
+
+      restored = LavinMQ::Clustering::Checksums.new(data_dir)
+      restored.restore
+      restored["q/msgs.0000000001"]?.should eq hash
+      restored.hash_for?("q/msgs.0000000001", 5i64).should eq hash
+      restored.hash_for?("q/msgs.0000000001", 4i64).should be_nil
+    end
+  end
+
+  it "keeps covered sizes across a store rewrite" do
+    with_datadir do |data_dir|
+      hash = Digest::SHA1.digest("hello")
+      checksums = LavinMQ::Clustering::Checksums.new(data_dir)
+      checksums.set("q/msgs.0000000001", hash, 5i64)
+      checksums.store
+
+      restored = LavinMQ::Clustering::Checksums.new(data_dir)
+      restored.restore
+      restored.hash_for?("q/msgs.0000000001", 5i64).should eq hash
+    end
+  end
+
+  it "restores sizeless entries and never serves them for a sized lookup" do
+    with_datadir do |data_dir|
+      hash = Digest::SHA1.digest("hello")
+      File.write File.join(data_dir, "checksums.sha1"), "#{hash.hexstring} *q/msgs.0000000001\n"
+
+      checksums = LavinMQ::Clustering::Checksums.new(data_dir)
+      checksums.restore
+      checksums["q/msgs.0000000001"]?.should eq hash
+      checksums.hash_for?("q/msgs.0000000001", 5i64).should be_nil
+    end
+  end
 end

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -61,26 +61,28 @@ module ClientSyncSpec
     client.close
   end
 
-  def self.persisted_checksums(data_dir : String) : Hash(String, String)
+  def self.persisted_checksums(data_dir : String) : Hash(String, {String, String})
     path = File.join(data_dir, "checksums.sha1")
-    return Hash(String, String).new unless File.exists?(path)
+    return Hash(String, {String, String}).new unless File.exists?(path)
     File.read_lines(path).to_h do |line|
-      hash, _, filename = line.partition(" *")
-      {filename, hash} # a later line wins, as in Checksums#restore
+      hash, _, rest = line.partition(" ")
+      size, _, filename = rest.partition(" *")
+      {filename, {hash, size}} # a later line wins, as in Checksums#restore
     end
   end
 
-  # Every line in checksums.sha1 must be the hash of what's on disk right now:
-  # one that isn't makes the next sync throw the file away and re-fetch it from
-  # the leader. Returns them for further assertions.
+  # Every line in checksums.sha1 must be the hash and size of what's on disk
+  # right now: one that isn't makes the next sync throw the file away and
+  # re-fetch it from the leader. Returns the hashes for further assertions.
   def self.checksums_matching_disk(data_dir : String) : Hash(String, String)
-    checksums = persisted_checksums(data_dir)
-    checksums.each do |filename, hash|
+    persisted_checksums(data_dir).to_h do |filename, (hash, size)|
       path = File.join(data_dir, filename)
       File.exists?(path).should be_true, "checksum for missing file #{filename}"
-      hash.should eq Digest::SHA1.digest(File.read(path)).hexstring
+      content = File.read(path)
+      hash.should eq Digest::SHA1.digest(content).hexstring
+      size.should eq content.bytesize.to_s
+      {filename, hash}
     end
-    checksums
   end
 
   describe LavinMQ::Clustering::Client do
@@ -629,7 +631,7 @@ module ClientSyncSpec
           checksums_file = File.join(data_dir, "checksums.sha1")
           File.exists?(checksums_file).should be_true
           expected = Digest::SHA1.digest(content).hexstring
-          File.read(checksums_file).should contain "#{expected} *queue1/messages.dat"
+          File.read(checksums_file).should contain "#{expected} #{content.bytesize} *queue1/messages.dat"
         end
       end
 
@@ -660,7 +662,7 @@ module ClientSyncSpec
           checksums_file = File.join(data_dir, "checksums.sha1")
           File.exists?(checksums_file).should be_true
           expected = Digest::SHA1.digest(content).hexstring
-          File.read(checksums_file).should contain "#{expected} *queue1/messages.dat"
+          File.read(checksums_file).should contain "#{expected} #{content.bytesize} *queue1/messages.dat"
         end
       end
 

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -85,6 +85,8 @@ module ClientSyncSpec
     end
   end
 
+  alias Entry = LavinMQ::Clustering::Checksums::Entry
+
   describe LavinMQ::Clustering::Client do
     describe "stream_changes" do
       # Regression: a single large action must be acked incrementally as its
@@ -367,12 +369,12 @@ module ClientSyncSpec
           client = make_client(data_dir)
           client.hash_local_files_public
 
-          client.@checksums["queue1/messages.dat"]?.should eq Digest::SHA1.digest("a")
-          client.@checksums["definitions.amqp"]?.should eq Digest::SHA1.digest("b")
+          client.@checksums["queue1/messages.dat"]?.should eq Entry.new(Digest::SHA1.digest("a"), 1i64)
+          client.@checksums["definitions.amqp"]?.should eq Entry.new(Digest::SHA1.digest("b"), 1i64)
           # Persisted too, so a crash before the sync doesn't waste the work.
           checksums_file = File.read(File.join(data_dir, "checksums.sha1"))
-          checksums_file.should contain "#{Digest::SHA1.digest("a").hexstring} *queue1/messages.dat"
-          checksums_file.should contain "#{Digest::SHA1.digest("b").hexstring} *definitions.amqp"
+          checksums_file.should contain "#{Digest::SHA1.digest("a").hexstring} 1 *queue1/messages.dat"
+          checksums_file.should contain "#{Digest::SHA1.digest("b").hexstring} 1 *definitions.amqp"
         end
       end
 
@@ -394,12 +396,12 @@ module ClientSyncSpec
           File.write File.join(data_dir, "cached.dat"), "original"
           client = make_client(data_dir)
           cached = Digest::SHA1.digest("cached")
-          client.@checksums.append("cached.dat", cached)
+          client.@checksums.append("cached.dat", cached, 8i64)
 
           client.hash_local_files_public
 
           client.files_hashed.should eq 0
-          client.@checksums["cached.dat"]?.should eq cached
+          client.@checksums["cached.dat"]?.should eq Entry.new(cached, 8i64)
         end
       end
 
@@ -415,7 +417,7 @@ module ClientSyncSpec
           client.hash_local_files_public
 
           client.@checksums["unreadable.dat"]?.should be_nil
-          client.@checksums["readable.dat"]?.should eq Digest::SHA1.digest("yep")
+          client.@checksums["readable.dat"]?.should eq Entry.new(Digest::SHA1.digest("yep"), 3i64)
         end
       end
 

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -120,6 +120,47 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
       ensure
         FileUtils.rm_rf LavinMQ::Config.instance.data_dir
       end
+
+      # Regression: entries restored from an old-format checksums.sha1 have
+      # no size. The uncapped pass must treat them as misses and recompute,
+      # so the capped pass can reuse the healed entry instead of re-hashing
+      # every upgraded file under the lock.
+      it "heals restored sizeless entries in the uncapped pass" do
+        data_dir = LavinMQ::Config.instance.data_dir
+        Dir.mkdir_p(data_dir)
+        content = "hello world"
+        path = File.join(data_dir, "sizeless_heal_test")
+        File.write path, content
+        checksums_path = File.join(data_dir, "checksums.sha1")
+        stale_hash = Digest::SHA1.digest("stale")
+        File.write checksums_path, "#{stale_hash.hexstring} *sizeless_heal_test\n"
+
+        server = LavinMQ::Clustering::Server.new(
+          LavinMQ::Config.instance,
+          NullCoordinator.new,
+          0)
+        server.register_file(path)
+        tcp_server = TCPServer.new("localhost", 0)
+        spawn { server.listen(tcp_server) }
+        # restore (run by listen) truncates the file once it's loaded
+        wait_for { File.size(checksums_path) == 0 }
+
+        # The sizeless entry is a miss: recomputed, not served stale.
+        uncapped = [] of Bytes
+        server.files_with_hash { |_path, hash| uncapped << hash }
+        uncapped.should eq [Digest::SHA1.digest(content)]
+
+        # Deleted from disk: the capped pass can only reuse the healed entry.
+        File.delete path
+        caps = {"sizeless_heal_test" => content.bytesize.to_i64}
+        capped = [] of Bytes
+        server.files_with_hash(caps) { |_path, hash| capped << hash }
+        capped.should eq [Digest::SHA1.digest(content)]
+      ensure
+        server.try &.close
+        tcp_server.try &.close
+        FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+      end
     end
   end
 

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -74,6 +74,53 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
         FileUtils.rm_rf LavinMQ::Config.instance.data_dir
       end
     end
+
+    describe "with caps" do
+      it "reuses the cached hash when it covers exactly the cap" do
+        data_dir = LavinMQ::Config.instance.data_dir
+        Dir.mkdir_p(data_dir)
+        server = LavinMQ::Clustering::Server.new(
+          LavinMQ::Config.instance,
+          NullCoordinator.new,
+          0)
+        content = "hello world"
+        path = File.join(data_dir, "capped_cache_test")
+        File.write path, content
+        server.register_file(path)
+        server.files_with_hash { |_path_hash| }
+        # Deleted from disk: the capped pass can only produce the hash from
+        # the cache, proving it doesn't re-read the file.
+        File.delete path
+
+        caps = {"capped_cache_test" => content.bytesize.to_i64}
+        hashes = [] of Bytes
+        server.files_with_hash(caps) { |_path, hash| hashes << hash }
+        hashes.should eq [Digest::SHA1.digest(content)]
+      ensure
+        FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+      end
+
+      it "recomputes when the cap does not match the cached hash's size" do
+        data_dir = LavinMQ::Config.instance.data_dir
+        Dir.mkdir_p(data_dir)
+        server = LavinMQ::Clustering::Server.new(
+          LavinMQ::Config.instance,
+          NullCoordinator.new,
+          0)
+        content = "hello world"
+        path = File.join(data_dir, "capped_recompute_test")
+        File.write path, content
+        server.register_file(path)
+        server.files_with_hash { |_path_hash| }
+
+        caps = {"capped_recompute_test" => 5i64}
+        hashes = [] of Bytes
+        server.files_with_hash(caps) { |_path, hash| hashes << hash }
+        hashes.should eq [Digest::SHA1.digest(content[0, 5])]
+      ensure
+        FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+      end
+    end
   end
 
   describe "#followers" do

--- a/spec/clustering_spec.cr
+++ b/spec/clustering_spec.cr
@@ -626,9 +626,9 @@ describe LavinMQ::Clustering::Client, tags: %w[etcd slow] do
         # Should have checksums for multiple files (queue definition + message segments)
         lines.size.should be >= 2
 
-        # Verify each line has correct checksum format: 40 hex chars, space, asterisk, path
+        # Verify each line has correct checksum format: 40 hex chars, covered size, asterisk, path
         lines.each do |line|
-          line.should match(/^[0-9a-f]{40} \*/)
+          line.should match(/^[0-9a-f]{40} \d+ \*/)
         end
 
         # Should have checksum for the queue's message segment file

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -3,10 +3,8 @@ module LavinMQ
     class Checksums
       Log = LavinMQ::Log.for "clustering.checksums"
 
-      # `size` is the number of bytes the hash covers. Only entries restored
-      # from an old-format checksums.sha1 lack it; callers must treat those
-      # as unusable until recomputed.
-      record Entry, hash : Bytes, size : Int64?
+      # `size` is the number of bytes the hash covers.
+      record Entry, hash : Bytes, size : Int64
 
       @checksums = Hash(String, Entry).new
       # Always-open handle to checksums.sha1, kept open across rewrites so
@@ -52,11 +50,12 @@ module LavinMQ
           loop do
             hash = f.read_string(40).hexbytes
             rest = f.read_line
-            if rest.starts_with?(" *") # sizeless format: "<hash> *<path>"
-              @checksums[rest[2..]] = Entry.new(hash, nil)
-            elsif idx = rest.index(" *", 1) # sized format: "<hash> <size> *<path>"
-              size = rest[1...idx].to_i64?
-              @checksums[rest[idx + 2..]] = Entry.new(hash, size)
+            # Line format: "<hash> <size> *<path>". Old-format lines without a
+            # size are dropped; a hash with unknown coverage is unusable.
+            if idx = rest.index(" *", 1)
+              if size = rest[1...idx].to_i64?
+                @checksums[rest[idx + 2..]] = Entry.new(hash, size)
+              end
             end
           rescue IO::EOFError
             break
@@ -94,11 +93,7 @@ module LavinMQ
       end
 
       private def line(path : String, entry : Entry) : String
-        if size = entry.size
-          "#{entry.hash.hexstring} #{size} *#{path}"
-        else
-          "#{entry.hash.hexstring} *#{path}"
-        end
+        "#{entry.hash.hexstring} #{entry.size} *#{path}"
       end
 
       private def checksums_path : String

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -6,29 +6,7 @@ module LavinMQ
       # `size` is the number of bytes the hash covers, when known. Entries
       # without a size (older checksums.sha1 files, follower-written entries)
       # can never be served for a sized lookup (#hash_for?).
-      record Entry, hash : Bytes, size : Int64? do
-        # One line per entry: "<hash> <size> *<path>", or "<hash> *<path>"
-        # when the size is unknown. The path is the caller's hash key, so it
-        # travels alongside the entry rather than being stored in it.
-        def to_io(io : IO, path : String) : Nil
-          io << hash.hexstring
-          if s = size
-            io << ' ' << s
-          end
-          io << " *" << path << '\n'
-        end
-
-        # Returns nil for malformed lines. Raises IO::EOFError at end of file.
-        def self.from_io(io : IO) : {String, Entry}?
-          hash = io.read_string(40).hexbytes
-          rest = io.read_line
-          if rest.starts_with?(" *")
-            {rest[2..], new(hash, nil)}
-          elsif idx = rest.index(" *", 1)
-            {rest[idx + 2..], new(hash, rest[1...idx].to_i64?)}
-          end
-        end
-      end
+      record Entry, hash : Bytes, size : Int64?
 
       @checksums = Hash(String, Entry).new
       # Always-open handle to checksums.sha1, kept open across rewrites so
@@ -49,7 +27,7 @@ module LavinMQ
         tmp = "#{checksums_path}.tmp"
         f = File.new(tmp, "w")
         @checksums.each do |path, entry|
-          entry.to_io(f, path)
+          f.puts line(path, entry)
         end
         f.flush
         File.rename(tmp, checksums_path)
@@ -65,16 +43,20 @@ module LavinMQ
       def append(path : String, hash : Bytes, size : Int64? = nil) : Nil
         entry = Entry.new(hash, size)
         @checksums[path] = entry
-        entry.to_io(@checksum_file, path)
+        @checksum_file.puts line(path, entry)
         @checksum_file.flush
       end
 
       def restore : Nil
         File.open(checksums_path) do |f|
           loop do
-            if parsed = Entry.from_io(f)
-              path, entry = parsed
-              @checksums[path] = entry
+            hash = f.read_string(40).hexbytes
+            rest = f.read_line
+            if rest.starts_with?(" *") # sizeless format: "<hash> *<path>"
+              @checksums[rest[2..]] = Entry.new(hash, nil)
+            elsif idx = rest.index(" *", 1) # sized format: "<hash> <size> *<path>"
+              size = rest[1...idx].to_i64?
+              @checksums[rest[idx + 2..]] = Entry.new(hash, size)
             end
           rescue IO::EOFError
             break
@@ -118,6 +100,14 @@ module LavinMQ
 
       def size
         @checksums.size
+      end
+
+      private def line(path : String, entry : Entry) : String
+        if size = entry.size
+          "#{entry.hash.hexstring} #{size} *#{path}"
+        else
+          "#{entry.hash.hexstring} *#{path}"
+        end
       end
 
       private def checksums_path : String

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -6,7 +6,29 @@ module LavinMQ
       # `size` is the number of bytes the hash covers, when known. Entries
       # without a size (older checksums.sha1 files, follower-written entries)
       # can never be served for a sized lookup (#hash_for?).
-      record Entry, hash : Bytes, size : Int64?
+      record Entry, hash : Bytes, size : Int64? do
+        # One line per entry: "<hash> <size> *<path>", or "<hash> *<path>"
+        # when the size is unknown. The path is the caller's hash key, so it
+        # travels alongside the entry rather than being stored in it.
+        def to_io(io : IO, path : String) : Nil
+          io << hash.hexstring
+          if s = size
+            io << ' ' << s
+          end
+          io << " *" << path << '\n'
+        end
+
+        # Returns nil for malformed lines. Raises IO::EOFError at end of file.
+        def self.from_io(io : IO) : {String, Entry}?
+          hash = io.read_string(40).hexbytes
+          rest = io.read_line
+          if rest.starts_with?(" *")
+            {rest[2..], new(hash, nil)}
+          elsif idx = rest.index(" *", 1)
+            {rest[idx + 2..], new(hash, rest[1...idx].to_i64?)}
+          end
+        end
+      end
 
       @checksums = Hash(String, Entry).new
       # Always-open handle to checksums.sha1, kept open across rewrites so
@@ -27,7 +49,7 @@ module LavinMQ
         tmp = "#{checksums_path}.tmp"
         f = File.new(tmp, "w")
         @checksums.each do |path, entry|
-          f.puts line(path, entry)
+          entry.to_io(f, path)
         end
         f.flush
         File.rename(tmp, checksums_path)
@@ -43,20 +65,16 @@ module LavinMQ
       def append(path : String, hash : Bytes, size : Int64? = nil) : Nil
         entry = Entry.new(hash, size)
         @checksums[path] = entry
-        @checksum_file.puts line(path, entry)
+        entry.to_io(@checksum_file, path)
         @checksum_file.flush
       end
 
       def restore : Nil
         File.open(checksums_path) do |f|
           loop do
-            hash = f.read_string(40).hexbytes
-            rest = f.read_line
-            if rest.starts_with?(" *") # sizeless format: "<hash> *<path>"
-              @checksums[rest[2..]] = Entry.new(hash, nil)
-            elsif idx = rest.index(" *", 1) # sized format: "<hash> <size> *<path>"
-              size = rest[1...idx].to_i64?
-              @checksums[rest[idx + 2..]] = Entry.new(hash, size)
+            if parsed = Entry.from_io(f)
+              path, entry = parsed
+              @checksums[path] = entry
             end
           rescue IO::EOFError
             break
@@ -100,14 +118,6 @@ module LavinMQ
 
       def size
         @checksums.size
-      end
-
-      private def line(path : String, entry : Entry) : String
-        if size = entry.size
-          "#{entry.hash.hexstring} #{size} *#{path}"
-        else
-          "#{entry.hash.hexstring} *#{path}"
-        end
       end
 
       private def checksums_path : String

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -2,7 +2,13 @@ module LavinMQ
   module Clustering
     class Checksums
       Log = LavinMQ::Log.for "clustering.checksums"
-      @checksums = Hash(String, Bytes).new
+
+      # `size` is the number of bytes the hash covers, when known. Entries
+      # without a size (older checksums.sha1 files, follower-written entries)
+      # can never be served for a sized lookup (#hash_for?).
+      record Entry, hash : Bytes, size : Int64?
+
+      @checksums = Hash(String, Entry).new
       # Always-open handle to checksums.sha1, kept open across rewrites so
       # #append never has to check/reopen it: #append writes one line at a time
       # and #store adopts the freshly-renamed file's handle here.
@@ -20,8 +26,8 @@ module LavinMQ
         # can keep using it afterwards.
         tmp = "#{checksums_path}.tmp"
         f = File.new(tmp, "w")
-        @checksums.each do |path, hash|
-          f.puts "#{hash.hexstring} *#{path}"
+        @checksums.each do |path, entry|
+          f.puts line(path, entry)
         end
         f.flush
         File.rename(tmp, checksums_path)
@@ -34,9 +40,10 @@ module LavinMQ
       # progress survives a crash mid-sync (see Client#sync_files). No fsync:
       # the page cache survives a process crash and the cache is only an
       # optimization (a stale entry just triggers a re-fetch, never data loss).
-      def append(path : String, hash : Bytes) : Nil
-        @checksums[path] = hash
-        @checksum_file.puts "#{hash.hexstring} *#{path}"
+      def append(path : String, hash : Bytes, size : Int64? = nil) : Nil
+        entry = Entry.new(hash, size)
+        @checksums[path] = entry
+        @checksum_file.puts line(path, entry)
         @checksum_file.flush
       end
 
@@ -44,9 +51,13 @@ module LavinMQ
         File.open(checksums_path) do |f|
           loop do
             hash = f.read_string(40).hexbytes
-            f.skip(2) # " *"
-            path = f.read_line
-            @checksums[path] = hash
+            rest = f.read_line
+            if rest.starts_with?(" *") # sizeless format: "<hash> *<path>"
+              @checksums[rest[2..]] = Entry.new(hash, nil)
+            elsif idx = rest.index(" *", 1) # sized format: "<hash> <size> *<path>"
+              size = rest[1...idx].to_i64?
+              @checksums[rest[idx + 2..]] = Entry.new(hash, size)
+            end
           rescue IO::EOFError
             break
           end
@@ -60,12 +71,23 @@ module LavinMQ
         Log.info { "Checksums not found" }
       end
 
-      def []?(path)
-        @checksums[path]?
+      def []?(path) : Bytes?
+        @checksums[path]?.try &.hash
       end
 
-      def []=(path, value)
-        @checksums[path] = value
+      # The hash for `path` only if it covers exactly `size` bytes.
+      def hash_for?(path, size : Int64) : Bytes?
+        if entry = @checksums[path]?
+          entry.hash if entry.size == size
+        end
+      end
+
+      def []=(path, hash : Bytes)
+        @checksums[path] = Entry.new(hash, nil)
+      end
+
+      def set(path : String, hash : Bytes, size : Int64) : Nil
+        @checksums[path] = Entry.new(hash, size)
       end
 
       def delete(path)
@@ -78,6 +100,14 @@ module LavinMQ
 
       def size
         @checksums.size
+      end
+
+      private def line(path : String, entry : Entry) : String
+        if size = entry.size
+          "#{entry.hash.hexstring} #{size} *#{path}"
+        else
+          "#{entry.hash.hexstring} *#{path}"
+        end
       end
 
       private def checksums_path : String

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -3,9 +3,9 @@ module LavinMQ
     class Checksums
       Log = LavinMQ::Log.for "clustering.checksums"
 
-      # `size` is the number of bytes the hash covers, when known. Entries
-      # without a size (older checksums.sha1 files, follower-written entries)
-      # can never be served for a sized lookup (#hash_for?).
+      # `size` is the number of bytes the hash covers. Only entries restored
+      # from an old-format checksums.sha1 lack it; callers must treat those
+      # as unusable until recomputed.
       record Entry, hash : Bytes, size : Int64?
 
       @checksums = Hash(String, Entry).new
@@ -40,7 +40,7 @@ module LavinMQ
       # progress survives a crash mid-sync (see Client#sync_files). No fsync:
       # the page cache survives a process crash and the cache is only an
       # optimization (a stale entry just triggers a re-fetch, never data loss).
-      def append(path : String, hash : Bytes, size : Int64? = nil) : Nil
+      def append(path : String, hash : Bytes, size : Int64) : Nil
         entry = Entry.new(hash, size)
         @checksums[path] = entry
         @checksum_file.puts line(path, entry)
@@ -71,19 +71,10 @@ module LavinMQ
         Log.info { "Checksums not found" }
       end
 
-      def []?(path) : Bytes?
-        @checksums[path]?.try &.hash
-      end
-
-      # The hash for `path` only if it covers exactly `size` bytes.
-      def hash_for?(path, size : Int64) : Bytes?
-        if entry = @checksums[path]?
-          entry.hash if entry.size == size
-        end
-      end
-
-      def []=(path, hash : Bytes)
-        @checksums[path] = Entry.new(hash, nil)
+      # Hash and size are handed out together; the caller decides whether
+      # the recorded coverage fits its use.
+      def []?(path) : Entry?
+        @checksums[path]?
       end
 
       def set(path : String, hash : Bytes, size : Int64) : Nil

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -209,8 +209,8 @@ module LavinMQ
       # covers only part of the content) or the file is gone.
       private def adopt_digest(filename : String, sha1 : Digest::SHA1?) : Nil
         return unless sha1
-        return unless File.exists?(File.join(@data_dir, filename))
-        @checksums[filename] = sha1.final
+        return unless info = File.info?(File.join(@data_dir, filename))
+        @checksums.set(filename, sha1.final, info.size)
       end
 
       private def set_socket_opts(socket)
@@ -351,10 +351,11 @@ module LavinMQ
       # survives a crash.
       private def hash_file(filename : String, path : String) : Bytes
         Log.debug { "Calculating checksum for #{filename}" }
+        size = File.size(path)
         sha1 = Digest::SHA1.new
         sha1.file(path)
         hash = sha1.final
-        @checksums.append(filename, hash)
+        @checksums.append(filename, hash, size)
         hash
       end
 
@@ -421,7 +422,7 @@ module LavinMQ
           remaining.zero? || raise IO::EOFError.new
           # Persist immediately too: a file received here is complete and
           # stable, so a crash mid-sync won't force re-hashing it on restart.
-          @checksums.append(filename, sha1.final)
+          @checksums.append(filename, sha1.final, length)
         end
         Log.debug { "Received #{filename}, #{length.humanize_bytes}" }
       end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -260,7 +260,7 @@ module LavinMQ
           if File.exists? path
             # Pre-computed by #hash_local_files, except for files that appeared
             # after that pass.
-            unless local_hash = @checksums[filename]?
+            unless local_hash = @checksums[filename]?.try &.hash
               local_hash = hash_file(filename, path)
               Fiber.yield # CPU bound, so allow other fibers to run
             end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -198,7 +198,11 @@ module LavinMQ
         sha1 = Digest::SHA1.new
         snapshot.each do |path, mfile|
           # The cache holds full-size hashes; a capped pass must recompute.
-          cached_hash = caps ? nil : @file_index.shared { |_files, checksums| checksums[path]? }
+          cached_hash = @file_index.shared do |_f, checksums|
+            entry = checksums[path]?
+            cap = caps ? (caps[path]? || 0u64) : nil
+            entry if entry && (cap.nil? || entry.size == caps)
+          end
           if cached_hash
             yield({path, cached_hash})
           else

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -198,7 +198,7 @@ module LavinMQ
         sha1 = Digest::SHA1.new
         snapshot.each do |path, mfile|
           cap = caps ? caps[path]? || 0i64 : nil
-          if cached_hash = cached_hash(path, cap)
+          if cached_hash = cached_hash?(path, cap)
             yield({path, cached_hash})
           else
             filename = File.join(@data_dir, path)
@@ -222,19 +222,13 @@ module LavinMQ
       end
 
       # Reuse a cached hash only when its recorded coverage fits: exactly
-      # `cap` bytes for a capped pass, any known coverage otherwise. Checking
+      # `cap` bytes for a capped pass, any coverage otherwise. Checking
       # a cap against the file's current size instead would race local writes
-      # that haven't invalidated the cache yet. A sizeless entry (restored
-      # from an old-format file) is never reused, so the uncapped pass
-      # recomputes it and it gains a size a later capped pass can trust.
-      private def cached_hash(path : String, cap : Int64?) : Bytes?
+      # that haven't invalidated the cache yet.
+      private def cached_hash?(path : String, cap : Int64?) : Bytes?
         @file_index.shared do |_files, checksums|
           if entry = checksums[path]?
-            if cap
-              entry.hash if entry.size == cap
-            elsif entry.size
-              entry.hash
-            end
+            entry.hash if cap.nil? || entry.size == cap
           end
         end
       end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -197,25 +197,33 @@ module LavinMQ
         snapshot = @file_index.shared { |files, _checksums| files.dup }
         sha1 = Digest::SHA1.new
         snapshot.each do |path, mfile|
-          # The cache holds full-size hashes; a capped pass must recompute.
-          cached_hash = @file_index.shared do |_f, checksums|
-            entry = checksums[path]?
-            cap = caps ? (caps[path]? || 0u64) : nil
-            entry if entry && (cap.nil? || entry.size == caps)
+          # Without caps any cached hash is valid: every write invalidates the
+          # entry, so an entry that still exists covers the whole file. With
+          # caps the hash must cover exactly caps[path] bytes. Checking the
+          # cap against the file's current size instead would race local
+          # writes that haven't invalidated the cache yet.
+          cached_hash = @file_index.shared do |_files, checksums|
+            if caps
+              checksums.hash_for?(path, caps[path]? || 0i64)
+            else
+              checksums[path]?
+            end
           end
           if cached_hash
             yield({path, cached_hash})
           else
             filename = File.join(@data_dir, path)
             begin
+              hashed_size = 0i64
               File.open(filename) do |f|
                 size = mfile ? mfile.size : f.size.to_i64
                 size = Math.min(size, caps[path]? || 0i64) if caps
+                hashed_size = size.to_i64
                 sha1.update IO::Sized.new(f, size)
               end
               hash = sha1.final
               sha1.reset
-              @file_index.lock { |_files, checksums| checksums[path] = hash } unless caps
+              @file_index.lock { |_files, checksums| checksums.set(path, hash, hashed_size) } unless caps
               yield({path, hash})
             rescue File::NotFoundError
               next # File disappeared since we took the snapshot, just skip it.

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -197,19 +197,8 @@ module LavinMQ
         snapshot = @file_index.shared { |files, _checksums| files.dup }
         sha1 = Digest::SHA1.new
         snapshot.each do |path, mfile|
-          # Without caps any cached hash is valid: every write invalidates the
-          # entry, so an entry that still exists covers the whole file. With
-          # caps the hash must cover exactly caps[path] bytes. Checking the
-          # cap against the file's current size instead would race local
-          # writes that haven't invalidated the cache yet.
-          cached_hash = @file_index.shared do |_files, checksums|
-            if caps
-              checksums.hash_for?(path, caps[path]? || 0i64)
-            else
-              checksums[path]?
-            end
-          end
-          if cached_hash
+          cap = caps ? caps[path]? || 0i64 : nil
+          if cached_hash = cached_hash(path, cap)
             yield({path, cached_hash})
           else
             filename = File.join(@data_dir, path)
@@ -217,7 +206,7 @@ module LavinMQ
               hashed_size = 0i64
               File.open(filename) do |f|
                 size = mfile ? mfile.size : f.size.to_i64
-                size = Math.min(size, caps[path]? || 0i64) if caps
+                size = Math.min(size, cap) if cap
                 hashed_size = size.to_i64
                 sha1.update IO::Sized.new(f, size)
               end
@@ -227,6 +216,24 @@ module LavinMQ
               yield({path, hash})
             rescue File::NotFoundError
               next # File disappeared since we took the snapshot, just skip it.
+            end
+          end
+        end
+      end
+
+      # Reuse a cached hash only when its recorded coverage fits: exactly
+      # `cap` bytes for a capped pass, any known coverage otherwise. Checking
+      # a cap against the file's current size instead would race local writes
+      # that haven't invalidated the cache yet. A sizeless entry (restored
+      # from an old-format file) is never reused, so the uncapped pass
+      # recomputes it and it gains a size a later capped pass can trust.
+      private def cached_hash(path : String, cap : Int64?) : Bytes?
+        @file_index.shared do |_files, checksums|
+          if entry = checksums[path]?
+            if cap
+              entry.hash if entry.size == cap
+            elsif entry.size
+              entry.hash
             end
           end
         end


### PR DESCRIPTION
Fixes #2162.

Builds on @lukas8219's 80cd1992, which spotted the capped pass never using the checksum cache. That commit is cherry-picked here with a corrected reuse condition on top: it compared the digest's byte length against the caps hash, so it could never be true and the capped pass still recomputed everything.

During the final full_sync pass the leader hashes every file up to a snapshotted cut while holding the lock that all replicated operations need, so publishing stalls until the pass is done. The checksum cache was bypassed because entries did not record how many bytes a hash covers, so a cached hash could not be trusted for a capped size.

Every checksum write now records the covered byte count, on the leader as well as on the follower, so a size may only be recorded by code that just hashed exactly that many bytes. Lookups hand out the whole entry, hash and size together, and the caller decides whether the recorded coverage fits its use. The capped pass reuses a cached hash exactly when it covers the requested cut, which is every file not written to between the two passes, so it no longer re-reads tens of thousands of unchanged files under the lock. Comparing the cap against the file's current size instead would race local writes that have not invalidated the cache yet, which is why the covered size is stored rather than inferred.

The size is persisted in checksums.sha1 as "hash size *path". Files written by older versions parse as entries without a size; the uncapped pass recomputes those and records sizes, so an old cache heals in one pass and the capped pass never trusts a sizeless entry.

Specs: the reuse spec deletes the file from disk before the capped pass, so the hash can only come from the cache, and it fails without this change. Further specs cover recompute on cap mismatch, healing of old-format entries, size persistence across append/store/restore, and that follower-written checksums match both content and size on disk.
