### PR TITLE
chore: fix all ameba 1.7.0-dev lint findings

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -59,6 +59,3 @@ Style/HeredocIndent: # 33 problems
 
 Style/RedundantSelf: # 12 problems
   Enabled: false
-
-Style/RedundantNilInControlExpression: # 8 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -86,19 +86,6 @@ Lint/VoidOutsideLib: # 1 problem
 # Kept enabled so they still guard the rest of the tree; only the files that
 # regressed are excluded.
 
-Style/RedundantBegin: # 14 problems
-  Excluded:
-  - spec/config_spec.cr
-  - spec/etcd_spec.cr
-  - spec/spec_helper.cr
-  - src/lavinmq/auth/jwt/jwks_fetcher.cr
-  - src/lavinmq/clustering/controller.cr
-  - src/lavinmq/clustering/follower.cr
-  - src/lavinmq/clustering/proxy.cr
-  - src/lavinmq/http/controller/prometheus.cr
-  - src/lavinmq/ip_matcher.cr
-  - src/lavinmqperf/amqp/queue_count.cr
-  - src/lavinmqperf/amqp/throughput.cr
 
 Style/RedundantReturn: # 10 problems
   Excluded:

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -81,15 +81,3 @@ Lint/SignalTrap: # 3 problems
 
 Lint/VoidOutsideLib: # 1 problem
   Enabled: false
-
-# Rules that already ran under 1.6.4 but detect more in 1.7.0-dev (37 problems).
-# Kept enabled so they still guard the rest of the tree; only the files that
-# regressed are excluded.
-
-Lint/UnneededDisableDirective: # 5 problems
-  Excluded:
-  - src/lavinmq/amqp/argument/dead_lettering.cr
-  - src/lavinmq/amqp/queue/queue.cr
-  - src/lavinmq/http/controller/prometheus.cr
-  - src/lavinmq/http/controller/static.cr
-  - src/lavinmq/shovel/amqp_source.cr

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -60,9 +60,6 @@ Lint/SpecEqWithBoolOrNilLiteral: # 34 problems
 Style/HeredocIndent: # 33 problems
   Enabled: false
 
-Lint/UnusedRescueVariable: # 12 problems
-  Enabled: false
-
 Style/RedundantSelf: # 12 problems
   Enabled: false
 

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -71,6 +71,3 @@ Style/VerboseNilType: # 9 problems
 
 Style/RedundantNilInControlExpression: # 8 problems
   Enabled: false
-
-Lint/ElseNil: # 6 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -86,13 +86,6 @@ Lint/VoidOutsideLib: # 1 problem
 # Kept enabled so they still guard the rest of the tree; only the files that
 # regressed are excluded.
 
-Lint/UselessAssign: # 6 problems
-  Excluded:
-  - spec/control_socket_spec.cr
-  - spec/etcd_spec.cr
-  - src/lavinmq/etcd.cr
-  - src/lavinmq/etcd/lease.cr
-
 # Complexity is scored differently in 1.7.0-dev: `Queue#message_expire_loop`
 # (16/12) and `Link#monitor_consumers` (13/12) newly trip the limit, while some
 # existing `# ameba:disable Metrics/CyclomaticComplexity` comments became

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -48,9 +48,6 @@ Lint/SignalTrap:
 # Rules that don't exist in 1.6.4 at all (254 problems).
 # Disabled wholesale -- these have never run against this code base.
 
-Style/MultilineStringLiteral: # 79 problems
-  Enabled: false
-
 Lint/WhitespaceAroundMacroExpression: # 46 problems
   Enabled: false
 

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -34,19 +34,3 @@ Documentation/DocumentationAdmonition:
 # also cover USR1/USR2/SEGV, so they're Unix-only anyway.
 Lint/SignalTrap:
   Enabled: false
-
-# ---------------------------------------------------------------------------
-# Ameba 1.6.4 -> 1.7.0-dev upgrade backlog (291 problems)
-#
-# Ameba 1.6.4 doesn't compile on Crystal 1.21, so the dependency tracks master
-# until 1.7.0 is released. Everything below is pre-existing code that the newer
-# ameba flags; none of it is Crystal 1.21 related. Parked here so there is one
-# place to work through in follow-up PRs.
-# Run `ameba --only <Rule>` for details on any single entry.
-# ---------------------------------------------------------------------------
-
-# Rules that don't exist in 1.6.4 at all (254 problems).
-# Disabled wholesale -- these have never run against this code base.
-
-Lint/WhitespaceAroundMacroExpression: # 46 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -86,17 +86,6 @@ Lint/VoidOutsideLib: # 1 problem
 # Kept enabled so they still guard the rest of the tree; only the files that
 # regressed are excluded.
 
-
-Style/RedundantReturn: # 10 problems
-  Excluded:
-  - src/lavinmq/amqp/connection_factory.cr
-  - src/lavinmq/amqp/consumer.cr
-  - src/lavinmq/amqp/stream/stream_consumer.cr
-  - src/lavinmq/amqp/stream/stream_message_store.cr
-  - src/lavinmq/http/controller/vhost-limits.cr
-  - src/lavinmq/http/handler/auth_handler.cr
-  - src/lavinmq/mqtt/connection_factory.cr
-
 Lint/UselessAssign: # 6 problems
   Excluded:
   - spec/control_socket_spec.cr

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -56,6 +56,3 @@ Lint/SpecEqWithBoolOrNilLiteral: # 34 problems
 
 Style/HeredocIndent: # 33 problems
   Enabled: false
-
-Style/RedundantSelf: # 12 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -53,6 +53,3 @@ Lint/WhitespaceAroundMacroExpression: # 46 problems
 
 Lint/SpecEqWithBoolOrNilLiteral: # 34 problems
   Enabled: false
-
-Style/HeredocIndent: # 33 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -78,6 +78,3 @@ Style/MultilineCurlyBlock: # 5 problems
 
 Lint/SignalTrap: # 3 problems
   Enabled: false
-
-Lint/VoidOutsideLib: # 1 problem
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -74,6 +74,3 @@ Style/RedundantNilInControlExpression: # 8 problems
 
 Lint/ElseNil: # 6 problems
   Enabled: false
-
-Lint/AssignmentInCallArgument: # 6 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -66,8 +66,5 @@ Lint/UnusedRescueVariable: # 12 problems
 Style/RedundantSelf: # 12 problems
   Enabled: false
 
-Style/VerboseNilType: # 9 problems
-  Enabled: false
-
 Style/RedundantNilInControlExpression: # 8 problems
   Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -86,15 +86,6 @@ Lint/VoidOutsideLib: # 1 problem
 # Kept enabled so they still guard the rest of the tree; only the files that
 # regressed are excluded.
 
-# Complexity is scored differently in 1.7.0-dev: `Queue#message_expire_loop`
-# (16/12) and `Link#monitor_consumers` (13/12) newly trip the limit, while some
-# existing `# ameba:disable Metrics/CyclomaticComplexity` comments became
-# redundant.
-Metrics/CyclomaticComplexity: # 2 problems
-  Excluded:
-  - src/lavinmq/amqp/queue/queue.cr
-  - src/lavinmq/federation/link.cr
-
 Lint/UnneededDisableDirective: # 5 problems
   Excluded:
   - src/lavinmq/amqp/argument/dead_lettering.cr

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -50,6 +50,3 @@ Lint/SignalTrap:
 
 Lint/WhitespaceAroundMacroExpression: # 46 problems
   Enabled: false
-
-Lint/SpecEqWithBoolOrNilLiteral: # 34 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -77,6 +77,3 @@ Lint/ElseNil: # 6 problems
 
 Lint/AssignmentInCallArgument: # 6 problems
   Enabled: false
-
-Style/MultilineCurlyBlock: # 5 problems
-  Enabled: false

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -30,6 +30,11 @@ Lint/NotNil:
 Documentation/DocumentationAdmonition:
   Enabled: false
 
+# `Process.on_terminate` only buys Windows portability, and the signal traps
+# also cover USR1/USR2/SEGV, so they're Unix-only anyway.
+Lint/SignalTrap:
+  Enabled: false
+
 # ---------------------------------------------------------------------------
 # Ameba 1.6.4 -> 1.7.0-dev upgrade backlog (291 problems)
 #
@@ -74,7 +79,4 @@ Lint/AssignmentInCallArgument: # 6 problems
   Enabled: false
 
 Style/MultilineCurlyBlock: # 5 problems
-  Enabled: false
-
-Lint/SignalTrap: # 3 problems
   Enabled: false

--- a/spec/api/bindings_spec.cr
+++ b/spec/api/bindings_spec.cr
@@ -58,10 +58,12 @@ describe LavinMQ::HTTP::BindingsController do
       with_http_server do |http, s|
         s.vhosts["/"].declare_exchange("be1", "topic", false, false)
         s.vhosts["/"].declare_queue("bindings_q1", false, false)
-        body = %({
-        "routing_key": "rk",
-        "arguments": {}
-      })
+        body = <<-JSON
+          {
+            "routing_key": "rk",
+            "arguments": {}
+          }
+          JSON
         response = http.post("/api/bindings/%2f/e/be1/q/bindings_q1", body: body)
         response.status_code.should eq 201
         response.headers["Location"].should eq "bindings_q1/rk"
@@ -91,10 +93,12 @@ describe LavinMQ::HTTP::BindingsController do
     it "should return forbidden for the default exchange" do
       with_http_server do |http, s|
         s.vhosts["/"].declare_queue("bindings_q2", false, false)
-        body = %({
-        "routing_key": "rk",
-        "arguments": {}
-      })
+        body = <<-JSON
+          {
+            "routing_key": "rk",
+            "arguments": {}
+          }
+          JSON
         response = http.post("/api/bindings/%2f/e/amq.default/q/bindings_q2", body: body)
         response.status_code.should eq 403
       end
@@ -104,10 +108,12 @@ describe LavinMQ::HTTP::BindingsController do
       with_http_server do |http, s|
         s.vhosts["/"].declare_exchange("ch1", "x-consistent-hash", false, false)
         s.vhosts["/"].declare_queue("bindings_q1", false, false)
-        body = %({
-        "routing_key": "",
-        "arguments": {}
-      })
+        body = <<-JSON
+          {
+            "routing_key": "",
+            "arguments": {}
+          }
+          JSON
         response = http.post("/api/bindings/%2f/e/ch1/q/bindings_q1", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -166,10 +172,12 @@ describe LavinMQ::HTTP::BindingsController do
       with_http_server do |http, s|
         s.vhosts["/"].declare_exchange("be1", "topic", false, false)
         s.vhosts["/"].declare_exchange("be2", "topic", false, false)
-        body = %({
-        "routing_key": "rk",
-        "arguments": {}
-      })
+        body = <<-JSON
+          {
+            "routing_key": "rk",
+            "arguments": {}
+          }
+          JSON
         response = http.post("/api/bindings/%2f/e/be1/e/be2", body: body)
         response.status_code.should eq 201
       end
@@ -177,10 +185,12 @@ describe LavinMQ::HTTP::BindingsController do
 
     it "should return forbidden for the default exchange" do
       with_http_server do |http, _|
-        body = %({
-        "routing_key": "rk",
-        "arguments": {}
-      })
+        body = <<-JSON
+          {
+            "routing_key": "rk",
+            "arguments": {}
+          }
+          JSON
         response = http.post("/api/bindings/%2f/e/amq.default/e/amq.direct", body: body)
         response.status_code.should eq 403
       end

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -200,28 +200,30 @@ describe LavinMQ::HTTP::Server do
 
     it "imports users" do
       with_http_server do |http, s|
-        body = %({
-        "users":[{
-          "name":"sha256",
-          "password_hash":"nEeL9j6VAMtdsehezoLxjI655S4vkTWs1/EJcsjVY7o",
-          "hashing_algorithm":"rabbit_password_hashing_sha256","tags":[]
-        },
-        {
-          "name":"sha512",
-          "password_hash":"wiwLjmFjJauaeABIerBxpPx2548gydUaqj9wpxyeio7+gmye+/KuGaLeAqrV1Tx1pk6bwYGR0gHMx+whOqxD6Q",
-          "hashing_algorithm":"rabbit_password_hashing_sha512","tags":[]
-        },
-        {
-          "name":"bcrypt",
-          "password_hash":"$2a$04$g5IMwYwvgDLACYdAQxCpCulKuK/Ym2I56Tz6T9Wi9DGdKQG.DE8Gi",
-          "hashing_algorithm":"Bcrypt","tags":[]
-        },
-        {
-          "name":"md5",
-          "password_hash":"VBxXlgu5l5QmVdFOO5YH+Q==",
-          "hashing_algorithm":"rabbit_password_hashing_md5","tags":[]
-        }]
-      })
+        body = <<-JSON
+          {
+            "users":[{
+              "name":"sha256",
+              "password_hash":"nEeL9j6VAMtdsehezoLxjI655S4vkTWs1/EJcsjVY7o",
+              "hashing_algorithm":"rabbit_password_hashing_sha256","tags":[]
+            },
+            {
+              "name":"sha512",
+              "password_hash":"wiwLjmFjJauaeABIerBxpPx2548gydUaqj9wpxyeio7+gmye+/KuGaLeAqrV1Tx1pk6bwYGR0gHMx+whOqxD6Q",
+              "hashing_algorithm":"rabbit_password_hashing_sha512","tags":[]
+            },
+            {
+              "name":"bcrypt",
+              "password_hash":"$2a$04$g5IMwYwvgDLACYdAQxCpCulKuK/Ym2I56Tz6T9Wi9DGdKQG.DE8Gi",
+              "hashing_algorithm":"Bcrypt","tags":[]
+            },
+            {
+              "name":"md5",
+              "password_hash":"VBxXlgu5l5QmVdFOO5YH+Q==",
+              "hashing_algorithm":"rabbit_password_hashing_md5","tags":[]
+            }]
+          }
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         {"sha256", "sha512", "bcrypt", "md5"}.each do |name|
@@ -365,24 +367,26 @@ describe LavinMQ::HTTP::Server do
         s.vhosts["/"].declare_exchange("import_x1", "topic", false, true)
         s.vhosts["/"].declare_exchange("import_x2", "fanout", false, true)
         s.vhosts["/"].declare_queue("import_q1", false, true)
-        body = %({ "bindings": [
-        {
-          "source": "import_x1",
-          "vhost": "/",
-          "destination": "import_x2",
-          "destination_type": "exchange",
-          "routing_key": "r.k2",
-          "arguments": {}
-        },
-        {
-          "source": "import_x1",
-          "vhost": "/",
-          "destination": "import_q1",
-          "destination_type": "queue",
-          "routing_key": "rk",
-          "arguments": {}
-        }
-      ]})
+        body = <<-JSON
+          { "bindings": [
+            {
+              "source": "import_x1",
+              "vhost": "/",
+              "destination": "import_x2",
+              "destination_type": "exchange",
+              "routing_key": "r.k2",
+              "arguments": {}
+            },
+            {
+              "source": "import_x1",
+              "vhost": "/",
+              "destination": "import_q1",
+              "destination_type": "queue",
+              "routing_key": "rk",
+              "arguments": {}
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         ex = s.vhosts["/"].exchange("import_x1")
@@ -405,15 +409,17 @@ describe LavinMQ::HTTP::Server do
     it "imports permissions" do
       with_http_server do |http, s|
         s.users.create("u1", "")
-        body = %({ "permissions": [
-        {
-          "user": "u1",
-          "vhost": "/",
-          "configure": "c",
-          "write": "w",
-          "read": "r"
-        }
-      ]})
+        body = <<-JSON
+          { "permissions": [
+            {
+              "user": "u1",
+              "vhost": "/",
+              "configure": "c",
+              "write": "w",
+              "read": "r"
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         s.users["u1"].permissions["/"][:write].should eq(/w/)
@@ -422,18 +428,20 @@ describe LavinMQ::HTTP::Server do
 
     it "imports policies" do
       with_http_server do |http, s|
-        body = %({ "policies": [
-        {
-          "name": "import_p1",
-          "vhost": "/",
-          "apply-to": "queues",
-          "priority": 1,
-          "pattern": "^.*",
-          "definition": {
-            "x-max-length": 10
-          }
-        }
-      ]})
+        body = <<-JSON
+          { "policies": [
+            {
+              "name": "import_p1",
+              "vhost": "/",
+              "apply-to": "queues",
+              "priority": 1,
+              "pattern": "^.*",
+              "definition": {
+                "x-max-length": 10
+              }
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         s.vhosts["/"].policies.has_key?("import_p1").should be_true
@@ -442,19 +450,21 @@ describe LavinMQ::HTTP::Server do
 
     it "imports parameters" do
       with_http_server do |http, s|
-        body = %({ "parameters": [
-          {
-            "name": "import_shovel_param",
-            "component": "shovel",
-            "vhost": "/",
-            "value": {
-              "src-uri": "#{s.amqp_server.url}",
-              "src-queue": "shovel_will_declare_q1",
-              "dest-uri": "#{s.amqp_server.url}",
-              "dest-queue": "shovel_will_declare_q1"
+        body = <<-JSON
+          { "parameters": [
+            {
+              "name": "import_shovel_param",
+              "component": "shovel",
+              "vhost": "/",
+              "value": {
+                "src-uri": "#{s.amqp_server.url}",
+                "src-queue": "shovel_will_declare_q1",
+                "dest-uri": "#{s.amqp_server.url}",
+                "dest-queue": "shovel_will_declare_q1"
+              }
             }
-          }
-        ]})
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         # Because we run shovels in a new Fiber we have to make sure the shovel is not started
@@ -475,30 +485,32 @@ describe LavinMQ::HTTP::Server do
         # overflows Int8 and raises while parsing. Entries are validated up front,
         # so a malformed entry makes the whole import a clean no-op: the shovel
         # before it is neither applied in memory nor written to disk.
-        body = %({ "parameters": [
-          {
-            "name": "regression_shovel_2073",
-            "component": "shovel",
-            "vhost": "/",
-            "value": {
-              "src-uri": "#{s.amqp_server.url}",
-              "src-queue": "regression_q_2073",
-              "dest-uri": "#{s.amqp_server.url}",
-              "dest-queue": "regression_q_2073"
+        body = <<-JSON
+          { "parameters": [
+            {
+              "name": "regression_shovel_2073",
+              "component": "shovel",
+              "vhost": "/",
+              "value": {
+                "src-uri": "#{s.amqp_server.url}",
+                "src-queue": "regression_q_2073",
+                "dest-uri": "#{s.amqp_server.url}",
+                "dest-queue": "regression_q_2073"
+              }
+            },
+            {
+              "name": "regression_op_2073",
+              "component": "operator_policy",
+              "vhost": "/",
+              "value": {
+                "pattern": "^.*",
+                "apply-to": "queues",
+                "priority": 999,
+                "definition": { "max-length": 10 }
+              }
             }
-          },
-          {
-            "name": "regression_op_2073",
-            "component": "operator_policy",
-            "vhost": "/",
-            "value": {
-              "pattern": "^.*",
-              "apply-to": "queues",
-              "priority": 999,
-              "definition": { "max-length": 10 }
-            }
-          }
-        ]})
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should_not eq 200
         vhost = s.vhosts["/"]
@@ -513,24 +525,26 @@ describe LavinMQ::HTTP::Server do
         # A valid policy followed by one with priority > 127, which overflows Int8
         # while parsing. The whole import is a clean no-op: the first policy is
         # neither applied in memory nor written to disk.
-        body = %({ "policies": [
-          {
-            "name": "regression_policy_2073",
-            "vhost": "/",
-            "pattern": "^.*",
-            "apply-to": "queues",
-            "priority": 1,
-            "definition": { "max-length": 10 }
-          },
-          {
-            "name": "regression_bad_policy_2073",
-            "vhost": "/",
-            "pattern": "^.*",
-            "apply-to": "queues",
-            "priority": 999,
-            "definition": { "max-length": 10 }
-          }
-        ]})
+        body = <<-JSON
+          { "policies": [
+            {
+              "name": "regression_policy_2073",
+              "vhost": "/",
+              "pattern": "^.*",
+              "apply-to": "queues",
+              "priority": 1,
+              "definition": { "max-length": 10 }
+            },
+            {
+              "name": "regression_bad_policy_2073",
+              "vhost": "/",
+              "pattern": "^.*",
+              "apply-to": "queues",
+              "priority": 999,
+              "definition": { "max-length": 10 }
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should_not eq 200
         vhost = s.vhosts["/"]
@@ -542,12 +556,14 @@ describe LavinMQ::HTTP::Server do
 
     it "imports global parameters" do
       with_http_server do |http, s|
-        body = %({ "global_parameters": [
-        {
-          "name": "global_p1",
-          "value": {}
-        }
-      ]})
+        body = <<-JSON
+          { "global_parameters": [
+            {
+              "name": "global_p1",
+              "value": {}
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 200
         s.parameters.any? { |_, p| p.parameter_name == "global_p1" }.should be_true
@@ -579,13 +595,15 @@ describe LavinMQ::HTTP::Server do
 
     it "should return sensible error for invalid password hash" do
       with_http_server do |http, _|
-        body = %({
-          "users": [{
-            "name": "testuser",
-            "password_hash": "invalid_hash",
-            "tags": "administrator"
-          }]
-        })
+        body = <<-JSON
+          {
+            "users": [{
+              "name": "testuser",
+              "password_hash": "invalid_hash",
+              "tags": "administrator"
+            }]
+          }
+          JSON
         response = http.post("/api/definitions", body: body)
         response.status_code.should eq 400
         error_body = JSON.parse(response.body)
@@ -876,24 +894,26 @@ describe LavinMQ::HTTP::Server do
         s.vhosts["/"].declare_exchange("import_x1", "direct", false, true)
         s.vhosts["/"].declare_exchange("import_x2", "fanout", false, true)
         s.vhosts["/"].declare_queue("import_q1", false, true)
-        body = %({ "bindings": [
-        {
-          "source": "import_x1",
-          "vhost": "/",
-          "destination": "import_x2",
-          "destination_type": "exchange",
-          "routing_key": "r.k2",
-          "arguments": {}
-        },
-        {
-          "source": "import_x1",
-          "vhost": "/",
-          "destination": "import_q1",
-          "destination_type": "queue",
-          "routing_key": "rk",
-          "arguments": {}
-        }
-      ]})
+        body = <<-JSON
+          { "bindings": [
+            {
+              "source": "import_x1",
+              "vhost": "/",
+              "destination": "import_x2",
+              "destination_type": "exchange",
+              "routing_key": "r.k2",
+              "arguments": {}
+            },
+            {
+              "source": "import_x1",
+              "vhost": "/",
+              "destination": "import_q1",
+              "destination_type": "queue",
+              "routing_key": "rk",
+              "arguments": {}
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
         ex = s.vhosts["/"].exchange("import_x1")
@@ -915,18 +935,20 @@ describe LavinMQ::HTTP::Server do
 
     it "imports policies" do
       with_http_server do |http, s|
-        body = %({ "policies": [
-        {
-          "name": "import_p1",
-          "vhost": "/",
-          "apply-to": "queues",
-          "priority": 1,
-          "pattern": "^.*",
-          "definition": {
-            "x-max-length": 10
-          }
-        }
-      ]})
+        body = <<-JSON
+          { "policies": [
+            {
+              "name": "import_p1",
+              "vhost": "/",
+              "apply-to": "queues",
+              "priority": 1,
+              "pattern": "^.*",
+              "definition": {
+                "x-max-length": 10
+              }
+            }
+          ]}
+          JSON
         response = http.post("/api/definitions/%2f", body: body)
         response.status_code.should eq 200
         s.vhosts["/"].policies.has_key?("import_p1").should be_true
@@ -1071,13 +1093,15 @@ describe LavinMQ::HTTP::Server do
   it "should update existing user on import" do
     with_http_server do |http, s|
       name = "bcryptuser"
-      body = %({
-      "users":[{
-        "name":"#{name}",
-        "password_hash":"$2a$04$g5IMwYwvgDLACYdAQxCpCulKuK/Ym2I56Tz6T9Wi9DGdKQG.DE8Gi",
-        "hashing_algorithm":"Bcrypt","tags":[]
-      }]
-    })
+      body = <<-JSON
+        {
+          "users":[{
+            "name":"#{name}",
+            "password_hash":"$2a$04$g5IMwYwvgDLACYdAQxCpCulKuK/Ym2I56Tz6T9Wi9DGdKQG.DE8Gi",
+            "hashing_algorithm":"Bcrypt","tags":[]
+          }]
+        }
+        JSON
 
       response = http.post("/api/definitions", body: body)
       response.status_code.should eq 200
@@ -1087,13 +1111,15 @@ describe LavinMQ::HTTP::Server do
       ok = u.not_nil!.password.not_nil!.verify "hej"
       {u.name, ok}.should eq({name, true})
 
-      update_body = %({
-      "users":[{
-        "name":"#{name}",
-        "password_hash":"$2a$04$PuoK2zgHy/NHRU3CRUCidOKaSTwFkv97Sm.zTspKZRWJkn6l37YOe",
-        "hashing_algorithm":"Bcrypt","tags":[]
-      }]
-    })
+      update_body = <<-JSON
+        {
+          "users":[{
+            "name":"#{name}",
+            "password_hash":"$2a$04$PuoK2zgHy/NHRU3CRUCidOKaSTwFkv97Sm.zTspKZRWJkn6l37YOe",
+            "hashing_algorithm":"Bcrypt","tags":[]
+          }]
+        }
+        JSON
       response = http.post("/api/definitions", body: update_body)
       response.status_code.should eq 200
 
@@ -1116,13 +1142,15 @@ describe LavinMQ::HTTP::Server do
 
   it "should be able to import delayed exchanges created in LavinMQ (issue #743)" do
     with_http_server do |http, s|
-      body = %({
-        "type": "direct",
-        "durable": true,
-        "internal": false,
-        "auto_delete": false,
-        "delayed": true
-      })
+      body = <<-JSON
+        {
+          "type": "direct",
+          "durable": true,
+          "internal": false,
+          "auto_delete": false,
+          "delayed": true
+        }
+        JSON
       http.put("/api/exchanges/%2f/test-delayed", body: body)
       response = http.get("/api/definitions")
       body = JSON.parse(response.body)

--- a/spec/api/exchanges_spec.cr
+++ b/spec/api/exchanges_spec.cr
@@ -44,15 +44,17 @@ describe LavinMQ::HTTP::ExchangesController do
   describe "PUT /api/exchanges/vhost/name" do
     it "should create exchange" do
       with_http_server do |http, _|
-        body = %({
-        "type": "topic",
-        "durable": false,
-        "internal": false,
-        "auto_delete": true,
-        "arguments": {
-          "alternate-exchange": "spexchange"
-        }
-      })
+        body = <<-JSON
+          {
+            "type": "topic",
+            "durable": false,
+            "internal": false,
+            "auto_delete": true,
+            "arguments": {
+              "alternate-exchange": "spexchange"
+            }
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/spechange", body: body)
         response.status_code.should eq 201
         response = http.get("/api/exchanges/%2f/spechange")
@@ -108,22 +110,26 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should require durable to be the same when overwriting" do
       with_http_server do |http, _|
-        body = %({
-        "type": "topic",
-        "durable": true,
-        "arguments": {
-          "alternate-exchange": "tjotjo"
-        }
-      })
+        body = <<-JSON
+          {
+            "type": "topic",
+            "durable": true,
+            "arguments": {
+              "alternate-exchange": "tjotjo"
+            }
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/spechange", body: body)
         response.status_code.should eq 201
-        body = %({
-        "type": "topic",
-        "durable": false,
-        "arguments": {
-          "alternate-exchange": "tjotjo"
-        }
-      })
+        body = <<-JSON
+          {
+            "type": "topic",
+            "durable": false,
+            "arguments": {
+              "alternate-exchange": "tjotjo"
+            }
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/spechange", body: body)
         response.status_code.should eq 400
       end
@@ -131,9 +137,11 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should not be possible to declare amq. prefixed exchanges" do
       with_http_server do |http, _|
-        body = %({
-        "type": "topic"
-      })
+        body = <<-JSON
+          {
+            "type": "topic"
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/amq.test", body: body)
         response.status_code.should eq 400
       end
@@ -141,16 +149,18 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should redeclare identical delayed_message_exchange" do
       with_http_server do |http, _|
-        body = %({
-        "type": "x-delayed-message",
-        "durable": true,
-        "internal": false,
-        "auto_delete": false,
-        "arguments": {
-          "x-delayed-type": "fanout",
-          "test": "hello"
-        }
-      })
+        body = <<-JSON
+          {
+            "type": "x-delayed-message",
+            "durable": true,
+            "internal": false,
+            "auto_delete": false,
+            "arguments": {
+              "x-delayed-type": "fanout",
+              "test": "hello"
+            }
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/spechange", body: body)
         response.status_code.should eq 201
         response = http.put("/api/exchanges/%2f/spechange", body: body)
@@ -160,9 +170,11 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should require config access to declare" do
       with_http_server do |http, _|
-        body = %({
-        "type": "topic"
-      })
+        body = <<-JSON
+          {
+            "type": "topic"
+          }
+          JSON
         hdrs = HTTP::Headers{"Authorization" => "Basic dGVzdF9wZXJtOnB3"}
         response = http.put("/api/exchanges/%2f/test_perm", headers: hdrs, body: body)
         response.status_code.should eq 401
@@ -249,12 +261,14 @@ describe LavinMQ::HTTP::ExchangesController do
         s.vhosts["/"].declare_exchange("spechange", "topic", false, false)
         s.vhosts["/"].declare_queue("q1p", false, false)
         s.vhosts["/"].bind_queue("q1p", "spechange", "*")
-        body = %({
-        "properties": {},
-        "routing_key": "rk",
-        "payload": "test",
-        "payload_encoding": "string"
-      })
+        body = <<-JSON
+          {
+            "properties": {},
+            "routing_key": "rk",
+            "payload": "test",
+            "payload_encoding": "string"
+          }
+          JSON
         response = http.post("/api/exchanges/%2f/spechange/publish", body: body)
         response.status_code.should eq 200
         body = JSON.parse(response.body)
@@ -265,12 +279,14 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should require expiration to be a number" do
       with_http_server do |http, _|
-        body = %({
-        "properties": { "expiration": "foo" },
-        "routing_key": "rk",
-        "payload": "test",
-        "payload_encoding": "string"
-      })
+        body = <<-JSON
+          {
+            "properties": { "expiration": "foo" },
+            "routing_key": "rk",
+            "payload": "test",
+            "payload_encoding": "string"
+          }
+          JSON
         response = http.post("/api/exchanges/%2f/amq.direct/publish", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -280,12 +296,14 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should require expiration to be a non-negative number" do
       with_http_server do |http, _|
-        body = %({
-        "properties": { "expiration": -100 },
-        "routing_key": "rk",
-        "payload": "test",
-        "payload_encoding": "string"
-      })
+        body = <<-JSON
+          {
+            "properties": { "expiration": -100 },
+            "routing_key": "rk",
+            "payload": "test",
+            "payload_encoding": "string"
+          }
+          JSON
         response = http.post("/api/exchanges/%2f/amq.direct/publish", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -305,12 +323,14 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should handle string encoding" do
       with_http_server do |http, s|
-        body = %({
-        "properties": {},
-        "routing_key": "rk",
-        "payload": "test",
-        "payload_encoding": "string"
-      })
+        body = <<-JSON
+          {
+            "properties": {},
+            "routing_key": "rk",
+            "payload": "test",
+            "payload_encoding": "string"
+          }
+          JSON
         with_channel(s) do |ch|
           q = ch.queue("q2", durable: false)
           x = ch.exchange("str_enc", "topic", passive: false)
@@ -328,12 +348,14 @@ describe LavinMQ::HTTP::ExchangesController do
     it "should handle base64 encoding" do
       with_http_server do |http, s|
         payload = Base64.urlsafe_encode("test")
-        body = %({
-        "properties": {},
-        "routing_key": "rk",
-        "payload": "#{payload}",
-        "payload_encoding": "base64"
-      })
+        body = <<-JSON
+          {
+            "properties": {},
+            "routing_key": "rk",
+            "payload": "#{payload}",
+            "payload_encoding": "base64"
+          }
+          JSON
         with_channel(s) do |ch|
           q = ch.queue("q2", durable: false)
           x = ch.exchange("str_enc", "topic", passive: false)
@@ -354,12 +376,14 @@ describe LavinMQ::HTTP::ExchangesController do
         s.vhosts["/"].declare_exchange("of_ex", "topic", false, false)
         s.vhosts["/"].declare_queue("of_q", false, false, args)
         s.vhosts["/"].bind_queue("of_q", "of_ex", "rk")
-        body = %({
-        "properties": {},
-        "routing_key": "rk",
-        "payload": "test",
-        "payload_encoding": "string"
-      })
+        body = <<-JSON
+          {
+            "properties": {},
+            "routing_key": "rk",
+            "payload": "test",
+            "payload_encoding": "string"
+          }
+          JSON
         response = http.post("/api/exchanges/%2f/of_ex/publish", body: body)
         response.status_code.should eq 200
         JSON.parse(response.body)["routed"].as_bool.should be_true
@@ -378,12 +402,14 @@ describe LavinMQ::HTTP::ExchangesController do
         s.vhosts["/"].declare_queue("mof_open", false, false)
         s.vhosts["/"].bind_queue("mof_full", "mof_ex", "rk")
         s.vhosts["/"].bind_queue("mof_open", "mof_ex", "rk")
-        body = %({
-        "properties": {},
-        "routing_key": "rk",
-        "payload": "test",
-        "payload_encoding": "string"
-      })
+        body = <<-JSON
+          {
+            "properties": {},
+            "routing_key": "rk",
+            "payload": "test",
+            "payload_encoding": "string"
+          }
+          JSON
         response = http.post("/api/exchanges/%2f/mof_ex/publish", body: body)
         response.status_code.should eq 200
         JSON.parse(response.body)["routed"].as_bool.should be_true
@@ -399,13 +425,15 @@ describe LavinMQ::HTTP::ExchangesController do
   describe "GET /api/exchanges/vhost/name with x-hash-on argument" do
     it "should include x-hash-on in effective_arguments for consistent hash exchange" do
       with_http_server do |http, _|
-        body = %({
-        "type": "x-consistent-hash",
-        "durable": false,
-        "arguments": {
-          "x-hash-on": "cluster"
-        }
-      })
+        body = <<-JSON
+          {
+            "type": "x-consistent-hash",
+            "durable": false,
+            "arguments": {
+              "x-hash-on": "cluster"
+            }
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/test-hash", body: body)
         response.status_code.should eq 201
         response = http.get("/api/exchanges/%2f/test-hash")
@@ -417,10 +445,12 @@ describe LavinMQ::HTTP::ExchangesController do
 
     it "should not include x-hash-on in effective_arguments when not set" do
       with_http_server do |http, _|
-        body = %({
-        "type": "x-consistent-hash",
-        "durable": false
-      })
+        body = <<-JSON
+          {
+            "type": "x-consistent-hash",
+            "durable": false
+          }
+          JSON
         response = http.put("/api/exchanges/%2f/test-hash-2", body: body)
         response.status_code.should eq 201
         response = http.get("/api/exchanges/%2f/test-hash-2")

--- a/spec/api/parameters_spec.cr
+++ b/spec/api/parameters_spec.cr
@@ -66,9 +66,11 @@ describe LavinMQ::HTTP::ParametersController do
   describe "PUT /api/parameters/component/vhost/name" do
     it "should create parameters for a component on vhost" do
       with_http_server do |http, s|
-        body = %({
-        "value": { "key": "value" }
-      })
+        body = <<-JSON
+          {
+            "value": { "key": "value" }
+          }
+          JSON
         response = http.put("/api/parameters/test/%2f/name", body: body)
         response.status_code.should eq 201
         s.vhosts["/"].parameters[{"test", "name"}].value.should eq({"key" => "value"})
@@ -79,9 +81,11 @@ describe LavinMQ::HTTP::ParametersController do
       with_http_server do |http, s|
         p = LavinMQ::Parameter.new("test", "name", JSON::Any.new(%({ "key": "old value" })))
         s.vhosts["/"].add_parameter(p)
-        body = %({
-        "value": { "key": "new value" }
-      })
+        body = <<-JSON
+          {
+            "value": { "key": "new value" }
+          }
+          JSON
         response = http.put("/api/parameters/test/%2f/name", body: body)
         response.status_code.should eq 204
         s.vhosts["/"].parameters[{"test", "name"}].value.should eq({"key" => "new value"})
@@ -128,14 +132,16 @@ describe LavinMQ::HTTP::ParametersController do
     it "should validate shovel config with valid config" do
       with_http_server do |http, s|
         s.users.add_permission("guest", "/", /.*/, /.*/, /.*/)
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body)
         response.status_code.should eq 201
       end
@@ -144,13 +150,15 @@ describe LavinMQ::HTTP::ParametersController do
     it "should reject shovel without source queue or exchange" do
       with_http_server do |http, s|
         s.users.add_permission("guest", "/", /.*/, /.*/, /.*/)
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -161,13 +169,15 @@ describe LavinMQ::HTTP::ParametersController do
     it "should reject shovel without destination" do
       with_http_server do |http, s|
         s.users.add_permission("guest", "/", /.*/, /.*/, /.*/)
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -180,14 +190,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /.*/, /.*/, /^$/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "dest-exchange": "dest-exchange"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "dest-exchange": "dest-exchange"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -200,14 +212,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^$/, /.*/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "dest-exchange": "dest-exchange"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "dest-exchange": "dest-exchange"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -220,15 +234,17 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^(?!dest-queue$).*/, /.*/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "dest-exchange": "dest-exchange",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "dest-exchange": "dest-exchange",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -241,14 +257,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /.*/, /^$/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -261,14 +279,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^(?!source-queue$).*/, /.*/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "dest-exchange": "dest-exchange"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "dest-exchange": "dest-exchange"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -281,14 +301,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /.*/, /^(?!source-exchange$).*/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-exchange": "source-exchange",
-            "dest-exchange": "dest-exchange"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-exchange": "source-exchange",
+              "dest-exchange": "dest-exchange"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -301,15 +323,17 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^$/, /.*/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "src-exchange": "source-exchange",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "src-exchange": "source-exchange",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 400
         body = JSON.parse(response.body)
@@ -322,16 +346,18 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("sufficient", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("sufficient", "/", /.*/, /.*/, /.*/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic c3VmZmljaWVudDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://",
-            "src-queue": "source-queue",
-            "src-exchange": "source-exchange",
-            "dest-exchange": "dest-exchange",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://",
+              "src-queue": "source-queue",
+              "src-exchange": "source-exchange",
+              "dest-exchange": "dest-exchange",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 201
       end
@@ -342,14 +368,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^$/, /^$/, /^$/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://external-host",
-            "dest-uri": "amqp://external-host",
-            "src-queue": "source-queue",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://external-host",
+              "dest-uri": "amqp://external-host",
+              "src-queue": "source-queue",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 201
       end
@@ -360,14 +388,16 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^$/, /^$/, /^$/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://someuser:pass@localhost",
-            "dest-uri": "amqp://someuser:pass@localhost",
-            "src-queue": "source-queue",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://someuser:pass@localhost",
+              "dest-uri": "amqp://someuser:pass@localhost",
+              "src-queue": "source-queue",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 201
       end
@@ -378,15 +408,17 @@ describe LavinMQ::HTTP::ParametersController do
         s.users.create("limited", "pw", [LavinMQ::Tag::PolicyMaker])
         s.users.add_permission("limited", "/", /^amq\.topic$/, /^amq\.topic$/, /^$/)
         hdrs = ::HTTP::Headers{"Authorization" => "Basic bGltaXRlZDpwdw=="}
-        body = %({
-          "value": {
-            "src-uri": "amqp://",
-            "dest-uri": "amqp://external-host",
-            "src-exchange": "amq.topic",
-            "src-exchange-key": "#",
-            "dest-queue": "dest-queue"
+        body = <<-JSON
+          {
+            "value": {
+              "src-uri": "amqp://",
+              "dest-uri": "amqp://external-host",
+              "src-exchange": "amq.topic",
+              "src-exchange-key": "#",
+              "dest-queue": "dest-queue"
+            }
           }
-        })
+          JSON
         response = http.put("/api/parameters/shovel/%2f/test-shovel", body: body, headers: hdrs)
         response.status_code.should eq 201
       end
@@ -469,9 +501,11 @@ describe LavinMQ::HTTP::ParametersController do
     it "should create global parameter" do
       with_http_server do |http, s|
         s.delete_parameter(nil, "name")
-        body = %({
-        "value": {}
-      })
+        body = <<-JSON
+          {
+            "value": {}
+          }
+          JSON
         response = http.put("/api/global-parameters/name", body: body)
         response.status_code.should eq 201
       end
@@ -481,9 +515,11 @@ describe LavinMQ::HTTP::ParametersController do
       with_http_server do |http, s|
         p = LavinMQ::Parameter.new(nil, "name", JSON::Any.new(%({ "key": "old value" })))
         s.add_parameter(p)
-        body = %({
-        "value": { "key": "new value" }
-      })
+        body = <<-JSON
+          {
+            "value": { "key": "new value" }
+          }
+          JSON
         response = http.put("/api/global-parameters/name", body: body)
         response.status_code.should eq 204
         s.parameters[{nil, "name"}].value.should eq({"key" => "new value"})
@@ -584,12 +620,14 @@ describe LavinMQ::HTTP::ParametersController do
   describe "PUT /api/policies/vhost/name" do
     it "should create policy" do
       with_http_server do |http, s|
-        body = %({
-        "apply-to": "queues",
-        "priority": 4,
-        "definition": { "max-length": 10 },
-        "pattern": ".*"
-      })
+        body = <<-JSON
+          {
+            "apply-to": "queues",
+            "priority": 4,
+            "definition": { "max-length": 10 },
+            "pattern": ".*"
+          }
+          JSON
         response = http.put("/api/policies/%2f/name", body: body)
         response.status_code.should eq 201
         s.vhosts["/"].policies["name"].definition["max-length"].as_i.should eq 10
@@ -602,10 +640,12 @@ describe LavinMQ::HTTP::ParametersController do
         definitions = {"max-length" => JSON::Any.new(10_i64)}
         s.vhosts["/"].add_policy(policy_name, "^.*$", "all", definitions, -10_i8)
 
-        body = %({
-        "pattern": ".*",
-        "definition": { "max-length": 20 }
-      })
+        body = <<-JSON
+          {
+            "pattern": ".*",
+            "definition": { "max-length": 20 }
+          }
+          JSON
         response = http.put("/api/policies/%2f/#{policy_name}", body: body)
         response.status_code.should eq 204
         s.vhosts["/"].policies[policy_name].definition["max-length"].as_i.should eq 20
@@ -639,12 +679,14 @@ describe LavinMQ::HTTP::ParametersController do
 
     it "should handle invalid definition types" do
       with_http_server do |http, _|
-        body = %({
-        "apply-to": "queues",
-        "priority": 0,
-        "definition": { "max-length": "String" },
-        "pattern": ".*"
-      })
+        body = <<-JSON
+          {
+            "apply-to": "queues",
+            "priority": 0,
+            "definition": { "max-length": "String" },
+            "pattern": ".*"
+          }
+          JSON
         response = http.put("/api/policies/%2f/name", body: body)
         response.status_code.should eq 400
       end
@@ -654,12 +696,14 @@ describe LavinMQ::HTTP::ParametersController do
   describe "PUT /api/operator-policies/vhost/name" do
     it "should handle invalid definition types" do
       with_http_server do |http, _|
-        body = %({
-        "apply-to": "queues",
-        "priority": 0,
-        "definition": { "max-length": "String" },
-        "pattern": ".*"
-      })
+        body = <<-JSON
+          {
+            "apply-to": "queues",
+            "priority": 0,
+            "definition": { "max-length": "String" },
+            "pattern": ".*"
+          }
+          JSON
         response = http.put("/api/operator-policies/%2f/name", body: body)
         response.status_code.should eq 400
       end
@@ -681,12 +725,14 @@ describe LavinMQ::HTTP::ParametersController do
   describe "PUT /api/operator-policies/vhost/name" do
     it "should handle invalid definition types" do
       with_http_server do |http, _|
-        body = %({
-        "apply-to": "queues",
-        "priority": 0,
-        "definition": { "max-length": "String" },
-        "pattern": ".*"
-      })
+        body = <<-JSON
+          {
+            "apply-to": "queues",
+            "priority": 0,
+            "definition": { "max-length": "String" },
+            "pattern": ".*"
+          }
+          JSON
         response = http.put("/api/operator-policies/%2f/name", body: body)
         response.status_code.should eq 400
         body = JSON.parse(response.body)

--- a/spec/api/permissions_spec.cr
+++ b/spec/api/permissions_spec.cr
@@ -38,11 +38,13 @@ describe LavinMQ::HTTP::PermissionsController do
       with_http_server do |http, s|
         s.users.create("test_user", "pw")
         s.vhosts.create("test_vhost")
-        body = %({
-        "configure": ".*",
-        "read": ".*",
-        "write": ".*"
-      })
+        body = <<-JSON
+          {
+            "configure": ".*",
+            "read": ".*",
+            "write": ".*"
+          }
+          JSON
         response = http.put("/api/permissions/test_vhost/test_user", body: body)
         response.status_code.should eq 201
         s.users["test_user"].permissions["test_vhost"].should eq({config: /.*/, read: /.*/, write: /.*/})
@@ -54,11 +56,13 @@ describe LavinMQ::HTTP::PermissionsController do
         s.vhosts.create("test_vhost")
         s.users.add_permission("guest", "test_vhost", /.*/, /.*/, /.*/)
 
-        body = %({
-        "configure": ".*",
-        "read": ".*",
-        "write": "^tut"
-      })
+        body = <<-JSON
+          {
+            "configure": ".*",
+            "read": ".*",
+            "write": "^tut"
+          }
+          JSON
         response = http.put("/api/permissions/test_vhost/guest", body: body)
         response.status_code.should eq 204
         s.users["guest"].permissions["test_vhost"]["write"].should eq(/^tut/)

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -322,14 +322,18 @@ describe LavinMQ::HTTP::QueuesController do
 
     it "should require durable to be the same when overwriting" do
       with_http_server do |http, _|
-        body = %({
-        "durable": true
-      })
+        body = <<-JSON
+          {
+            "durable": true
+          }
+          JSON
         response = http.put("/api/queues/%2f/q1d", body: body)
         response.status_code.should eq 201
-        body = %({
-        "durable": false
-      })
+        body = <<-JSON
+          {
+            "durable": false
+          }
+          JSON
         response = http.put("/api/queues/%2f/q1d", body: body)
         response.status_code.should eq 400
       end
@@ -347,9 +351,11 @@ describe LavinMQ::HTTP::QueuesController do
         # supplying 'x-dead-letter-routing-key' is only valid if
         # 'x-dead-letter-exchange' is also in the request
         # so this request generates a Error::PreconditionFailed
-        body = %({
-        "arguments": {"x-dead-letter-routing-key": "value"}
-      })
+        body = <<-JSON
+          {
+            "arguments": {"x-dead-letter-routing-key": "value"}
+          }
+          JSON
         response = http.put("/api/queues/%2f/precond-failed", body: body)
         response.status_code.should eq 400
       end
@@ -378,11 +384,13 @@ describe LavinMQ::HTTP::QueuesController do
           q = ch.queue("q3", auto_delete: false, durable: true, exclusive: false)
           q.publish "m1"
           sleep 0.05.milliseconds
-          body = %({
-          "count": 1,
-          "ack_mode": "reject_requeue_true",
-          "encoding": "auto"
-        })
+          body = <<-JSON
+            {
+              "count": 1,
+              "ack_mode": "reject_requeue_true",
+              "encoding": "auto"
+            }
+            JSON
           response = http.post("/api/queues/%2f/q3/get", body: body)
           response.status_code.should eq 200
           body = JSON.parse(response.body)
@@ -511,11 +519,13 @@ describe LavinMQ::HTTP::QueuesController do
           q = ch.queue("q5", auto_delete: false, durable: true, exclusive: false)
           q.publish "m1"
           sleep 0.05.milliseconds
-          body = %({
-          "count": 2,
-          "ack_mode": "get",
-          "encoding": "auto"
-        })
+          body = <<-JSON
+            {
+              "count": 2,
+              "ack_mode": "get",
+              "encoding": "auto"
+            }
+            JSON
           response = http.post("/api/queues/%2f/q5/get", body: body)
           response.status_code.should eq 200
         end
@@ -526,11 +536,13 @@ describe LavinMQ::HTTP::QueuesController do
       with_http_server do |http, s|
         with_channel(s) do |ch|
           ch.queue("q6")
-          body = %({
-          "count": 1,
-          "ack_mode": "get",
-          "encoding": "auto"
-        })
+          body = <<-JSON
+            {
+              "count": 1,
+              "ack_mode": "get",
+              "encoding": "auto"
+            }
+            JSON
           response = http.post("/api/queues/%2f/q6/get", body: body)
           response.status_code.should eq 200
           body = JSON.parse(response.body)
@@ -545,11 +557,13 @@ describe LavinMQ::HTTP::QueuesController do
           q = ch.queue("q7")
           q.publish "m1"
           sleep 0.05.milliseconds
-          body = %({
-          "count": 1,
-          "ack_mode": "get",
-          "encoding": "base64"
-        })
+          body = <<-JSON
+            {
+              "count": 1,
+              "ack_mode": "get",
+              "encoding": "base64"
+            }
+            JSON
           response = http.post("/api/queues/%2f/q7/get", body: body)
           response.status_code.should eq 200
           body = JSON.parse(response.body)
@@ -564,12 +578,14 @@ describe LavinMQ::HTTP::QueuesController do
           q = ch.queue("q8")
           q.publish "m1"
           sleep 0.05.milliseconds
-          body = %({
-          "count": 1,
-          "ack_mode": "get",
-          "requeue": true,
-          "encoding": "base64"
-        })
+          body = <<-JSON
+            {
+              "count": 1,
+              "ack_mode": "get",
+              "requeue": true,
+              "encoding": "base64"
+            }
+            JSON
           response = http.post("/api/queues/%2f/q8/get", body: body)
           response.status_code.should eq 400
           body = JSON.parse(response.body)

--- a/spec/api/users_spec.cr
+++ b/spec/api/users_spec.cr
@@ -38,9 +38,11 @@ describe LavinMQ::HTTP::UsersController do
       with_http_server do |http, s|
         s.users.create("alan1", "alan")
         s.users.create("alan2", "alan")
-        body = %({
-        "users": ["alan1", "alan2"]
-      })
+        body = <<-JSON
+          {
+            "users": ["alan1", "alan2"]
+          }
+          JSON
         response = http.post("/api/users/bulk-delete", body: body)
         response.status_code.should eq 204
       end
@@ -83,9 +85,11 @@ describe LavinMQ::HTTP::UsersController do
   describe "PUT /api/users/name" do
     it "should create user with password" do
       with_http_server do |http, s|
-        body = %({
-        "password": "test"
-      })
+        body = <<-JSON
+          {
+            "password": "test"
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 201
         u = s.users["alan"]
@@ -96,9 +100,11 @@ describe LavinMQ::HTTP::UsersController do
 
     it "should create user with password_hash" do
       with_http_server do |http, s|
-        body = %({
-        "password_hash": "kI3GCqW5JLMJa4iX1lo7X4D6XbYqlLgxIs30+P6tENUV2POR"
-      })
+        body = <<-JSON
+          {
+            "password_hash": "kI3GCqW5JLMJa4iX1lo7X4D6XbYqlLgxIs30+P6tENUV2POR"
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 201
         u = s.users["alan"]
@@ -138,9 +144,11 @@ describe LavinMQ::HTTP::UsersController do
 
     it "should create user with empty password_hash" do
       with_http_server do |http, _|
-        body = %({
-        "password_hash": ""
-      })
+        body = <<-JSON
+          {
+            "password_hash": ""
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 201
         hrds = HTTP::Headers{"Authorization" => "Basic YWxhbjo="} # alan:
@@ -163,10 +171,12 @@ describe LavinMQ::HTTP::UsersController do
 
     it "should create user with uniq tags" do
       with_http_server do |http, s|
-        body = %({
-        "password": "test",
-        "tags": "management,management"
-      })
+        body = <<-JSON
+          {
+            "password": "test",
+            "tags": "management,management"
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 201
         s.users["alan"].tags.size.should eq 1
@@ -177,10 +187,12 @@ describe LavinMQ::HTTP::UsersController do
     it "should update user" do
       with_http_server do |http, s|
         s.users.create("alan", "pw")
-        body = %({
-        "password": "test",
-        "tags": "management"
-      })
+        body = <<-JSON
+          {
+            "password": "test",
+            "tags": "management"
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 204
         s.users["alan"].tags.should eq([LavinMQ::Tag::Management])
@@ -190,10 +202,12 @@ describe LavinMQ::HTTP::UsersController do
     it "should update user with uniq tags" do
       with_http_server do |http, s|
         s.users.create("alan", "pw")
-        body = %({
-        "password": "test",
-        "tags": "management,management"
-      })
+        body = <<-JSON
+          {
+            "password": "test",
+            "tags": "management,management"
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 204
         s.users["alan"].tags.size.should eq 1
@@ -229,9 +243,11 @@ describe LavinMQ::HTTP::UsersController do
     it "should not create user if disk is full" do
       with_http_server do |http, s|
         s.flow(false)
-        body = %({
-        "password": "test"
-      })
+        body = <<-JSON
+          {
+            "password": "test"
+          }
+          JSON
         response = http.put("/api/users/alan", body: body)
         response.status_code.should eq 412
         body = JSON.parse(response.body)
@@ -258,9 +274,11 @@ describe LavinMQ::HTTP::UsersController do
   describe "PUT /api/auth/hash_password" do
     it "should return hashed password" do
       with_http_server do |http, _s|
-        body = %({
-        "password": "a_pasword_to_hash"
-      })
+        body = <<-JSON
+          {
+            "password": "a_pasword_to_hash"
+          }
+          JSON
         response = http.put("/api/auth/hash_password", body: body)
         response.status_code.should eq 200
         JSON.parse(response.body)["password_hash"].as_s.size.should eq 48

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -97,9 +97,8 @@ describe LavinMQ::Config do
   end
 
   it "Can parse all INI arguments" do
-    begin
-      config_file = File.tempfile do |file|
-        file.print <<-CONFIG
+    config_file = File.tempfile do |file|
+      file.print <<-CONFIG
           [main]
           data_dir = /tmp/lavinmq-test
           log_level = debug
@@ -181,93 +180,92 @@ describe LavinMQ::Config do
           on_leader_elected = echo "Leader elected"
           on_leader_lost = echo "Leader lost"
         CONFIG
-      end
-      config = LavinMQ::Config.new
-      argv = ["-c", config_file.path]
-      config.parse(argv)
-
-      # Main section
-      config.data_dir.should eq "/tmp/lavinmq-test"
-      config.log_level.should eq ::Log::Severity::Debug
-      config.log_file.should eq "/tmp/lavinmq-test.log"
-      config.stats_interval.should eq 10000
-      config.stats_log_size.should eq 240
-      config.set_timestamp?.should be_true
-      config.socket_buffer_size.should eq 32768
-      config.tcp_nodelay?.should be_true
-      config.segment_size.should eq 16777216
-      config.sync?.should be_false
-      config.tcp_keepalive.should eq({120, 20, 5})
-      config.tcp_recv_buffer_size.should eq 65536
-      config.tcp_send_buffer_size.should eq 65536
-      config.log_exchange?.should be_true
-      config.free_disk_min.should eq 1073741824
-      config.free_disk_warn.should eq 5368709120
-      config.max_deleted_definitions.should eq 16384
-      config.consumer_timeout.should eq 3600
-      config.consumer_timeout_loop_interval.should eq 120
-      config.auth_backends.should eq ["ldap", "basic"]
-      config.default_consumer_prefetch.should eq 1000
-      config.default_user.should eq "admin"
-      config.default_user_only_loopback?.should be_false
-      config.data_dir_lock?.should be_false
-      config.tls_cert_path.should eq "/etc/lavinmq/cert.pem"
-      config.tls_ciphers.should eq "ECDHE-RSA-AES256-GCM-SHA384"
-      config.tls_key_path.should eq "/etc/lavinmq/key.pem"
-      config.tls_min_version.should eq "1.3"
-      config.tls_keylog_file.should eq "/tmp/keylog.txt"
-      config.metrics_http_bind.should eq "0.0.0.0"
-      config.metrics_http_port.should eq 9090
-      config.control_unix_path.should eq "/tmp/lavinmqctl-ini.sock"
-
-      # AMQP section
-      config.amqp_bind.should eq "0.0.0.0"
-      config.amqp_port.should eq 5673
-      config.amqps_port.should eq 5674
-      config.unix_path.should eq "/tmp/lavinmq.sock"
-      config.tcp_proxy_protocol?.should be_true
-      config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
-      config.heartbeat.should eq 600
-      config.frame_max.should eq 262144
-      config.channel_max.should eq 4096
-      config.max_message_size.should eq 268435456
-      config.amqp_systemd_socket_name.should eq "custom-amqp.socket"
-
-      # MQTT section
-      config.mqtt_bind.should eq "0.0.0.0"
-      config.mqtt_port.should eq 1884
-      config.mqtts_port.should eq 8884
-      config.mqtt_unix_path.should eq "/tmp/mqtt.sock"
-      config.mqtt_permission_check_enabled?.should be_true
-      config.mqtt_max_packet_size.should eq 536870910
-      config.max_inflight_messages.should eq 100
-      config.default_mqtt_vhost.should eq "/mqtt"
-      config.mqtt_client_id_validation.should eq LavinMQ::MQTT::ClientIdValidation::Username
-
-      # MGMT section
-      config.http_bind.should eq "0.0.0.0"
-      config.http_port.should eq 15673
-      config.https_port.should eq 15674
-      config.http_unix_path.should eq "/tmp/mgmt.sock"
-      config.http_systemd_socket_name.should eq "custom-http.socket"
-
-      # Experimental section
-      config.yield_each_received_bytes.should eq 262144
-      config.yield_each_delivered_bytes.should eq 2097152
-
-      # Clustering section
-      config.clustering?.should be_true
-      config.clustering_bind.should eq "0.0.0.0"
-      config.clustering_port.should eq 5680
-      config.clustering_etcd_endpoints.should eq "localhost:2380,localhost:2381"
-      config.clustering_etcd_prefix.should eq "test-lavinmq"
-      config.clustering_advertised_uri.should eq "lavinmq://localhost:5680"
-      config.clustering_on_leader_elected.should eq "echo \"Leader elected\""
-      config.clustering_on_leader_lost.should eq "echo \"Leader lost\""
-    ensure
-      # Reset log level to default for other specs
-      Log.setup(:fatal)
     end
+    config = LavinMQ::Config.new
+    argv = ["-c", config_file.path]
+    config.parse(argv)
+
+    # Main section
+    config.data_dir.should eq "/tmp/lavinmq-test"
+    config.log_level.should eq ::Log::Severity::Debug
+    config.log_file.should eq "/tmp/lavinmq-test.log"
+    config.stats_interval.should eq 10000
+    config.stats_log_size.should eq 240
+    config.set_timestamp?.should be_true
+    config.socket_buffer_size.should eq 32768
+    config.tcp_nodelay?.should be_true
+    config.segment_size.should eq 16777216
+    config.sync?.should be_false
+    config.tcp_keepalive.should eq({120, 20, 5})
+    config.tcp_recv_buffer_size.should eq 65536
+    config.tcp_send_buffer_size.should eq 65536
+    config.log_exchange?.should be_true
+    config.free_disk_min.should eq 1073741824
+    config.free_disk_warn.should eq 5368709120
+    config.max_deleted_definitions.should eq 16384
+    config.consumer_timeout.should eq 3600
+    config.consumer_timeout_loop_interval.should eq 120
+    config.auth_backends.should eq ["ldap", "basic"]
+    config.default_consumer_prefetch.should eq 1000
+    config.default_user.should eq "admin"
+    config.default_user_only_loopback?.should be_false
+    config.data_dir_lock?.should be_false
+    config.tls_cert_path.should eq "/etc/lavinmq/cert.pem"
+    config.tls_ciphers.should eq "ECDHE-RSA-AES256-GCM-SHA384"
+    config.tls_key_path.should eq "/etc/lavinmq/key.pem"
+    config.tls_min_version.should eq "1.3"
+    config.tls_keylog_file.should eq "/tmp/keylog.txt"
+    config.metrics_http_bind.should eq "0.0.0.0"
+    config.metrics_http_port.should eq 9090
+    config.control_unix_path.should eq "/tmp/lavinmqctl-ini.sock"
+
+    # AMQP section
+    config.amqp_bind.should eq "0.0.0.0"
+    config.amqp_port.should eq 5673
+    config.amqps_port.should eq 5674
+    config.unix_path.should eq "/tmp/lavinmq.sock"
+    config.tcp_proxy_protocol?.should be_true
+    config.proxy_protocol_trusted_sources[0].matches?("10.0.0.1").should be_true
+    config.heartbeat.should eq 600
+    config.frame_max.should eq 262144
+    config.channel_max.should eq 4096
+    config.max_message_size.should eq 268435456
+    config.amqp_systemd_socket_name.should eq "custom-amqp.socket"
+
+    # MQTT section
+    config.mqtt_bind.should eq "0.0.0.0"
+    config.mqtt_port.should eq 1884
+    config.mqtts_port.should eq 8884
+    config.mqtt_unix_path.should eq "/tmp/mqtt.sock"
+    config.mqtt_permission_check_enabled?.should be_true
+    config.mqtt_max_packet_size.should eq 536870910
+    config.max_inflight_messages.should eq 100
+    config.default_mqtt_vhost.should eq "/mqtt"
+    config.mqtt_client_id_validation.should eq LavinMQ::MQTT::ClientIdValidation::Username
+
+    # MGMT section
+    config.http_bind.should eq "0.0.0.0"
+    config.http_port.should eq 15673
+    config.https_port.should eq 15674
+    config.http_unix_path.should eq "/tmp/mgmt.sock"
+    config.http_systemd_socket_name.should eq "custom-http.socket"
+
+    # Experimental section
+    config.yield_each_received_bytes.should eq 262144
+    config.yield_each_delivered_bytes.should eq 2097152
+
+    # Clustering section
+    config.clustering?.should be_true
+    config.clustering_bind.should eq "0.0.0.0"
+    config.clustering_port.should eq 5680
+    config.clustering_etcd_endpoints.should eq "localhost:2380,localhost:2381"
+    config.clustering_etcd_prefix.should eq "test-lavinmq"
+    config.clustering_advertised_uri.should eq "lavinmq://localhost:5680"
+    config.clustering_on_leader_elected.should eq "echo \"Leader elected\""
+    config.clustering_on_leader_lost.should eq "echo \"Leader lost\""
+  ensure
+    # Reset log level to default for other specs
+    Log.setup(:fatal)
   end
 
   it "can parse all CLI argumetns" do
@@ -362,88 +360,84 @@ describe LavinMQ::Config do
   end
 
   it "can parse all ENV arguments" do
-    begin
-      ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = "/etc/custom"
-      ENV["LAVINMQ_DATADIR"] = "/tmp/lavinmq-env"
-      ENV["LAVINMQ_AMQP_PORT"] = "5674"
-      ENV["LAVINMQ_AMQP_BIND"] = "10.1.1.1"
-      ENV["LAVINMQ_AMQPS_PORT"] = "5676"
-      ENV["LAVINMQ_HTTP_BIND"] = "10.2.2.2"
-      ENV["LAVINMQ_HTTP_PORT"] = "15674"
-      ENV["LAVINMQ_HTTPS_PORT"] = "15676"
-      ENV["LAVINMQ_TLS_CERT_PATH"] = "/etc/certs/env-cert.pem"
-      ENV["LAVINMQ_TLS_CIPHERS"] = "ENV-CIPHER-SUITE"
-      ENV["LAVINMQ_TLS_KEY_PATH"] = "/etc/certs/env-key.pem"
-      ENV["LAVINMQ_TLS_MIN_VERSION"] = "1.2"
-      ENV["LAVINMQ_DEFAULT_CONSUMER_PREFETCH"] = "2000"
-      ENV["LAVINMQ_DEFAULT_USER"] = "envuser"
-      ENV["LAVINMQ_CLUSTERING"] = "true"
-      ENV["LAVINMQ_CLUSTERING_ADVERTISED_URI"] = "lavinmq://env:5679"
-      ENV["LAVINMQ_CLUSTERING_BIND"] = "10.3.3.3"
-      ENV["LAVINMQ_CLUSTERING_ETCD_ENDPOINTS"] = "env-etcd:2379"
-      ENV["LAVINMQ_CLUSTERING_ETCD_PREFIX"] = "env-prefix"
-      ENV["LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS"] = "2048"
-      ENV["LAVINMQ_CLUSTERING_PORT"] = "5681"
-      ENV["LAVINMQ_SYNC"] = "false"
-      ENV["LAVINMQ_CONTROL_UNIX_PATH"] = "/tmp/lavinmqctl-env.sock"
-      config = LavinMQ::Config.new
-      config.parse([] of String)
+    ENV["LAVINMQ_CONFIGURATION_DIRECTORY"] = "/etc/custom"
+    ENV["LAVINMQ_DATADIR"] = "/tmp/lavinmq-env"
+    ENV["LAVINMQ_AMQP_PORT"] = "5674"
+    ENV["LAVINMQ_AMQP_BIND"] = "10.1.1.1"
+    ENV["LAVINMQ_AMQPS_PORT"] = "5676"
+    ENV["LAVINMQ_HTTP_BIND"] = "10.2.2.2"
+    ENV["LAVINMQ_HTTP_PORT"] = "15674"
+    ENV["LAVINMQ_HTTPS_PORT"] = "15676"
+    ENV["LAVINMQ_TLS_CERT_PATH"] = "/etc/certs/env-cert.pem"
+    ENV["LAVINMQ_TLS_CIPHERS"] = "ENV-CIPHER-SUITE"
+    ENV["LAVINMQ_TLS_KEY_PATH"] = "/etc/certs/env-key.pem"
+    ENV["LAVINMQ_TLS_MIN_VERSION"] = "1.2"
+    ENV["LAVINMQ_DEFAULT_CONSUMER_PREFETCH"] = "2000"
+    ENV["LAVINMQ_DEFAULT_USER"] = "envuser"
+    ENV["LAVINMQ_CLUSTERING"] = "true"
+    ENV["LAVINMQ_CLUSTERING_ADVERTISED_URI"] = "lavinmq://env:5679"
+    ENV["LAVINMQ_CLUSTERING_BIND"] = "10.3.3.3"
+    ENV["LAVINMQ_CLUSTERING_ETCD_ENDPOINTS"] = "env-etcd:2379"
+    ENV["LAVINMQ_CLUSTERING_ETCD_PREFIX"] = "env-prefix"
+    ENV["LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS"] = "2048"
+    ENV["LAVINMQ_CLUSTERING_PORT"] = "5681"
+    ENV["LAVINMQ_SYNC"] = "false"
+    ENV["LAVINMQ_CONTROL_UNIX_PATH"] = "/tmp/lavinmqctl-env.sock"
+    config = LavinMQ::Config.new
+    config.parse([] of String)
 
-      config.data_dir.should eq "/tmp/lavinmq-env"
-      config.amqp_port.should eq 5674
-      config.amqp_bind.should eq "10.1.1.1"
-      config.amqps_port.should eq 5676
-      config.http_bind.should eq "10.2.2.2"
-      config.http_port.should eq 15674
-      config.https_port.should eq 15676
-      config.tls_cert_path.should eq "/etc/certs/env-cert.pem"
-      config.tls_ciphers.should eq "ENV-CIPHER-SUITE"
-      config.tls_key_path.should eq "/etc/certs/env-key.pem"
-      config.tls_min_version.should eq "1.2"
-      config.default_consumer_prefetch.should eq 2000
-      config.default_user.should eq "envuser"
-      config.clustering?.should be_true
-      config.clustering_advertised_uri.should eq "lavinmq://env:5679"
-      config.clustering_bind.should eq "10.3.3.3"
-      config.clustering_etcd_endpoints.should eq "env-etcd:2379"
-      config.clustering_etcd_prefix.should eq "env-prefix"
-      config.clustering_port.should eq 5681
-      config.control_unix_path.should eq "/tmp/lavinmqctl-env.sock"
-    ensure
-      ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
-      ENV.delete("LAVINMQ_DATADIR")
-      ENV.delete("LAVINMQ_AMQP_PORT")
-      ENV.delete("LAVINMQ_AMQP_BIND")
-      ENV.delete("LAVINMQ_AMQPS_PORT")
-      ENV.delete("LAVINMQ_HTTP_BIND")
-      ENV.delete("LAVINMQ_HTTP_PORT")
-      ENV.delete("LAVINMQ_HTTPS_PORT")
-      ENV.delete("LAVINMQ_TLS_CERT_PATH")
-      ENV.delete("LAVINMQ_TLS_CIPHERS")
-      ENV.delete("LAVINMQ_TLS_KEY_PATH")
-      ENV.delete("LAVINMQ_TLS_MIN_VERSION")
-      ENV.delete("LAVINMQ_DEFAULT_CONSUMER_PREFETCH")
-      ENV.delete("LAVINMQ_DEFAULT_USER")
-      ENV.delete("LAVINMQ_CLUSTERING")
-      ENV.delete("LAVINMQ_CLUSTERING_ADVERTISED_URI")
-      ENV.delete("LAVINMQ_CLUSTERING_BIND")
-      ENV.delete("LAVINMQ_CLUSTERING_ETCD_ENDPOINTS")
-      ENV.delete("LAVINMQ_CLUSTERING_ETCD_PREFIX")
-      ENV.delete("LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS")
-      ENV.delete("LAVINMQ_CLUSTERING_PORT")
-      ENV.delete("LAVINMQ_CONTROL_UNIX_PATH")
-    end
+    config.data_dir.should eq "/tmp/lavinmq-env"
+    config.amqp_port.should eq 5674
+    config.amqp_bind.should eq "10.1.1.1"
+    config.amqps_port.should eq 5676
+    config.http_bind.should eq "10.2.2.2"
+    config.http_port.should eq 15674
+    config.https_port.should eq 15676
+    config.tls_cert_path.should eq "/etc/certs/env-cert.pem"
+    config.tls_ciphers.should eq "ENV-CIPHER-SUITE"
+    config.tls_key_path.should eq "/etc/certs/env-key.pem"
+    config.tls_min_version.should eq "1.2"
+    config.default_consumer_prefetch.should eq 2000
+    config.default_user.should eq "envuser"
+    config.clustering?.should be_true
+    config.clustering_advertised_uri.should eq "lavinmq://env:5679"
+    config.clustering_bind.should eq "10.3.3.3"
+    config.clustering_etcd_endpoints.should eq "env-etcd:2379"
+    config.clustering_etcd_prefix.should eq "env-prefix"
+    config.clustering_port.should eq 5681
+    config.control_unix_path.should eq "/tmp/lavinmqctl-env.sock"
+  ensure
+    ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
+    ENV.delete("LAVINMQ_DATADIR")
+    ENV.delete("LAVINMQ_AMQP_PORT")
+    ENV.delete("LAVINMQ_AMQP_BIND")
+    ENV.delete("LAVINMQ_AMQPS_PORT")
+    ENV.delete("LAVINMQ_HTTP_BIND")
+    ENV.delete("LAVINMQ_HTTP_PORT")
+    ENV.delete("LAVINMQ_HTTPS_PORT")
+    ENV.delete("LAVINMQ_TLS_CERT_PATH")
+    ENV.delete("LAVINMQ_TLS_CIPHERS")
+    ENV.delete("LAVINMQ_TLS_KEY_PATH")
+    ENV.delete("LAVINMQ_TLS_MIN_VERSION")
+    ENV.delete("LAVINMQ_DEFAULT_CONSUMER_PREFETCH")
+    ENV.delete("LAVINMQ_DEFAULT_USER")
+    ENV.delete("LAVINMQ_CLUSTERING")
+    ENV.delete("LAVINMQ_CLUSTERING_ADVERTISED_URI")
+    ENV.delete("LAVINMQ_CLUSTERING_BIND")
+    ENV.delete("LAVINMQ_CLUSTERING_ETCD_ENDPOINTS")
+    ENV.delete("LAVINMQ_CLUSTERING_ETCD_PREFIX")
+    ENV.delete("LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS")
+    ENV.delete("LAVINMQ_CLUSTERING_PORT")
+    ENV.delete("LAVINMQ_CONTROL_UNIX_PATH")
   end
 
   it "uses systemd STATE_DIRECTORY as default for data_dir" do
-    begin
-      ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
-      config = LavinMQ::Config.new
-      config.parse([] of String)
-      config.data_dir.should eq "/var/lib/custom-state"
-    ensure
-      ENV.delete("STATE_DIRECTORY")
-    end
+    ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
+    config = LavinMQ::Config.new
+    config.parse([] of String)
+    config.data_dir.should eq "/var/lib/custom-state"
+  ensure
+    ENV.delete("STATE_DIRECTORY")
   end
 
   it "STATE_DIRECTORY takes precedence over INI data_dir" do
@@ -464,16 +458,14 @@ describe LavinMQ::Config do
   end
 
   it "LAVINMQ_DATADIR takes precedence over STATE_DIRECTORY" do
-    begin
-      ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
-      ENV["LAVINMQ_DATADIR"] = "/var/lib/lavinmq-explicit"
-      config = LavinMQ::Config.new
-      config.parse([] of String)
-      config.data_dir.should eq "/var/lib/lavinmq-explicit"
-    ensure
-      ENV.delete("STATE_DIRECTORY")
-      ENV.delete("LAVINMQ_DATADIR")
-    end
+    ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
+    ENV["LAVINMQ_DATADIR"] = "/var/lib/lavinmq-explicit"
+    config = LavinMQ::Config.new
+    config.parse([] of String)
+    config.data_dir.should eq "/var/lib/lavinmq-explicit"
+  ensure
+    ENV.delete("STATE_DIRECTORY")
+    ENV.delete("LAVINMQ_DATADIR")
   end
 
   it "uses systemd CONFIGURATION_DIRECTORY for config file lookup" do

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -756,17 +756,17 @@ describe LavinMQ::Config do
 
   describe "tcp_proxy_protocol" do
     {% for value, expected in {"1": true, "yes": true, "2": true, "-1": false, "no": false, "false": false, "0": false} %}
-      it "sets tcp_proxy_protocol to {{expected}} when value is {{value}}" do
+      it "sets tcp_proxy_protocol to {{ expected }} when value is {{ value }}" do
         config_file = File.tempfile do |file|
           file.print <<-CONFIG
                 [amqp]
-                tcp_proxy_protocol = {{value}}
+                tcp_proxy_protocol = {{ value }}
               CONFIG
         end
         config = LavinMQ::Config.new
         argv = ["-c", config_file.path]
         config.parse(argv)
-        config.tcp_proxy_protocol?.should eq {{expected}}
+        config.tcp_proxy_protocol?.should eq {{ expected }}
       end
     {% end %}
   end

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -21,7 +21,7 @@ describe LavinMQ::Config do
         data_dir = /tmp/lavinmq-spec
         [mgmt]
         [amqp]
-      CONFIG
+        CONFIG
     end
     config = LavinMQ::Config.new
     argv = ["-c", config_file.path]
@@ -41,7 +41,7 @@ describe LavinMQ::Config do
         [main]
         log_level = fatal
         data_dir = /tmp/lavinmq-ini
-      CONFIG
+        CONFIG
     end
     ENV["LAVINMQ_DATADIR"] = "/tmp/lavinmq-env"
     config = LavinMQ::Config.new
@@ -57,7 +57,7 @@ describe LavinMQ::Config do
       file.print <<-CONFIG
         [main]
         data_dir = /tmp/lavinmq-ini
-      CONFIG
+        CONFIG
     end
     ENV["LAVINMQ_DATADIR"] = "/tmp/lavinmq-env"
     config = LavinMQ::Config.new
@@ -74,7 +74,7 @@ describe LavinMQ::Config do
       File.write(config_file.path, <<-CONFIG
         [main]
         log_level = info
-      CONFIG
+        CONFIG
       )
       config = LavinMQ::Config.new
       argv = ["-c", config_file.path]
@@ -85,7 +85,7 @@ describe LavinMQ::Config do
       File.write(config_file.path, <<-CONFIG
         [main]
         log_level = debug
-      CONFIG
+        CONFIG
       )
       config.reload
       config.log_level.should eq ::Log::Severity::Debug
@@ -445,7 +445,7 @@ describe LavinMQ::Config do
       file.print <<-CONFIG
         [main]
         data_dir = /tmp/lavinmq-ini
-      CONFIG
+        CONFIG
     end
     begin
       ENV["STATE_DIRECTORY"] = "/var/lib/custom-state"
@@ -512,7 +512,7 @@ describe LavinMQ::Config do
         data_dir = /tmp/lavinmq-spec
         [http]
         port = 15699
-      CONFIG
+        CONFIG
     end
     io = IO::Memory.new
     config = LavinMQ::Config.new(io)
@@ -548,7 +548,7 @@ describe LavinMQ::Config do
       file.print <<-CONFIG
         [invalid_section]
         some_option = value
-      CONFIG
+        CONFIG
     end
     config = LavinMQ::Config.new
     argv = ["-c", config_file.path]
@@ -560,7 +560,7 @@ describe LavinMQ::Config do
       file.print <<-CONFIG
         [main]
         invalid_option = value
-      CONFIG
+        CONFIG
     end
     config = LavinMQ::Config.new(IO::Memory.new)
     argv = ["-c", config_file.path]
@@ -581,7 +581,7 @@ describe LavinMQ::Config do
         log_level = fatal
         data_dir = /tmp/lavinmq-spec
         pidfile = /tmp/lavinmq.pid
-      CONFIG
+        CONFIG
     end
     config = LavinMQ::Config.new
     argv = ["-c", config_file.path]
@@ -604,7 +604,7 @@ describe LavinMQ::Config do
         file.print <<-CONFIG
           [main]
           stats_interval = 500
-        CONFIG
+          CONFIG
       end
       config = LavinMQ::Config.new
       config.parse(["-c", config_file.path])
@@ -617,7 +617,7 @@ describe LavinMQ::Config do
           file.print <<-CONFIG
             [main]
             stats_interval = #{ms}
-          CONFIG
+            CONFIG
         end
         config = LavinMQ::Config.new
         expect_raises(LavinMQ::Config::Error, /stats_interval/) do
@@ -702,20 +702,20 @@ describe LavinMQ::Config do
       config_file = File.tempfile("lavinmq-config", ".ini")
       begin
         File.write(config_file.path, <<-INI)
-        [sni:foobar.localhost]
-        tls_cert = spec/resources/foobar_localhost_certificate.pem
-        tls_key = spec/resources/foobar_localhost_key.pem
-        INI
+          [sni:foobar.localhost]
+          tls_cert = spec/resources/foobar_localhost_certificate.pem
+          tls_key = spec/resources/foobar_localhost_key.pem
+          INI
         config = LavinMQ::Config.new
         config.parse(["-c", config_file.path])
         config.sni_manager.get_host("foobar.localhost").should_not be_nil
         config.sni_manager.get_host("test.example.com").should be_nil
 
         File.write(config_file.path, <<-INI)
-        [sni:*.example.com]
-        tls_cert = spec/resources/wildcard_example_certificate.pem
-        tls_key = spec/resources/wildcard_example_key.pem
-        INI
+          [sni:*.example.com]
+          tls_cert = spec/resources/wildcard_example_certificate.pem
+          tls_key = spec/resources/wildcard_example_key.pem
+          INI
         config.reload
 
         # reload swaps in a fresh SNIManager: the new host resolves, the old one is gone.
@@ -824,44 +824,6 @@ describe LavinMQ::Launcher do
   describe "config reload" do
     it "serves the configured SNI certificate, and a rotated one after reload" do
       with_launcher(<<-INI) do |launcher, _config, config_file|
-      [main]
-      tls_cert = spec/resources/server_certificate.pem
-      tls_key = spec/resources/server_key.pem
-
-      [sni:foobar.localhost]
-      tls_cert = spec/resources/foobar_localhost_certificate.pem
-      tls_key = spec/resources/foobar_localhost_key.pem
-      INI
-        amqp_ctx = launcher.@amqp_tls_context.not_nil!
-        served_cn(amqp_ctx, "foobar.localhost").should eq "foobar.localhost"
-        served_cn(amqp_ctx, "other.example.com").should eq "anders" # default cert
-
-        # Rotate the SNI host's certificate and reload.
-        File.write(config_file.path, <<-INI)
-        [main]
-        tls_cert = spec/resources/server_certificate.pem
-        tls_key = spec/resources/server_key.pem
-
-        [sni:foobar.localhost]
-        tls_cert = spec/resources/server_certificate.pem
-        tls_key = spec/resources/server_key.pem
-        INI
-        launcher.reload!
-        served_cn(amqp_ctx, "foobar.localhost").should eq "anders"
-      end
-    end
-
-    it "serves a per-host certificate for an SNI host added on reload" do
-      with_launcher(<<-INI) do |launcher, _config, config_file|
-      [main]
-      tls_cert = spec/resources/server_certificate.pem
-      tls_key = spec/resources/server_key.pem
-      INI
-        amqp_ctx = launcher.@amqp_tls_context.not_nil!
-        served_cn(amqp_ctx, "foobar.localhost").should eq "anders" # default cert, no SNI host yet
-
-        # Add an SNI host and reload, as a SIGHUP would.
-        File.write(config_file.path, <<-INI)
         [main]
         tls_cert = spec/resources/server_certificate.pem
         tls_key = spec/resources/server_key.pem
@@ -870,6 +832,44 @@ describe LavinMQ::Launcher do
         tls_cert = spec/resources/foobar_localhost_certificate.pem
         tls_key = spec/resources/foobar_localhost_key.pem
         INI
+        amqp_ctx = launcher.@amqp_tls_context.not_nil!
+        served_cn(amqp_ctx, "foobar.localhost").should eq "foobar.localhost"
+        served_cn(amqp_ctx, "other.example.com").should eq "anders" # default cert
+
+        # Rotate the SNI host's certificate and reload.
+        File.write(config_file.path, <<-INI)
+          [main]
+          tls_cert = spec/resources/server_certificate.pem
+          tls_key = spec/resources/server_key.pem
+
+          [sni:foobar.localhost]
+          tls_cert = spec/resources/server_certificate.pem
+          tls_key = spec/resources/server_key.pem
+          INI
+        launcher.reload!
+        served_cn(amqp_ctx, "foobar.localhost").should eq "anders"
+      end
+    end
+
+    it "serves a per-host certificate for an SNI host added on reload" do
+      with_launcher(<<-INI) do |launcher, _config, config_file|
+        [main]
+        tls_cert = spec/resources/server_certificate.pem
+        tls_key = spec/resources/server_key.pem
+        INI
+        amqp_ctx = launcher.@amqp_tls_context.not_nil!
+        served_cn(amqp_ctx, "foobar.localhost").should eq "anders" # default cert, no SNI host yet
+
+        # Add an SNI host and reload, as a SIGHUP would.
+        File.write(config_file.path, <<-INI)
+          [main]
+          tls_cert = spec/resources/server_certificate.pem
+          tls_key = spec/resources/server_key.pem
+
+          [sni:foobar.localhost]
+          tls_cert = spec/resources/foobar_localhost_certificate.pem
+          tls_key = spec/resources/foobar_localhost_key.pem
+          INI
         launcher.reload!
         served_cn(amqp_ctx, "foobar.localhost").should eq "foobar.localhost"
       end
@@ -879,10 +879,10 @@ describe LavinMQ::Launcher do
       with_launcher("[main]\nstats_interval = 5000\n") do |launcher, _config, config_file|
         launcher.@amqp_tls_context.should be_nil
         File.write(config_file.path, <<-INI)
-        [main]
-        tls_cert = spec/resources/server_certificate.pem
-        tls_key = spec/resources/server_key.pem
-        INI
+          [main]
+          tls_cert = spec/resources/server_certificate.pem
+          tls_key = spec/resources/server_key.pem
+          INI
         Log.capture("lmq.launcher", :warn) do |logs|
           launcher.reload!
           logs.check(:warn, /Enabling TLS requires a restart/)
@@ -893,10 +893,10 @@ describe LavinMQ::Launcher do
 
     it "warns that disabling TLS requires a restart" do
       with_launcher(<<-INI) do |launcher, _config, config_file|
-      [main]
-      tls_cert = spec/resources/server_certificate.pem
-      tls_key = spec/resources/server_key.pem
-      INI
+        [main]
+        tls_cert = spec/resources/server_certificate.pem
+        tls_key = spec/resources/server_key.pem
+        INI
         launcher.@amqp_tls_context.should_not be_nil
         File.write(config_file.path, "[main]\ntls_cert =\n")
         Log.capture("lmq.launcher", :warn) do |logs|

--- a/spec/control_socket_spec.cr
+++ b/spec/control_socket_spec.cr
@@ -153,7 +153,6 @@ describe "control socket" do
         LavinMQ::Config.instance = config
         with_datadir do |data_dir|
           config.data_dir = data_dir
-          client : LavinMQ::Clustering::Client? = nil
           begin
             client = LavinMQ::Clustering::Client.new(config, 1, "secret", proxy: false)
             File.exists?(socket_path).should be_false

--- a/spec/deprecated_config_spec.cr
+++ b/spec/deprecated_config_spec.cr
@@ -12,7 +12,7 @@ module LavinMQ
         {% for ivar in @type.instance_vars %}
           {% anno = ivar.annotation(IniOpt) %}
           {% if anno && anno[:deprecated] %}
-            {{ivar.name.stringify}} => { {{anno[:section]}}, {{(anno[:ini_name] || ivar.name).stringify}} },
+            {{ ivar.name.stringify }} => { {{ anno[:section] }}, {{ (anno[:ini_name] || ivar.name).stringify }} },
           {% end %}
         {% end %}
       }
@@ -26,7 +26,7 @@ module LavinMQ
         {% for ivar in @type.instance_vars %}
           {% anno = ivar.annotation(CliOpt) %}
           {% if anno && anno[:deprecated] %}
-            {{ivar.name.stringify}} => {{anno.args[1]}},
+            {{ ivar.name.stringify }} => {{ anno.args[1] }},
           {% end %}
         {% end %}
       }
@@ -38,7 +38,7 @@ module LavinMQ
       {% begin %}
       case name
       {% for ivar in @type.instance_vars %}
-      when {{ivar.name.stringify}} then @{{ivar.name}}.to_s
+      when {{ ivar.name.stringify }} then @{{ ivar.name }}.to_s
       {% end %}
       else raise "Unknown config option: #{name}"
       end

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -171,9 +171,6 @@ describe LavinMQ::Etcd, tags: "etcd" do
       isr_key = "#{prefix}/isr"
       stale_etcd = LavinMQ::Etcd.new(cluster.endpoints)
       current_etcd = LavinMQ::Etcd.new(cluster.endpoints)
-      stale_lease = nil
-      current_lease = nil
-
       begin
         config = LavinMQ::Config.new
         config.clustering = true
@@ -198,7 +195,6 @@ describe LavinMQ::Etcd, tags: "etcd" do
           elected.close
         end
         sl.release
-        stale_lease = nil
 
         select
         when elected.receive

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -11,7 +11,7 @@ describe LavinMQ::Etcd, tags: "etcd" do
     cluster.run do
       etcd = LavinMQ::Etcd.new(cluster.endpoints)
       etcd.del("foo")
-      etcd.put("foo", "bar").should eq nil
+      etcd.put("foo", "bar").should be_nil
       etcd.get("foo").should eq "bar"
       etcd.put("foo", "bar2").should eq "bar"
     end
@@ -60,7 +60,7 @@ describe LavinMQ::Etcd, tags: "etcd" do
       etcd.put "foo", "rab"
       w.receive.should eq "rab"
       etcd.del "foo"
-      w.receive.should eq nil
+      w.receive.should be_nil
     end
   end
 

--- a/spec/etcd_spec.cr
+++ b/spec/etcd_spec.cr
@@ -80,11 +80,9 @@ describe LavinMQ::Etcd, tags: "etcd" do
       lease = etcd.elect(key, "bar", 1)
       leader.receive.should eq "bar"
       spawn(name: "elect other leader spec") do
-        begin
-          etcd.elect(key, "bar2", 1)
-        rescue SpecExit
-          # expect this when etcd nodes are terminated
-        end
+        etcd.elect(key, "bar2", 1)
+      rescue SpecExit
+        # expect this when etcd nodes are terminated
       end
       select
       when new = leader.receive

--- a/spec/mqtt/integrations/retain_store_spec.cr
+++ b/spec/mqtt/integrations/retain_store_spec.cr
@@ -173,7 +173,7 @@ module MqttSpecs
           # Should receive the retained message without crashing
           pub = read_packet(io).as(MQTT::Protocol::Publish)
           pub.topic.should eq("test/retain")
-          pub.retain?.should eq(true)
+          pub.retain?.should be_true
           String.new(pub.payload).should start_with("retained_message_")
 
           disconnect(io)
@@ -197,7 +197,7 @@ module MqttSpecs
           # Should receive the retained message without crashing
           pub = read_packet(io).as(MQTT::Protocol::Publish)
           pub.topic.should eq("test/retain")
-          pub.retain?.should eq(true)
+          pub.retain?.should be_true
           String.new(pub.payload).should start_with("retained_message_")
 
           disconnect(io)

--- a/spec/mqtt/integrations/retained_messages_spec.cr
+++ b/spec/mqtt/integrations/retained_messages_spec.cr
@@ -17,7 +17,7 @@ module MqttSpecs
           subscribe(io, topic_filters: [subtopic("a/b")])
           pub = read_packet(io).as(MQTT::Protocol::Publish)
           pub.topic.should eq("a/b")
-          pub.retain?.should eq(true)
+          pub.retain?.should be_true
           disconnect(io)
         end
       end
@@ -36,7 +36,7 @@ module MqttSpecs
           end
 
           msg = read_packet(sub_io).as(MQTT::Protocol::Publish)
-          msg.retain?.should eq(false)
+          msg.retain?.should be_false
         end
       end
     end
@@ -56,8 +56,8 @@ module MqttSpecs
           pub = read_packet(io).as(MQTT::Protocol::Publish)
           pub.qos.should eq(1u8)
           pub.topic.should eq("a/b")
-          pub.retain?.should eq(true)
-          pub.dup?.should eq(false)
+          pub.retain?.should be_true
+          pub.dup?.should be_false
         end
 
         with_client_io(server) do |io|
@@ -65,8 +65,8 @@ module MqttSpecs
           pub = read_packet(io).as(MQTT::Protocol::Publish)
           pub.qos.should eq(1u8)
           pub.topic.should eq("a/b")
-          pub.retain?.should eq(true)
-          pub.dup?.should eq(true)
+          pub.retain?.should be_true
+          pub.dup?.should be_true
           puback(io, pub.packet_id)
         end
       end

--- a/spec/mqtt/integrations/will_spec.cr
+++ b/spec/mqtt/integrations/will_spec.cr
@@ -99,7 +99,7 @@ module MqttSpecs
           pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
           pub.payload.should eq("dead".to_slice)
           pub.topic.should eq("will/t")
-          pub.retain?.should eq(true)
+          pub.retain?.should be_true
 
           disconnect(io)
         end

--- a/spec/mqtt/spec_helper/mqtt_matchers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_matchers_spec.cr
@@ -8,7 +8,7 @@ module MqttMatchers
       return true if actual.closed?
       read_packet(actual)
       false
-    rescue e : IO::Error
+    rescue IO::Error
       true
     end
 

--- a/spec/mqtt/spec_helper/mqtt_protocol_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_protocol_spec.cr
@@ -3,7 +3,7 @@ module MQTT
     abstract struct Packet
       def to_slice
         io = ::IO::Memory.new
-        self.to_io(IO.new(io))
+        to_io(IO.new(io))
         io.rewind
         io.to_slice
       end

--- a/spec/oauth_config_spec.cr
+++ b/spec/oauth_config_spec.cr
@@ -47,9 +47,9 @@ describe LavinMQ::Config do
     it "parses oauth section from config with issuer_url" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -60,10 +60,10 @@ describe LavinMQ::Config do
     it "parses resource_server_id" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        resource_server_id = my-service
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          resource_server_id = my-service
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -74,10 +74,10 @@ describe LavinMQ::Config do
     it "parses preferred_username_claims as comma-separated list" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        preferred_username_claims = email, preferred_username, sub
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          preferred_username_claims = email, preferred_username, sub
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -88,10 +88,10 @@ describe LavinMQ::Config do
     it "parses additional_scopes_keys" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        additional_scopes_keys = custom_permissions
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          additional_scopes_keys = custom_permissions
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -102,10 +102,10 @@ describe LavinMQ::Config do
     it "parses multiple comma-separated additional_scopes_keys" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        additional_scopes_keys = roles, permissions
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          additional_scopes_keys = roles, permissions
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -116,10 +116,10 @@ describe LavinMQ::Config do
     it "parses scope_prefix" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        scope_prefix = mq.
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          scope_prefix = mq.
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -130,10 +130,10 @@ describe LavinMQ::Config do
     it "parses mgmt_scopes" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        mgmt_scopes = openid email offline_access
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          mgmt_scopes = openid email offline_access
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -144,10 +144,10 @@ describe LavinMQ::Config do
     it "parses verify_aud as boolean" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        verify_aud = false
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          verify_aud = false
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -158,10 +158,10 @@ describe LavinMQ::Config do
     it "parses audience" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        audience = lavinmq-api
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          audience = lavinmq-api
+          CONFIG
       end
 
       config = LavinMQ::Config.new
@@ -172,10 +172,10 @@ describe LavinMQ::Config do
     it "parses jwks_cache_ttl as seconds" do
       config_file = File.tempfile do |file|
         file.print <<-CONFIG
-        [oauth]
-        issuer = https://auth.example.com
-        jwks_cache_ttl = 7200
-        CONFIG
+          [oauth]
+          issuer = https://auth.example.com
+          jwks_cache_ttl = 7200
+          CONFIG
       end
 
       config = LavinMQ::Config.new

--- a/spec/observable_spec.cr
+++ b/spec/observable_spec.cr
@@ -37,8 +37,10 @@ module ObservableSpec
         it "registers observers" do
           observable = Observable(FooEvent).new
 
-          observable.register_observer(obs1 = Observer(FooEvent).new { |_, _| nil })
-          observable.register_observer(obs2 = Observer(FooEvent).new { |_, _| nil })
+          obs1 = Observer(FooEvent).new { |_, _| nil }
+          obs2 = Observer(FooEvent).new { |_, _| nil }
+          observable.register_observer(obs1)
+          observable.register_observer(obs2)
 
           observable.@__t_observers.should eq Set{obs1, obs2}
         end
@@ -48,8 +50,10 @@ module ObservableSpec
         it "unregisters observers" do
           observable = Observable(FooEvent).new
 
-          observable.register_observer(obs1 = Observer(FooEvent).new { |_, _| nil })
-          observable.register_observer(obs2 = Observer(FooEvent).new { |_, _| nil })
+          obs1 = Observer(FooEvent).new { |_, _| nil }
+          obs2 = Observer(FooEvent).new { |_, _| nil }
+          observable.register_observer(obs1)
+          observable.register_observer(obs2)
           observable.unregister_observer(obs1)
 
           observable.@__t_observers.should eq Set{obs2}

--- a/spec/policies_spec.cr
+++ b/spec/policies_spec.cr
@@ -380,7 +380,7 @@ describe LavinMQ::VHost do
         sleep 10.milliseconds
         vhost.queue("test1").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 1
         vhost.queue("test2").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq 11
-        vhost.queue("test3").as(LavinMQ::AMQP::Queue).@delivery_limit.should eq nil
+        vhost.queue("test3").as(LavinMQ::AMQP::Queue).@delivery_limit.should be_nil
       end
     end
   end

--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -469,7 +469,7 @@ describe LavinMQ::AMQP::PriorityQueue do
         q.publish "prio1", props: AMQP::Client::Properties.new(priority: 1)
         msg = q.get(no_ack: false)
         msg = msg.should_not be_nil
-        msg.redelivered.should eq false
+        msg.redelivered.should be_false
       end
     end
   end

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -79,7 +79,7 @@ describe LavinMQ::AMQP::Queue do
         x.publish_confirm("ttl", q.name)
         msg = wait_for { dlq.get }
         msg.not_nil!.body_io.to_s.should eq "ttl"
-        q.get.should eq nil
+        q.get.should be_nil
       end
     end
   end
@@ -298,7 +298,7 @@ describe LavinMQ::AMQP::Queue do
         end
 
         with_channel(s) do |ch|
-          ch.has_subscriber?(tag).should eq false
+          ch.has_subscriber?(tag).should be_false
         end
 
         # Queue is closed, delete to prevent spec failure because of closed queue

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -103,7 +103,7 @@ describe LavinMQ::Server do
         m1 = q.get(no_ack: false)
         m1.try(&.reject)
         m1 = q.get(no_ack: false)
-        m1.should eq(nil)
+        m1.should be_nil
       end
     end
   end
@@ -255,8 +255,8 @@ describe LavinMQ::Server do
   it "can handle messages going to no queue" do
     with_amqp_server do |s|
       with_channel(s) do |ch|
-        ch.basic_publish_confirm("m1", "amq.direct", "none").should eq true
-        ch.basic_publish_confirm("m2", "amq.direct", "none").should eq true
+        ch.basic_publish_confirm("m1", "amq.direct", "none").should be_true
+        ch.basic_publish_confirm("m2", "amq.direct", "none").should be_true
       end
     end
   end
@@ -493,7 +493,7 @@ describe LavinMQ::Server do
         tag = q.subscribe { |msg| msgs << msg }
         q.unsubscribe(tag)
         sleep 10.milliseconds
-        ch.has_subscriber?(tag).should eq false
+        ch.has_subscriber?(tag).should be_false
       end
     end
   end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -445,12 +445,15 @@ describe LavinMQ::Shovel do
           _q2 = ch.queue("rc_q2")
           q1.publish_confirm "shovel me 1", props: AMQ::Protocol::Properties.new(delivery_mode: 2_u8)
         end
-        config = %({
-        "src-uri": "#{s.amqp_server.url}",
-        "src-queue": "rc_q1",
-        "dest-uri": "#{s.amqp_server.url}",
-        "dest-queue": "rc_q2",
-        "src-prefetch-count": 2})
+        config = <<-JSON
+          {
+            "src-uri": "#{s.amqp_server.url}",
+            "src-queue": "rc_q1",
+            "dest-uri": "#{s.amqp_server.url}",
+            "dest-queue": "rc_q2",
+            "src-prefetch-count": 2
+          }
+          JSON
         p = LavinMQ::Parameter.new("shovel", "rc_shovel", JSON.parse(config))
         s.vhosts["/"].add_parameter(p)
         restart_server(s)
@@ -760,13 +763,16 @@ describe LavinMQ::Shovel do
             q1.publish "msg #{i}", "#{queue_name}q1"
           end
 
-          config = %({
-            "src-uri": "#{s.amqp_server.url}",
-            "src-queue": "#{queue_name}q1",
-            "dest-uri": "#{s.amqp_server.url}",
-            "dest-queue": "#{queue_name}q2",
-            "src-delete-after": "queue-length",
-            "src-prefetch-count": 2})
+          config = <<-JSON
+            {
+              "src-uri": "#{s.amqp_server.url}",
+              "src-queue": "#{queue_name}q1",
+              "dest-uri": "#{s.amqp_server.url}",
+              "dest-queue": "#{queue_name}q2",
+              "src-delete-after": "queue-length",
+              "src-prefetch-count": 2
+            }
+            JSON
           p = LavinMQ::Parameter.new("shovel", queue_name, JSON.parse(config))
           vhost.add_parameter(p)
           wait_for { vhost.shovels.size > 0 }
@@ -789,11 +795,14 @@ describe LavinMQ::Shovel do
       with_amqp_server do |s|
         vhost = s.vhosts.create("pause:resume:vhost")
         shovel_name = "shovel:pause:resume"
-        config = %({
-        "src-uri": "#{s.amqp_server.url}",
-        "src-queue": "#{shovel_name}_q1",
-        "dest-uri": "#{s.amqp_server.url}",
-        "dest-queue": "#{shovel_name}_q2" })
+        config = <<-JSON
+          {
+            "src-uri": "#{s.amqp_server.url}",
+            "src-queue": "#{shovel_name}_q1",
+            "dest-uri": "#{s.amqp_server.url}",
+            "dest-queue": "#{shovel_name}_q2"
+          }
+          JSON
         p = LavinMQ::Parameter.new("shovel", shovel_name, JSON.parse(config))
         s.vhosts[vhost.name].add_parameter(p)
         shovel = s.vhosts[vhost.name].shovels[shovel_name]

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -734,11 +734,11 @@ describe LavinMQ::Shovel do
           # duplicating them on q2. This races under load on macOS CI.
           wait_for { s.vhosts["/"].queue("#{queue_name}q1").unacked_count.zero? }
           shovel.pause
-          shovel.paused?.should eq true
+          shovel.paused?.should be_true
 
           q1.publish_confirm "shovel me 3", "#{queue_name}q1"
           q1.publish_confirm "shovel me 4", "#{queue_name}q1"
-          q2.get(no_ack: true).try(&.body_io.to_s).should eq nil
+          q2.get(no_ack: true).try(&.body_io.to_s).should be_nil
 
           spawn shovel.resume
           wait_for { shovel.running? } # Ensure it gets back to Running state
@@ -807,7 +807,7 @@ describe LavinMQ::Shovel do
         s.vhosts[vhost.name].add_parameter(p)
         shovel = s.vhosts[vhost.name].shovels[shovel_name]
         shovel.pause
-        shovel.paused?.should eq true
+        shovel.paused?.should be_true
         restart_server(s)
         should_eventually(be_true) { s.vhosts[vhost.name].shovels[shovel.name].paused? }
       end

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -178,7 +178,7 @@ describe LavinMQ::Config do
 
       mtls_host = config.sni_manager.get_host("mtls.example.com").not_nil!
       mtls_host.tls_verify_peer?.should be_true
-      mtls_host.http_tls_verify_peer.should eq(false)
+      mtls_host.http_tls_verify_peer.should be_false
     ensure
       File.delete(config_file)
     end

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -129,22 +129,22 @@ describe LavinMQ::Config do
 
     # Create a test config file
     config_content = <<-INI
-    [main]
-    data_dir = /tmp/lavinmq-sni-spec
+      [main]
+      data_dir = /tmp/lavinmq-sni-spec
 
-    [sni:example.com]
-    tls_cert = spec/resources/server_certificate.pem
-    tls_key = spec/resources/server_key.pem
-    tls_min_version = 1.2
-    tls_verify_peer = false
+      [sni:example.com]
+      tls_cert = spec/resources/server_certificate.pem
+      tls_key = spec/resources/server_key.pem
+      tls_min_version = 1.2
+      tls_verify_peer = false
 
-    [sni:mtls.example.com]
-    tls_cert = spec/resources/server_certificate.pem
-    tls_key = spec/resources/server_key.pem
-    tls_verify_peer = true
-    tls_ca_cert = spec/resources/ca_certificate.pem
-    http_tls_verify_peer = false
-    INI
+      [sni:mtls.example.com]
+      tls_cert = spec/resources/server_certificate.pem
+      tls_key = spec/resources/server_key.pem
+      tls_verify_peer = true
+      tls_ca_cert = spec/resources/ca_certificate.pem
+      http_tls_verify_peer = false
+      INI
 
     config_file = File.tempname("lavinmq", ".ini")
     File.write(config_file, config_content)
@@ -189,17 +189,17 @@ describe LavinMQ::Config do
     config.data_dir = "/tmp/lavinmq-sni-spec"
 
     config_content = <<-INI
-    [main]
-    data_dir = /tmp/lavinmq-sni-spec
+      [main]
+      data_dir = /tmp/lavinmq-sni-spec
 
-    [sni:*.example.com]
-    tls_cert = spec/resources/wildcard_example_certificate.pem
-    tls_key = spec/resources/wildcard_example_key.pem
+      [sni:*.example.com]
+      tls_cert = spec/resources/wildcard_example_certificate.pem
+      tls_key = spec/resources/wildcard_example_key.pem
 
-    [sni:test.example.com]
-    tls_cert = spec/resources/foobar_localhost_certificate.pem
-    tls_key = spec/resources/foobar_localhost_key.pem
-    INI
+      [sni:test.example.com]
+      tls_cert = spec/resources/foobar_localhost_certificate.pem
+      tls_key = spec/resources/foobar_localhost_key.pem
+      INI
 
     config_file = File.tempname("lavinmq", ".ini")
     File.write(config_file, config_content)

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -242,8 +242,6 @@ describe OpenSSL::SSL::Context::Server do
       received_hostname = hostname
       if hostname == "alt.example.com"
         alt_ctx
-      else
-        nil
       end
     end
 
@@ -279,8 +277,6 @@ describe "SNI end-to-end" do
     default_ctx.on_server_name do |hostname|
       if sni_host = sni_manager.get_host(hostname)
         sni_host.amqp_tls_context
-      else
-        nil
       end
     end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -353,13 +353,11 @@ Spec.around_each do |example|
   done = Channel(Exception?).new
 
   spawn(name: "Spec: #{example.example.description}") do
-    begin
-      example.run
-    rescue e
-      done.send(e)
-    else
-      done.send(nil)
-    end
+    example.run
+  rescue e
+    done.send(e)
+  else
+    done.send(nil)
   end
 
   timeout = SPEC_TIMEOUT

--- a/spec/stream_queue_spec.cr
+++ b/spec/stream_queue_spec.cr
@@ -937,7 +937,7 @@ describe LavinMQ::AMQP::Stream do
         sleep 0.1.seconds
 
         msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
-        msg_store.last_offset_by_consumer_tag(tag_prefix + 1.to_s).should eq nil
+        msg_store.last_offset_by_consumer_tag(tag_prefix + 1.to_s).should be_nil
         msg_store.last_offset_by_consumer_tag(tag_prefix + 0.to_s).should eq offsets[0]
         msg_store.close
       end
@@ -1015,7 +1015,7 @@ describe LavinMQ::AMQP::Stream do
         end
 
         msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
-        msg_store.last_offset_by_consumer_tag(consumer_tag).should eq nil
+        msg_store.last_offset_by_consumer_tag(consumer_tag).should be_nil
       end
     end
 
@@ -1040,7 +1040,7 @@ describe LavinMQ::AMQP::Stream do
         sleep 0.1.seconds
         data_dir = File.join(s.vhosts["/"].data_dir, Digest::SHA1.hexdigest queue_name)
         msg_store = LavinMQ::AMQP::StreamMessageStore.new(data_dir, nil)
-        msg_store.last_offset_by_consumer_tag(c_tag).should eq nil
+        msg_store.last_offset_by_consumer_tag(c_tag).should be_nil
       end
     end
 

--- a/spec/support/channel.cr
+++ b/spec/support/channel.cr
@@ -20,11 +20,11 @@ module Spec::Expectations
   # a loaded runner (e.g. federation delivery on macOS CI). Pass an explicit,
   # shorter timeout when asserting something is *not* received within a bound.
   macro be_receiving(value, *, timeout = 15.seconds)
-    ChannelReceiveExpectation.new({{value}}, {{timeout}})
+    ChannelReceiveExpectation.new({{ value }}, {{ timeout }})
   end
 
   macro be_sending(value, *, timeout = 15.seconds)
-    ChannelSendExpectation.new({{value}}, {{timeout}})
+    ChannelSendExpectation.new({{ value }}, {{ timeout }})
   end
 end
 

--- a/spec/support/queue_factory.cr
+++ b/spec/support/queue_factory.cr
@@ -19,7 +19,7 @@ module LavinMQ
         no_wait: true,
         arguments: arguments
       )
-      self.make(vhost, frame)
+      make(vhost, frame)
     end
   end
 end

--- a/spec/support/rough_time.cr
+++ b/spec/support/rough_time.cr
@@ -43,9 +43,9 @@ module RoughTime
   end
 
   def self.paused(&)
-    self.pause
+    pause
     yield self
   ensure
-    self.resume
+    resume
   end
 end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -558,14 +558,14 @@ describe LavinMQ::Federation::Upstream do
     end
 
     {% for descr, v in {nil: nil, empty: ""} %}
-    describe "when @exchange is {{descr}}" do
+    describe "when @exchange is {{ descr }}" do
       it "should use downstream exchange name as upstream exchange" do
         with_amqp_server do |s|
           vhost = s.vhosts["/"]
 
           vhost.declare_exchange("ex1", "topic", true, false)
 
-          upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", {{v}})
+          upstream = LavinMQ::Federation::Upstream.new(vhost, "test", "amqp://", {{ v }})
           link1 = upstream.link(vhost.exchange("ex1"))
 
           link1.@upstream_exchange.should eq "ex1"

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -529,11 +529,11 @@ describe LavinMQ::Federation::Upstream do
           downstream_ex = ch.exchange("downstream_ex", "topic")
           link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
-          upstream_vhost.queue_exists?(federation_name).should eq true
-          upstream_vhost.exchange_exists?(federation_name).should eq true
+          upstream_vhost.queue_exists?(federation_name).should be_true
+          upstream_vhost.exchange_exists?(federation_name).should be_true
           link.delete
-          upstream_vhost.queue_exists?(federation_name).should eq false
-          upstream_vhost.exchange_exists?(federation_name).should eq false
+          upstream_vhost.queue_exists?(federation_name).should be_false
+          upstream_vhost.exchange_exists?(federation_name).should be_false
         end
       end
     end
@@ -548,11 +548,11 @@ describe LavinMQ::Federation::Upstream do
           downstream_ex = ch.exchange("downstream_ex", "topic")
           link = upstream.link(vhost.exchange(downstream_ex.name))
           wait_for { link.state.running? }
-          upstream_vhost.queue_exists?(federation_name).should eq true
-          upstream_vhost.exchange_exists?(federation_name).should eq true
+          upstream_vhost.queue_exists?(federation_name).should be_true
+          upstream_vhost.exchange_exists?(federation_name).should be_true
           upstream.close # broker shutdown path — must not delete upstream resources
-          upstream_vhost.queue_exists?(federation_name).should eq true
-          upstream_vhost.exchange_exists?(federation_name).should eq true
+          upstream_vhost.queue_exists?(federation_name).should be_true
+          upstream_vhost.exchange_exists?(federation_name).should be_true
         end
       end
     end

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -13,7 +13,7 @@ module UpstreamSpecHelpers
 
   def self.setup_federation(s, upstream_name, exchange = nil, queue = nil, prefetch = 1000_u16, *,
                             reconnect_delay = 1.millisecond)
-    self.cleanup_vhosts(s)
+    cleanup_vhosts(s)
     upstream_vhost = s.vhosts.create("upstream")
     downstream_vhost = s.vhosts.create("downstream")
     upstream = LavinMQ::Federation::Upstream.new(

--- a/spec/users_spec.cr
+++ b/spec/users_spec.cr
@@ -210,6 +210,29 @@ describe LavinMQ::Server do
       end
     end
 
+    it "should ignore unknown keys in users.json" do
+      with_datadir do |data_dir|
+        users_json = File.join(data_dir, "users.json")
+        File.write(users_json, <<-JSON)
+          [
+            {
+              "name": "alan",
+              "password_hash": "",
+              "hashing_algorithm": null,
+              "tags": "",
+              "permissions": {"/": {"config": ".*", "read": ".*", "write": ".*", "future": 1}},
+              "future_field": {"nested": [1, 2]}
+            }
+          ]
+          JSON
+
+        store = LavinMQ::Auth::UserStore.new(data_dir, nil)
+        u = store["alan"]?
+        u.should_not be_nil
+        u.not_nil!.permissions["/"][:config].should eq /.*/
+      end
+    end
+
     it "should reload successfully after a passwordless user was created via the HTTP API" do
       with_http_server do |http, s|
         response = http.put("/api/users/alan", body: %({"password_hash": ""}))

--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -59,7 +59,6 @@ module LavinMQ::AMQP
         # except to the queue itself if a cycle is detected.
         # This is also how it's done in rabbitmq
 
-        # ameba:disable Metrics/CyclomaticComplexity
         def route(msg : BytesMessage, reason, dlx_tasks : Tasks? = nil, &routed : MessageRoutedCallback) : Nil
           # No dead letter exchange => nothing to do
           return routed.call unless dlx = (msg.dlx || dlx())

--- a/src/lavinmq/amqp/connection_factory.cr
+++ b/src/lavinmq/amqp/connection_factory.cr
@@ -26,7 +26,7 @@ module LavinMQ
               if tune_ok = tune(stream, logger)
                 if vhost = open(stream, user, logger)
                   socket.read_timeout = heartbeat_timeout(tune_ok)
-                  return LavinMQ::AMQP::Client.new(socket, connection_info, vhost, user, tune_ok, start_ok)
+                  LavinMQ::AMQP::Client.new(socket, connection_info, vhost, user, tune_ok, start_ok)
                 end
               end
             end

--- a/src/lavinmq/amqp/consumer.cr
+++ b/src/lavinmq/amqp/consumer.cr
@@ -165,7 +165,7 @@ module LavinMQ
             break if higher_prio_consumers.empty?
             next
           end
-          return true
+          true
         end
       end
 
@@ -193,7 +193,7 @@ module LavinMQ
             @log.debug { "Queue is not paused" }
           when @notify_closed.receive
           end
-          return true
+          true
         end
       end
 
@@ -203,7 +203,7 @@ module LavinMQ
           flush
           @flow_change.when_true.receive
           @log.debug { "Channel flow=true" }
-          return true
+          true
         end
       end
 

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -622,7 +622,6 @@ module LavinMQ::AMQP
       publish_internal(msg)
     end
 
-    # ameba:disable Metrics/CyclomaticComplexity
     protected def publish_internal(msg : Message, dlx_tasks : Argument::DeadLettering::Tasks? = nil) : PublishResult
       return PublishResult::Dropped if @closed
       if d = @deduper

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -140,49 +140,10 @@ module LavinMQ::AMQP
     private def message_expire_loop
       @vhost.closed.when_false.receive?
       loop do
-        select
-        when @consumers_empty.when_true.receive
-          @log.debug { "Consumers empty" }
-        when timeout EXPIRE_FIBER_IDLE_THRESHOLD
-          @log.debug { "Idle timeout while waiting for consumers empty, stopping fiber" }
-          break
-        end
-
-        select
-        when @msg_store.empty.when_false.receive
-          @log.debug { "Message store not empty" }
-        when timeout EXPIRE_FIBER_IDLE_THRESHOLD
-          @log.debug { "Idle timeout while waiting for messages, stopping fiber" }
-          break
-        end
-
+        break unless wait_for_consumers_empty
+        break unless wait_for_messages
         next unless @consumers.empty?
-        if ttl = time_to_message_expiration
-          @log.debug { "Next message TTL: #{ttl}" }
-          select
-          when @message_ttl_change.receive
-            @log.debug { "Message TTL changed" }
-          when @msg_store.empty.when_true.receive # might be empty now (from basic get)
-            @log.debug { "Message store is empty" }
-          when @consumers_empty.when_false.receive
-            @log.debug { "Got consumers" }
-          when timeout ttl
-            @log.debug { "Message TTL reached" }
-            expire_messages
-          end
-        else
-          # first message in queue should not be expired
-          # wait for empty queue or TTL change
-          select
-          when @message_ttl_change.receive
-            @log.debug { "Message TTL changed" }
-          when @msg_store.empty.when_true.receive
-            @log.debug { "Msg store is empty" }
-          when timeout EXPIRE_FIBER_IDLE_THRESHOLD
-            @log.debug { "Idle timeout while no messages need expiring, stopping fiber" }
-            break
-          end
-        end
+        break unless wait_for_message_expiration
       end
     rescue ex : MessageStore::Error
       @log.error(ex) { "Queue closed due to error" }
@@ -192,6 +153,63 @@ module LavinMQ::AMQP
     ensure
       @message_expire_fiber_active.set(false, :release)
       ensure_expire_fiber # restart if msg arrived during teardown
+    end
+
+    # The wait_for_* helpers below return false once the fiber has been idle
+    # long enough to stop, and true when the loop should keep going.
+
+    private def wait_for_consumers_empty : Bool
+      select
+      when @consumers_empty.when_true.receive
+        @log.debug { "Consumers empty" }
+        true
+      when timeout EXPIRE_FIBER_IDLE_THRESHOLD
+        @log.debug { "Idle timeout while waiting for consumers empty, stopping fiber" }
+        false
+      end
+    end
+
+    private def wait_for_messages : Bool
+      select
+      when @msg_store.empty.when_false.receive
+        @log.debug { "Message store not empty" }
+        true
+      when timeout EXPIRE_FIBER_IDLE_THRESHOLD
+        @log.debug { "Idle timeout while waiting for messages, stopping fiber" }
+        false
+      end
+    end
+
+    private def wait_for_message_expiration : Bool
+      if ttl = time_to_message_expiration
+        @log.debug { "Next message TTL: #{ttl}" }
+        select
+        when @message_ttl_change.receive
+          @log.debug { "Message TTL changed" }
+        when @msg_store.empty.when_true.receive # might be empty now (from basic get)
+          @log.debug { "Message store is empty" }
+        when @consumers_empty.when_false.receive
+          @log.debug { "Got consumers" }
+        when timeout ttl
+          @log.debug { "Message TTL reached" }
+          expire_messages
+        end
+        true
+      else
+        # first message in queue should not be expired
+        # wait for empty queue or TTL change
+        select
+        when @message_ttl_change.receive
+          @log.debug { "Message TTL changed" }
+          true
+        when @msg_store.empty.when_true.receive
+          @log.debug { "Msg store is empty" }
+          true
+        when timeout EXPIRE_FIBER_IDLE_THRESHOLD
+          @log.debug { "Idle timeout while no messages need expiring, stopping fiber" }
+          false
+        end
+      end
     end
 
     getter name, arguments, vhost

--- a/src/lavinmq/amqp/stream/filters/gis.cr
+++ b/src/lavinmq/amqp/stream/filters/gis.cr
@@ -25,7 +25,7 @@ module LavinMQ::AMQP
         io << "Point(lat=" << @lat << ", lon=" << @lon << ")"
       end
 
-      def self.from_headers(headers : AMQP::Table | Nil) : Point | Nil
+      def self.from_headers(headers : AMQP::Table?) : Point?
         return unless headers
 
         lat = headers["x-geo-lat"]?

--- a/src/lavinmq/amqp/stream/stream.cr
+++ b/src/lavinmq/amqp/stream/stream.cr
@@ -244,7 +244,7 @@ module LavinMQ::AMQP
       end
     end
 
-    private def parse_max_age(value) : Time::Span | Time::MonthSpan | Nil
+    private def parse_max_age(value) : (Time::Span | Time::MonthSpan)?
       return if value.nil?
       if str = value.as?(String)
         if match = str.match(/\A(\d+)([YMDhms])\z/)

--- a/src/lavinmq/amqp/stream/stream_consumer.cr
+++ b/src/lavinmq/amqp/stream/stream_consumer.cr
@@ -120,7 +120,7 @@ module LavinMQ
             @new_message_available.set(false) # Reset the flag
           when @notify_closed.receive
           end
-          return true
+          true
         end
       end
 

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -11,7 +11,7 @@ module LavinMQ::AMQP
     getter new_messages = ::Channel(Bool).new
     property max_length : Int64?
     property max_length_bytes : Int64?
-    property max_age : Time::Span | Time::MonthSpan | Nil
+    property max_age : (Time::Span | Time::MonthSpan)?
     getter last_offset : Int64
     @segment_last_ts = Hash(UInt32, Int64).new(0i64) # used for max-age
     @segment_first_offset = Hash(UInt32, Int64).new  # segment_id => offset of first msg

--- a/src/lavinmq/amqp/stream/stream_message_store.cr
+++ b/src/lavinmq/amqp/stream/stream_message_store.cr
@@ -165,7 +165,7 @@ module LavinMQ::AMQP
     def last_offset_by_consumer_tag(consumer_tag)
       if pos = @consumer_offset_positions[consumer_tag]?
         tx = @consumer_offsets.to_slice(pos, 8)
-        return IO::ByteFormat::LittleEndian.decode(Int64, tx)
+        IO::ByteFormat::LittleEndian.decode(Int64, tx)
       end
     end
 

--- a/src/lavinmq/auth/authenticators/oauth.cr
+++ b/src/lavinmq/auth/authenticators/oauth.cr
@@ -16,7 +16,7 @@ module LavinMQ
       def authenticate(context : Context) : BaseUser?
         claims = @token_verifier.parse_token(String.new(context.password))
         OAuthUser.new(claims.username, claims.tags, claims.permissions, claims.expires_at, @token_verifier)
-      rescue ex : JWT::PasswordFormatError
+      rescue JWT::PasswordFormatError
         Log.debug do
           "skipping authentication for user \"#{context.username}\": " \
           "password is not a JWT token"

--- a/src/lavinmq/auth/authenticators/oauth.cr
+++ b/src/lavinmq/auth/authenticators/oauth.cr
@@ -17,14 +17,20 @@ module LavinMQ
         claims = @token_verifier.parse_token(String.new(context.password))
         OAuthUser.new(claims.username, claims.tags, claims.permissions, claims.expires_at, @token_verifier)
       rescue ex : JWT::PasswordFormatError
-        Log.debug { "skipping authentication for user \"#{context.username}\": " \
-                    "password is not a JWT token" }
+        Log.debug do
+          "skipping authentication for user \"#{context.username}\": " \
+          "password is not a JWT token"
+        end
       rescue ex : JWT::DecodeError
-        Log.debug { "authentication failed for user \"#{context.username}\": " \
-                    "Could not decode token - #{ex.message}" }
+        Log.debug do
+          "authentication failed for user \"#{context.username}\": " \
+          "Could not decode token - #{ex.message}"
+        end
       rescue ex : JWT::VerificationError
-        Log.debug { "authentication failed for user \"#{context.username}\": " \
-                    "Token verification failed - #{ex.message}" }
+        Log.debug do
+          "authentication failed for user \"#{context.username}\": " \
+          "Token verification failed - #{ex.message}"
+        end
       rescue ex : Exception
         Log.error(exception: ex) { "authentication failed for user \"#{context.username}\": #{ex.message}" }
       end

--- a/src/lavinmq/auth/chain.cr
+++ b/src/lavinmq/auth/chain.cr
@@ -37,7 +37,7 @@ module LavinMQ
           # Default to local auth if no backends configured
           authenticators << LocalAuthenticator.new(users)
         end
-        self.new(authenticators)
+        new(authenticators)
       end
 
       def cleanup

--- a/src/lavinmq/auth/context.cr
+++ b/src/lavinmq/auth/context.cr
@@ -11,7 +11,7 @@ module LavinMQ
                          when IPSocket   then remote.remote_address
                          when UNIXSocket then remote.remote_address
                          end
-        self.new(username, password, remote_address)
+        new(username, password, remote_address)
       end
 
       def self.new(username : String, password : Bytes, address : ::Socket::Address?)

--- a/src/lavinmq/auth/jwt/jwks_fetcher.cr
+++ b/src/lavinmq/auth/jwt/jwks_fetcher.cr
@@ -94,20 +94,18 @@ module LavinMQ
           max_retry_delay = 5.minutes
           spawn do
             loop do
-              begin
-                @fetch_lock.synchronize { update_keys }
-                retry_delay = 5.seconds
-                wait_time = calculate_wait_time
-                select
-                when @stopped.when_true.receive
-                  break
-                when timeout(wait_time)
-                end
-              rescue ex
-                Log.error(exception: ex) { "Failed to fetch JWKS, retrying in #{retry_delay}: #{ex.message}" }
-                sleep retry_delay
-                retry_delay = {retry_delay * 2, max_retry_delay}.min
+              @fetch_lock.synchronize { update_keys }
+              retry_delay = 5.seconds
+              wait_time = calculate_wait_time
+              select
+              when @stopped.when_true.receive
+                break
+              when timeout(wait_time)
               end
+            rescue ex
+              Log.error(exception: ex) { "Failed to fetch JWKS, retrying in #{retry_delay}: #{ex.message}" }
+              sleep retry_delay
+              retry_delay = {retry_delay * 2, max_retry_delay}.min
             end
           end
         end

--- a/src/lavinmq/auth/jwt/jwt.cr
+++ b/src/lavinmq/auth/jwt/jwt.cr
@@ -58,12 +58,12 @@ module LavinMQ
         property iat : Int64?
         property nbf : Int64?
         property iss : String?
-        property aud : String | Array(String) | Nil
+        property aud : (String | Array(String))?
         property sub : String?
         property scope : String?
         property resource_access : Hash(String, ResourceRoles)?
 
-        def initialize(*, @exp : Int64? = nil, @iat : Int64? = nil, @nbf : Int64? = nil, @iss : String? = nil, @aud : String | Array(String) | Nil = nil, @sub : String? = nil, @scope : String? = nil, @resource_access : Hash(String, ResourceRoles)? = nil)
+        def initialize(*, @exp : Int64? = nil, @iat : Int64? = nil, @nbf : Int64? = nil, @iss : String? = nil, @aud : (String | Array(String))? = nil, @sub : String? = nil, @scope : String? = nil, @resource_access : Hash(String, ResourceRoles)? = nil)
           @json_unmapped = {} of String => JSON::Any
         end
 

--- a/src/lavinmq/auth/jwt/public_keys.cr
+++ b/src/lavinmq/auth/jwt/public_keys.cr
@@ -19,8 +19,8 @@ module LavinMQ
 
         def get? : Hash(String, String)?
           @mutex.synchronize do
-            return nil if @keys.nil?
-            return nil if expired?
+            return if @keys.nil?
+            return if expired?
             @keys
           end
         end

--- a/src/lavinmq/auth/jwt/token_claim.cr
+++ b/src/lavinmq/auth/jwt/token_claim.cr
@@ -32,8 +32,6 @@ module LavinMQ
                          payload.sub
                        when "iss"
                          payload.iss
-                       else
-                         nil
                        end
             return username if username
 

--- a/src/lavinmq/auth/user.cr
+++ b/src/lavinmq/auth/user.cr
@@ -34,7 +34,8 @@ module LavinMQ
             parse_permissions(pull)
           when "tags"
             @tags = Tag.parse_list(pull.read_string)
-          else nil
+          else
+            pull.skip # unknown keys must still be consumed, or read_object fails
           end
         end
         raise JSON::ParseException.new("Missing json attribute: name", *loc) if name.nil?
@@ -140,7 +141,7 @@ module LavinMQ
             when "config" then config = Regex.from_json(pull)
             when "read"   then read = Regex.from_json(pull)
             when "write"  then write = Regex.from_json(pull)
-            else               nil
+            else               pull.skip
             end
           end
           @permissions[vhost] = {config: config, read: read, write: write}

--- a/src/lavinmq/auth/user.cr
+++ b/src/lavinmq/auth/user.cr
@@ -50,7 +50,7 @@ module LavinMQ
 
       def self.create(name : String, password : String, hash_algorithm : String, tags : Array(Tag))
         pwd = hash_password(password, hash_algorithm)
-        self.new(name, pwd, tags)
+        new(name, pwd, tags)
       end
 
       def self.hash_password(password, hash_algorithm)
@@ -91,7 +91,7 @@ module LavinMQ
       def self.create_hidden_user(name)
         password = Random::Secure.urlsafe_base64(32)
         password_hash = hash_password(password, "sha256")
-        user = self.new(name, password_hash, [Tag::Administrator])
+        user = new(name, password_hash, [Tag::Administrator])
         user.plain_text_password = password
         user
       end

--- a/src/lavinmq/auth/user.cr
+++ b/src/lavinmq/auth/user.cr
@@ -73,7 +73,7 @@ module LavinMQ
       end
 
       private def parse_password(hash, hash_algorithm, loc = nil)
-        return nil unless hash_algorithm
+        return unless hash_algorithm
         case hash_algorithm
         when /bcrypt$/i then Password::BcryptPassword.new(hash)
         when /sha256$/i then Password::SHA256Password.new(hash)

--- a/src/lavinmq/clustering/checksums.cr
+++ b/src/lavinmq/clustering/checksums.cr
@@ -27,7 +27,7 @@ module LavinMQ
         File.rename(tmp, checksums_path)
         @checksum_file.close
         @checksum_file = f
-        Log.info { "Wrote #{self.size} checksums to disk" }
+        Log.info { "Wrote #{size} checksums to disk" }
       end
 
       # Set in memory AND persist immediately by appending one line, so hashing
@@ -55,7 +55,7 @@ module LavinMQ
         # next clean store must not reload these (possibly stale) hashes.
         # Truncate rather than delete so @checksum_file stays valid for #append.
         @checksum_file.truncate(0)
-        Log.info { "Restored #{self.size} checksums from disk" }
+        Log.info { "Restored #{size} checksums from disk" }
       rescue File::NotFoundError
         Log.info { "Checksums not found" }
       end

--- a/src/lavinmq/clustering/controller.cr
+++ b/src/lavinmq/clustering/controller.cr
@@ -183,16 +183,14 @@ class LavinMQ::Clustering::Controller
     Log.info { "Executing #{event} hook in background: #{command}" }
 
     spawn name: "#{event} hook" do
-      begin
-        status = Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
-        if status.success?
-          Log.info { "#{event} hook completed successfully" }
-        else
-          Log.warn { "#{event} hook failed with exit code #{status.exit_code}" }
-        end
-      rescue ex
-        Log.error(exception: ex) { "Failed to execute #{event} hook" }
+      status = Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      if status.success?
+        Log.info { "#{event} hook completed successfully" }
+      else
+        Log.warn { "#{event} hook failed with exit code #{status.exit_code}" }
       end
+    rescue ex
+      Log.error(exception: ex) { "Failed to execute #{event} hook" }
     end
   end
 

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -96,31 +96,29 @@ module LavinMQ
         # last ack (which would be stale after an idle period).
         unacked_since : Time::Instant? = nil
         loop do
-          begin
-            len = @socket.read_bytes(Int64, IO::ByteFormat::LittleEndian)
-            @acked_bytes.add(len)
-            unacked_since = nil       # progress; restart the deadline
-            @ack_notify.try_send(nil) # wake any publish-confirm waiter
-          rescue IO::TimeoutError
-            @write_lock.synchronize do
-              @lz4.flush
+          len = @socket.read_bytes(Int64, IO::ByteFormat::LittleEndian)
+          @acked_bytes.add(len)
+          unacked_since = nil       # progress; restart the deadline
+          @ack_notify.try_send(nil) # wake any publish-confirm waiter
+        rescue IO::TimeoutError
+          @write_lock.synchronize do
+            @lz4.flush
+          end
+          # A connected follower that stops acking while data is outstanding
+          # (blocked on its own sync, GC pause, half-open socket) would
+          # otherwise stall publish confirms indefinitely. Drop it from the
+          # replica set like the write_timeout path does for blocked writes;
+          # it will re-sync on reconnect. Healthy-but-behind followers keep
+          # acking, so unacked_since keeps resetting and they're never dropped.
+          if lag_in_bytes > 0
+            now = Time.instant
+            unacked_since ||= now
+            if now - unacked_since > ack_timeout
+              Log.warn { "No ack for #{ack_timeout}, disconnecting follower id=#{@id.to_s(36)}" }
+              break
             end
-            # A connected follower that stops acking while data is outstanding
-            # (blocked on its own sync, GC pause, half-open socket) would
-            # otherwise stall publish confirms indefinitely. Drop it from the
-            # replica set like the write_timeout path does for blocked writes;
-            # it will re-sync on reconnect. Healthy-but-behind followers keep
-            # acking, so unacked_since keeps resetting and they're never dropped.
-            if lag_in_bytes > 0
-              now = Time.instant
-              unacked_since ||= now
-              if now - unacked_since > ack_timeout
-                Log.warn { "No ack for #{ack_timeout}, disconnecting follower id=#{@id.to_s(36)}" }
-                break
-              end
-            else
-              unacked_since = nil
-            end
+          else
+            unacked_since = nil
           end
         end
       rescue IO::EOFError | Socket::Error | IO::Error

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -266,7 +266,7 @@ module LavinMQ
       # When `caps` is set, a file missing from it is capped at 0 (sent empty,
       # then filled via the change stream); otherwise the file is uncapped.
       private def cap_for(caps : Hash(String, Int64)?, path : String) : Int64?
-        return nil unless caps
+        return unless caps
         caps[path]? || 0i64
       end
 

--- a/src/lavinmq/clustering/proxy.cr
+++ b/src/lavinmq/clustering/proxy.cr
@@ -43,13 +43,11 @@ module LavinMQ
           end
         end
         spawn(name: "Proxy client copy loop") do
-          begin
-            IO.copy(target, client)
-          rescue IO::Error
-          ensure
-            target.close rescue nil
-            client.close rescue nil
-          end
+          IO.copy(target, client)
+        rescue IO::Error
+        ensure
+          target.close rescue nil
+          client.close rescue nil
         end
         IO.copy(client, target)
       rescue IO::Error

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -324,11 +324,11 @@ module LavinMQ
           @followers << follower # Starts in Syncing state
         end
         sync_and_serve(follower)
-      rescue ex : AuthenticationError
+      rescue AuthenticationError
         Log.warn { "Follower negotiation error" }
       rescue ex : InvalidStartHeaderError
         Log.warn { ex.message }
-      rescue ex : IO::EOFError
+      rescue IO::EOFError
         Log.info { "Follower disconnected" }
       rescue ex : IO::Error
         Log.warn(exception: ex) { "Follower disonnected: #{ex.message}" }

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -453,7 +453,7 @@ module LavinMQ
       end
 
       def <=>(other : Option)
-        self.compare_value <=> other.compare_value
+        compare_value <=> other.compare_value
       end
 
       # Sort options alphabetically by short flag. Options without short flags

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -108,15 +108,15 @@ module LavinMQ
     # dropped after the warning. Shared by `parse_cli` and `parse_section`.
     private macro assign_option(var_name, value, transform, deprecation_message)
       {% if deprecation_message %}
-        @io.puts "WARNING: {{deprecation_message.id}}"
+        @io.puts "WARNING: {{ deprecation_message.id }}"
         # Since deprecation_message is set, the variable is deprecated. It may
         # be forwarded to another variable using a setter, but it may also be
         # completley removed, therefore we need to check for a setter.
         {% if @type.has_method?("#{var_name.id}=") %}
-          self.{{var_name.id}} = parse_value({{value}}, {{transform}})
+          self.{{ var_name.id }} = parse_value({{ value }}, {{ transform }})
         {% end %}
       {% else %}
-        self.{{var_name.id}} = parse_value({{value}}, {{transform}})
+        self.{{ var_name.id }} = parse_value({{ value }}, {{ transform }})
       {% end %}
     end
 
@@ -124,8 +124,8 @@ module LavinMQ
       {% for ivar in @type.instance_vars.select(&.annotation(EnvOpt)) %}
         {% for ann in ivar.annotations(EnvOpt) %}
           {% env_name, transform = ann.args %}
-          if v = ENV.fetch({{env_name}}, nil)
-            @{{ivar}} = parse_value(v, {{transform || ivar.type}})
+          if v = ENV.fetch({{ env_name }}, nil)
+            @{{ ivar }} = parse_value(v, {{ transform || ivar.type }})
           end
         {% end %}
       {% end %}
@@ -157,8 +157,8 @@ module LavinMQ
           %}
           # Create Option object with CLI args and a block that parses and stores the value
           # when the option is encountered during command line parsing
-          sections[:{{section_id}}][:options] << Option.new({{parser_arg.splat}}) do |value|
-            assign_option({{ivar.name}}, value, {{value_parser}}, {{cli_opt[:deprecated]}})
+          sections[:{{ section_id }}][:options] << Option.new({{ parser_arg.splat }}) do |value|
+            assign_option({{ ivar.name }}, value, {{ value_parser }}, {{ cli_opt[:deprecated] }})
           end
         {% end %}
         sections.each do |_section_id, section|
@@ -184,8 +184,8 @@ module LavinMQ
       ini.each do |section, settings|
         case section
         {% for section in INI_SECTIONS %}
-        when {{section}}
-          parse_section({{section}}, settings)
+        when {{ section }}
+          parse_section({{ section }}, settings)
         {% end %}
         when "http"
           @io.puts "WARNING: Config section [http] is deprecated, use [mgmt] instead"
@@ -278,26 +278,26 @@ module LavinMQ
     settings.each do |name, v|
       case name
         {% for var in ivars_in_section %}
-          when "{{var[:ini_name]}}"
-            assign_option({{var[:var_name]}}, v, {{var[:transform]}}, {{var[:deprecated]}})
+          when "{{ var[:ini_name] }}"
+            assign_option({{ var[:var_name] }}, v, {{ var[:transform] }}, {{ var[:deprecated] }})
         {% end %}
      else
-       @io.puts "WARNING: Unknown setting '#{name}' in section [{{section.id}}]"
+       @io.puts "WARNING: Unknown setting '#{name}' in section [{{ section.id }}]"
       end
     rescue ex
-      raise Error.new("Failed to handle value for '#{name}' in [{{section.id}}]: #{ex.message}")
+      raise Error.new("Failed to handle value for '#{name}' in [{{ section.id }}]: #{ex.message}")
     end
   {% end %}
     end
 
     {% for int in [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64] %}
-      private def parse_value(value, type : {{int}}.class)
-        {{int}}.new(value)
+      private def parse_value(value, type : {{ int }}.class)
+        {{ int }}.new(value)
       end
 
-      private def parse_value(value, type : {{int}}?.class)
+      private def parse_value(value, type : {{ int }}?.class)
         if v = value
-          {{int}}.new(v)
+          {{ int }}.new(v)
         end
       end
     {% end %}
@@ -368,7 +368,7 @@ module LavinMQ
     # variable and is untouched, keeping `Config.instance` references valid.
     protected def apply(other : self)
       {% for ivar in @type.instance_vars %}
-        @{{ivar.id}} = other.@{{ivar.id}}
+        @{{ ivar.id }} = other.@{{ ivar.id }}
       {% end %}
     end
 

--- a/src/lavinmq/consistent_hasher.cr
+++ b/src/lavinmq/consistent_hasher.cr
@@ -25,7 +25,7 @@ class RingConsistentHasher(T) < Hasher(T)
 
   def get(key : String) : T?
     size = @ring.size
-    return nil if size.zero?
+    return if size.zero?
     return @ring.first.last if size == 1
     key_hash = hash_key(key)
     ring_hash = @sorted_keys.bsearch { |x| x >= key_hash }

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -292,7 +292,7 @@ module LavinMQ
           else
             raise "Cannot apply frame #{f.class} in vhost #{@vhost.name}"
           end
-        rescue ex : IO::EOFError
+        rescue IO::EOFError
           break
         end
       end

--- a/src/lavinmq/etcd.cr
+++ b/src/lavinmq/etcd.cr
@@ -203,7 +203,6 @@ module LavinMQ
     end
 
     private def read_chunks(tcp, & : String -> _) : Nil
-      response_finished = false
       loop do
         bytesize = read_chunk_size(tcp)
         chunk = read_string(tcp, bytesize)

--- a/src/lavinmq/etcd/lease.cr
+++ b/src/lavinmq/etcd/lease.cr
@@ -33,7 +33,6 @@ module LavinMQ
           sleep (ttl / 3).seconds
           ttl = @etcd.lease_keepalive(@id)
         end
-        error : Exception? = nil
       rescue ex : Etcd::Error # only rescue etcd errors
         unless @expired.closed?
           error = ex

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -226,14 +226,7 @@ module LavinMQ
               end
               @log.info { "Lost consumers, cancel upstream subscriber" }
               has_consumer = false
-              # cancel our consumer!
-              if channel = @upstream_channel
-                begin
-                  channel.basic_cancel(@upstream.consumer_tag)
-                rescue ex : ::AMQP::Client::Error
-                  @log.debug(exception: ex) { "Tried to cancel upstream consumer tag=#{@upstream.consumer_tag}" }
-                end
-              end
+              cancel_upstream_consumer
             else
               # Wait for queue get a consumer, or for the link
               # to stop
@@ -253,6 +246,13 @@ module LavinMQ
             end
           end
         rescue ::Channel::ClosedError
+        end
+
+        private def cancel_upstream_consumer
+          return unless channel = @upstream_channel
+          channel.basic_cancel(@upstream.consumer_tag)
+        rescue ex : ::AMQP::Client::Error
+          @log.debug(exception: ex) { "Tried to cancel upstream consumer tag=#{@upstream.consumer_tag}" }
         end
 
         def name : String

--- a/src/lavinmq/federation/link.cr
+++ b/src/lavinmq/federation/link.cr
@@ -117,8 +117,10 @@ module LavinMQ
               break
             when event = @state_changed.receive?
               break if stop_link?(event)
-              @log.debug { "#wait_before_reconnect @state_changed.received? triggerd " \
-                           "@state_changed.closed?=#{@state_changed.closed?}" }
+              @log.debug do
+                "#wait_before_reconnect @state_changed.received? triggerd " \
+                "@state_changed.closed?=#{@state_changed.closed?}"
+              end
             end
           end
         end

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -167,7 +167,7 @@ module LavinMQ
         else
           bad_request(context, "Request body required")
         end
-      rescue e : JSON::ParseException
+      rescue JSON::ParseException
         bad_request(context, "Malformed JSON")
       end
 

--- a/src/lavinmq/http/controller/oauth.cr
+++ b/src/lavinmq/http/controller/oauth.cr
@@ -49,7 +49,7 @@ module LavinMQ
       private def authenticate_token(token, remote_address) : Auth::BaseUser?
         auth_context = Auth::Context.new("", token.to_slice, remote_address)
         user = @oauth_authenticator.authenticate(auth_context)
-        return nil if user.nil? || user.tags.empty?
+        return if user.nil? || user.tags.empty?
         user
       end
 

--- a/src/lavinmq/http/controller/permissions.cr
+++ b/src/lavinmq/http/controller/permissions.cr
@@ -59,7 +59,7 @@ module LavinMQ
             @server.users
               .add_permission(u.name, vhost.name, Regex.new(config), Regex.new(read), Regex.new(write))
             context.response.status_code = is_update ? 204 : 201
-          rescue ex : ArgumentError
+          rescue ArgumentError
             bad_request(context, "Permissions must be valid Regex")
           end
         end

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -93,11 +93,9 @@ module LavinMQ
         mem = 0
         elapsed = Time.measure do
           mem = Benchmark.memory do
-            begin
-              yield
-            rescue ex
-              Log.error(exception: ex) { "Error while reporting prometheus metrics" }
-            end
+            yield
+          rescue ex
+            Log.error(exception: ex) { "Error while reporting prometheus metrics" }
           end
         end
         writer = PrometheusWriter.new(io, "telemetry")

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -219,7 +219,6 @@ module LavinMQ
         vhosts.to_a
       end
 
-      # ameba:disable Metrics/CyclomaticComplexity
       private def register_routes
         get "/metrics" do |context, _|
           context.response.content_type = "text/plain"

--- a/src/lavinmq/http/controller/static.cr
+++ b/src/lavinmq/http/controller/static.cr
@@ -129,7 +129,6 @@ module LavinMQ
         end
       {% end %}
 
-      # ameba:disable Metrics/CyclomaticComplexity
       private def mime_type(path)
         case File.extname(path)
         when ".txt"        then "text/plain;charset=utf-8"

--- a/src/lavinmq/http/controller/vhost-limits.cr
+++ b/src/lavinmq/http/controller/vhost-limits.cr
@@ -64,7 +64,7 @@ module LavinMQ
         end
 
         def self_if_limited : VHostLimitsView?
-          return self if @vhost.max_connections || @vhost.max_queues
+          self if @vhost.max_connections || @vhost.max_queues
         end
 
         def details_tuple

--- a/src/lavinmq/http/handler/auth_handler.cr
+++ b/src/lavinmq/http/handler/auth_handler.cr
@@ -37,7 +37,7 @@ module LavinMQ
         if auth = context.request.headers["Authorization"]?
           if auth.starts_with? "Basic "
             base64 = auth[6..]
-            return decode(base64)
+            decode(base64)
           end
         end
       end
@@ -49,7 +49,7 @@ module LavinMQ
           return if m.value.starts_with?("|oauth:")
           if idx = m.value.rindex(':')
             auth = URI.decode(m.value[idx + 1..])
-            return decode(auth)
+            decode(auth)
           end
         end
       end

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -58,11 +58,9 @@ module LavinMQ
         .map(&.strip)
         .reject(&.empty?)
         .map do |source|
-          begin
-            parse(source)
-          rescue ex : Socket::Error | ArgumentError
-            raise ArgumentError.new("Invalid IP/CIDR '#{source}': #{ex.message}")
-          end
+          parse(source)
+        rescue ex : Socket::Error | ArgumentError
+          raise ArgumentError.new("Invalid IP/CIDR '#{source}': #{ex.message}")
         end
     end
 

--- a/src/lavinmq/ip_matcher.cr
+++ b/src/lavinmq/ip_matcher.cr
@@ -106,8 +106,8 @@ module LavinMQ
     # If *fields* is an IPv4-mapped IPv6 address (::ffff:a.b.c.d), return the
     # embedded 4-byte IPv4 address, otherwise nil.
     private def ipv4_mapped_bytes(fields : StaticArray(UInt16, 8)) : Bytes?
-      return nil unless fields[0].zero? && fields[1].zero? && fields[2].zero? &&
-                        fields[3].zero? && fields[4].zero? && fields[5] == 0xffff_u16
+      return unless fields[0].zero? && fields[1].zero? && fields[2].zero? &&
+                    fields[3].zero? && fields[4].zero? && fields[5] == 0xffff_u16
       Bytes[
         (fields[6] >> 8).to_u8, (fields[6] & 0xFF).to_u8,
         (fields[7] >> 8).to_u8, (fields[7] & 0xFF).to_u8,

--- a/src/lavinmq/jump_consistent_hasher.cr
+++ b/src/lavinmq/jump_consistent_hasher.cr
@@ -30,7 +30,7 @@ class JumpConsistentHasher(T) < Hasher(T)
   end
 
   def get(key : String) : T?
-    return nil if @buckets.empty?
+    return if @buckets.empty?
     return @buckets.first if @buckets.size == 1
 
     bucket_index = jump_hash(hash_key64(key), @buckets.size)

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -135,10 +135,10 @@ module LavinMQ
       path = @config.load_definitions
       return if path.empty?
       GlobalDefinitions.import_from_file(path, amqp_server)
-    rescue ex : File::NotFoundError
+    rescue File::NotFoundError
       Log.error { "Failed to load definitions: file '#{path}' does not exist" }
       exit 1
-    rescue ex : File::AccessDeniedError
+    rescue File::AccessDeniedError
       Log.error { "Failed to load definitions: cannot read '#{path}': permission denied" }
       exit 1
     rescue ex : JSON::ParseException

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -638,7 +638,7 @@ module LavinMQ
         next if deleted?(seg, pos)
         @bytesize += bytesize
         @size += 1
-      rescue ex : IO::EOFError
+      rescue IO::EOFError
         break
       rescue ex : OverflowError | AMQ::Protocol::Error::FrameDecode
         @log.error { "Could not initialize segment, closing message store: Failed to read segment #{seg} at pos #{mfile.pos}. #{ex}" }

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -586,10 +586,10 @@ module LavinMQ
       orphan_count = positions.size - valid.size
       return if orphan_count.zero?
 
-      @log.warn {
+      @log.warn do
         "Msgs/acks files for segment #{seg} are out of sync (possibly because of " \
         "an unclean shutdown). Removing #{orphan_count} orphaned ack position(s)."
-      }
+      end
 
       if valid.empty?
         @deleted.delete(seg)

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -28,7 +28,7 @@ module LavinMQ
             validate_client_id!(packet.client_id, user.name)
             session_present = broker.session_present?(packet.client_id, packet.clean_session?)
             connack io, session_present, Protocol::Connack::ReturnCode::Accepted
-            return broker.run_client(io, connection_info, user, packet)
+            broker.run_client(io, connection_info, user, packet)
           end
         rescue ex : Protocol::Error::Connect
           logger.warn { "Connect error #{ex.inspect}" }

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -36,7 +36,7 @@ module LavinMQ
             connack io, false, Protocol::Connack::ReturnCode.new(ex.return_code)
           end
           socket.close
-        rescue ex : ::IO::EOFError
+        rescue ::IO::EOFError
           socket.close
         rescue ex
           logger.warn { "Received invalid Connect packet: #{ex.inspect}" }

--- a/src/lavinmq/mqtt/topic_tree.cr
+++ b/src/lavinmq/mqtt/topic_tree.cr
@@ -28,11 +28,11 @@ module LavinMQ
         end
       end
 
-      def []?(topic : String) : (TEntity | Nil)
+      def []?(topic : String) : TEntity?
         self[StringTokenIterator.new(topic, '/')]?
       end
 
-      def []?(topic : StringTokenIterator) : (TEntity | Nil)
+      def []?(topic : StringTokenIterator) : TEntity?
         current = topic.next
         if topic.next?
           return unless @sublevels.has_key?(current)

--- a/src/lavinmq/proxy_protocol.cr
+++ b/src/lavinmq/proxy_protocol.cr
@@ -31,8 +31,6 @@ module LavinMQ
         ProxyProtocol::V1.parse(io)
       elsif header_prefix?(peeked, ProxyProtocol::V2::Signature.to_slice)
         ProxyProtocol::V2.parse(io)
-      else
-        nil
       end
     ensure
       io.read_timeout = nil

--- a/src/lavinmq/shovel/amqp_source.cr
+++ b/src/lavinmq/shovel/amqp_source.cr
@@ -98,7 +98,6 @@ module LavinMQ
         (@prefetch / 2).ceil.to_i
       end
 
-      # ameba:disable Metrics/CyclomaticComplexity
       private def open_channel
         @ch.try &.close
         conn = @conn || raise "Connection not established"

--- a/src/lavinmq/shovel/amqp_source.cr
+++ b/src/lavinmq/shovel/amqp_source.cr
@@ -164,7 +164,7 @@ module LavinMQ
             ch.basic_cancel(@tag, no_wait: true)
             @done.wait # wait for last ack before returning, which will close connection
           end
-        rescue e : FailedDeliveryError
+        rescue FailedDeliveryError
           msg.reject
         end
       rescue e

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -541,7 +541,7 @@ module LavinMQ
       FileUtils.rm_rf @data_dir
     end
 
-    def apply_policies(resources : Array(Queue | Exchange) | Nil = nil)
+    def apply_policies(resources : Array(Queue | Exchange)? = nil)
       policies = @policies.values.sort_by!(&.priority).reverse
       operator_policies = @operator_policies.values.sort_by!(&.priority).reverse
       if r = resources

--- a/src/lavinmqperf/amqp/connection_count.cr
+++ b/src/lavinmqperf/amqp/connection_count.cr
@@ -66,7 +66,8 @@ module LavinMQPerf
             @io.puts " #{(stop - start).total_milliseconds.round}ms"
           end
           puts
-          @io.print "#{count += @connections} connections "
+          count += @connections
+          @io.print "#{count} connections "
           @io.print "#{count * @channels} channels "
           @io.print "#{count * @channels * @consumers} consumers. "
           @io.puts "Using #{rss.humanize_bytes} memory."

--- a/src/lavinmqperf/amqp/queue_count.cr
+++ b/src/lavinmqperf/amqp/queue_count.cr
@@ -20,16 +20,14 @@ module LavinMQPerf
           @exclusive = false
         end
         @parser.on("--arguments=JSON", "Queue arguments as a JSON string") do |v|
-          begin
-            json = JSON.parse(v)
-            if args = json.as_h?
-              @args = ::AMQP::Client::Arguments.new(args)
-            else
-              abort "Error: --arguments must be a JSON object"
-            end
-          rescue JSON::ParseException
-            abort "Error: Invalid JSON in --arguments parameter"
+          json = JSON.parse(v)
+          if args = json.as_h?
+            @args = ::AMQP::Client::Arguments.new(args)
+          else
+            abort "Error: --arguments must be a JSON object"
           end
+        rescue JSON::ParseException
+          abort "Error: Invalid JSON in --arguments parameter"
         end
         @parser.on("-n", "--no-wait", "Don't wait for queue declaration confirm") do
           @no_wait = true

--- a/src/lavinmqperf/amqp/queue_count.cr
+++ b/src/lavinmqperf/amqp/queue_count.cr
@@ -47,7 +47,8 @@ module LavinMQPerf
             @io.print '.'
           end
           puts
-          @io.print "#{count += @queues} queues "
+          count += @queues
+          @io.print "#{count} queues "
           @io.puts "Using #{rss.humanize_bytes} memory."
           @io.puts "Press enter to add #{@queues} more queues or ctrl-c to abort"
           gets

--- a/src/lavinmqperf/amqp/throughput.cr
+++ b/src/lavinmqperf/amqp/throughput.cr
@@ -230,11 +230,9 @@ module LavinMQPerf
         @io.print "Publish rate: #{pub_rate} msgs/s Consume rate: #{cons_rate} msgs/s"
         if @measure_latency
           stats = @latencies_mutex.synchronize do
-            begin
-              calculate_percentiles(@last_latencies)
-            ensure
-              @last_latencies.clear
-            end
+            calculate_percentiles(@last_latencies)
+          ensure
+            @last_latencies.clear
           end
           if stats
             @io.print " | Latency (ms) min/median/75th/95th/99th: #{stats[:min].round(3)}/#{stats[:median].round(3)}/#{stats[:p75].round(3)}/#{stats[:p95].round(3)}/#{stats[:p99].round(3)}"

--- a/src/stdlib/openssl_on_server_name.cr
+++ b/src/stdlib/openssl_on_server_name.cr
@@ -61,7 +61,7 @@ class OpenSSL::SSL::Context::Server
     callback_box = Box.box(block)
     @sni_callback_box = callback_box
 
-    LibSSL.ssl_ctx_callback_ctrl(@handle, LibSSL::SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, c_callback.unsafe_as(Proc(Void)))
+    LibSSL.ssl_ctx_callback_ctrl(@handle, LibSSL::SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, c_callback.unsafe_as(Proc(Nil)))
     LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG, 0, callback_box)
   end
 end


### PR DESCRIPTION
Clears the lint backlog parked at the bottom of `.ameba.yml` during the Crystal 1.21 upgrade (#2170). Ameba 1.6.4 doesn't compile on Crystal 1.21, so the shard tracks master (`1.7.0-dev`), which reported 291 problems across 18 rules -- all pre-existing code the newer ameba flags, none of it 1.21 related.

One commit per rule, so this reviews best commit by commit. 17 rules fixed, 1 declined. The backlog section is gone and `.ameba.yml` is back to just the rules this project deliberately configures.

### Worth a closer look

- **`49de9e697` is a real bug fix, not a lint change.** `Lint/ElseNil` flagged the `else nil` branches in `User`'s JSON parsing, but `JSON::PullParser#read_object` requires the block to consume every value. An unknown key in `users.json` therefore raised `JSON::ParseException`, and since `UserStore#load!` re-raises, the broker fails to start -- on a downgrade, or a hand-edited file. Deleting the line as the rule wanted would have cemented it, so it became `pull.skip` with a regression spec. The definitions import endpoint is unaffected; it parses users as `JSON::Any`.
- **`09e04623a`** found two perf tools mutating a running total inside a format string (`"#{count += @connections} connections "`), where the prints that follow read the post-increment value -- statement order was load-bearing but invisible.
- **`241b053be` declines `Lint/SignalTrap`.** `Process.on_terminate` only buys Windows portability, and `setup_signal_traps` also traps USR1/USR2 and resets SEGV, so it's Unix-only either way. Note its autofix is unsafe: it rewrites each trap into its own `Process.on_terminate`, and since every call re-registers all three signals, only the last would survive.

### Known CI failure: `Compile changed *.cr files independently`

That job fails on `src/lavinmq/amqp/argument/dead_lettering.cr`:

```
alias Task = {AMQP::Queue, Message} | MessageRoutedCallback
Error: undefined constant AMQP::Queue
```

**This is pre-existing and not caused by this PR.** The file references `AMQP::Queue` without requiring `queue/queue.cr`, so it has never compiled on its own. Checking out `main`'s version of the file and building it standalone fails identically. The job only compiles *changed* files, and the only change here is deleting a now-redundant `# ameba:disable Metrics/CyclomaticComplexity` comment -- which was enough to pull the file into the changed set and surface the latent breakage for the first time.

Not fixed here, to keep this PR to lint changes. The require cannot simply be added: `queue/queue.cr` does `include Argument::DeadLettering`, so requiring it back is a cycle that fails on the `include` instead. It needs either a forward declaration of `Queue` in `dead_lettering.cr` or moving the `Task` alias somewhere both files can see.

### Test plan

```
crystal tool format --check                    clean
make lint                                      390 inspected, 0 failures
crystal build --error-on-warnings (3 targets)  0 warnings
make test                                      2091 examples, 0 failures, 0 errors, 10 pending
```

2090 -> 2091 is the new regression spec. The 10 pending are pre-existing and unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

