### PR TITLE
fix: don't double-decrement unacked_count on partial HTTP get failure

### DIFF
--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -479,6 +479,32 @@ describe LavinMQ::HTTP::QueuesController do
       end
     end
 
+    it "should not double-decrement unacked_count when an ack fails mid-batch" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("q4")
+          q4 = s.vhosts["/"].queue("q4").as(LavinMQ::AMQP::Queue)
+          3.times { q.publish_confirm "m1" }
+          wait_for { q4.message_count == 3 }
+
+          # Let the first ack of the batch succeed and the next one fail. The
+          # failing ack has already decremented unacked_count, so the recovery
+          # path must only requeue the messages it hasn't finalized yet.
+          q4.@msg_store.raise_on_delete_after = 1
+
+          body = %({ "count": 3, "ack_mode": "get", "encoding": "auto" })
+          begin
+            http.post("/api/queues/%2f/q4/get", body: body)
+          rescue # the endpoint re-raises the injected failure
+          end
+          q4.@msg_store.raise_on_delete_after = nil
+
+          q4.unacked_count.should eq 0
+          http.get("/api/overview").status_code.should eq 200
+        end
+      end
+    end
+
     it "should handle count > message_count" do
       with_http_server do |http, s|
         with_channel(s) do |ch|

--- a/spec/support/failing_message_store.cr
+++ b/spec/support/failing_message_store.cr
@@ -1,0 +1,19 @@
+# Spec-only failure injection for MessageStore.
+#
+# Some error-recovery paths are only reachable when the message store itself
+# fails (ENOSPC while appending to the acks file, a dropped segment, etc.),
+# which can't be provoked through the public API. Set `raise_on_delete_after`
+# to let N deletes succeed and have every later delete raise, so specs can
+# exercise a failure that happens *partway* through a batch of acks.
+class LavinMQ::MessageStore
+  property raise_on_delete_after : Int32? = nil
+  @spec_delete_count = 0
+
+  def delete(sp) : Nil
+    if after = @raise_on_delete_after
+      raise IO::Error.new("spec: injected message store delete failure") if @spec_delete_count >= after
+      @spec_delete_count += 1
+    end
+    previous_def
+  end
+end

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -216,7 +216,10 @@ module LavinMQ
                     end
                   end || break
                 end
-                sps.each do |sp|
+                # Shift each sp off before finalizing it, so `sps` only holds messages
+                # that aren't finalized yet. An sp whose #ack/#reject raised halfway
+                # has already been decremented, so the rescue below must not touch it.
+                while sp = sps.shift?
                   if ack
                     q.ack(sp)
                   else
@@ -224,10 +227,10 @@ module LavinMQ
                   end
                 end
               rescue e : Exception
-                # Requeue all unacked messages on error
+                # Requeue the messages that aren't finalized yet
                 if unacked_sps = sps
-                  unacked_sps.each do |sp|
-                    q.reject(sp, true)
+                  unacked_sps.each do |unacked_sp|
+                    q.reject(unacked_sp, true)
                   end
                 end
                 raise e


### PR DESCRIPTION
Fixes #2153

The error handler in `POST /api/queues/:vhost/:name/get` requeued the entire `sps` batch, including the messages the loop above had already ack'd/rejected. `Queue#ack` and `#reject` decrement `unacked_count` unconditionally, so a failure partway through the batch decremented the already-finalized messages a second time.

`unacked_count` is an `Atomic(UInt32)`, so the extra decrements wrapped it to ~`UInt32::MAX` instead of raising. `GET /api/overview` sums every queue's `unacked_count` into a `UInt32`, which then raised `OverflowError` on every request until the node was restarted - taking the whole management UI down, since every page polls it.

The fix shifts each sp off the array before finalizing it, so the array only ever holds messages that aren't finalized yet.

The same handler also called `q.reject(sp, true)` on already-*acked* sps, which requeues a deleted message into the store, so this was duplicate delivery as well as counter corruption.

## Test plan

`spec/support/failing_message_store.cr` adds a default-off `raise_on_delete_after` hook (spec-only reopen, same pattern as `spec/support/rough_time.cr`) that injects the real-world trigger: an IO error appending to the acks file. The new spec gets 3 messages, fails the 2nd ack, and asserts `unacked_count` is 0 and `/api/overview` still returns 200.

Before the fix that spec fails with `Expected: 0, got: 4294967294`.
