### PR TITLE
chore: build with Crystal 1.21

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -29,3 +29,107 @@ Lint/NotNil:
 # Run `ameba --only Documentation/DocumentationAdmonition` for details
 Documentation/DocumentationAdmonition:
   Enabled: false
+
+# ---------------------------------------------------------------------------
+# Ameba 1.6.4 -> 1.7.0-dev upgrade backlog (291 problems)
+#
+# Ameba 1.6.4 doesn't compile on Crystal 1.21, so the dependency tracks master
+# until 1.7.0 is released. Everything below is pre-existing code that the newer
+# ameba flags; none of it is Crystal 1.21 related. Parked here so there is one
+# place to work through in follow-up PRs.
+# Run `ameba --only <Rule>` for details on any single entry.
+# ---------------------------------------------------------------------------
+
+# Rules that don't exist in 1.6.4 at all (254 problems).
+# Disabled wholesale -- these have never run against this code base.
+
+Style/MultilineStringLiteral: # 79 problems
+  Enabled: false
+
+Lint/WhitespaceAroundMacroExpression: # 46 problems
+  Enabled: false
+
+Lint/SpecEqWithBoolOrNilLiteral: # 34 problems
+  Enabled: false
+
+Style/HeredocIndent: # 33 problems
+  Enabled: false
+
+Lint/UnusedRescueVariable: # 12 problems
+  Enabled: false
+
+Style/RedundantSelf: # 12 problems
+  Enabled: false
+
+Style/VerboseNilType: # 9 problems
+  Enabled: false
+
+Style/RedundantNilInControlExpression: # 8 problems
+  Enabled: false
+
+Lint/ElseNil: # 6 problems
+  Enabled: false
+
+Lint/AssignmentInCallArgument: # 6 problems
+  Enabled: false
+
+Style/MultilineCurlyBlock: # 5 problems
+  Enabled: false
+
+Lint/SignalTrap: # 3 problems
+  Enabled: false
+
+Lint/VoidOutsideLib: # 1 problem
+  Enabled: false
+
+# Rules that already ran under 1.6.4 but detect more in 1.7.0-dev (37 problems).
+# Kept enabled so they still guard the rest of the tree; only the files that
+# regressed are excluded.
+
+Style/RedundantBegin: # 14 problems
+  Excluded:
+  - spec/config_spec.cr
+  - spec/etcd_spec.cr
+  - spec/spec_helper.cr
+  - src/lavinmq/auth/jwt/jwks_fetcher.cr
+  - src/lavinmq/clustering/controller.cr
+  - src/lavinmq/clustering/follower.cr
+  - src/lavinmq/clustering/proxy.cr
+  - src/lavinmq/http/controller/prometheus.cr
+  - src/lavinmq/ip_matcher.cr
+  - src/lavinmqperf/amqp/queue_count.cr
+  - src/lavinmqperf/amqp/throughput.cr
+
+Style/RedundantReturn: # 10 problems
+  Excluded:
+  - src/lavinmq/amqp/connection_factory.cr
+  - src/lavinmq/amqp/consumer.cr
+  - src/lavinmq/amqp/stream/stream_consumer.cr
+  - src/lavinmq/amqp/stream/stream_message_store.cr
+  - src/lavinmq/http/controller/vhost-limits.cr
+  - src/lavinmq/http/handler/auth_handler.cr
+  - src/lavinmq/mqtt/connection_factory.cr
+
+Lint/UselessAssign: # 6 problems
+  Excluded:
+  - spec/control_socket_spec.cr
+  - spec/etcd_spec.cr
+  - src/lavinmq/etcd.cr
+  - src/lavinmq/etcd/lease.cr
+
+# Complexity is scored differently in 1.7.0-dev: `Queue#message_expire_loop`
+# (16/12) and `Link#monitor_consumers` (13/12) newly trip the limit, while some
+# existing `# ameba:disable Metrics/CyclomaticComplexity` comments became
+# redundant.
+Metrics/CyclomaticComplexity: # 2 problems
+  Excluded:
+  - src/lavinmq/amqp/queue/queue.cr
+  - src/lavinmq/federation/link.cr
+
+Lint/UnneededDisableDirective: # 5 problems
+  Excluded:
+  - src/lavinmq/amqp/argument/dead_lettering.cr
+  - src/lavinmq/amqp/queue/queue.cr
+  - src/lavinmq/http/controller/prometheus.cr
+  - src/lavinmq/http/controller/static.cr
+  - src/lavinmq/shovel/amqp_source.cr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           for f in ${{ steps.changed.outputs.files }}; do
             if [ -f "$f" ]; then
               echo "::group::crystal build --no-codegen $f"
-              crystal build --no-codegen --error-on-warnings -Dpreview_mt -Dexecution_context "$f" || status=1
+              crystal build --no-codegen --error-on-warnings "$f" || status=1
               echo "::endgroup::"
             fi
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you receive a review that requests changes, switch your PR back to `draft` mo
 1. Run specs with `make test`
 1. Run a specific spec file with `make test SPEC=spec/storage_spec.cr`
 1. Build locally with `make bin/lavinmq CRYSTAL_FLAGS=`
-1. Compile and run locally with `crystal run src/lavinmq.cr -Dpreview_mt -Dexecution_context`
+1. Compile and run locally with `crystal run src/lavinmq.cr`
 1. Pull js dependencies with `make js`
 1. Build API docs with `make docs` (requires `npx`)
 1. Build with `shards build`

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VIEW_TARGETS := $(patsubst views/%.shtml,static/%.html,$(VIEW_SOURCES))
 VIEW_PARTIALS := $(wildcard views/partials/*.shtml)
 JS := static/js/lib/chunks/helpers.segment.js static/js/lib/chart.js static/js/lib/luxon.js static/js/lib/chartjs-adapter-luxon.esm.js static/js/lib/elements-8.2.0.js static/js/lib/elements-8.2.0.css $(wildcard static/js/*.js)
 CRYSTAL_FLAGS := --release
-override CRYSTAL_FLAGS += --stats -Dpreview_mt -Dexecution_context --link-flags="$(LDFLAGS)"
+override CRYSTAL_FLAGS += --stats --link-flags="$(LDFLAGS)"
 .DELETE_ON_ERROR:
 
 .DEFAULT_GOAL := all
@@ -97,7 +97,10 @@ js: $(JS)
 .PHONY: deps
 deps: js lib views
 
-lib/ameba/bin/ameba:
+lib/ameba/bin/ameba: lib/ameba
+	crystal build lib/ameba/src/cli.cr -o $@
+
+lib/ameba:
 	shards install
 
 .PHONY: lint
@@ -114,7 +117,7 @@ lint-openapi:
 
 .PHONY: test
 test: lib views
-	crystal spec --order random --verbose -Dpreview_mt -Dexecution_context $(if $(TAGS),--tag '$(TAGS)') $(SPEC)
+	crystal spec --order random --verbose $(if $(TAGS),--tag '$(TAGS)') $(SPEC)
 
 .PHONY: format
 format:

--- a/extras/alloc_bench.cr
+++ b/extras/alloc_bench.cr
@@ -4,7 +4,7 @@
 # in-process (no sockets), so numbers are attributable to LavinMQ itself.
 #
 # Usage:
-#   crystal run --release -Dpreview_mt -Dexecution_context extras/alloc_bench.cr
+#   crystal run --release extras/alloc_bench.cr
 require "../src/lavinmq/config"
 require "../src/lavinmq/server"
 require "../src/lavinmq/http/http_server"

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.6.4
+    version: 1.7.0-dev+git.commit.cdd58b34b0d8a9c785d67183a7a8f07541549e55
 
   amq-protocol:
     git: https://github.com/cloudamqp/amq-protocol.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -39,7 +39,11 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    # 1.6.4 doesn't compile on Crystal 1.21. Pinned to a master commit rather
+    # than tracking the branch, so new rules don't appear unannounced.
+    # Revert to a version constraint once 1.7.0 is released.
+    commit: cdd58b34b0d8a9c785d67183a7a8f07541549e55
 
-crystal: 1.20.1
+crystal: 1.21.0
 
 license: Apache-2.0

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -630,7 +630,7 @@ describe LavinMQ::AMQP::Queue do
       Dir.mkdir_p data_dir
       begin
         store = LavinMQ::MessageStore.new(data_dir, nil)
-        body = IO::Memory.new(Random::Secure.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
+        body = IO::Memory.new(Random::Secure.random_bytes(LavinMQ::Config.instance.segment_size), writable: false)
         msg = LavinMQ::Message.new(1i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
         sps = Array(LavinMQ::SegmentPosition).new(10) { store.push msg }
         sps.each { |sp| store.delete sp }
@@ -646,7 +646,7 @@ describe LavinMQ::AMQP::Queue do
       data_dir = File.join(LavinMQ::Config.instance.data_dir, "msgstore2")
       Dir.mkdir_p data_dir
       begin
-        body = IO::Memory.new(Random::Secure.random_bytes(LavinMQ::Config.instance.segment_size), writeable: false)
+        body = IO::Memory.new(Random::Secure.random_bytes(LavinMQ::Config.instance.segment_size), writable: false)
         msg = LavinMQ::Message.new(1i64, "amq.topic", "rk", AMQ::Protocol::Properties.new, body.size.to_u64, body)
 
         store = LavinMQ::MessageStore.new(data_dir, nil)

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -111,9 +111,7 @@ module LavinMQ
       {% unless flag?(:release) %}
         Log.warn { "Not built in release mode" }
       {% end %}
-      {% if flag?(:preview_mt) %}
-        Log.info { "Multithreading: #{ENV.fetch("CRYSTAL_WORKERS", "4")} threads" }
-      {% end %}
+      Log.info { "Parallelism: #{Fiber::ExecutionContext.default.capacity}" }
       Log.info { "PID: #{Process.pid}" }
       # we do this here to have nice consistent logging
       Pidfile.new(@config.pidfile).acquire unless @config.pidfile.empty?

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -25,7 +25,7 @@ module LavinMQ
 
         timestamp = RoughTime.unix_ms
         bodysize = packet.payload.bytesize.to_u64
-        body = ::IO::Memory.new(packet.payload, writeable: false)
+        body = ::IO::Memory.new(packet.payload, writable: false)
 
         if packet.retain?
           @retain_store.retain(packet.topic, body, bodysize)

--- a/src/lavinmqperf/perf.cr
+++ b/src/lavinmqperf/perf.cr
@@ -41,7 +41,6 @@ module LavinMQPerf
         flags << "--release" if flag?(:release)
         flags << "--debug" if flag?(:debug)
         flags << "--no-debug" unless flag?(:debug)
-        flags << "--Dpreview_mt" if flag?(:preview_mt)
         flags << "--Dmt" if flag?(:mt)
       %}
       {{ flags.join(" ") }}


### PR DESCRIPTION
Execution contexts were released in Crystal 1.21, so `-Dpreview_mt` and `-Dexecution_context` are no longer needed and `preview_mt` is deprecated. Both flags are dropped from the build, the spec run and CI.

This requires Crystal 1.21: on 1.20.1 `fiber/execution_context.cr` raises unless both flags are set, so `shard.yml` moves to `crystal: 1.21.0`.

**No behaviour change.** The default execution context started at parallelism 1 on 1.20.1 too, so the three explicit `Isolated` contexts (`RoughTime`, publish confirm loop, etcd lease) are still the only threads. `CRYSTAL_WORKERS` never had any effect here either, since `crystal/scheduler.cr` where it is parsed is `skip_file`'d whenever `-Dexecution_context` is set. Resizing the default context to enable real multithreading is deliberately left for a separate PR.

Also in here:

- `IO::Memory.new(bytes, writeable:)` is deprecated in favour of `writable:`. The one in `mqtt/exchange.cr` would have failed the `--error-on-warnings` build.
- The startup log printed `Multithreading: $CRYSTAL_WORKERS threads` behind a `preview_mt` check, inaccurate ever since the flags were added. It now reports the default context's actual parallelism.
- Ameba 1.6.4 doesn't compile on 1.21, so it is pinned to master commit `cdd58b3`. That version adds 13 rules that have never run against this code base and detects more in 5 existing ones, 291 problems total. They are parked in one clearly marked section in `.ameba.yml` to work through in follow-up PRs; the 5 pre-existing rules stay enabled and only exclude the affected files. Ameba master also dropped its `postinstall`, so the Makefile builds the binary itself.

## Test plan

Verified locally on Crystal 1.21.0:

| Check | Result |
| --- | --- |
| `crystal tool format --check` | clean |
| `crystal build --error-on-warnings` (all 3 targets) | 0 warnings |
| `make lint` | 390 inspected, 0 failures |
| `make test` | 2090 examples, 0 failures, 10 pending (same as `main`) |