### PR TITLE
Fix wrong checksums for files appended to mid-content

### DIFF
--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -3,6 +3,85 @@ require "lz4"
 
 module ClientSyncSpec
   extend ClusteringSpecHelper
+  # `extend` only copies methods, not the module's nested types.
+  alias TestClient = ClusteringSpecHelper::TestClient
+
+  # Runs one file-list comparison pass against a leader offering `leader_files`,
+  # with `resync` picking the reconnect variant (see TestClient).
+  def self.sync_with_leader(client : TestClient, leader_files : Hash(String, String), resync = false)
+    server_io, client_io = UNIXSocket.pair
+    lz4_reader = Compress::LZ4::Reader.new(client_io)
+    done = Channel(Nil).new
+    spawn do
+      simulate_leader(server_io, leader_files)
+      done.send nil
+    end
+    if resync
+      client.resync_files_public(client_io, lz4_reader)
+    else
+      client.sync_files_public(client_io, lz4_reader)
+    end
+    select
+    when done.receive
+    when timeout(1.second)
+      raise "leader fiber timed out"
+    end
+  ensure
+    server_io.try &.close
+    client_io.try &.close
+  end
+
+  # One replication record: a negative length appends, a positive one replaces.
+  def self.write_record(lz4 : Compress::LZ4::Writer, filename : String, len : Int64, bytes : Bytes)
+    lz4.write_bytes filename.bytesize, IO::ByteFormat::LittleEndian
+    lz4.write filename.to_slice
+    lz4.write_bytes len, IO::ByteFormat::LittleEndian
+    lz4.write bytes
+    lz4.flush
+  end
+
+  # Bytes the follower acks for a whole record: framing plus payload.
+  def self.record_size(filename : String, payload_size : Int) : Int64
+    (sizeof(Int32) + filename.bytesize + sizeof(Int64) + payload_size).to_i64
+  end
+
+  def self.read_acks(io : IO, target : Int64)
+    io.read_timeout = 2.seconds
+    acked = 0i64
+    while acked < target
+      acked += io.read_bytes(Int64, IO::ByteFormat::LittleEndian)
+    end
+    acked.should eq target
+  end
+
+  # follow() was never called in this harness, so satisfy close's follower-done
+  # handshake ourselves.
+  def self.close_client(client : TestClient)
+    spawn(name: "follower done feeder") { client.@follower_done.send(nil) }
+    client.close
+  end
+
+  def self.persisted_checksums(data_dir : String) : Hash(String, String)
+    path = File.join(data_dir, "checksums.sha1")
+    return Hash(String, String).new unless File.exists?(path)
+    File.read_lines(path).to_h do |line|
+      hash, _, filename = line.partition(" *")
+      {filename, hash} # a later line wins, as in Checksums#restore
+    end
+  end
+
+  # Every line in checksums.sha1 must be the hash of what's on disk right now:
+  # one that isn't makes the next sync throw the file away and re-fetch it from
+  # the leader. Returns them for further assertions.
+  def self.checksums_matching_disk(data_dir : String) : Hash(String, String)
+    checksums = persisted_checksums(data_dir)
+    checksums.each do |filename, hash|
+      path = File.join(data_dir, filename)
+      File.exists?(path).should be_true, "checksum for missing file #{filename}"
+      hash.should eq Digest::SHA1.digest(File.read(path)).hexstring
+    end
+    checksums
+  end
 
   describe LavinMQ::Clustering::Client do
     describe "stream_changes" do
@@ -615,6 +694,227 @@ module ClientSyncSpec
           checksums_file = File.join(data_dir, "checksums.sha1")
           File.exists?(checksums_file).should be_true
           File.read(checksums_file).should contain "queue1/messages.dat"
+        end
+      end
+    end
+
+    # A digest that didn't start at byte 0 of the file covers only the bytes it
+    # saw, so persisting it as that file's checksum makes the next sync mismatch
+    # and re-fetch a file the follower already has.
+    describe "checksums persisted on close" do
+      it "persists no checksum for a file appended to after sync" do
+        with_datadir do |data_dir|
+          filename = "queue1/msgs.0000000001"
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          File.write File.join(data_dir, filename), "hello"
+
+          client = make_client(data_dir)
+          # Sync first, so the file's pre-append hash is known and persisted.
+          sync_with_leader(client, {filename => "hello"})
+
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          payload = " world"
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+          read_acks(leader_io, record_size(filename, payload.bytesize))
+
+          client_socket.close
+          close_client(client)
+
+          File.read(File.join(data_dir, filename)).should eq "hello world"
+          # Dropped when the append arrived, so the next sync re-hashes the file
+          # locally instead of trusting the hash of just the appended bytes.
+          checksums_matching_disk(data_dir).has_key?(filename).should be_false
+        end
+      end
+
+      it "persists the checksum of a file it created by appending" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          # The file doesn't exist locally, so the digest sees all of it — over
+          # both records.
+          filename = "queue1/msgs.0000000001"
+          {"abc", "def"}.each do |payload|
+            write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+            read_acks(leader_io, record_size(filename, payload.bytesize))
+          end
+
+          client_socket.close
+          close_client(client)
+
+          File.read(File.join(data_dir, filename)).should eq "abcdef"
+          checksums_matching_disk(data_dir)[filename].should eq Digest::SHA1.digest("abcdef").hexstring
+        end
+      end
+
+      it "persists the checksum of a replaced file" do
+        with_datadir do |data_dir|
+          filename = "definitions.amqp"
+          File.write File.join(data_dir, filename), "old content"
+
+          client = make_client(data_dir)
+          sync_with_leader(client, {filename => "old content"})
+
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          content = "brand new content"
+          write_record(lz4_writer, filename, content.bytesize.to_i64, content.to_slice)
+          read_acks(leader_io, record_size(filename, content.bytesize))
+
+          client_socket.close
+          close_client(client)
+
+          checksums_matching_disk(data_dir)[filename].should eq Digest::SHA1.digest(content).hexstring
+        end
+      end
+
+      # The digest of an aborted replace covers content that was never installed,
+      # so it must not become the file's checksum; the old file is still on disk
+      # and keeps its own (matching) hash.
+      it "keeps the old checksum when a replace never completes" do
+        with_datadir do |data_dir|
+          filename = "definitions.amqp"
+          File.write File.join(data_dir, filename), "old content"
+
+          client = make_client(data_dir)
+          sync_with_leader(client, {filename => "old content"})
+
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          stream_done = Channel(Nil).new(1)
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          ensure
+            stream_done.send nil
+          end
+
+          # Announce twice the bytes we send, then hang up: the replace writes a
+          # partial .tmp file and raises before renaming it into place.
+          content = "new content"
+          write_record(lz4_writer, filename, (content.bytesize * 2).to_i64, content.to_slice)
+          leader_io.close
+
+          select
+          when stream_done.receive
+          when timeout(2.seconds)
+            fail "stream fiber did not exit"
+          end
+
+          close_client(client)
+
+          File.read(File.join(data_dir, filename)).should eq "old content"
+          checksums_matching_disk(data_dir)[filename].should eq Digest::SHA1.digest("old content").hexstring
+        end
+      end
+
+      # checksums.sha1 is carried across restarts wholesale (restore, then store
+      # at shutdown), so a line for a file that's been deleted would never leave
+      # it again.
+      it "drops the checksum of a file the sync deleted" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          filename = "gone_from_leader"
+          payload = "data"
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+          read_acks(leader_io, record_size(filename, payload.bytesize))
+          client_socket.close
+
+          # Reconnect to a leader that no longer has the file: the sync sweeps it.
+          sync_with_leader(client, {} of String => String, resync: true)
+          File.exists?(File.join(data_dir, filename)).should be_false
+
+          close_client(client)
+          checksums_matching_disk(data_dir).has_key?(filename).should be_false
+        end
+      end
+    end
+
+    # The open append handles and running digests belong to one connection: a
+    # sync deletes and re-fetches local files that don't match the leader, so
+    # anything held over from the previous connection can describe an inode
+    # that's no longer at that path.
+    describe "state carried across a re-sync" do
+      it "appends to the file the re-sync installed, not the replaced inode" do
+        with_datadir do |data_dir|
+          filename = "queue1/msgs.0000000001"
+          Dir.mkdir_p File.join(data_dir, "queue1")
+          File.write File.join(data_dir, filename), "old"
+
+          client = make_client(data_dir)
+          sync_with_leader(client, {filename => "old"})
+
+          # Stream an append, which leaves an open handle on the current inode.
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+          write_record(lz4_writer, filename, -1i64, "A".to_slice)
+          read_acks(leader_io, record_size(filename, 1))
+          File.read(File.join(data_dir, filename)).should eq "oldA"
+          client_socket.close
+
+          # Reconnect to a leader whose copy differs: the sync unlinks our file
+          # and re-fetches it, so the path now points at a new inode.
+          sync_with_leader(client, {filename => "new"}, resync: true)
+          File.read(File.join(data_dir, filename)).should eq "new"
+
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+          spawn(name: "client stream_changes after resync") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+          write_record(lz4_writer, filename, -1i64, "B".to_slice)
+          read_acks(leader_io, record_size(filename, 1))
+
+          # A stale handle would have sent this into the unlinked inode, where
+          # it's invisible — and acked it as durable.
+          File.read(File.join(data_dir, filename)).should eq "newB"
+
+          client_socket.close
+          close_client(client)
+          checksums_matching_disk(data_dir)
         end
       end
     end

--- a/spec/support/clustering_helper.cr
+++ b/spec/support/clustering_helper.cr
@@ -33,6 +33,13 @@ module ClusteringSpecHelper
       super
     end
 
+    # Mirrors what #sync does on a reconnect: drop the state describing the data
+    # dir as the previous connection left it, then compare against the leader.
+    def resync_files_public(socket, lz4)
+      reset_file_state
+      sync_files(socket, lz4)
+    end
+
     # Instrumentation for the close/ack-loop fd race spec: slow each sync down
     # and record whether one ever ran against a closed data dir fd — the real
     # implementation would Log.fatal and exit 1 there.

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -37,7 +37,12 @@ module LavinMQ
       @socket : TCPSocket?
       @internal_http_server : ::HTTP::Server?
       @streamed_bytes = 0_u64
-      @file_digests = Hash(String, Digest::SHA1).new
+      # Running SHA1 of each file's *whole* content, persisted as that file's
+      # checksum on graceful shutdown. A nil value means the file is untracked:
+      # we started seeing it mid-content and Digest::SHA1 can't be seeded with a
+      # hash, so no digest here could cover the bytes already on disk. See
+      # #digest_for.
+      @file_digests = Hash(String, Digest::SHA1?).new
       @follower_done = Channel(Nil).new
       # Buffers acks from the stream-reading fiber to the ack-sending fiber.
       # Replaced with a fresh channel on each (re)connect in #stream_changes.
@@ -184,11 +189,37 @@ module LavinMQ
         Log.info { "Fully synchronised in #{full_sync_time.total_seconds} seconds" }
       end
 
-      # handles from a previous connection may point at unlinked inodes
+      # Drop everything that describes the data dir as the previous connection
+      # left it. A sync deletes and re-fetches every local file whose hash
+      # doesn't match the leader's, so a cached append handle can be left
+      # pointing at an unlinked inode (writes to it would silently vanish while
+      # still being acked as durable) and a running digest can describe content
+      # that's no longer on disk.
       private def reset_file_state : Nil
+        finalize_digests
         @files.each_value &.close
         @files.clear
+      end
+
+      # Adopt the running digests as the files' checksums and stop tracking
+      # them. A digest only describes a file's whole content if it was started
+      # while the file was empty (see #digest_for), so untracked (nil) entries
+      # are skipped, as are files that no longer exist on disk — a checksum for
+      # a missing file can only ever fail to match.
+      private def finalize_digests : Nil
+        @file_digests.each do |filename, sha1|
+          adopt_digest(filename, sha1)
+        end
         @file_digests.clear
+      end
+
+      # Adopt `sha1` as `filename`'s checksum, if it's one we can trust: an
+      # untracked (nil) digest describes only part of the file, and a file that's
+      # no longer on disk can't be matched by any checksum.
+      private def adopt_digest(filename : String, sha1 : Digest::SHA1?) : Nil
+        return unless sha1
+        return unless File.exists?(File.join(@data_dir, filename))
+        @checksums[filename] = sha1.final
       end
 
       private def set_socket_opts(socket)
@@ -447,7 +478,32 @@ module LavinMQ
       private def append(filename, len, lz4)
         Log.debug { "Appending #{len.abs} bytes to #{filename}" }
         f = @files[filename]
-        stream_with_checksum(filename, lz4, f, len.abs)
+        stream_with_checksum(lz4, f, len.abs, digest_for(filename, f))
+      end
+
+      # The running digest over `filename`'s whole content, or nil if we can't
+      # keep one for it. Decided once per file (per connection) on its first
+      # append: a digest is only a valid checksum for the file if it has seen
+      # every byte in it, and Digest::SHA1 can't be seeded with a hash, so
+      # tracking can only start while the file is still empty. When it isn't,
+      # any checksum we hold for the file goes stale with this append, so it's
+      # dropped: the next sync then re-hashes the file from disk instead of
+      # trusting a hash that doesn't match its content (which would make the
+      # leader re-send a file we already have).
+      #
+      # `file` is opened in append mode, which doesn't change its size, so the
+      # size seen here is the file's size before this append.
+      private def digest_for(filename : String, file : File) : Digest::SHA1?
+        # #fetch, not #[]?, to tell an absent entry from an untracked file
+        @file_digests.fetch(filename) do
+          if file.size.zero?
+            @file_digests[filename] = Digest::SHA1.new
+          else
+            Log.debug { "Not checksumming #{filename}, appending to existing content" }
+            @checksums.delete(filename)
+            @file_digests[filename] = nil
+          end
+        end
       end
 
       private def delete(filename)
@@ -493,8 +549,15 @@ module LavinMQ
         Log.debug { "Replacing file #{filename} (#{len} bytes)" }
         @files.delete(filename).try &.close
 
-        # Reset SHA1 digest for replaced file
-        @file_digests[filename] = Digest::SHA1.new
+        # A replace rewrites the file from byte 0, so a digest over the streamed
+        # bytes covers its whole content — but only once the rename below has
+        # installed it. Until then the old file is what's on disk, so let it keep
+        # its checksum (adopting any running digest, which is the up-to-date hash
+        # of it) and hold the new digest aside until the rename: an aborted
+        # replace then leaves a checksum that still matches the file, instead of
+        # a hash of content that never got installed.
+        adopt_digest(filename, @file_digests.delete(filename))
+        sha1 = Digest::SHA1.new
 
         path = File.join(@data_dir, "#{filename}.tmp")
         Dir.mkdir_p File.dirname(path)
@@ -503,18 +566,18 @@ module LavinMQ
           # The record's final ack tells the leader the replace is durable, so
           # it must not be sent while the new content only exists as the .tmp
           # file; hold it back until the rename has installed the file.
-          deferred = stream_with_checksum(filename, lz4, f, len, defer_final_ack: true)
+          deferred = stream_with_checksum(lz4, f, len, sha1, defer_final_ack: true)
           f.rename f.path[0..-5]
+          @file_digests[filename] = sha1
           ack(deferred)
         end
       end
 
       # Read from lz4, update SHA1, and write to file incrementally.
       # Returns the number of bytes received but not yet acked (see below).
-      private def stream_with_checksum(filename : String, lz4 : IO, file : IO, length : Int64, defer_final_ack = false) : Int64
-        # Get or create SHA1 digest for this file
-        sha1 = @file_digests[filename] ||= Digest::SHA1.new
-
+      # `sha1` is nil for a file whose content we can't checksum incrementally
+      # (see #digest_for); the bytes are then streamed without hashing.
+      private def stream_with_checksum(lz4 : IO, file : IO, length : Int64, sha1 : Digest::SHA1?, defer_final_ack = false) : Int64
         # Read, hash, and write incrementally. Each chunk is acked as soon as
         # it's persisted so the leader sees continuous progress within a large
         # action and won't evict us on its ack deadline (a 128 MiB message would
@@ -529,7 +592,7 @@ module LavinMQ
           raise IO::EOFError.new if len.zero?
           bytes = buffer.to_slice[0, len]
           file.write(bytes)
-          sha1.update(bytes)
+          sha1.try &.update(bytes)
           remaining -= len
           return len.to_i64 if remaining.zero? && defer_final_ack
           ack(len)
@@ -641,10 +704,7 @@ module LavinMQ
         @acks.close
         @ack_loops.wait
         # Finalize all pending checksums
-        @file_digests.each do |filename, sha1|
-          @checksums[filename] = sha1.final
-        end
-        @file_digests.clear
+        finalize_digests
         @checksums.store
         LibC.close(@data_dir_fd) if @data_dir_fd >= 0
         @data_dir_lock.release

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -16,8 +16,8 @@ module LavinMQ
       # LZ4::Reader's internal 64 KiB buffer.
       BUFFER_SIZE = 64 * 1024
 
-      # Files #hash_local_files hashes between Fiber.yields. Hashing is CPU
-      # bound, but a yield per (often tiny) file costs more than it gives back.
+      # Files #hash_local_files hashes between Fiber.yields; a yield per (often
+      # tiny) file costs more than it gives back.
       HASH_YIELD_INTERVAL = 32
 
       # Capacity of the channel buffering acks from the stream-reading fiber to
@@ -37,11 +37,9 @@ module LavinMQ
       @socket : TCPSocket?
       @internal_http_server : ::HTTP::Server?
       @streamed_bytes = 0_u64
-      # Running SHA1 of each file's *whole* content, persisted as that file's
-      # checksum on graceful shutdown. A nil value means the file is untracked:
-      # we started seeing it mid-content and Digest::SHA1 can't be seeded with a
-      # hash, so no digest here could cover the bytes already on disk. See
-      # #digest_for.
+      # Running SHA1 over each file's whole content, adopted as its checksum when
+      # tracking ends. nil when we started seeing the file mid-content, so no
+      # digest can cover the bytes already on disk (see #digest_for).
       @file_digests = Hash(String, Digest::SHA1?).new
       @follower_done = Channel(Nil).new
       # Buffers acks from the stream-reading fiber to the ack-sending fiber.
@@ -189,23 +187,17 @@ module LavinMQ
         Log.info { "Fully synchronised in #{full_sync_time.total_seconds} seconds" }
       end
 
-      # Drop everything that describes the data dir as the previous connection
-      # left it. A sync deletes and re-fetches every local file whose hash
-      # doesn't match the leader's, so a cached append handle can be left
-      # pointing at an unlinked inode (writes to it would silently vanish while
-      # still being acked as durable) and a running digest can describe content
-      # that's no longer on disk.
+      # Forget the data dir as the previous connection left it. The sync ahead
+      # deletes and re-fetches every file whose hash doesn't match the leader's,
+      # which would leave cached handles writing to unlinked inodes and digests
+      # covering content that's no longer on disk.
       private def reset_file_state : Nil
         finalize_digests
         @files.each_value &.close
         @files.clear
       end
 
-      # Adopt the running digests as the files' checksums and stop tracking
-      # them. A digest only describes a file's whole content if it was started
-      # while the file was empty (see #digest_for), so untracked (nil) entries
-      # are skipped, as are files that no longer exist on disk — a checksum for
-      # a missing file can only ever fail to match.
+      # Adopt the running digests as the files' checksums and stop tracking them.
       private def finalize_digests : Nil
         @file_digests.each do |filename, sha1|
           adopt_digest(filename, sha1)
@@ -213,9 +205,8 @@ module LavinMQ
         @file_digests.clear
       end
 
-      # Adopt `sha1` as `filename`'s checksum, if it's one we can trust: an
-      # untracked (nil) digest describes only part of the file, and a file that's
-      # no longer on disk can't be matched by any checksum.
+      # Store `sha1` as `filename`'s checksum, unless it's untracked (nil, i.e.
+      # covers only part of the content) or the file is gone.
       private def adopt_digest(filename : String, sha1 : Digest::SHA1?) : Nil
         return unless sha1
         return unless File.exists?(File.join(@data_dir, filename))
@@ -235,10 +226,9 @@ module LavinMQ
         Log.info { "Waiting for list of files" }
         hash_size = Digest::SHA1.new.digest_size
 
-        # Drain the entire file list FIRST, doing no hashing in this loop. Any
-        # CPU-bound work between entries stalls the leader's file-list flush
-        # until its write timeout fires and it disconnects us. Once the list is
-        # read the leader blocks reading our file requests, so the comparison
+        # Drain the whole file list before hashing anything: stalling between
+        # entries can make the leader's file-list write time out and drop us.
+        # Once the list is read it waits for our file requests, so the comparison
         # below is free to hash.
         remote_files = Array({String, Bytes}).new
         loop do
@@ -296,7 +286,7 @@ module LavinMQ
         files_to_delete.each do |path|
           Log.debug { "File not on leader: #{path}" }
           File.delete path
-          # #hash_local_files hashed this file too, drop it or the checksum map
+          # It got a checksum from #hash_local_files; drop it or the checksum map
           # accumulates dead paths.
           @checksums.delete(relative_path(path))
         rescue ex : File::Error
@@ -325,10 +315,9 @@ module LavinMQ
         Log.info { "Received all #{requested_files.size} files" } unless requested_files.empty?
       end
 
-      # Hash every local file before connecting to the leader. Hashing while
-      # connected stalls the leader, which holds its sync lock (and, in the
-      # second sync pass, its replication lock) until we answer. Files already
-      # in @checksums (from disk or an earlier pass) are skipped.
+      # Hash every local file before connecting, because hashing while connected
+      # holds up the leader, which keeps its sync lock until we answer. Files
+      # already in @checksums (from disk or an earlier pass) are skipped.
       private def hash_local_files : Nil
         computed = 0
         files, _dirs = ls_r(@data_dir)
@@ -347,8 +336,8 @@ module LavinMQ
             Log.debug(exception: ex) { "#{path} disappeared while hashing" }
           rescue ex : File::Error
             # This pass also hashes files the leader doesn't have, so one
-            # unreadable file must not wedge us in the reconnect loop. Left
-            # uncached, so the compare loop still fails if the leader has it.
+            # unreadable file must not wedge the reconnect loop. Left uncached,
+            # so the compare loop still fails if the leader has it.
             Log.warn(exception: ex) { "Failed to calculate checksum for #{path}" }
           end
           # #restore truncated checksums.sha1, so snapshot the full set or a
@@ -482,17 +471,11 @@ module LavinMQ
       end
 
       # The running digest over `filename`'s whole content, or nil if we can't
-      # keep one for it. Decided once per file (per connection) on its first
-      # append: a digest is only a valid checksum for the file if it has seen
-      # every byte in it, and Digest::SHA1 can't be seeded with a hash, so
-      # tracking can only start while the file is still empty. When it isn't,
-      # any checksum we hold for the file goes stale with this append, so it's
-      # dropped: the next sync then re-hashes the file from disk instead of
-      # trusting a hash that doesn't match its content (which would make the
-      # leader re-send a file we already have).
-      #
-      # `file` is opened in append mode, which doesn't change its size, so the
-      # size seen here is the file's size before this append.
+      # keep one: Digest::SHA1 can't be seeded with a hash, so tracking can only
+      # start while the file is empty (`file` is opened in append mode, so its
+      # size here is still the pre-append size). If it isn't, the checksum we
+      # hold goes stale with this append and is dropped, making the next sync
+      # re-hash the file from disk.
       private def digest_for(filename : String, file : File) : Digest::SHA1?
         # #fetch, not #[]?, to tell an absent entry from an untracked file
         @file_digests.fetch(filename) do
@@ -549,13 +532,10 @@ module LavinMQ
         Log.debug { "Replacing file #{filename} (#{len} bytes)" }
         @files.delete(filename).try &.close
 
-        # A replace rewrites the file from byte 0, so a digest over the streamed
-        # bytes covers its whole content — but only once the rename below has
-        # installed it. Until then the old file is what's on disk, so let it keep
-        # its checksum (adopting any running digest, which is the up-to-date hash
-        # of it) and hold the new digest aside until the rename: an aborted
-        # replace then leaves a checksum that still matches the file, instead of
-        # a hash of content that never got installed.
+        # A replace rewrites the file from byte 0, so the digest below covers its
+        # whole content — but only once the rename installs it. Until then the old
+        # file is on disk, so leave it with a checksum matching it and start
+        # tracking the new digest only after the rename.
         adopt_digest(filename, @file_digests.delete(filename))
         sha1 = Digest::SHA1.new
 
@@ -575,8 +555,7 @@ module LavinMQ
 
       # Read from lz4, update SHA1, and write to file incrementally.
       # Returns the number of bytes received but not yet acked (see below).
-      # `sha1` is nil for a file whose content we can't checksum incrementally
-      # (see #digest_for); the bytes are then streamed without hashing.
+      # A nil `sha1` streams the bytes without hashing them (see #digest_for).
       private def stream_with_checksum(lz4 : IO, file : IO, length : Int64, sha1 : Digest::SHA1?, defer_final_ack = false) : Int64
         # Read, hash, and write incrementally. Each chunk is acked as soon as
         # it's persisted so the leader sees continuous progress within a large


### PR DESCRIPTION
### WHAT is this pull request doing?

`stream_with_checksum` created a SHA1 digest for any file that lacked one, including files that already had content on disk.  Such a digest only covers the appended bytes, so persisting it on graceful shutdown claimed the hash of a tail was the hash of the whole file. On the next start `sync_files` compared it against the leader's hash, mismatched, and deleted and re-fetched a file we already had — for every active segment, ack file, consumer_offsets and definitions.amqp, on every restart.

A digest is only a valid checksum if it has seen the file from byte 0, and `Digest::SHA1` can't be seeded with a hash, so a file first seen mid-content is now left untracked (a nil entry in `@file_digests`) and its cached checksum dropped: the next sync re-hashes it locally instead of trusting a hash that doesn't match its content. Files created by appends and files installed by a replace are still tracked.

replace holds its digest aside until the rename has installed the file, adopting any running digest as the old file's checksum first, so an aborted replace leaves a checksum that still matches what's on disk instead of a hash of content that was never installed.

### HOW can this pull request be tested?
Specs
