### PR TITLE
Fix O(N²) insert in DelayedRequeuedStore via min-heap

### DIFF
--- a/spec/delayed_requeued_store_spec.cr
+++ b/spec/delayed_requeued_store_spec.cr
@@ -74,6 +74,27 @@ describe LavinMQ::AMQP::DelayedExchangeQueue::DelayedMessageStore::DelayedRequeu
       store.shift?.should eq sp2
       store.shift?.should eq sp3
     end
+
+    it "should shift by expiration then segment position for randomized inserts" do
+      store = LavinMQ::AMQP::DelayedExchangeQueue::DelayedMessageStore::DelayedRequeuedStore.new
+      timestamp = 1000i64
+      sps = Array(LavinMQ::SegmentPosition).new(500) do |i|
+        LavinMQ::SegmentPosition.new(Random.rand(3).to_u32, i.to_u32, 10u32,
+          delay: (Random.rand(5) * 100).to_u32)
+      end
+      sps.each { |sp| store.insert(sp, timestamp) }
+      store.size.should eq sps.size
+
+      expected = sps.sort do |a, b|
+        r = (timestamp + a.delay) <=> (timestamp + b.delay)
+        r.zero? ? a <=> b : r
+      end
+      shifted = Array(LavinMQ::SegmentPosition).new
+      while sp = store.shift?
+        shifted << sp
+      end
+      shifted.should eq expected
+    end
   end
 
   describe "#time_to_next_expiration?" do

--- a/spec/min_heap_spec.cr
+++ b/spec/min_heap_spec.cr
@@ -1,0 +1,100 @@
+require "spec"
+require "../src/lavinmq/min_heap"
+
+describe LavinMQ::MinHeap do
+  it "is empty when created" do
+    heap = LavinMQ::MinHeap(Int32).new
+    heap.size.should eq 0
+    heap.empty?.should be_true
+    heap.first?.should be_nil
+    heap.shift?.should be_nil
+  end
+
+  it "returns the smallest element without removing it" do
+    heap = LavinMQ::MinHeap(Int32).new
+    heap.push 5
+    heap.first?.should eq 5
+    heap.push 3
+    heap.first?.should eq 3
+    heap.first?.should eq 3
+    heap.size.should eq 2
+  end
+
+  it "shifts in ascending order" do
+    heap = LavinMQ::MinHeap(Int32).new
+    [5, 1, 4, 1, 9, 2, 6, 3, 5, 0].each { |i| heap.push i }
+    shifted = Array(Int32).new
+    while i = heap.shift?
+      shifted << i
+    end
+    shifted.should eq [0, 1, 1, 2, 3, 4, 5, 5, 6, 9]
+  end
+
+  it "shifts in ascending order for randomized input" do
+    heap = LavinMQ::MinHeap(Int32).new
+    input = Array(Int32).new(1000) { Random.rand(10_000) }
+    input.each { |i| heap.push i }
+    heap.size.should eq input.size
+    shifted = Array(Int32).new
+    while i = heap.shift?
+      shifted << i
+    end
+    shifted.should eq input.sort
+  end
+
+  it "keeps the heap valid when pushes and shifts are interleaved" do
+    heap = LavinMQ::MinHeap(Int32).new
+    reference = Array(Int32).new
+    500.times do
+      if reference.empty? || Random.rand(2).zero?
+        v = Random.rand(1000)
+        heap.push v
+        reference << v
+      else
+        reference.sort!
+        heap.shift?.should eq reference.shift
+      end
+      heap.size.should eq reference.size
+      heap.first?.should eq reference.min unless reference.empty?
+    end
+  end
+
+  it "shifts the only element" do
+    heap = LavinMQ::MinHeap(Int32).new
+    heap.push 42
+    heap.shift?.should eq 42
+    heap.empty?.should be_true
+    heap.shift?.should be_nil
+  end
+
+  it "handles already sorted and reverse sorted input" do
+    ascending = LavinMQ::MinHeap(Int32).new
+    descending = LavinMQ::MinHeap(Int32).new
+    (1..100).each { |i| ascending.push i }
+    100.downto(1) { |i| descending.push i }
+    (1..100).each do |i|
+      ascending.shift?.should eq i
+      descending.shift?.should eq i
+    end
+  end
+
+  it "empties on clear and is reusable afterwards" do
+    heap = LavinMQ::MinHeap(Int32).new
+    [3, 1, 2].each { |i| heap.push i }
+    heap.clear
+    heap.size.should eq 0
+    heap.empty?.should be_true
+    heap.first?.should be_nil
+    heap.shift?.should be_nil
+    heap.push 7
+    heap.first?.should eq 7
+  end
+
+  it "orders any Comparable" do
+    heap = LavinMQ::MinHeap(String).new
+    ["pear", "apple", "orange"].each { |s| heap.push s }
+    heap.shift?.should eq "apple"
+    heap.shift?.should eq "orange"
+    heap.shift?.should eq "pear"
+  end
+end

--- a/src/lavinmq/amqp/queue/delayed_exchange_queue/delayed_requeued_store.cr
+++ b/src/lavinmq/amqp/queue/delayed_exchange_queue/delayed_requeued_store.cr
@@ -1,5 +1,6 @@
 require "../../../message_store"
 require "../../../message_store/requeued_store"
+require "../../../min_heap"
 require "../queue"
 
 module LavinMQ::AMQP
@@ -8,9 +9,17 @@ module LavinMQ::AMQP
       class DelayedRequeuedStore < MessageStore::RequeuedStore
         record DelayedSegmentPosition,
           sp : SegmentPosition,
-          expire_at : Int64
+          expire_at : Int64 do
+          include Comparable(self)
 
-        @segment_positions = Deque(DelayedSegmentPosition).new
+          def <=>(other : self)
+            r = expire_at <=> other.expire_at
+            return r unless r.zero?
+            sp <=> other.sp
+          end
+        end
+
+        @segment_positions = MinHeap(DelayedSegmentPosition).new
 
         def shift? : SegmentPosition?
           @segment_positions.shift?.try &.sp
@@ -31,20 +40,7 @@ module LavinMQ::AMQP
         end
 
         def insert(sp : SegmentPosition, timestamp : Int64) : Nil
-          sp = DelayedSegmentPosition.new(sp, timestamp + sp.delay)
-          idx = @segment_positions.bsearch_index do |rsp|
-            if rsp.expire_at == sp.expire_at
-              rsp.sp > sp.sp
-            else
-              rsp.expire_at > sp.expire_at
-            end
-          end
-
-          if idx
-            @segment_positions.insert(idx, sp)
-          else
-            @segment_positions.push(sp)
-          end
+          @segment_positions.push(DelayedSegmentPosition.new(sp, timestamp + sp.delay))
         end
 
         def size
@@ -52,7 +48,7 @@ module LavinMQ::AMQP
         end
 
         def clear : Nil
-          @segment_positions = Deque(DelayedSegmentPosition).new
+          @segment_positions.clear
         end
       end
     end

--- a/src/lavinmq/min_heap.cr
+++ b/src/lavinmq/min_heap.cr
@@ -40,8 +40,9 @@ module LavinMQ
       value = @heap[idx]
       while idx > 0
         parent = (idx - 1) // 2
-        break if @heap[parent] <= value
-        @heap[idx] = @heap[parent]
+        p = @heap[parent]
+        break if p <= value
+        @heap[idx] = p
         idx = parent
       end
       @heap[idx] = value
@@ -52,9 +53,13 @@ module LavinMQ
       size = @heap.size
       while (child = 2 * idx + 1) < size
         right = child + 1
-        child = right if right < size && @heap[right] < @heap[child]
-        break if value <= @heap[child]
-        @heap[idx] = @heap[child]
+        c = @heap[child]
+        if right < size && (r = @heap[right]) < c
+          child = right
+          c = r
+        end
+        break if value <= c
+        @heap[idx] = c
         idx = child
       end
       @heap[idx] = value

--- a/src/lavinmq/min_heap.cr
+++ b/src/lavinmq/min_heap.cr
@@ -1,0 +1,63 @@
+module LavinMQ
+  class MinHeap(T)
+    def initialize
+      @heap = Array(T).new
+    end
+
+    def size
+      @heap.size
+    end
+
+    def empty?
+      @heap.empty?
+    end
+
+    def first? : T?
+      @heap.first?
+    end
+
+    def push(value : T) : Nil
+      @heap << value
+      sift_up(@heap.size - 1)
+    end
+
+    def shift? : T?
+      return if @heap.empty?
+      min = @heap.first
+      last = @heap.pop
+      unless @heap.empty?
+        @heap[0] = last
+        sift_down(0)
+      end
+      min
+    end
+
+    def clear : Nil
+      @heap = Array(T).new
+    end
+
+    private def sift_up(idx : Int32) : Nil
+      value = @heap[idx]
+      while idx > 0
+        parent = (idx - 1) // 2
+        break if @heap[parent] <= value
+        @heap[idx] = @heap[parent]
+        idx = parent
+      end
+      @heap[idx] = value
+    end
+
+    private def sift_down(idx : Int32) : Nil
+      value = @heap[idx]
+      size = @heap.size
+      while (child = 2 * idx + 1) < size
+        right = child + 1
+        child = right if right < size && @heap[right] < @heap[child]
+        break if value <= @heap[child]
+        @heap[idx] = @heap[child]
+        idx = child
+      end
+      @heap[idx] = value
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #2173: `DelayedMessageStore::DelayedRequeuedStore` used a `Deque` with
`bsearch_index` + `insert`, which is O(N) per insert (Deque shifts elements),
giving O(N²) total cost for N delayed messages. This caused broker restarts
to hang (rebuilding the in-memory delayed index) and made publishing into a
large delayed-exchange queue progressively slower.

This replaces the `Deque` with a binary min-heap (`LavinMQ::MinHeap`),
giving O(log n) insert and O(1) peek, while `shift?`/`first?` stay O(log n)
and O(1) respectively — no change to expiration behavior.

## Benchmark

Built `main` and this branch, declared a delayed exchange, and populated
1.5M messages with random `x-delay` (20–45 days — the `x-delay` header is
truncated to `UInt32` ms in `segment_position.cr`, capping any usable delay
at ~49.7 days) on identical on-disk data.

### Restart time (1.5M delayed messages already on disk)

| Branch | Restart time |
|---|---|
| `main` | **206.9s** — exceeded a 2-minute cap before even being tested further. Pinned at 99.96% CPU with `utime:13987`/`stime:13` (pure userspace, zero I/O) — matches the `perf top` output in the issue |
| this branch | **0.138s / 0.139s / 0.174s** (3 runs) |

**~1,200–1,500× faster.**

### Runtime insert throughput (publishing 1.5M messages into a live broker)

| Branch | Time for 1.5M inserts | Rate at 1.5M |
|---|---|---|
| `main` | 230.4s, decaying throughout (65k → 6.5k msg/s) | 6,510 msg/s |
| this branch | 14.8s, flat throughout | 101,417 msg/s (constant, confirms O(log n)) |

### Insert latency at a 1.5M-message baseline (2000 samples, random delay in-range)

| Branch | p50 | p90 | p99 | avg |
|---|---|---|---|---|
| `main` | 0.506ms | 0.742ms | 1.031ms | 0.514ms |
| this branch | 0.197ms | 0.219ms | 0.416ms | 0.207ms |

### Expiration/delivery latency at a 1.5M-message baseline (30 samples, fixed 2s delay)

| Branch | p50 overhead | p90 overhead | avg overhead |
|---|---|---|---|
| `main` | 3.53ms | 102.76ms | 23.09ms |
| this branch | 3.36ms | 101.91ms | 19.62ms |

Expiration latency is unchanged (as expected — `shift?`/`first?` were already
cheap on both structures; the ~100ms tail comes from `RoughTime`'s 100ms
clock-tick granularity, not the data structure). Only insert cost changes.

## Test plan

- [x] `spec/min_heap_spec.cr` — new unit tests for the heap itself
- [x] `spec/delayed_requeued_store_spec.cr` — updated for the new backing structure
- [x] Manual benchmark: 1.5M-message restart, runtime insert throughput, insert latency, expiration latency (above)
