### PR TITLE
fix: make dead_lettering.cr compile standalone

### DIFF
--- a/src/lavinmq/amqp/argument/dead_lettering.cr
+++ b/src/lavinmq/amqp/argument/dead_lettering.cr
@@ -197,3 +197,6 @@ module LavinMQ::AMQP
     end
   end
 end
+
+# Required after the module: Queue includes DeadLettering, so a top require would break the include.
+require "../queue/queue"


### PR DESCRIPTION
The CI job that compiles each changed `*.cr` file independently has been failing on `src/lavinmq/amqp/argument/dead_lettering.cr`:

```
Error: undefined constant AMQP::Queue
```

The file references `AMQP::Queue` in `alias Task = {AMQP::Queue, Message} | MessageRoutedCallback` but never requires it. It only builds as part of the full program because `queue.cr` requires it.

Requiring `../queue/queue` at the top doesn't work - `queue.cr` does `include Argument::DeadLettering`, and an `include` needs the module body already processed, so entering from `dead_lettering.cr` just fails the other way (`undefined constant Argument::DeadLettering`). Requiring it after the module is defined satisfies both entry points: the in-progress require is a no-op on the second pass, and the alias target resolves in the later semantic phase.

Note this wasn't introduced by 8256effc - the file already failed standalone before it. That commit was just the first to touch the file after the changed-files check landed, which is where it surfaced.

## Test plan

- `crystal build --no-codegen --error-on-warnings src/lavinmq/amqp/argument/dead_lettering.cr` passes
- Same sweep over every `src/**/*.cr` - this was the only failure repo-wide
- `crystal build --no-codegen --error-on-warnings src/lavinmq.cr`, `make lint`, `crystal tool format --check src/` all clean
- `make test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)