### PR TITLE
Stop follower log fiber when streaming stops

### DIFF
--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -18,6 +18,17 @@ module ClientSyncSpec
     getter syncs_started = 0
     getter? synced_on_closed_fd = false
 
+    # Instrumentation for the log-loop lifecycle spec: how many streamed-bytes
+    # logging fibers are currently running.
+    getter log_loops_running = 0
+
+    private def log_streamed_bytes_loop(done : Channel(Nil))
+      @log_loops_running += 1
+      super
+    ensure
+      @log_loops_running -= 1
+    end
+
     private def sync_data_dir : Nil
       @syncs_started += 1
       sleep @sync_delay unless @sync_delay.zero?
@@ -192,6 +203,28 @@ module ClientSyncSpec
           end
           acked.should eq framing
           File.exists?(File.join(data_dir, filename)).should be_false
+          client_socket.close
+        end
+      end
+
+      # Regression: the streamed-bytes logging fiber looped forever, so every
+      # reconnect (each of which spawns one) leaked another fiber logging the
+      # same counter.
+      it "stops the streamed bytes logging fiber when the stream ends" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+            # leader disconnected below to end the loop
+          end
+          wait_for { client.log_loops_running == 1 }
+
+          leader_io.close # disconnect, so stream_changes raises and returns
+          wait_for { client.log_loops_running.zero? }
           client_socket.close
         end
       end

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -340,7 +340,10 @@ module LavinMQ
       private def stream_changes(socket, lz4)
         acks = @acks = Channel(Int64).new(ACK_BUFFER_CAPACITY)
         @ack_loops.spawn(name: "Send ack loop") { send_ack_loop(acks, socket) }
-        spawn log_streamed_bytes_loop, name: "Log streamed bytes loop"
+        # Stops the logging fiber when this stream ends, so a reconnect doesn't
+        # leave one behind per connection (they all report the same counter).
+        log_loop_done = Channel(Nil).new
+        spawn log_streamed_bytes_loop(log_loop_done), name: "Log streamed bytes loop"
         loop do
           filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
           next if filename_len.zero?
@@ -369,6 +372,7 @@ module LavinMQ
         end
       ensure
         @acks.close
+        log_loop_done.try &.close
       end
 
       private def append(filename, len, lz4)
@@ -516,11 +520,18 @@ module LavinMQ
         {% end %}
       end
 
-      private def log_streamed_bytes_loop
+      # Logs the streamed byte count until #stream_changes closes the done
+      # channel (or the client is closed), so the fiber doesn't outlive the
+      # stream that spawned it.
+      private def log_streamed_bytes_loop(done : Channel(Nil))
         loop do
-          sleep 30.seconds
-          break if @closed
-          Log.info { "Total streamed bytes: #{@streamed_bytes}" }
+          select
+          when done.receive?
+            break
+          when timeout(30.seconds)
+            break if @closed
+            Log.info { "Total streamed bytes: #{@streamed_bytes}" }
+          end
         end
       end
 


### PR DESCRIPTION
### WHAT is this pull request doing?
A follower is logging how many bytes that has been streamed. This is done in a separate fiber which is spawned when the streaming starts. This fiber was never stopped, so if the streaming stopped (e.g. IO error) and the follower reconnected, it started a second fiber and double entries are logged.

This PR makes sure the log fiber is stopped when the streaming stops.

### HOW can this pull request be tested?
Specs / manually
