### PR TITLE
Leader controls follower's syncfs 

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -43,6 +43,8 @@ After bulk sync, the leader streams changes in real-time:
 - **Rewrites** — files that have been completely rewritten (e.g., compacted definitions)
 - **Control records** — instructions rather than file data, e.g. a request to make everything replicated so far durable before the leader confirms a publish
 
+A follower acks the byte count of every record it has received and applied. An ack on its own does not mean the data is on disk — durability is fenced by the sync control record, and it is that record's ack the leader waits for before confirming a publish or acknowledging a durable definition change.
+
 Data is compressed with LZ4 during replication.
 
 ### What Gets Replicated

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -41,6 +41,7 @@ After bulk sync, the leader streams changes in real-time:
 - **Appends** — bytes to append to data files (message segments, definitions)
 - **Deletes** — files that have been removed
 - **Rewrites** — files that have been completely rewritten (e.g., compacted definitions)
+- **Control records** — instructions rather than file data, e.g. a request to make everything replicated so far durable before the leader confirms a publish
 
 Data is compressed with LZ4 during replication.
 

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -197,7 +197,7 @@ module ClientSyncSpec
           rescue IO::Error
           end
 
-          control = LavinMQ::Clustering::SyncControlPacket::PATH
+          control = LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
           write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
           write_record(lz4_writer, control, 0i64, Bytes.empty)
           streamed = record_size(filename, payload.bytesize) + record_size(control, 0)
@@ -216,7 +216,7 @@ module ClientSyncSpec
       # An instruction, not file data: nothing is written to disk or tracked for
       # its path. The leader still counts its bytes as sent and waits for the
       # ack, so skipping it would stall every publish confirm.
-      it "acks a $ctrl/sync record without creating a file for it" do
+      it "acks a sync record without creating a file for it" do
         with_datadir do |data_dir|
           client = make_client(data_dir)
           client_socket, leader_io = FakeSocket.pair
@@ -224,7 +224,7 @@ module ClientSyncSpec
           lz4_writer = Compress::LZ4::Writer.new(leader_io,
             Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
 
-          control = LavinMQ::Clustering::SyncControlPacket::PATH
+          control = LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
           filename = "after_control"
           payload = "replicated bytes"
 
@@ -241,7 +241,6 @@ module ClientSyncSpec
 
           File.read(File.join(data_dir, filename)).should eq payload
           File.exists?(File.join(data_dir, control)).should be_false
-          Dir.exists?(File.join(data_dir, "$ctrl")).should be_false
           close_client(client)
           # Not tracked as a file either, so no checksum is persisted for it
           persisted_checksums(data_dir).keys.should eq [filename]
@@ -249,10 +248,10 @@ module ClientSyncSpec
         end
       end
 
-      # An instruction from a newer leader must be ignored rather than kill the
-      # stream or lose its alignment. Control records carry no body, so there is
-      # nothing to drain — the record is its framing.
-      it "acks an unknown control record without acting on it" do
+      # A symbol this build doesn't know isn't a control record at all, so the
+      # record is read as file data — a zero length being a delete of a path
+      # that never existed. Harmless, and the stream stays aligned.
+      it "acks a record with an unknown symbol without creating a file for it" do
         with_datadir do |data_dir|
           client = make_client(data_dir)
           client_socket, leader_io = FakeSocket.pair
@@ -260,7 +259,7 @@ module ClientSyncSpec
           lz4_writer = Compress::LZ4::Writer.new(leader_io,
             Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
 
-          unknown = "#{LavinMQ::Clustering::ControlPacket::PREFIX}from_the_future"
+          unknown = "%from_the_future"
           filename = "after_unknown_control"
           payload = "replicated bytes"
 
@@ -277,6 +276,68 @@ module ClientSyncSpec
           # The record after it arrived intact, so the stream stayed aligned.
           File.read(File.join(data_dir, filename)).should eq payload
           File.exists?(File.join(data_dir, unknown)).should be_false
+          client.syncfs_calls.should eq 0 # and nothing was synced for it
+          client_socket.close
+        end
+      end
+
+      # `$` + a path: a file the follower has open is fsynced on its own, so a
+      # per-file sync must not reach for syncfs.
+      it "fsyncs just the named file when the sync path names one" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+
+          filename = "vhost_dir/one_file"
+          payload = "replicated bytes"
+          file_sync = "#{LavinMQ::Clustering::SyncControlPacket::SYMBOL}#{filename}"
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+          write_record(lz4_writer, file_sync, 0i64, Bytes.empty)
+
+          read_acks(leader_io, record_size(filename, payload.bytesize) + record_size(file_sync, 0))
+
+          client.syncs_started.should eq 0 # the file was fsynced, not the fs
+          File.read(File.join(data_dir, filename)).should eq payload
+          File.exists?(File.join(data_dir, file_sync)).should be_false
+          client_socket.close
+        end
+      end
+
+      # Anything that isn't a file we have open — a directory here — falls back
+      # to the whole filesystem, which can never sync too little.
+      it "syncs the filesystem when the sync path names a directory" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+
+          dir = "vhost_dir"
+          filename = File.join(dir, "a_file")
+          payload = "replicated bytes"
+          dir_sync = "#{LavinMQ::Clustering::SyncControlPacket::SYMBOL}#{dir}"
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+          write_record(lz4_writer, dir_sync, 0i64, Bytes.empty)
+
+          read_acks(leader_io, record_size(filename, payload.bytesize) + record_size(dir_sync, 0))
+
+          client.syncfs_calls.should be > 0
           client_socket.close
         end
       end
@@ -1042,7 +1103,7 @@ module ClientSyncSpec
             # socket closed at spec end, or acks closed by close
           end
 
-          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::PATH, 0i64, Bytes.empty)
+          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s, 0i64, Bytes.empty)
           wait_for { client.syncs_started > 0 } # the sync is now in its delay
 
           # follow() was never called in this harness, so satisfy close's
@@ -1077,7 +1138,7 @@ module ClientSyncSpec
           spawn(name: "follower done feeder") { client.@follower_done.send(nil) }
           client.close
 
-          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::PATH, 0i64, Bytes.empty)
+          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s, 0i64, Bytes.empty)
           # The record is read and counted, but its action is skipped.
           wait_for { client.@streamed_bytes > 0 }
           client.syncs_started.should eq 0

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -197,7 +197,7 @@ module ClientSyncSpec
           rescue IO::Error
           end
 
-          control = LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
+          control = LavinMQ::Clustering::SyncPacket::SYMBOL.to_s
           write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
           write_record(lz4_writer, control, 0i64, Bytes.empty)
           streamed = record_size(filename, payload.bytesize) + record_size(control, 0)
@@ -224,7 +224,7 @@ module ClientSyncSpec
           lz4_writer = Compress::LZ4::Writer.new(leader_io,
             Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
 
-          control = LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
+          control = LavinMQ::Clustering::SyncPacket::SYMBOL.to_s
           filename = "after_control"
           payload = "replicated bytes"
 
@@ -293,7 +293,7 @@ module ClientSyncSpec
 
           filename = "vhost_dir/one_file"
           payload = "replicated bytes"
-          file_sync = "#{LavinMQ::Clustering::SyncControlPacket::SYMBOL}#{filename}"
+          file_sync = "#{LavinMQ::Clustering::SyncPacket::SYMBOL}#{filename}"
 
           spawn(name: "client stream_changes") do
             client.stream_changes_public(client_socket, lz4_reader)
@@ -325,7 +325,7 @@ module ClientSyncSpec
           dir = "vhost_dir"
           filename = File.join(dir, "a_file")
           payload = "replicated bytes"
-          dir_sync = "#{LavinMQ::Clustering::SyncControlPacket::SYMBOL}#{dir}"
+          dir_sync = "#{LavinMQ::Clustering::SyncPacket::SYMBOL}#{dir}"
 
           spawn(name: "client stream_changes") do
             client.stream_changes_public(client_socket, lz4_reader)
@@ -1103,7 +1103,7 @@ module ClientSyncSpec
             # socket closed at spec end, or acks closed by close
           end
 
-          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s, 0i64, Bytes.empty)
+          write_record(lz4_writer, LavinMQ::Clustering::SyncPacket::SYMBOL.to_s, 0i64, Bytes.empty)
           wait_for { client.syncs_started > 0 } # the sync is now in its delay
 
           # follow() was never called in this harness, so satisfy close's
@@ -1138,7 +1138,7 @@ module ClientSyncSpec
           spawn(name: "follower done feeder") { client.@follower_done.send(nil) }
           client.close
 
-          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s, 0i64, Bytes.empty)
+          write_record(lz4_writer, LavinMQ::Clustering::SyncPacket::SYMBOL.to_s, 0i64, Bytes.empty)
           # The record is read and counted, but its action is skipped.
           wait_for { client.@streamed_bytes > 0 }
           client.syncs_started.should eq 0

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -249,9 +249,10 @@ module ClientSyncSpec
         end
       end
 
-      # An instruction from a newer leader must be skipped, payload and all,
-      # rather than kill the stream or lose its alignment.
-      it "drains and acks an unknown control record" do
+      # An instruction from a newer leader must be ignored rather than kill the
+      # stream or lose its alignment. Control records carry no body, so there is
+      # nothing to drain — the record is its framing.
+      it "acks an unknown control record without acting on it" do
         with_datadir do |data_dir|
           client = make_client(data_dir)
           client_socket, leader_io = FakeSocket.pair
@@ -259,8 +260,7 @@ module ClientSyncSpec
           lz4_writer = Compress::LZ4::Writer.new(leader_io,
             Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
 
-          unknown = "#{LavinMQ::Clustering::CONTROL_PREFIX}from_the_future"
-          body = "instruction payload"
+          unknown = "#{LavinMQ::Clustering::ControlPacket::PREFIX}from_the_future"
           filename = "after_unknown_control"
           payload = "replicated bytes"
 
@@ -269,11 +269,12 @@ module ClientSyncSpec
           rescue IO::Error
           end
 
-          write_record(lz4_writer, unknown, body.bytesize.to_i64, body.to_slice)
+          write_record(lz4_writer, unknown, 0i64, Bytes.empty)
           write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
 
-          read_acks(leader_io, record_size(unknown, body.bytesize) + record_size(filename, payload.bytesize))
+          read_acks(leader_io, record_size(unknown, 0) + record_size(filename, payload.bytesize))
 
+          # The record after it arrived intact, so the stream stayed aligned.
           File.read(File.join(data_dir, filename)).should eq payload
           File.exists?(File.join(data_dir, unknown)).should be_false
           client_socket.close

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -214,8 +214,8 @@ module ClientSyncSpec
       end
 
       # An instruction, not file data: nothing is written to disk or tracked for
-      # its path. Its bytes are still counted as sent by the leader, which waits
-      # for them to be acked, so skipping it would stall every publish confirm.
+      # its path. The leader still counts its bytes as sent and waits for the
+      # ack, so skipping it would stall every publish confirm.
       it "acks a $ctrl/sync record without creating a file for it" do
         with_datadir do |data_dir|
           client = make_client(data_dir)
@@ -1024,9 +1024,8 @@ module ClientSyncSpec
     describe "#close" do
       # Regression: close used to wait only for the follow loop, then tear the
       # data dir down while a syncfs on @data_dir_fd could still be running. The
-      # resulting EBADF made the follower Log.fatal and exit 1 in the middle of a
-      # graceful shutdown or a promotion to leader. Syncs are requested by the
-      # leader as control records, so close waits for those (see #control).
+      # EBADF made the follower Log.fatal and exit 1 mid shutdown or promotion.
+      # Syncs come from the leader as control records, so close waits for those.
       it "waits for an in-flight control action before closing the data dir fd" do
         with_datadir do |data_dir|
           client = make_client(data_dir)

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -197,7 +197,7 @@ module ClientSyncSpec
           rescue IO::Error
           end
 
-          control = LavinMQ::Clustering::SYNC_CONTROL_PATH
+          control = LavinMQ::Clustering::SyncControlPacket::PATH
           write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
           write_record(lz4_writer, control, 0i64, Bytes.empty)
           streamed = record_size(filename, payload.bytesize) + record_size(control, 0)
@@ -224,7 +224,7 @@ module ClientSyncSpec
           lz4_writer = Compress::LZ4::Writer.new(leader_io,
             Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
 
-          control = LavinMQ::Clustering::SYNC_CONTROL_PATH
+          control = LavinMQ::Clustering::SyncControlPacket::PATH
           filename = "after_control"
           payload = "replicated bytes"
 
@@ -1041,7 +1041,7 @@ module ClientSyncSpec
             # socket closed at spec end, or acks closed by close
           end
 
-          write_record(lz4_writer, LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64, Bytes.empty)
+          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::PATH, 0i64, Bytes.empty)
           wait_for { client.syncs_started > 0 } # the sync is now in its delay
 
           # follow() was never called in this harness, so satisfy close's
@@ -1076,7 +1076,7 @@ module ClientSyncSpec
           spawn(name: "follower done feeder") { client.@follower_done.send(nil) }
           client.close
 
-          write_record(lz4_writer, LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64, Bytes.empty)
+          write_record(lz4_writer, LavinMQ::Clustering::SyncControlPacket::PATH, 0i64, Bytes.empty)
           # The record is read and counted, but its action is skipped.
           wait_for { client.@streamed_bytes > 0 }
           client.syncs_started.should eq 0

--- a/spec/clustering/client_sync_spec.cr
+++ b/spec/clustering/client_sync_spec.cr
@@ -173,7 +173,109 @@ module ClientSyncSpec
 
           acked.should eq framing + payload.bytesize
           client.syncs_started.should eq 0
+          client.syncfs_calls.should eq 0 # a skipped sync isn't counted either
           File.read(File.join(data_dir, filename)).should eq payload
+          client_socket.close
+        end
+      end
+
+      # Reported next to the streamed bytes: the ratio shows how much data each
+      # sync covers.
+      it "counts syncfs calls and logs them with the streamed bytes" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+
+          filename = "synced_stream_file"
+          payload = "replicated bytes"
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          control = LavinMQ::Clustering::SYNC_CONTROL_PATH
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+          write_record(lz4_writer, control, 0i64, Bytes.empty)
+          streamed = record_size(filename, payload.bytesize) + record_size(control, 0)
+          # The sync record is acked once handled, i.e. once its sync has run.
+          read_acks(leader_io, streamed)
+
+          syncs = client.syncfs_calls
+          syncs.should be > 0
+          syncs.should eq client.syncs_started # only the syncs actually performed
+          client.stream_stats_message_public
+            .should eq "Total streamed bytes: #{streamed}, syncfs calls: #{syncs}"
+          client_socket.close
+        end
+      end
+
+      # An instruction, not file data: nothing is written to disk or tracked for
+      # its path. Its bytes are still counted as sent by the leader, which waits
+      # for them to be acked, so skipping it would stall every publish confirm.
+      it "acks a $ctrl/sync record without creating a file for it" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+
+          control = LavinMQ::Clustering::SYNC_CONTROL_PATH
+          filename = "after_control"
+          payload = "replicated bytes"
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          write_record(lz4_writer, control, 0i64, Bytes.empty)
+          # A record after the control one proves the stream stayed aligned.
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+
+          read_acks(leader_io, record_size(control, 0) + record_size(filename, payload.bytesize))
+
+          File.read(File.join(data_dir, filename)).should eq payload
+          File.exists?(File.join(data_dir, control)).should be_false
+          Dir.exists?(File.join(data_dir, "$ctrl")).should be_false
+          close_client(client)
+          # Not tracked as a file either, so no checksum is persisted for it
+          persisted_checksums(data_dir).keys.should eq [filename]
+          client_socket.close
+        end
+      end
+
+      # An instruction from a newer leader must be skipped, payload and all,
+      # rather than kill the stream or lose its alignment.
+      it "drains and acks an unknown control record" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+
+          unknown = "#{LavinMQ::Clustering::CONTROL_PREFIX}from_the_future"
+          body = "instruction payload"
+          filename = "after_unknown_control"
+          payload = "replicated bytes"
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error
+          end
+
+          write_record(lz4_writer, unknown, body.bytesize.to_i64, body.to_slice)
+          write_record(lz4_writer, filename, -payload.bytesize.to_i64, payload.to_slice)
+
+          read_acks(leader_io, record_size(unknown, body.bytesize) + record_size(filename, payload.bytesize))
+
+          File.read(File.join(data_dir, filename)).should eq payload
+          File.exists?(File.join(data_dir, unknown)).should be_false
           client_socket.close
         end
       end
@@ -920,15 +1022,15 @@ module ClientSyncSpec
     end
 
     describe "#close" do
-      # Regression: close used to wait only for the follow loop, then close
-      # the data dir fd while the ack-sending fiber could still be draining
-      # buffered acks — each preceded by a syncfs on that fd. The resulting
-      # EBADF made the follower Log.fatal and exit 1 in the middle of a
-      # graceful shutdown or a promotion to leader.
-      it "waits for the ack loop's pending syncs before closing the data dir fd" do
+      # Regression: close used to wait only for the follow loop, then tear the
+      # data dir down while a syncfs on @data_dir_fd could still be running. The
+      # resulting EBADF made the follower Log.fatal and exit 1 in the middle of a
+      # graceful shutdown or a promotion to leader. Syncs are requested by the
+      # leader as control records, so close waits for those (see #control).
+      it "waits for an in-flight control action before closing the data dir fd" do
         with_datadir do |data_dir|
           client = make_client(data_dir)
-          client.sync_delay = 50.milliseconds
+          client.sync_delay = 200.milliseconds # still syncing when close starts
           client_socket, leader_io = FakeSocket.pair
           lz4_reader = Compress::LZ4::Reader.new(client_socket)
           lz4_writer = Compress::LZ4::Writer.new(leader_io,
@@ -936,37 +1038,49 @@ module ClientSyncSpec
 
           spawn(name: "client stream_changes") do
             client.stream_changes_public(client_socket, lz4_reader)
-          rescue IO::Error
+          rescue IO::Error | Channel::ClosedError
+            # socket closed at spec end, or acks closed by close
           end
 
-          # Stream a small append so acks start flowing and the ack loop
-          # enters its (slowed) sync.
-          filename = "ack_file"
-          payload = "data"
-          lz4_writer.write_bytes filename.bytesize, IO::ByteFormat::LittleEndian
-          lz4_writer.write filename.to_slice
-          lz4_writer.write_bytes -payload.bytesize.to_i64, IO::ByteFormat::LittleEndian
-          lz4_writer.write payload.to_slice
-          lz4_writer.flush
-          wait_for { client.syncs_started > 0 }
-
-          # Keep acks arriving while close runs, so a sync is in flight or
-          # pending throughout the shutdown.
-          spawn(name: "ack feeder") do
-            20.times do
-              client.@acks.send(1i64)
-              sleep 10.milliseconds
-            end
-          rescue Channel::ClosedError
-            # close drained and closed the channel
-          end
+          write_record(lz4_writer, LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64, Bytes.empty)
+          wait_for { client.syncs_started > 0 } # the sync is now in its delay
 
           # follow() was never called in this harness, so satisfy close's
           # follower-done handshake ourselves.
           spawn(name: "follower done feeder") { client.@follower_done.send(nil) }
           client.close
 
-          sleep 200.milliseconds # let any straggler sync run after close returned
+          # A sync that ran to completion counted itself; one that woke up to a
+          # closed fd flagged it instead.
+          wait_for { client.syncfs_calls > 0 || client.synced_on_closed_fd? }
+          client.synced_on_closed_fd?.should be_false
+          client_socket.close
+          leader_io.close
+        end
+      end
+
+      # The other half of the guard: a control record read after close must skip
+      # its action rather than sync a closed (or reused) fd.
+      it "skips a control action requested after close" do
+        with_datadir do |data_dir|
+          client = make_client(data_dir)
+          client_socket, leader_io = FakeSocket.pair
+          lz4_reader = Compress::LZ4::Reader.new(client_socket)
+          lz4_writer = Compress::LZ4::Writer.new(leader_io,
+            Compress::LZ4::CompressOptions.new(auto_flush: true, block_mode_linked: true))
+
+          spawn(name: "client stream_changes") do
+            client.stream_changes_public(client_socket, lz4_reader)
+          rescue IO::Error | Channel::ClosedError
+          end
+
+          spawn(name: "follower done feeder") { client.@follower_done.send(nil) }
+          client.close
+
+          write_record(lz4_writer, LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64, Bytes.empty)
+          # The record is read and counted, but its action is skipped.
+          wait_for { client.@streamed_bytes > 0 }
+          client.syncs_started.should eq 0
           client.synced_on_closed_fd?.should be_false
           client_socket.close
           leader_io.close

--- a/spec/clustering/control_packet_spec.cr
+++ b/spec/clustering/control_packet_spec.cr
@@ -3,7 +3,7 @@ require "../../src/lavinmq/clustering/control_packet"
 
 module ControlPacketSpec
   describe LavinMQ::Clustering::ControlPacket do
-    symbol = LavinMQ::Clustering::SyncControlPacket::SYMBOL
+    symbol = LavinMQ::Clustering::SyncPacket::SYMBOL
 
     # Answers "is this an instruction?" where .from_str answers "which one?".
     describe ".control?" do
@@ -21,14 +21,14 @@ module ControlPacketSpec
     describe ".from_str" do
       it "returns the packet the symbol stands for, with the rest as its path" do
         packet = LavinMQ::Clustering::ControlPacket.from_str("#{symbol}vhost_dir/msgs.0000001")
-        packet.should be_a LavinMQ::Clustering::SyncControlPacket
-        packet.as(LavinMQ::Clustering::SyncControlPacket).path.should eq "vhost_dir/msgs.0000001"
+        packet.should be_a LavinMQ::Clustering::SyncPacket
+        packet.as(LavinMQ::Clustering::SyncPacket).path.should eq "vhost_dir/msgs.0000001"
       end
 
       # The empty path names the data dir itself: sync the whole filesystem.
       it "returns an empty path for a bare symbol" do
         LavinMQ::Clustering::ControlPacket.from_str(symbol.to_s)
-          .as(LavinMQ::Clustering::SyncControlPacket).path.should eq ""
+          .as(LavinMQ::Clustering::SyncPacket).path.should eq ""
       end
 
       it "returns nil for a symbol this build doesn't know" do
@@ -41,14 +41,14 @@ module ControlPacketSpec
     # what the leader writes is what the follower parses back.
     it "parses back the record it writes" do
       io = IO::Memory.new
-      packet = LavinMQ::Clustering::SyncControlPacket.new("vhost_dir/msgs.0000001")
+      packet = LavinMQ::Clustering::SyncPacket.new("vhost_dir/msgs.0000001")
       packet.to_io(io)
       io.size.should eq packet.bytesize # what's counted as sent is what's written
 
       io.rewind
       len = io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
       LavinMQ::Clustering::ControlPacket.from_str(io.read_string(len))
-        .as(LavinMQ::Clustering::SyncControlPacket).path.should eq "vhost_dir/msgs.0000001"
+        .as(LavinMQ::Clustering::SyncPacket).path.should eq "vhost_dir/msgs.0000001"
       io.read_bytes(Int64, IO::ByteFormat::LittleEndian).should eq 0 # empty body
     end
   end

--- a/spec/clustering/control_packet_spec.cr
+++ b/spec/clustering/control_packet_spec.cr
@@ -5,7 +5,7 @@ module ControlPacketSpec
   describe LavinMQ::Clustering::ControlPacket do
     describe ".from_str" do
       it "returns the packet a record's path stands for" do
-        LavinMQ::Clustering::ControlPacket.from_str(LavinMQ::Clustering::SYNC_CONTROL_PATH)
+        LavinMQ::Clustering::ControlPacket.from_str(LavinMQ::Clustering::SyncControlPacket::PATH)
           .should be_a LavinMQ::Clustering::SyncControlPacket
       end
 

--- a/spec/clustering/control_packet_spec.cr
+++ b/spec/clustering/control_packet_spec.cr
@@ -3,45 +3,52 @@ require "../../src/lavinmq/clustering/control_packet"
 
 module ControlPacketSpec
   describe LavinMQ::Clustering::ControlPacket do
-    # Answers "is this an instruction?" where .from_str answers "which one?" —
-    # so a record only a newer leader knows is still recognised as a control
-    # record, rather than read as a delete of its path.
+    symbol = LavinMQ::Clustering::SyncControlPacket::SYMBOL
+
+    # Answers "is this an instruction?" where .from_str answers "which one?".
     describe ".control?" do
-      it "is true for any $ctrl/ record, known or not" do
-        LavinMQ::Clustering::ControlPacket
-          .control?(LavinMQ::Clustering::SyncControlPacket::PATH).should be_true
-        LavinMQ::Clustering::ControlPacket
-          .control?("#{LavinMQ::Clustering::ControlPacket::PREFIX}from_the_future").should be_true
+      it "is true for a record named by a symbol, with or without an argument" do
+        LavinMQ::Clustering::ControlPacket.control?(symbol.to_s).should be_true
+        LavinMQ::Clustering::ControlPacket.control?("#{symbol}vhost_dir/msgs.0000001").should be_true
       end
 
       it "is false for a replicated file path" do
-        LavinMQ::Clustering::ControlPacket.control?("queue_dir/msgs.0000001").should be_false
+        LavinMQ::Clustering::ControlPacket.control?("vhost_dir/msgs.0000001").should be_false
+        LavinMQ::Clustering::ControlPacket.control?("").should be_false
       end
     end
 
     describe ".from_str" do
-      it "returns the packet a record's path stands for" do
-        LavinMQ::Clustering::ControlPacket.from_str(LavinMQ::Clustering::SyncControlPacket::PATH)
-          .should be_a LavinMQ::Clustering::SyncControlPacket
+      it "returns the packet the symbol stands for, with the rest as its path" do
+        packet = LavinMQ::Clustering::ControlPacket.from_str("#{symbol}vhost_dir/msgs.0000001")
+        packet.should be_a LavinMQ::Clustering::SyncControlPacket
+        packet.as(LavinMQ::Clustering::SyncControlPacket).path.should eq "vhost_dir/msgs.0000001"
       end
 
-      # A newer leader's instruction: the follower skips it rather than dying,
-      # so the stream stays aligned (see Client#control).
-      it "returns nil for an unknown instruction" do
-        LavinMQ::Clustering::ControlPacket
-          .from_str("#{LavinMQ::Clustering::ControlPacket::PREFIX}from_the_future").should be_nil
+      # The empty path names the data dir itself: sync the whole filesystem.
+      it "returns an empty path for a bare symbol" do
+        LavinMQ::Clustering::ControlPacket.from_str(symbol.to_s)
+          .as(LavinMQ::Clustering::SyncControlPacket).path.should eq ""
+      end
+
+      it "returns nil for a symbol this build doesn't know" do
+        LavinMQ::Clustering::ControlPacket.from_str("%from_the_future").should be_nil
+        LavinMQ::Clustering::ControlPacket.from_str("vhost_dir/msgs.0000001").should be_nil
       end
     end
 
-    # Both sides of the wire agree on the path because they share the packet:
+    # Both sides of the wire agree on the format because they share the packet:
     # what the leader writes is what the follower parses back.
     it "parses back the record it writes" do
       io = IO::Memory.new
-      LavinMQ::Clustering::SyncControlPacket.new.to_io(io)
+      packet = LavinMQ::Clustering::SyncControlPacket.new("vhost_dir/msgs.0000001")
+      packet.to_io(io)
+      io.size.should eq packet.bytesize # what's counted as sent is what's written
+
       io.rewind
       len = io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
       LavinMQ::Clustering::ControlPacket.from_str(io.read_string(len))
-        .should be_a LavinMQ::Clustering::SyncControlPacket
+        .as(LavinMQ::Clustering::SyncControlPacket).path.should eq "vhost_dir/msgs.0000001"
       io.read_bytes(Int64, IO::ByteFormat::LittleEndian).should eq 0 # empty body
     end
   end

--- a/spec/clustering/control_packet_spec.cr
+++ b/spec/clustering/control_packet_spec.cr
@@ -3,6 +3,22 @@ require "../../src/lavinmq/clustering/control_packet"
 
 module ControlPacketSpec
   describe LavinMQ::Clustering::ControlPacket do
+    # Answers "is this an instruction?" where .from_str answers "which one?" —
+    # so a record only a newer leader knows is still recognised as a control
+    # record, rather than read as a delete of its path.
+    describe ".control?" do
+      it "is true for any $ctrl/ record, known or not" do
+        LavinMQ::Clustering::ControlPacket
+          .control?(LavinMQ::Clustering::SyncControlPacket::PATH).should be_true
+        LavinMQ::Clustering::ControlPacket
+          .control?("#{LavinMQ::Clustering::ControlPacket::PREFIX}from_the_future").should be_true
+      end
+
+      it "is false for a replicated file path" do
+        LavinMQ::Clustering::ControlPacket.control?("queue_dir/msgs.0000001").should be_false
+      end
+    end
+
     describe ".from_str" do
       it "returns the packet a record's path stands for" do
         LavinMQ::Clustering::ControlPacket.from_str(LavinMQ::Clustering::SyncControlPacket::PATH)
@@ -13,7 +29,7 @@ module ControlPacketSpec
       # so the stream stays aligned (see Client#control).
       it "returns nil for an unknown instruction" do
         LavinMQ::Clustering::ControlPacket
-          .from_str("#{LavinMQ::Clustering::CONTROL_PREFIX}from_the_future").should be_nil
+          .from_str("#{LavinMQ::Clustering::ControlPacket::PREFIX}from_the_future").should be_nil
       end
     end
 

--- a/spec/clustering/control_packet_spec.cr
+++ b/spec/clustering/control_packet_spec.cr
@@ -1,0 +1,32 @@
+require "../spec_helper"
+require "../../src/lavinmq/clustering/control_packet"
+
+module ControlPacketSpec
+  describe LavinMQ::Clustering::ControlPacket do
+    describe ".from_str" do
+      it "returns the packet a record's path stands for" do
+        LavinMQ::Clustering::ControlPacket.from_str(LavinMQ::Clustering::SYNC_CONTROL_PATH)
+          .should be_a LavinMQ::Clustering::SyncControlPacket
+      end
+
+      # A newer leader's instruction: the follower skips it rather than dying,
+      # so the stream stays aligned (see Client#control).
+      it "returns nil for an unknown instruction" do
+        LavinMQ::Clustering::ControlPacket
+          .from_str("#{LavinMQ::Clustering::CONTROL_PREFIX}from_the_future").should be_nil
+      end
+    end
+
+    # Both sides of the wire agree on the path because they share the packet:
+    # what the leader writes is what the follower parses back.
+    it "parses back the record it writes" do
+      io = IO::Memory.new
+      LavinMQ::Clustering::SyncControlPacket.new.to_io(io)
+      io.rewind
+      len = io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
+      LavinMQ::Clustering::ControlPacket.from_str(io.read_string(len))
+        .should be_a LavinMQ::Clustering::SyncControlPacket
+      io.read_bytes(Int64, IO::ByteFormat::LittleEndian).should eq 0 # empty body
+    end
+  end
+end

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -689,8 +689,11 @@ module FollowerSpec
         spawn { follower.ack_loop }
 
         follower.request_sync
-        # flush_loop counts the record as it writes it
-        wait_for { follower.lag_in_bytes == record_size }
+        # Counted before request_sync returns, not when flush_loop writes it:
+        # wait_for_confirm snapshots @sent_bytes, so a record counted later
+        # could be missing from the snapshot and the fence skipped — the
+        # follower would be confirmed against bytes it never persisted.
+        follower.lag_in_bytes.should eq record_size
 
         confirmed = Channel(Bool).new(1)
         spawn { confirmed.send follower.wait_for_confirm }

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -13,7 +13,7 @@ end
 # What Clustering::Server#request_sync queues: the record, then the flush that
 # puts it on the socket and releases `wg`.
 private def request_sync(follower, wg : WaitGroup)
-  follower.control LavinMQ::Clustering::SyncControlPacket.new
+  follower.control LavinMQ::Clustering::SyncPacket.new
   follower.control LavinMQ::Clustering::FlushPacket.new(wg)
 end
 
@@ -648,7 +648,7 @@ module FollowerSpec
   end
 
   describe "#control" do
-    packet_size = LavinMQ::Clustering::SyncControlPacket.new.bytesize
+    packet_size = LavinMQ::Clustering::SyncPacket.new.bytesize
 
     it "sends a sync record with an empty body, without waiting for the ack-loop fallback flush" do
       with_datadir do |data_dir|
@@ -672,7 +672,7 @@ module FollowerSpec
         # Must arrive via control_loop, well before ack_loop's 100ms fallback
         select
         when record = received.receive
-          record.should eq({LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s, 0i64})
+          record.should eq({LavinMQ::Clustering::SyncPacket::SYMBOL.to_s, 0i64})
         when timeout(50.milliseconds)
           fail "the packet's record was not flushed to the follower"
         end
@@ -703,7 +703,7 @@ module FollowerSpec
           # socket closed at spec end
         end
 
-        follower.control LavinMQ::Clustering::SyncControlPacket.new
+        follower.control LavinMQ::Clustering::SyncPacket.new
         # Written and counted, but not pushed: well inside ack_loop's 100ms
         # fallback flush, the follower must have seen nothing.
         select
@@ -719,7 +719,7 @@ module FollowerSpec
 
         select
         when filename = received.receive
-          filename.should eq LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
+          filename.should eq LavinMQ::Clustering::SyncPacket::SYMBOL.to_s
         when timeout(50.milliseconds)
           fail "the flush packet did not push the record to the follower"
         end
@@ -855,7 +855,7 @@ module FollowerSpec
 
         select
         when filename = received.receive
-          filename.should eq LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
+          filename.should eq LavinMQ::Clustering::SyncPacket::SYMBOL.to_s
         when timeout(500.milliseconds)
           fail "the sync record never reached the wire"
         end
@@ -906,7 +906,7 @@ module FollowerSpec
         2.times do
           select
           when filename = records.receive
-            filename.should eq LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
+            filename.should eq LavinMQ::Clustering::SyncPacket::SYMBOL.to_s
           when timeout(500.milliseconds)
             fail "a packet did not get a record of its own"
           end

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -648,9 +648,9 @@ module FollowerSpec
   end
 
   describe "#control" do
-    packet_size = LavinMQ::Clustering::SyncControlPacket::RECORD.bytesize.to_i64
+    packet_size = LavinMQ::Clustering::SyncControlPacket.new.bytesize
 
-    it "sends a $ctrl/sync record with an empty body, without waiting for the ack-loop fallback flush" do
+    it "sends a sync record with an empty body, without waiting for the ack-loop fallback flush" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
@@ -672,7 +672,7 @@ module FollowerSpec
         # Must arrive via control_loop, well before ack_loop's 100ms fallback
         select
         when record = received.receive
-          record.should eq({LavinMQ::Clustering::SyncControlPacket::PATH, 0i64})
+          record.should eq({LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s, 0i64})
         when timeout(50.milliseconds)
           fail "the packet's record was not flushed to the follower"
         end
@@ -719,7 +719,7 @@ module FollowerSpec
 
         select
         when filename = received.receive
-          filename.should eq LavinMQ::Clustering::SyncControlPacket::PATH
+          filename.should eq LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
         when timeout(50.milliseconds)
           fail "the flush packet did not push the record to the follower"
         end
@@ -855,7 +855,7 @@ module FollowerSpec
 
         select
         when filename = received.receive
-          filename.should eq LavinMQ::Clustering::SyncControlPacket::PATH
+          filename.should eq LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
         when timeout(500.milliseconds)
           fail "the sync record never reached the wire"
         end
@@ -906,7 +906,7 @@ module FollowerSpec
         2.times do
           select
           when filename = records.receive
-            filename.should eq LavinMQ::Clustering::SyncControlPacket::PATH
+            filename.should eq LavinMQ::Clustering::SyncControlPacket::SYMBOL.to_s
           when timeout(500.milliseconds)
             fail "a packet did not get a record of its own"
           end

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -648,7 +648,7 @@ module FollowerSpec
   end
 
   describe "#control" do
-    packet_size = LavinMQ::Clustering::SyncControlPacket::PACKET.bytesize.to_i64
+    packet_size = LavinMQ::Clustering::SyncControlPacket::RECORD.bytesize.to_i64
 
     it "sends a $ctrl/sync record with an empty body, without waiting for the ack-loop fallback flush" do
       with_datadir do |data_dir|
@@ -672,7 +672,7 @@ module FollowerSpec
         # Must arrive via control_loop, well before ack_loop's 100ms fallback
         select
         when record = received.receive
-          record.should eq({LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64})
+          record.should eq({LavinMQ::Clustering::SyncControlPacket::PATH, 0i64})
         when timeout(50.milliseconds)
           fail "the packet's record was not flushed to the follower"
         end
@@ -719,7 +719,7 @@ module FollowerSpec
 
         select
         when filename = received.receive
-          filename.should eq LavinMQ::Clustering::SYNC_CONTROL_PATH
+          filename.should eq LavinMQ::Clustering::SyncControlPacket::PATH
         when timeout(50.milliseconds)
           fail "the flush packet did not push the record to the follower"
         end
@@ -855,7 +855,7 @@ module FollowerSpec
 
         select
         when filename = received.receive
-          filename.should eq LavinMQ::Clustering::SYNC_CONTROL_PATH
+          filename.should eq LavinMQ::Clustering::SyncControlPacket::PATH
         when timeout(500.milliseconds)
           fail "the sync record never reached the wire"
         end
@@ -906,7 +906,7 @@ module FollowerSpec
         2.times do
           select
           when filename = records.receive
-            filename.should eq LavinMQ::Clustering::SYNC_CONTROL_PATH
+            filename.should eq LavinMQ::Clustering::SyncControlPacket::PATH
           when timeout(500.milliseconds)
             fail "a packet did not get a record of its own"
           end

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -640,6 +640,128 @@ module FollowerSpec
     end
   end
 
+  describe "#request_sync" do
+    it "sends a $ctrl/sync record with an empty body, without waiting for the ack-loop fallback flush" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        spawn { follower.ack_loop }
+
+        received = Channel({String, Int64}).new(1)
+        spawn do
+          client_lz4 = Compress::LZ4::Reader.new(client_socket)
+          filename = read_filename(client_lz4)
+          received.send({filename, read_data_size(client_lz4)})
+        rescue IO::Error
+          # socket closed at spec end
+        end
+
+        follower.request_sync
+
+        # Must arrive via flush_loop, well before ack_loop's 100ms fallback
+        select
+        when record = received.receive
+          record.should eq({LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64})
+        when timeout(50.milliseconds)
+          fail "request_sync did not flush the sync record to the follower"
+        end
+
+        # The control path is not a file; nothing may be created for it
+        Dir.exists?(File.join(data_dir, "$ctrl")).should be_false
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # The whole point of the record: waiting for its ack is what makes an ack
+    # mean "persisted" rather than just "received".
+    it "counts the sync record as sent, so wait_for_confirm waits for its ack" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        record_size = LavinMQ::Clustering::Follower::SYNC_CONTROL_PACKET.bytesize.to_i64
+
+        spawn { follower.ack_loop }
+
+        follower.request_sync
+        # flush_loop counts the record as it writes it
+        wait_for { follower.lag_in_bytes == record_size }
+
+        confirmed = Channel(Bool).new(1)
+        spawn { confirmed.send follower.wait_for_confirm }
+        select
+        when confirmed.receive
+          fail "wait_for_confirm returned before the follower acked the sync"
+        when timeout(100.milliseconds)
+        end
+
+        client_socket.write_bytes record_size, IO::ByteFormat::LittleEndian
+        select
+        when ok = confirmed.receive
+          ok.should be_true
+        when timeout(1.second)
+          fail "wait_for_confirm did not return after the sync was acked"
+        end
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # The record shares the flush channel's single slot with plain flush
+    # requests. Dropping it when that slot is taken would silently skip the
+    # fence: nothing tells the follower to sync, yet the confirm goes out.
+    it "does not drop the record when a flush request is already pending" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        # No ack_loop yet, so nothing drains the channel: this takes the slot.
+        follower.request_flush
+
+        requested = Channel(Nil).new(1)
+        spawn do
+          follower.request_sync
+          requested.send nil
+        end
+
+        received = Channel(String).new(1)
+        spawn do
+          client_lz4 = Compress::LZ4::Reader.new(client_socket)
+          filename = read_filename(client_lz4)
+          read_data_size(client_lz4)
+          received.send filename
+        rescue IO::Error
+          # socket closed at spec end
+        end
+
+        spawn { follower.ack_loop }
+
+        select
+        when filename = received.receive
+          filename.should eq LavinMQ::Clustering::SYNC_CONTROL_PATH
+        when timeout(500.milliseconds)
+          fail "the sync record never reached the wire"
+        end
+        select
+        when requested.receive
+        when timeout(500.milliseconds)
+          fail "request_sync never returned"
+        end
+        follower.lag_in_bytes.should eq LavinMQ::Clustering::Follower::SYNC_CONTROL_PACKET.bytesize
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+  end
+
   describe "#close" do
     # Regression: a follower whose join failed after mark_synced! (e.g. the
     # ISR commit raised) never runs ack_loop, so ack_loop's ensure never

--- a/spec/clustering/follower_spec.cr
+++ b/spec/clustering/follower_spec.cr
@@ -10,6 +10,13 @@ private def read_data_size(io) : Int64
   io.read_bytes Int64, IO::ByteFormat::LittleEndian
 end
 
+# What Clustering::Server#request_sync queues: the record, then the flush that
+# puts it on the socket and releases `wg`.
+private def request_sync(follower, wg : WaitGroup)
+  follower.control LavinMQ::Clustering::SyncControlPacket.new
+  follower.control LavinMQ::Clustering::FlushPacket.new(wg)
+end
+
 module FollowerSpec
   # FakeFileIndex and FakeSocket live in spec/support/fake_follower.cr so the
   # clustering server spec can reuse them.
@@ -597,10 +604,10 @@ module FollowerSpec
   end
 
   describe "#request_flush" do
-    # Regression: @flush_requested was a Channel(Nil), and receive? returns
-    # nil both for a delivered message and for a closed channel, so
-    # flush_loop exited on the first request without ever flushing — every
-    # confirm then waited for ack_loop's 100ms fallback flush instead.
+    # Regression: the control queue was a Channel(Nil), and receive? returns
+    # nil both for a delivered message and for a closed channel, so the loop
+    # exited on the first request without ever flushing — every confirm then
+    # waited for ack_loop's 100ms fallback flush instead.
     it "pushes buffered bytes to the follower without waiting for the ack-loop fallback flush" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
@@ -626,7 +633,7 @@ module FollowerSpec
         end
 
         follower.request_flush
-        # Must arrive via flush_loop, well before ack_loop's 100ms fallback
+        # Must arrive via control_loop, well before ack_loop's 100ms fallback
         select
         when payload = received.receive
           payload.should eq "hello world"
@@ -640,7 +647,9 @@ module FollowerSpec
     end
   end
 
-  describe "#request_sync" do
+  describe "#control" do
+    packet_size = LavinMQ::Clustering::SyncControlPacket::PACKET.bytesize.to_i64
+
     it "sends a $ctrl/sync record with an empty body, without waiting for the ack-loop fallback flush" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
@@ -658,14 +667,14 @@ module FollowerSpec
           # socket closed at spec end
         end
 
-        follower.request_sync
+        request_sync follower, WaitGroup.new
 
-        # Must arrive via flush_loop, well before ack_loop's 100ms fallback
+        # Must arrive via control_loop, well before ack_loop's 100ms fallback
         select
         when record = received.receive
           record.should eq({LavinMQ::Clustering::SYNC_CONTROL_PATH, 0i64})
         when timeout(50.milliseconds)
-          fail "request_sync did not flush the sync record to the follower"
+          fail "the packet's record was not flushed to the follower"
         end
 
         # The control path is not a file; nothing may be created for it
@@ -676,39 +685,43 @@ module FollowerSpec
       end
     end
 
-    # The whole point of the record: waiting for its ack is what makes an ack
-    # mean "persisted" rather than just "received".
-    it "counts the sync record as sent, so wait_for_confirm waits for its ack" do
+    # What makes the flush packet worth waiting for: nothing else pushes the
+    # record out, so a waiter it releases knows the record is on the socket.
+    it "leaves the record in the compressor until a flush packet follows it" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        record_size = LavinMQ::Clustering::Follower::SYNC_CONTROL_PACKET.bytesize.to_i64
-
         spawn { follower.ack_loop }
 
-        follower.request_sync
-        # Counted before request_sync returns, not when flush_loop writes it:
-        # wait_for_confirm snapshots @sent_bytes, so a record counted later
-        # could be missing from the snapshot and the fence skipped — the
-        # follower would be confirmed against bytes it never persisted.
-        follower.lag_in_bytes.should eq record_size
-
-        confirmed = Channel(Bool).new(1)
-        spawn { confirmed.send follower.wait_for_confirm }
-        select
-        when confirmed.receive
-          fail "wait_for_confirm returned before the follower acked the sync"
-        when timeout(100.milliseconds)
+        received = Channel(String).new(1)
+        spawn do
+          client_lz4 = Compress::LZ4::Reader.new(client_socket)
+          received.send read_filename(client_lz4)
+        rescue IO::Error
+          # socket closed at spec end
         end
 
-        client_socket.write_bytes record_size, IO::ByteFormat::LittleEndian
+        follower.control LavinMQ::Clustering::SyncControlPacket.new
+        # Written and counted, but not pushed: well inside ack_loop's 100ms
+        # fallback flush, the follower must have seen nothing.
         select
-        when ok = confirmed.receive
-          ok.should be_true
-        when timeout(1.second)
-          fail "wait_for_confirm did not return after the sync was acked"
+        when filename = received.receive
+          fail "the record reached the wire without a flush packet: #{filename}"
+        when timeout(50.milliseconds)
+        end
+        follower.lag_in_bytes.should eq packet_size
+
+        wg = WaitGroup.new
+        follower.control LavinMQ::Clustering::FlushPacket.new(wg)
+        wg.wait # released once the flush has run, so the record is out
+
+        select
+        when filename = received.receive
+          filename.should eq LavinMQ::Clustering::SYNC_CONTROL_PATH
+        when timeout(50.milliseconds)
+          fail "the flush packet did not push the record to the follower"
         end
       ensure
         follower_socket.try &.close
@@ -716,23 +729,117 @@ module FollowerSpec
       end
     end
 
-    # The record shares the flush channel's single slot with plain flush
-    # requests. Dropping it when that slot is taken would silently skip the
-    # fence: nothing tells the follower to sync, yet the confirm goes out.
-    it "does not drop the record when a flush request is already pending" do
+    # The invariant the fence rests on: a byte count is only a position in the
+    # stream if every record is counted where it is written. Counting one when
+    # it's *requested* puts it in the total ahead of appends that reach the wire
+    # first, and those appends alone can then satisfy wait_for_confirm's target.
+    it "counts the record only once written, not when requested" do
       with_datadir do |data_dir|
         follower_socket, client_socket = FakeSocket.pair
         file_index = FakeFileIndex.new(data_dir)
         follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
 
-        # No ack_loop yet, so nothing drains the channel: this takes the slot.
-        follower.request_flush
-
-        requested = Channel(Nil).new(1)
         spawn do
-          follower.request_sync
-          requested.send nil
+          client_lz4 = Compress::LZ4::Reader.new(client_socket)
+          loop do
+            read_filename(client_lz4)
+            read_data_size(client_lz4)
+          end
+        rescue IO::Error
+          # socket closed at spec end
         end
+
+        # No ack_loop yet, so there is no control_loop to write the packet.
+        wg = WaitGroup.new
+        request_sync follower, wg
+        follower.lag_in_bytes.should eq 0
+
+        written = Channel(Nil).new(1)
+        spawn do
+          wg.wait
+          written.send nil
+        end
+
+        spawn { follower.ack_loop }
+
+        select
+        when written.receive
+        when timeout(500.milliseconds)
+          fail "the packet's waiter was not released after it was written"
+        end
+        follower.lag_in_bytes.should eq packet_size
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # Consequence of counting at the write: the record's bytes sit after
+    # everything written before it, so acking those can't satisfy a target
+    # taken once the record is out.
+    it "is not satisfied by acks for bytes written before the record" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        spawn do
+          client_lz4 = Compress::LZ4::Reader.new(client_socket)
+          loop do
+            read_filename(client_lz4)
+            size = read_data_size(client_lz4)
+            client_lz4.skip(size.abs)
+          end
+        rescue IO::Error
+          # socket closed at spec end
+        end
+
+        # Written (and counted) before the packet, which is still queued.
+        append_size = follower.append("#{data_dir}/file", Bytes.new(1024))
+        append_size.should be > packet_size # or the ack below couldn't overshoot
+
+        wg = WaitGroup.new
+        request_sync follower, wg
+        spawn { follower.ack_loop }
+        wg.wait
+
+        confirmed = Channel(Bool).new(1)
+        spawn { confirmed.send follower.wait_for_confirm }
+
+        client_socket.write_bytes append_size, IO::ByteFormat::LittleEndian
+        select
+        when confirmed.receive
+          fail "wait_for_confirm was satisfied by the append written before the record"
+        when timeout(100.milliseconds)
+        end
+
+        client_socket.write_bytes packet_size, IO::ByteFormat::LittleEndian
+        select
+        when ok = confirmed.receive
+          ok.should be_true
+        when timeout(1.second)
+          fail "wait_for_confirm did not return after the record was acked"
+        end
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # A full queue may drop a plain flush request — the packets in it flush
+    # those bytes anyway. It may not drop a packet: nothing would tell the
+    # follower to sync, yet the confirm would go out.
+    it "does not drop the packet when the control queue is full" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        # No ack_loop yet, so nothing drains the queue: these take every slot.
+        LavinMQ::Clustering::Follower::CONTROL_QUEUE_CAPACITY.times { follower.request_flush }
+
+        wg = WaitGroup.new
+        spawn { request_sync follower, wg }
 
         received = Channel(String).new(1)
         spawn do
@@ -752,12 +859,153 @@ module FollowerSpec
         when timeout(500.milliseconds)
           fail "the sync record never reached the wire"
         end
-        select
-        when requested.receive
-        when timeout(500.milliseconds)
-          fail "request_sync never returned"
+        follower.lag_in_bytes.should eq packet_size
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # Every packet gets its own record, so a second request can't be satisfied
+    # by a record already on the wire.
+    it "writes a record per packet, counting each one" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        records = Channel(String).new(2)
+        spawn do
+          client_lz4 = Compress::LZ4::Reader.new(client_socket)
+          loop do
+            filename = read_filename(client_lz4)
+            read_data_size(client_lz4)
+            records.send filename
+          end
+        rescue IO::Error
+          # socket closed at spec end
         end
-        follower.lag_in_bytes.should eq LavinMQ::Clustering::Follower::SYNC_CONTROL_PACKET.bytesize
+
+        spawn { follower.ack_loop }
+
+        wg = WaitGroup.new
+        2.times { request_sync follower, wg }
+
+        written = Channel(Nil).new(1)
+        spawn do
+          wg.wait
+          written.send nil
+        end
+
+        select
+        when written.receive
+        when timeout(500.milliseconds)
+          fail "not every packet released its waiter"
+        end
+
+        2.times do
+          select
+          when filename = records.receive
+            filename.should eq LavinMQ::Clustering::SYNC_CONTROL_PATH
+          when timeout(500.milliseconds)
+            fail "a packet did not get a record of its own"
+          end
+        end
+        follower.lag_in_bytes.should eq packet_size * 2
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # A waiter is released per follower, so one that will never write the packet
+    # has to say so — or the publish confirm loop blocks on it forever.
+    it "releases the waiter of a packet queued for a dead follower" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        follower.close
+        follower.dead?.should be_true
+
+        wg = WaitGroup.new
+        request_sync follower, wg
+
+        released = Channel(Nil).new(1)
+        spawn do
+          wg.wait
+          released.send nil
+        end
+        select
+        when released.receive
+        when timeout(500.milliseconds)
+          fail "a packet queued for a dead follower never released its waiter"
+        end
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    it "releases the waiters of packets still queued when the follower is closed" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        # Queued while there is no control_loop to carry it out, then released
+        # by close's drain rather than by a write.
+        wg = WaitGroup.new
+        request_sync follower, wg
+
+        released = Channel(Nil).new(1)
+        spawn do
+          wg.wait
+          released.send nil
+        end
+
+        follower.close
+
+        select
+        when released.receive
+        when timeout(500.milliseconds)
+          fail "closing the follower stranded a queued packet's waiter"
+        end
+      ensure
+        follower_socket.try &.close
+        client_socket.try &.close
+      end
+    end
+
+    # Once the follower is closed no control_loop will free a slot, so a packet
+    # waiting for one has to fail — and fail released, not stranded.
+    it "releases the waiter of a packet still waiting for a slot when the follower is closed" do
+      with_datadir do |data_dir|
+        follower_socket, client_socket = FakeSocket.pair
+        file_index = FakeFileIndex.new(data_dir)
+        follower = LavinMQ::Clustering::Follower.new(follower_socket, data_dir, file_index)
+
+        # No ack_loop, so nothing drains the queue: these take every slot and
+        # the packet below has to wait for one.
+        LavinMQ::Clustering::Follower::CONTROL_QUEUE_CAPACITY.times { follower.request_flush }
+
+        wg = WaitGroup.new
+        released = Channel(Nil).new(1)
+        spawn do
+          request_sync follower, wg
+          wg.wait
+          released.send nil
+        end
+        sleep 50.milliseconds # let the sender block on the full queue
+
+        follower.close
+
+        select
+        when released.receive
+        when timeout(500.milliseconds)
+          fail "closing the follower stranded a packet blocked on the channel"
+        end
       ensure
         follower_socket.try &.close
         client_socket.try &.close

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -65,6 +65,38 @@ private def sync_follower_with_stream(server, port, id : Int32) : {TCPSocket, Co
   {io, lz4}
 end
 
+# Acks every replicated record like a real follower — the leader's durable
+# operations block until it does — and counts the $ctrl/sync records it saw.
+# The count is bumped before the ack is written, so once a leader operation has
+# returned, the records it fenced on are already counted here: specs can assert
+# on #syncs without waiting.
+private class AckingFollower
+  @syncs = Atomic(Int32).new(0)
+
+  def initialize(@io : TCPSocket, @lz4 : Compress::LZ4::Reader)
+    spawn(name: "isr acking follower") { read_loop }
+  end
+
+  def syncs : Int32
+    @syncs.get
+  end
+
+  private def read_loop : Nil
+    loop do
+      filename_len = @lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
+      next if filename_len.zero?
+      filename = @lz4.read_string(filename_len)
+      len = @lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
+      @lz4.skip(len.abs) unless len.zero?
+      @syncs.add(1) if filename == LavinMQ::Clustering::SYNC_CONTROL_PATH
+      acked = (sizeof(Int32) + filename_len + sizeof(Int64) + len.abs).to_i64
+      @io.write_bytes acked, IO::ByteFormat::LittleEndian
+    end
+  rescue IO::Error
+    # socket closed at spec end
+  end
+end
+
 describe LavinMQ::Clustering::Server do
   describe "ISR maintenance on follower disconnect" do
     it "removes a follower that was behind from the ISR immediately, before the next write" do
@@ -309,34 +341,53 @@ describe LavinMQ::Clustering::Server do
           client_io = io
           wait_for { server.followers.any? &.id.== follower_id }
 
-          # Ack like a real follower (the declare and confirm below wait for it)
-          # and report the sync requests.
-          sync_requested = Channel(Nil).new(1)
-          spawn(name: "isr sync request follower") do
-            loop do
-              filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
-              next if filename_len.zero?
-              filename = lz4.read_string(filename_len)
-              len = lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
-              lz4.skip(len.abs) unless len.zero?
-              acked = (sizeof(Int32) + filename_len + sizeof(Int64) + len.abs).to_i64
-              io.write_bytes acked, IO::ByteFormat::LittleEndian
-              sync_requested.try_send(nil) if filename == LavinMQ::Clustering::SYNC_CONTROL_PATH
-            end
-          rescue IO::Error
-            # socket closed at spec end
-          end
+          follower = AckingFollower.new(io, lz4)
 
+          # The declare fences too, so count only what the publish adds.
           q = ch.queue("isr_sync_request", durable: true)
+          before = follower.syncs
+
           q.publish_confirm("m", props: AMQP::Client::Properties.new(delivery_mode: 2_u8)).should be_true
 
-          # The confirm waited for every sent byte to be acked, the sync
-          # request included, so it has arrived by now.
-          select
-          when sync_requested.receive
-          when timeout(2.seconds)
-            fail "the publish confirm never asked the follower to persist"
-          end
+          # The confirm waited for every sent byte to be acked, the sync record
+          # included, so the follower has necessarily counted it by now.
+          (follower.syncs - before).should be > 0
+        end
+      end
+    ensure
+      client_io.try &.close
+      server.try &.close
+      tcp_server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+
+    # A durable definition change is acknowledged (Declare-Ok) once its frame is
+    # fsynced locally and acked by every in-sync follower — and an ack only
+    # means persisted if a sync record precedes it, exactly like a publish
+    # confirm. Without the request the Declare-Ok would go out while the
+    # follower holds the frame in its page cache only.
+    it "asks in-sync followers to persist a durable declare before acknowledging it" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      coordinator = SpyCoordinator.new
+      server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, coordinator, 0)
+      tcp_server = TCPServer.new("localhost", 0)
+      spawn(server.listen(tcp_server), name: "isr declare sync request spec")
+
+      follower_id = 12
+      client_io = nil.as(TCPSocket?)
+      with_amqp_server(replicator: server) do |s|
+        with_channel(s) do |ch|
+          io, lz4 = sync_follower_with_stream(server, tcp_server.local_address.port, follower_id)
+          client_io = io
+          wait_for { server.followers.any? &.id.== follower_id }
+
+          follower = AckingFollower.new(io, lz4)
+          ch.queue("isr_declare_sync_request", durable: true)
+
+          # The declare waited for every sent byte to be acked, the sync record
+          # included, so the follower has necessarily counted it by now.
+          follower.syncs.should be > 0
         end
       end
     ensure

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -36,6 +36,13 @@ end
 # Drives the clustering handshake + two full-sync passes (requesting no files)
 # so the follower reaches the Synced state on the leader.
 private def sync_follower(server, port, id : Int32) : TCPSocket
+  sync_follower_with_stream(server, port, id).first
+end
+
+# As sync_follower, but also returns the LZ4 reader, positioned at the start of
+# the change stream: the leader keeps one LZ4 frame per connection, so a spec
+# reading replicated records must keep using this reader.
+private def sync_follower_with_stream(server, port, id : Int32) : {TCPSocket, Compress::LZ4::Reader}
   io = TCPSocket.new("localhost", port)
   io.write LavinMQ::Clustering::Start
   io.write_bytes server.password.bytesize.to_u8, IO::ByteFormat::LittleEndian
@@ -55,7 +62,7 @@ private def sync_follower(server, port, id : Int32) : TCPSocket
     io.write_bytes 0i32 # request no files
     io.flush
   end
-  io
+  {io, lz4}
 end
 
 describe LavinMQ::Clustering::Server do
@@ -284,6 +291,61 @@ describe LavinMQ::Clustering::Server do
   end
 
   describe "publish confirms against the ISR" do
+    # An append alone doesn't tell the follower the leader is fencing confirms
+    # on it, so the confirm loop says so with a $ctrl/sync record.
+    it "asks in-sync followers to persist replicated data before confirming a publish" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      coordinator = SpyCoordinator.new
+      server = LavinMQ::Clustering::Server.new(LavinMQ::Config.instance, coordinator, 0)
+      tcp_server = TCPServer.new("localhost", 0)
+      spawn(server.listen(tcp_server), name: "isr sync request spec")
+
+      follower_id = 11
+      client_io = nil.as(TCPSocket?)
+      with_amqp_server(replicator: server) do |s|
+        with_channel(s) do |ch|
+          io, lz4 = sync_follower_with_stream(server, tcp_server.local_address.port, follower_id)
+          client_io = io
+          wait_for { server.followers.any? &.id.== follower_id }
+
+          # Ack like a real follower (the declare and confirm below wait for it)
+          # and report the sync requests.
+          sync_requested = Channel(Nil).new(1)
+          spawn(name: "isr sync request follower") do
+            loop do
+              filename_len = lz4.read_bytes Int32, IO::ByteFormat::LittleEndian
+              next if filename_len.zero?
+              filename = lz4.read_string(filename_len)
+              len = lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
+              lz4.skip(len.abs) unless len.zero?
+              acked = (sizeof(Int32) + filename_len + sizeof(Int64) + len.abs).to_i64
+              io.write_bytes acked, IO::ByteFormat::LittleEndian
+              sync_requested.try_send(nil) if filename == LavinMQ::Clustering::SYNC_CONTROL_PATH
+            end
+          rescue IO::Error
+            # socket closed at spec end
+          end
+
+          q = ch.queue("isr_sync_request", durable: true)
+          q.publish_confirm("m", props: AMQP::Client::Properties.new(delivery_mode: 2_u8)).should be_true
+
+          # The confirm waited for every sent byte to be acked, the sync
+          # request included, so it has arrived by now.
+          select
+          when sync_requested.receive
+          when timeout(2.seconds)
+            fail "the publish confirm never asked the follower to persist"
+          end
+        end
+      end
+    ensure
+      client_io.try &.close
+      server.try &.close
+      tcp_server.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+
     it "flushes a dirty ISR before delivering a publish confirm" do
       data_dir = LavinMQ::Config.instance.data_dir
       Dir.mkdir_p(data_dir)

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -87,7 +87,7 @@ private class AckingFollower
       filename = @lz4.read_string(filename_len)
       len = @lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
       @lz4.skip(len.abs) unless len.zero?
-      @syncs.add(1) if filename == LavinMQ::Clustering::SYNC_CONTROL_PATH
+      @syncs.add(1) if filename == LavinMQ::Clustering::SyncControlPacket::PATH
       acked = (sizeof(Int32) + filename_len + sizeof(Int64) + len.abs).to_i64
       @io.write_bytes acked, IO::ByteFormat::LittleEndian
     end

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -87,7 +87,7 @@ private class AckingFollower
       filename = @lz4.read_string(filename_len)
       len = @lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
       @lz4.skip(len.abs) unless len.zero?
-      @syncs.add(1) if filename.starts_with?(LavinMQ::Clustering::SyncControlPacket::SYMBOL)
+      @syncs.add(1) if filename.starts_with?(LavinMQ::Clustering::SyncPacket::SYMBOL)
       acked = (sizeof(Int32) + filename_len + sizeof(Int64) + len.abs).to_i64
       @io.write_bytes acked, IO::ByteFormat::LittleEndian
     end

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -39,9 +39,9 @@ private def sync_follower(server, port, id : Int32) : TCPSocket
   sync_follower_with_stream(server, port, id).first
 end
 
-# As sync_follower, but also returns the LZ4 reader, positioned at the start of
-# the change stream: the leader keeps one LZ4 frame per connection, so a spec
-# reading replicated records must keep using this reader.
+# As sync_follower, but also returns the LZ4 reader positioned at the start of
+# the change stream. The leader keeps one LZ4 frame per connection, so a spec
+# reading records must keep using this reader.
 private def sync_follower_with_stream(server, port, id : Int32) : {TCPSocket, Compress::LZ4::Reader}
   io = TCPSocket.new("localhost", port)
   io.write LavinMQ::Clustering::Start
@@ -67,9 +67,8 @@ end
 
 # Acks every replicated record like a real follower — the leader's durable
 # operations block until it does — and counts the $ctrl/sync records it saw.
-# The count is bumped before the ack is written, so once a leader operation has
-# returned, the records it fenced on are already counted here: specs can assert
-# on #syncs without waiting.
+# The count is bumped before the ack, so a returned leader operation implies its
+# records are counted here and specs can assert on #syncs without waiting.
 private class AckingFollower
   @syncs = Atomic(Int32).new(0)
 
@@ -349,8 +348,8 @@ describe LavinMQ::Clustering::Server do
 
           q.publish_confirm("m", props: AMQP::Client::Properties.new(delivery_mode: 2_u8)).should be_true
 
-          # The confirm waited for every sent byte to be acked, the sync record
-          # included, so the follower has necessarily counted it by now.
+          # The confirm waited for every sent byte, the sync record included, so
+          # the follower has necessarily counted it by now.
           (follower.syncs - before).should be > 0
         end
       end
@@ -361,11 +360,9 @@ describe LavinMQ::Clustering::Server do
       FileUtils.rm_rf LavinMQ::Config.instance.data_dir
     end
 
-    # A durable definition change is acknowledged (Declare-Ok) once its frame is
-    # fsynced locally and acked by every in-sync follower — and an ack only
-    # means persisted if a sync record precedes it, exactly like a publish
-    # confirm. Without the request the Declare-Ok would go out while the
-    # follower holds the frame in its page cache only.
+    # Like a publish confirm: the Declare-Ok goes out once the frame is fsynced
+    # locally and acked by every in-sync follower, and an ack only means
+    # persisted if a sync record precedes it.
     it "asks in-sync followers to persist a durable declare before acknowledging it" do
       data_dir = LavinMQ::Config.instance.data_dir
       Dir.mkdir_p(data_dir)
@@ -385,8 +382,8 @@ describe LavinMQ::Clustering::Server do
           follower = AckingFollower.new(io, lz4)
           ch.queue("isr_declare_sync_request", durable: true)
 
-          # The declare waited for every sent byte to be acked, the sync record
-          # included, so the follower has necessarily counted it by now.
+          # The declare waited for every sent byte, the sync record included, so
+          # the follower has necessarily counted it by now.
           follower.syncs.should be > 0
         end
       end

--- a/spec/clustering/isr_spec.cr
+++ b/spec/clustering/isr_spec.cr
@@ -66,7 +66,7 @@ private def sync_follower_with_stream(server, port, id : Int32) : {TCPSocket, Co
 end
 
 # Acks every replicated record like a real follower — the leader's durable
-# operations block until it does — and counts the $ctrl/sync records it saw.
+# operations block until it does — and counts the sync records it saw.
 # The count is bumped before the ack, so a returned leader operation implies its
 # records are counted here and specs can assert on #syncs without waiting.
 private class AckingFollower
@@ -87,7 +87,7 @@ private class AckingFollower
       filename = @lz4.read_string(filename_len)
       len = @lz4.read_bytes Int64, IO::ByteFormat::LittleEndian
       @lz4.skip(len.abs) unless len.zero?
-      @syncs.add(1) if filename == LavinMQ::Clustering::SyncControlPacket::PATH
+      @syncs.add(1) if filename.starts_with?(LavinMQ::Clustering::SyncControlPacket::SYMBOL)
       acked = (sizeof(Int32) + filename_len + sizeof(Int64) + len.abs).to_i64
       @io.write_bytes acked, IO::ByteFormat::LittleEndian
     end
@@ -323,7 +323,7 @@ describe LavinMQ::Clustering::Server do
 
   describe "publish confirms against the ISR" do
     # An append alone doesn't tell the follower the leader is fencing confirms
-    # on it, so the confirm loop says so with a $ctrl/sync record.
+    # on it, so the confirm loop says so with a sync record.
     it "asks in-sync followers to persist replicated data before confirming a publish" do
       data_dir = LavinMQ::Config.instance.data_dir
       Dir.mkdir_p(data_dir)

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -102,6 +102,83 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
     end
   end
 
+  describe "#request_flush" do
+    it "pushes buffered bytes to synced followers" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      server = LavinMQ::Clustering::Server.new(
+        LavinMQ::Config.instance,
+        NullCoordinator.new,
+        0)
+      fi = FakeFileIndex.new(data_dir)
+      sock, client = FakeSocket.pair
+      follower = LavinMQ::Clustering::Follower.new(sock, data_dir, fi)
+      follower.mark_synced!
+      server.@followers << follower
+      spawn { follower.ack_loop }
+
+      path = File.join(data_dir, "request_flush_seg")
+      File.write(path, "")
+      server.register_file(path)
+      # Small enough to stay in the LZ4 writer's buffer (auto_flush is off);
+      # only a flush moves it to the socket.
+      server.append_bytes(path, "hello world".to_slice, 0i64)
+
+      server.request_flush
+
+      client.read_timeout = 1.second
+      buf = uninitialized UInt8[256]
+      client.read(buf.to_slice).should be > 0
+    ensure
+      sock.try &.close
+      client.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+  end
+
+  describe "#request_sync" do
+    it "hands the record to synced followers only, releasing the waiter for each" do
+      data_dir = LavinMQ::Config.instance.data_dir
+      Dir.mkdir_p(data_dir)
+      server = LavinMQ::Clustering::Server.new(
+        LavinMQ::Config.instance,
+        NullCoordinator.new,
+        0)
+      fi = FakeFileIndex.new(data_dir)
+      sock_a, client_a = FakeSocket.pair
+      sock_b, client_b = FakeSocket.pair
+      synced = LavinMQ::Clustering::Follower.new(sock_a, data_dir, fi)
+      syncing = LavinMQ::Clustering::Follower.new(sock_b, data_dir, fi)
+      synced.mark_synced!
+      server.@followers << synced << syncing # syncing left in Syncing state
+      spawn { synced.ack_loop }
+
+      wg = WaitGroup.new
+      server.request_sync(wg)
+      # A syncing follower has no control_loop to write the record, so handing
+      # it one would strand the waiter.
+      released = Channel(Nil).new(1)
+      spawn do
+        wg.wait
+        released.send nil
+      end
+      select
+      when released.receive
+      when timeout(2.seconds)
+        fail "request_sync never released the waiter"
+      end
+
+      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncControlPacket::PACKET.bytesize
+      syncing.lag_in_bytes.should eq 0
+    ensure
+      sock_a.try &.close
+      client_a.try &.close
+      sock_b.try &.close
+      client_b.try &.close
+      FileUtils.rm_rf LavinMQ::Config.instance.data_dir
+    end
+  end
+
   describe "#each_follower broken-follower cleanup" do
     it "removes a synced follower whose dispatch raises a socket error" do
       data_dir = LavinMQ::Config.instance.data_dir

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -168,7 +168,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
         fail "request_sync never released the waiter"
       end
 
-      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncControlPacket.new.bytesize
+      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncPacket.new.bytesize
       syncing.lag_in_bytes.should eq 0
     ensure
       sock_a.try &.close

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -168,7 +168,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
         fail "request_sync never released the waiter"
       end
 
-      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncControlPacket::RECORD.bytesize
+      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncControlPacket.new.bytesize
       syncing.lag_in_bytes.should eq 0
     ensure
       sock_a.try &.close

--- a/spec/clustering/server_spec.cr
+++ b/spec/clustering/server_spec.cr
@@ -168,7 +168,7 @@ describe LavinMQ::Clustering::Server, tags: "etcd" do
         fail "request_sync never released the waiter"
       end
 
-      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncControlPacket::PACKET.bytesize
+      synced.lag_in_bytes.should eq LavinMQ::Clustering::SyncControlPacket::RECORD.bytesize
       syncing.lag_in_bytes.should eq 0
     ensure
       sock_a.try &.close

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -81,7 +81,11 @@ class DefinitionsSpyReplicator
   def flush_isr : Nil
   end
 
-  def request_sync : Nil
+  def request_flush : Nil
+    @calls << :request_flush
+  end
+
+  def request_sync(wg : WaitGroup) : Nil
     @calls << :request_sync
   end
 
@@ -120,10 +124,9 @@ describe LavinMQ::DefinitionsStore do
     spy.violations.should be_empty
   end
 
-  # A follower acks bytes it has received, so the wait that gates the client's
-  # Declare-Ok only means "durable on every in-sync follower" if a sync request
-  # went out first. It must also come after the dispatch, or it would fence
-  # everything except the frame being acknowledged.
+  # A follower acks bytes it received, so the wait gating the Declare-Ok only
+  # means durable if a sync request went out first — and after the dispatch, or
+  # it would fence everything except the frame being acknowledged.
   it "fences followers on a durable definition change: dispatch, request sync, then wait" do
     spy = DefinitionsSpyReplicator.new
     with_amqp_server(replicator: spy) do |s|

--- a/spec/definitions_replication_spec.cr
+++ b/spec/definitions_replication_spec.cr
@@ -7,14 +7,22 @@ require "./spec_helper"
 # stream skips everything below the cut — so a frame sitting in a user-space
 # write buffer at dispatch time would be permanently missing on a follower
 # that joins in that window, even though it gets marked synced.
-class DiskVisibilitySpyReplicator
+#
+# Also records the order of the replication calls a definition change makes, for
+# the follower-fence spec below.
+class DefinitionsSpyReplicator
   include LavinMQ::Clustering::Replicator
 
   getter violations = Array(String).new
   getter dispatched_definitions = 0
+  # Definition dispatches and the calls that fence them, in call order.
+  getter calls = Array(Symbol).new
 
   def append_bytes(path : String, bytes : Bytes, offset : Int64)
-    @dispatched_definitions += 1 if path.ends_with?("definitions.amqp")
+    if path.ends_with?("definitions.amqp")
+      @dispatched_definitions += 1
+      @calls << :dispatch
+    end
     File.open(path) do |f|
       if f.size < offset + bytes.bytesize
         @violations << "#{path}: dispatched [#{offset}, #{offset + bytes.bytesize}) but only #{f.size} bytes are on disk"
@@ -73,7 +81,12 @@ class DiskVisibilitySpyReplicator
   def flush_isr : Nil
   end
 
+  def request_sync : Nil
+    @calls << :request_sync
+  end
+
   def wait_for_followers : Nil
+    @calls << :wait_for_followers
   end
 
   def close
@@ -95,7 +108,7 @@ describe LavinMQ::DefinitionsStore do
   # (and the fstat-based offsets they carried) could be invisible on disk
   # until the next flush/fsync — invisible to a concurrent join cut too.
   it "has definition frames on disk before they are dispatched to followers" do
-    spy = DiskVisibilitySpyReplicator.new
+    spy = DefinitionsSpyReplicator.new
     with_amqp_server(replicator: spy) do |s|
       with_channel(s) do |ch|
         q = ch.queue("disk_visibility_q", durable: true)
@@ -105,5 +118,24 @@ describe LavinMQ::DefinitionsStore do
     end
     spy.dispatched_definitions.should be >= 3 # queue + exchange + binding
     spy.violations.should be_empty
+  end
+
+  # A follower acks bytes it has received, so the wait that gates the client's
+  # Declare-Ok only means "durable on every in-sync follower" if a sync request
+  # went out first. It must also come after the dispatch, or it would fence
+  # everything except the frame being acknowledged.
+  it "fences followers on a durable definition change: dispatch, request sync, then wait" do
+    spy = DefinitionsSpyReplicator.new
+    with_amqp_server(replicator: spy) do |s|
+      with_channel(s) do |ch|
+        q = ch.queue("fence_order_q", durable: true)
+        x = ch.exchange("fence_order_x", "topic", durable: true)
+        q.bind(x.name, "rk")
+      end
+    end
+    fences = Array(Array(Symbol)).new
+    spy.calls.each_with_index { |call, i| fences << spy.calls[i, 3] if call == :dispatch }
+    fences.size.should be >= 3 # queue + exchange + binding
+    fences.each &.should eq [:dispatch, :request_sync, :wait_for_followers]
   end
 end

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -63,6 +63,9 @@ class SpyReplicator
   def flush_isr : Nil
   end
 
+  def request_sync : Nil
+  end
+
   def wait_for_followers : Nil
   end
 

--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -63,7 +63,10 @@ class SpyReplicator
   def flush_isr : Nil
   end
 
-  def request_sync : Nil
+  def request_flush : Nil
+  end
+
+  def request_sync(wg : WaitGroup) : Nil
   end
 
   def wait_for_followers : Nil

--- a/spec/support/clustering_helper.cr
+++ b/spec/support/clustering_helper.cr
@@ -47,6 +47,15 @@ module ClusteringSpecHelper
     getter syncs_started = 0
     getter? synced_on_closed_fd = false
 
+    # The client's own counter, i.e. what it reports in its stream stats.
+    def syncfs_calls : UInt64
+      @syncfs_calls
+    end
+
+    def stream_stats_message_public : String
+      stream_stats_message
+    end
+
     # Instrumentation for the log-loop lifecycle spec: how many streamed-bytes
     # logging fibers are currently running.
     getter log_loops_running = 0

--- a/src/lavinmq/clustering.cr
+++ b/src/lavinmq/clustering.cr
@@ -6,6 +6,15 @@ module LavinMQ
   module Clustering
     Start = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 1, 0, 0]
 
+    # Records with this filename prefix carry an instruction for the follower
+    # instead of file data. Reserved: never a real path, so nothing under it is
+    # created on disk or tracked in any file/checksum map.
+    CONTROL_PREFIX = "$ctrl/"
+
+    # Asks the follower to make everything replicated so far durable. Empty
+    # body, hence routed by prefix before the length is interpreted.
+    SYNC_CONTROL_PATH = "#{CONTROL_PREFIX}sync"
+
     class Error < Exception; end
 
     class InvalidStartHeaderError < Error

--- a/src/lavinmq/clustering.cr
+++ b/src/lavinmq/clustering.cr
@@ -6,9 +6,8 @@ module LavinMQ
   module Clustering
     Start = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 1, 0, 0]
 
-    # Records with this filename prefix carry an instruction for the follower
-    # instead of file data. Reserved: never a real path, so nothing under it is
-    # created on disk or tracked in any file/checksum map.
+    # Records with this prefix carry an instruction, not file data. Never a real
+    # path, so nothing under it is created on disk or tracked.
     CONTROL_PREFIX = "$ctrl/"
 
     # Asks the follower to make everything replicated so far durable. Empty

--- a/src/lavinmq/clustering.cr
+++ b/src/lavinmq/clustering.cr
@@ -6,11 +6,6 @@ module LavinMQ
   module Clustering
     Start = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 1, 0, 0]
 
-    # Records with this prefix carry an instruction, not file data. Never a real
-    # path, so nothing under it is created on disk or tracked. Which instruction
-    # is named by the rest of the path — see ControlPacket.from_str.
-    CONTROL_PREFIX = "$ctrl/"
-
     class Error < Exception; end
 
     class InvalidStartHeaderError < Error

--- a/src/lavinmq/clustering.cr
+++ b/src/lavinmq/clustering.cr
@@ -7,12 +7,9 @@ module LavinMQ
     Start = Bytes['R'.ord, 'E'.ord, 'P'.ord, 'L'.ord, 'I'.ord, 1, 0, 0]
 
     # Records with this prefix carry an instruction, not file data. Never a real
-    # path, so nothing under it is created on disk or tracked.
+    # path, so nothing under it is created on disk or tracked. Which instruction
+    # is named by the rest of the path — see ControlPacket.from_str.
     CONTROL_PREFIX = "$ctrl/"
-
-    # Asks the follower to make everything replicated so far durable. Empty
-    # body, hence routed by prefix before the length is interpreted.
-    SYNC_CONTROL_PATH = "#{CONTROL_PREFIX}sync"
 
     class Error < Exception; end
 

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -27,7 +27,7 @@ module LavinMQ
       ACK_BUFFER_CAPACITY = 8192
 
       @data_dir_lock : DataDirLock
-      @closed = false
+      @closed = Atomic(Bool).new(false)
       @amqp_proxy : Proxy?
       @http_proxy : Proxy?
       @mqtt_proxy : Proxy?
@@ -37,6 +37,8 @@ module LavinMQ
       @socket : TCPSocket?
       @internal_http_server : ::HTTP::Server?
       @streamed_bytes = 0_u64
+      # syncfs(2) calls made
+      @syncfs_calls = 0_u64
       # Running SHA1 over each file's whole content, adopted as its checksum when
       # tracking ends. nil when we started seeing the file mid-content, so no
       # digest can cover the bytes already on disk (see #digest_for).
@@ -45,10 +47,12 @@ module LavinMQ
       # Buffers acks from the stream-reading fiber to the ack-sending fiber.
       # Replaced with a fresh channel on each (re)connect in #stream_changes.
       @acks = Channel(Int64).new
-      # Tracks the ack-sending fiber: #close must wait for it to finish before
-      # closing @data_dir_fd, since it may sync (syncfs on that fd) before acks
-      # it sends — even acks still buffered in @acks after the stream ends.
+      # Tracks the ack-sending fiber, so #close lets it drain the acks still
+      # buffered in @acks after the stream ends before it shuts the client down.
       @ack_loops = WaitGroup.new
+      # Tracks control actions in flight, so #close waits for one to finish
+      # before tearing down the state it may touch (see #control).
+      @controls = WaitGroup.new
 
       def initialize(@config : Config, @id : Int32, @password : String, proxy = true)
         System.maximize_fd_limit
@@ -121,7 +125,7 @@ module LavinMQ
         end
         loop do
           hash_local_files
-          return if @closed
+          return if @closed.get
           @socket = socket = TCPSocket.new(host, port)
           socket.sync = true
           socket.read_buffering = false # use lz4 buffering
@@ -132,7 +136,7 @@ module LavinMQ
         rescue ex : IO::Error
           lz4.try &.close
           socket.try &.close
-          break if @closed
+          break if @closed.get
           Log.info { "Disconnected from server #{host}:#{port} (#{ex}), retrying..." }
           sleep 1.seconds
         end
@@ -325,7 +329,7 @@ module LavinMQ
           Log.info { "Calculating checksums for #{files.size} local files" }
           log_limiter = RateLimiter.new(2.seconds)
           files.each do |path|
-            break if @closed
+            break if @closed.get
             filename = relative_path(path)
             next if @checksums[filename]?
             hash_file(filename, path)
@@ -447,6 +451,13 @@ module LavinMQ
           # it tells the leader the deletion is durable — so it's only acked
           # once the deletion has been applied.
           framing = sizeof(Int32) + filename_len + sizeof(Int64)
+          # Routed before the length is interpreted: a control record's empty
+          # body would read as a delete. Acked once handled, like a delete.
+          if filename.starts_with?(CONTROL_PREFIX)
+            control(filename, len, lz4)
+            ack(framing + len.abs)
+            next
+          end
           case len
           when .negative? # append bytes to file
             ack(framing)
@@ -462,6 +473,41 @@ module LavinMQ
       ensure
         @acks.close
         log_loop_done.try &.close
+      end
+
+      # Apply a control record: nothing is written to disk or tracked for its
+      # path. An unknown instruction (a newer leader) is skipped, payload and
+      # all, rather than fatal, so the stream stays aligned.
+      #
+      # Counted in @controls so #close can't tear down the data dir under a
+      # running action. The @closed check sits inside that window: either close
+      # got there first and we skip the action, or we're counted and it waits
+      # for us. Skipping is safe — close has already closed the socket, so the
+      # leader has dropped us from the ISR and no confirm waits on our ack.
+      private def control(command, len, lz4) : Nil
+        @controls.add
+        skip_payload(len, lz4)
+        return if @closed.get
+        case command
+        when SYNC_CONTROL_PATH
+          Log.debug { "Sync requested" }
+          sync_to_disk
+        else
+          Log.warn { "Ignoring unknown control record #{command}" }
+        end
+      ensure
+        @controls.done
+      end
+
+      # Read and discard a record's payload; the caller acks it as a whole.
+      private def skip_payload(len : Int64, lz4) : Nil
+        remaining = len.abs
+        buffer = uninitialized UInt8[BUFFER_SIZE]
+        while remaining > 0
+          read = lz4.read(buffer.to_slice[0, Math.min(BUFFER_SIZE, remaining)])
+          raise IO::EOFError.new if read.zero?
+          remaining -= read
+        end
       end
 
       private def append(filename, len, lz4)
@@ -598,8 +644,8 @@ module LavinMQ
           while ack_bytes2 = acks.try_receive?
             ack_bytes += ack_bytes2
           end
-          sync_to_disk
           socket.write_bytes ack_bytes, IO::ByteFormat::LittleEndian # ack
+          Fiber.yield
         end
       rescue Channel::ClosedError
       rescue IO::Error
@@ -608,8 +654,8 @@ module LavinMQ
 
       # Make all replicated writes durable before acking the leader.
       private def sync_to_disk : Nil
-        return unless @config.sync?
-
+        # We dont need to return here, sync is controlled by leader...?
+        # return unless @config.sync?
         sync_data_dir
       rescue ex
         # Can't ack data that isn't durable; die fast so the leader drops us
@@ -619,6 +665,7 @@ module LavinMQ
       end
 
       private def sync_data_dir : Nil
+        @syncfs_calls &+= 1
         {% if flag?(:linux) %}
           ret = LibC.syncfs(@data_dir_fd)
           raise IO::Error.from_errno("syncfs") if ret != 0
@@ -627,19 +674,20 @@ module LavinMQ
         {% end %}
       end
 
-      # Logs the streamed byte count until #stream_changes closes the done
-      # channel (or the client is closed), so the fiber doesn't outlive the
-      # stream that spawned it.
       private def log_streamed_bytes_loop(done : Channel(Nil))
         loop do
           select
           when done.receive?
             break
-          when timeout(30.seconds)
-            break if @closed
-            Log.info { "Total streamed bytes: #{@streamed_bytes}" }
+          when timeout(5.seconds)
+            break if @closed.get
+            Log.info { stream_stats_message }
           end
         end
+      end
+
+      private def stream_stats_message : String
+        "Total streamed bytes: #{@streamed_bytes}, syncfs calls: #{@syncfs_calls}"
       end
 
       private def authenticate(socket)
@@ -657,8 +705,7 @@ module LavinMQ
       end
 
       def close
-        return if @closed
-        @closed = true
+        return if @closed.swap(true)
         @internal_http_server.try &.close
         @amqp_proxy.try &.close
         @http_proxy.try &.close
@@ -674,14 +721,17 @@ module LavinMQ
         when timeout(5.seconds)
           Log.warn { "Follower loop did not exit within timeout, forcing shutdown" }
         end
-        # The ack loop keeps draining acks buffered in @acks even after the
-        # channel is closed, syncing to disk before each send. Wait for it to
-        # finish before closing @data_dir_fd below, or its syncfs would hit a
-        # closed (or worse, reused) fd and the process would exit 1 mid
-        # shutdown/promotion. Closing @acks is normally done by stream_changes,
-        # but do it here too in case the follower loop is stuck.
+        # Let the ack loop drain the acks buffered in @acks after the stream
+        # ended. Closing @acks is normally done by stream_changes, but do it here
+        # too in case the follower loop is stuck.
         @acks.close
         @ack_loops.wait
+        # Nothing below may run while a control action does: a syncfs would hit a
+        # closed (or worse, reused) @data_dir_fd and the process would exit 1 mid
+        # shutdown/promotion, and the checksums would be stored from under it.
+        # The follower loop's exit above normally covers this; the wait matters
+        # when it timed out instead (see #control).
+        @controls.wait
         # Finalize all pending checksums
         finalize_digests
         @checksums.store

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -2,6 +2,7 @@ require "../data_dir_lock"
 require "../clustering"
 require "../rate_limiter"
 require "./checksums"
+require "./control_packet"
 require "./proxy"
 require "lz4"
 require "http/server"
@@ -493,11 +494,11 @@ module LavinMQ
         return if @closed.get
         @controls.add
         begin
-          case command
-          when SYNC_CONTROL_PATH
+          case ControlPacket.from_str(command)
+          in SyncControlPacket
             Log.debug { "Sync requested" }
             sync_to_disk
-          else
+          in Nil
             Log.warn { "Ignoring unknown control record #{command}" }
           end
         ensure

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -498,7 +498,7 @@ module LavinMQ
         @controls.add
         begin
           case packet = ControlPacket.from_str(command)
-          in SyncControlPacket
+          in SyncPacket
             Log.debug { "Sync requested: #{packet.path}" }
             sync_to_disk(packet.path)
           in Nil

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -48,10 +48,10 @@ module LavinMQ
       # Replaced with a fresh channel on each (re)connect in #stream_changes.
       @acks = Channel(Int64).new
       # Tracks the ack-sending fiber, so #close lets it drain the acks still
-      # buffered in @acks after the stream ends before it shuts the client down.
+      # buffered in @acks after the stream ends.
       @ack_loops = WaitGroup.new
       # Tracks control actions in flight, so #close waits for one to finish
-      # before tearing down the state it may touch (see #control).
+      # before tearing down the state it touches (see #control).
       @controls = WaitGroup.new
 
       def initialize(@config : Config, @id : Int32, @password : String, proxy = true)
@@ -447,9 +447,9 @@ module LavinMQ
           # are acked up front and the payload is acked incrementally as it's
           # written (see stream_with_checksum), so a single large action keeps
           # the leader's progress deadline reset instead of going silent until
-          # it's done. For a delete the framing is the entire record — acking
-          # it tells the leader the deletion is durable — so it's only acked
-          # once the deletion has been applied.
+          # it's done. For a delete the framing is the entire record, so it's
+          # only acked once the deletion has been applied: an ack may only cover
+          # records the follower has already carried out.
           framing = sizeof(Int32) + filename_len + sizeof(Int64)
           # Routed before the length is interpreted: a control record's empty
           # body would read as a delete. Acked once handled, like a delete.
@@ -479,24 +479,30 @@ module LavinMQ
       # path. An unknown instruction (a newer leader) is skipped, payload and
       # all, rather than fatal, so the stream stays aligned.
       #
-      # Counted in @controls so #close can't tear down the data dir under a
-      # running action. The @closed check sits inside that window: either close
-      # got there first and we skip the action, or we're counted and it waits
-      # for us. Skipping is safe — close has already closed the socket, so the
-      # leader has dropped us from the ISR and no confirm waits on our ack.
+      # A running action is counted in @controls so #close can't tear down the
+      # state it touches. @closed is checked before the count, not inside it:
+      # close sets @closed before it reaches @controls.wait, so a false reading
+      # means our #add lands before that wait. Counting first would let an #add
+      # land after the waiter woke, which makes WaitGroup#wait raise on a
+      # positive counter and aborts close halfway.
+      #
+      # Skipping is safe: close has closed the socket, so the leader dropped us
+      # from the ISR and no confirm waits on our ack.
       private def control(command, len, lz4) : Nil
-        @controls.add
         skip_payload(len, lz4)
         return if @closed.get
-        case command
-        when SYNC_CONTROL_PATH
-          Log.debug { "Sync requested" }
-          sync_to_disk
-        else
-          Log.warn { "Ignoring unknown control record #{command}" }
+        @controls.add
+        begin
+          case command
+          when SYNC_CONTROL_PATH
+            Log.debug { "Sync requested" }
+            sync_to_disk
+          else
+            Log.warn { "Ignoring unknown control record #{command}" }
+          end
+        ensure
+          @controls.done
         end
-      ensure
-        @controls.done
       end
 
       # Read and discard a record's payload; the caller acks it as a whole.
@@ -589,8 +595,8 @@ module LavinMQ
         Dir.mkdir_p File.dirname(path)
         File.open(path, "w") do |f|
           f.sync = true
-          # The record's final ack tells the leader the replace is durable, so
-          # it must not be sent while the new content only exists as the .tmp
+          # The record's final ack tells the leader the replace has been applied,
+          # so it must not be sent while the new content only exists as the .tmp
           # file; hold it back until the rename has installed the file.
           deferred = stream_with_checksum(lz4, f, len, sha1, defer_final_ack: true)
           f.rename f.path[0..-5]
@@ -633,11 +639,10 @@ module LavinMQ
       end
 
       # Concatenate as many acks as possible to generate few TCP packets.
-      # Data is synced to disk before each ack is sent unless sync is disabled:
-      # the leader holds publish confirms until in-sync followers have acked,
-      # so an acked byte must be durable here in normal operation. Syncing once
-      # per coalesced batch makes batching emerge naturally — acks accumulate
-      # while the blocking syncfs runs.
+      # Nothing is synced here: an ack means received and applied, and durability
+      # is fenced by the leader's $ctrl/sync records (see #control). The
+      # Fiber.yield lets a batch grow — the stream-reading fiber gets to queue
+      # more acks before we drain the channel again.
       private def send_ack_loop(acks, socket)
         socket.tcp_nodelay = true
         while ack_bytes = acks.receive?
@@ -652,7 +657,9 @@ module LavinMQ
         socket.close rescue nil
       end
 
-      # Make all replicated writes durable before acking the leader.
+      # Make all replicated writes durable. Only runs on request: the leader asks
+      # with a $ctrl/sync record, acked once this returns, and that ack is what
+      # tells it the data is persisted here.
       private def sync_to_disk : Nil
         # We dont need to return here, sync is controlled by leader...?
         # return unless @config.sync?
@@ -727,10 +734,9 @@ module LavinMQ
         @acks.close
         @ack_loops.wait
         # Nothing below may run while a control action does: a syncfs would hit a
-        # closed (or worse, reused) @data_dir_fd and the process would exit 1 mid
-        # shutdown/promotion, and the checksums would be stored from under it.
-        # The follower loop's exit above normally covers this; the wait matters
-        # when it timed out instead (see #control).
+        # closed (or worse, reused) @data_dir_fd and exit 1 mid promotion. The
+        # follower loop's exit above normally covers it; this wait matters when
+        # that timed out instead (see #control).
         @controls.wait
         # Finalize all pending checksums
         finalize_digests

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -455,7 +455,7 @@ module LavinMQ
           # Routed before the length is interpreted: a control record's empty
           # body would read as a delete. Acked once handled, like a delete.
           # Control records carry no body, so the framing is the whole record —
-          # and a $ctrl/ record that does carry one is not an instruction this
+          # and a control record that does carry one is not an instruction this
           # build can act on, so it falls through and is consumed as file data
           # rather than desyncing the stream.
           if len.zero? && ControlPacket.control?(filename)
@@ -497,10 +497,10 @@ module LavinMQ
         return if @closed.get
         @controls.add
         begin
-          case ControlPacket.from_str(command)
+          case packet = ControlPacket.from_str(command)
           in SyncControlPacket
-            Log.debug { "Sync requested" }
-            sync_to_disk
+            Log.debug { "Sync requested: #{packet.path}" }
+            sync_to_disk(packet.path)
           in Nil
             Log.warn { "Ignoring unknown control record #{command}" }
           end
@@ -633,7 +633,7 @@ module LavinMQ
 
       # Concatenate as many acks as possible to generate few TCP packets.
       # Nothing is synced here: an ack means received and applied, and durability
-      # is fenced by the leader's $ctrl/sync records (see #control). The
+      # is fenced by the leader's sync records (see #control). The
       # Fiber.yield lets a batch grow — the stream-reading fiber gets to queue
       # more acks before we drain the channel again.
       private def send_ack_loop(acks, socket)
@@ -650,13 +650,21 @@ module LavinMQ
         socket.close rescue nil
       end
 
-      # Make all replicated writes durable. Only runs on request: the leader asks
-      # with a $ctrl/sync record, acked once this returns, and that ack is what
-      # tells it the data is persisted here.
-      private def sync_to_disk : Nil
+      # Make replicated writes durable. Only runs on request: the leader asks
+      # with a $ record, acked once this returns, and that ack is what tells it
+      # the data is persisted here.
+      #
+      # A file we have open is fsynced on its own; anything else — a directory,
+      # the empty path (the data dir), a file we only ever replaced — falls back
+      # to the whole filesystem, which can never sync too little.
+      private def sync_to_disk(path : String) : Nil
         # We dont need to return here, sync is controlled by leader...?
         # return unless @config.sync?
-        sync_data_dir
+        if file = @files[path]?
+          file.fsync
+        else
+          sync_data_dir
+        end
       rescue ex
         # Can't ack data that isn't durable; die fast so the leader drops us
         # from the in-sync set and stops confirming publishes on our acks.

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -454,9 +454,13 @@ module LavinMQ
           framing = sizeof(Int32) + filename_len + sizeof(Int64)
           # Routed before the length is interpreted: a control record's empty
           # body would read as a delete. Acked once handled, like a delete.
-          if filename.starts_with?(CONTROL_PREFIX)
-            control(filename, len, lz4)
-            ack(framing + len.abs)
+          # Control records carry no body, so the framing is the whole record —
+          # and a $ctrl/ record that does carry one is not an instruction this
+          # build can act on, so it falls through and is consumed as file data
+          # rather than desyncing the stream.
+          if len.zero? && ControlPacket.control?(filename)
+            control(filename)
+            ack(framing)
             next
           end
           case len
@@ -476,9 +480,9 @@ module LavinMQ
         log_loop_done.try &.close
       end
 
-      # Apply a control record: nothing is written to disk or tracked for its
-      # path. An unknown instruction (a newer leader) is skipped, payload and
-      # all, rather than fatal, so the stream stays aligned.
+      # Apply a control record: nothing is read from the stream, written to disk
+      # or tracked for its path. An unknown instruction (a newer leader) is
+      # ignored rather than fatal.
       #
       # A running action is counted in @controls so #close can't tear down the
       # state it touches. @closed is checked before the count, not inside it:
@@ -489,8 +493,7 @@ module LavinMQ
       #
       # Skipping is safe: close has closed the socket, so the leader dropped us
       # from the ISR and no confirm waits on our ack.
-      private def control(command, len, lz4) : Nil
-        skip_payload(len, lz4)
+      private def control(command : String) : Nil
         return if @closed.get
         @controls.add
         begin
@@ -503,17 +506,6 @@ module LavinMQ
           end
         ensure
           @controls.done
-        end
-      end
-
-      # Read and discard a record's payload; the caller acks it as a whole.
-      private def skip_payload(len : Int64, lz4) : Nil
-        remaining = len.abs
-        buffer = uninitialized UInt8[BUFFER_SIZE]
-        while remaining > 0
-          read = lz4.read(buffer.to_slice[0, Math.min(BUFFER_SIZE, remaining)])
-          raise IO::EOFError.new if read.zero?
-          remaining -= read
         end
       end
 

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -658,8 +658,6 @@ module LavinMQ
       # the empty path (the data dir), a file we only ever replaced — falls back
       # to the whole filesystem, which can never sync too little.
       private def sync_to_disk(path : String) : Nil
-        # We dont need to return here, sync is controlled by leader...?
-        # return unless @config.sync?
         if file = @files[path]?
           file.fsync
         else

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -719,7 +719,6 @@ module LavinMQ
         @unix_amqp_proxy.try &.close
         @unix_http_proxy.try &.close
         @unix_mqtt_proxy.try &.close
-        @files.each_value &.close
         @socket.try &.close
         # Wait for follower loop to exit (with timeout to prevent hanging)
         select
@@ -737,8 +736,7 @@ module LavinMQ
         # follower loop's exit above normally covers it; this wait matters when
         # that timed out instead (see #control).
         @controls.wait
-        # Finalize all pending checksums
-        finalize_digests
+        reset_file_state
         @checksums.store
         LibC.close(@data_dir_fd) if @data_dir_fd >= 0
         @data_dir_lock.release

--- a/src/lavinmq/clustering/control_packet.cr
+++ b/src/lavinmq/clustering/control_packet.cr
@@ -1,0 +1,79 @@
+require "../clustering"
+require "wait_group"
+
+module LavinMQ
+  module Clustering
+    # An instruction for the follower, carried out by the leader's control_loop
+    # rather than by the fiber that asks for it (see Follower#control).
+    #
+    # Whoever takes a packet must #done it exactly once, whether or not it got
+    # as far as #to_io: one dropped without a #done hangs its waiter forever.
+    abstract struct ControlPacket
+      # How many bytes #to_io writes. Counted into the follower's sent-byte
+      # total at the position the record occupies on the wire.
+      abstract def bytesize : Int64
+
+      # Act on the follower's stream. Runs under the follower's @write_lock:
+      # touch the given IO and nothing else — no blocking, no other locks.
+      abstract def to_io(io : IO) : Nil
+
+      # Queued to one more follower; counted per follower, not per request.
+      def add : Nil
+      end
+
+      # Handled by one more follower: written, or given up on as dead.
+      def done : Nil
+      end
+    end
+
+    # Pushes what's buffered to the follower. Writes nothing itself, but
+    # everything queued ahead of it has been written by the time it runs — so a
+    # released `wg` means those bytes are on the socket, not in the compressor.
+    struct FlushPacket < ControlPacket
+      def initialize(@wg : WaitGroup? = nil)
+      end
+
+      def bytesize : Int64
+        0i64 # a flush adds nothing to the stream
+      end
+
+      def add : Nil
+        @wg.try &.add
+      end
+
+      def done : Nil
+        @wg.try &.done
+      end
+
+      def to_io(io : IO) : Nil
+        io.flush
+      end
+    end
+
+    # Asks the follower to make everything replicated so far durable. It fsyncs
+    # before acking this record (see Client#control), so this ack — unlike an
+    # ordinary one, which only means received and applied — means persisted.
+    #
+    # No waiter of its own: the queue is FIFO, so waiting for a FlushPacket
+    # queued after it covers this record too. Must always be followed by one, or
+    # it sits in the compressor until ack_loop's fallback flush.
+    struct SyncControlPacket < ControlPacket
+      # A whole $ctrl/sync record: filename framing plus a zero length, no body.
+      PACKET = begin
+        io = IO::Memory.new
+        io.write_bytes SYNC_CONTROL_PATH.bytesize.to_i32, IO::ByteFormat::LittleEndian
+        io.write SYNC_CONTROL_PATH.to_slice
+        io.write_bytes 0i64 # empty body (endian-agnostic)
+        io.to_slice
+      end
+
+      def bytesize : Int64
+        PACKET.bytesize.to_i64
+      end
+
+      def to_io(io : IO) : Nil
+        io.write PACKET
+      end
+    end
+  end
+end

--- a/src/lavinmq/clustering/control_packet.cr
+++ b/src/lavinmq/clustering/control_packet.cr
@@ -9,25 +9,24 @@ module LavinMQ
     # Whoever takes a packet must #done it exactly once, whether or not it got
     # as far as #to_io: one dropped without a #done hangs its waiter forever.
     abstract struct ControlPacket
-      # Records whose path starts with this carry an instruction, not file data.
-      # Never a real path, so nothing under it is created on disk or tracked.
-      PREFIX = "$ctrl/"
+      # The symbol of every packet that can be sent. A record whose filename
+      # starts with one carries that instruction instead of file data; what
+      # follows the symbol is the instruction's argument.
+      SYMBOLS = {SyncControlPacket::SYMBOL}
 
-      # True for a record that carries an instruction rather than file data,
-      # whether or not this build knows the instruction: an unknown one must
-      # still be recognised as a control record and skipped, not read as a
-      # delete of its path. Which instruction it is, .from_str answers.
+      # True for a record that carries an instruction rather than file data.
+      # Which instruction it is, .from_str answers.
       def self.control?(path : String) : Bool
-        path.starts_with?(PREFIX)
+        SYMBOLS.includes? path[0]?
       end
 
-      # The packet a received record's path stands for, nil for an instruction
-      # only a newer leader knows. Deliberately returns the narrow union of the
+      # The packet a received record's filename stands for, nil for a symbol
+      # this build doesn't know. Deliberately returns the narrow union of the
       # packets with a wire form, not ControlPacket?, so a `case ... in` on it
       # stops compiling when a new one is added (see Client#control).
       def self.from_str(str : String)
-        case str
-        when SyncControlPacket::PATH then SyncControlPacket.new
+        case str[0]?
+        when SyncControlPacket::SYMBOL then SyncControlPacket.new(str[1..])
         end
       end
 
@@ -72,33 +71,34 @@ module LavinMQ
       end
     end
 
-    # Asks the follower to make everything replicated so far durable. It fsyncs
-    # before acking this record (see Client#control), so this ack — unlike an
-    # ordinary one, which only means received and applied — means persisted.
+    # Asks the follower to make replicated writes durable: the file `path`
+    # names, or the whole filesystem when it names a directory — the empty path
+    # being the data dir itself. The follower syncs before acking this record
+    # (see Client#control), so this ack — unlike an ordinary one, which only
+    # means received and applied — means persisted.
     #
     # No waiter of its own: the queue is FIFO, so waiting for a FlushPacket
     # queued after it covers this record too. Must always be followed by one, or
     # it sits in the compressor until ack_loop's fallback flush.
     struct SyncControlPacket < ControlPacket
-      # Names this instruction on the wire; the empty body means the record is
-      # routed by prefix before its length is interpreted.
-      PATH = "#{PREFIX}sync"
+      # Names this instruction on the wire; `path` follows it as the argument.
+      SYMBOL = '$'
 
-      # The whole record: filename framing plus a zero length, no body.
-      RECORD = begin
-        io = IO::Memory.new
-        io.write_bytes PATH.bytesize.to_i32, IO::ByteFormat::LittleEndian
-        io.write PATH.to_slice
-        io.write_bytes 0i64 # empty body (endian-agnostic)
-        io.to_slice
+      getter path : String
+
+      def initialize(@path : String = "")
       end
 
       def bytesize : Int64
-        RECORD.bytesize.to_i64
+        (sizeof(Int32) + SYMBOL.bytesize + @path.bytesize + sizeof(Int64)).to_i64
       end
 
+      # Written symbol-then-path rather than from a joined string, so sending
+      # one allocates nothing.
       def to_io(io : IO) : Nil
-        io.write RECORD
+        io.write_bytes (SYMBOL.bytesize + @path.bytesize).to_i32, IO::ByteFormat::LittleEndian
+        io << SYMBOL << @path
+        io.write_bytes 0i64 # empty body (endian-agnostic)
       end
     end
   end

--- a/src/lavinmq/clustering/control_packet.cr
+++ b/src/lavinmq/clustering/control_packet.cr
@@ -15,7 +15,7 @@ module LavinMQ
       # stops compiling when a new one is added (see Client#control).
       def self.from_str(str : String)
         case str
-        when SYNC_CONTROL_PATH then SyncControlPacket.new
+        when SyncControlPacket::PATH then SyncControlPacket.new
         end
       end
 
@@ -68,21 +68,25 @@ module LavinMQ
     # queued after it covers this record too. Must always be followed by one, or
     # it sits in the compressor until ack_loop's fallback flush.
     struct SyncControlPacket < ControlPacket
-      # A whole $ctrl/sync record: filename framing plus a zero length, no body.
-      PACKET = begin
+      # Names this instruction on the wire; the empty body means the record is
+      # routed by prefix before its length is interpreted.
+      PATH = "#{CONTROL_PREFIX}sync"
+
+      # The whole record: filename framing plus a zero length, no body.
+      RECORD = begin
         io = IO::Memory.new
-        io.write_bytes SYNC_CONTROL_PATH.bytesize.to_i32, IO::ByteFormat::LittleEndian
-        io.write SYNC_CONTROL_PATH.to_slice
+        io.write_bytes PATH.bytesize.to_i32, IO::ByteFormat::LittleEndian
+        io.write PATH.to_slice
         io.write_bytes 0i64 # empty body (endian-agnostic)
         io.to_slice
       end
 
       def bytesize : Int64
-        PACKET.bytesize.to_i64
+        RECORD.bytesize.to_i64
       end
 
       def to_io(io : IO) : Nil
-        io.write PACKET
+        io.write RECORD
       end
     end
   end

--- a/src/lavinmq/clustering/control_packet.cr
+++ b/src/lavinmq/clustering/control_packet.cr
@@ -9,6 +9,18 @@ module LavinMQ
     # Whoever takes a packet must #done it exactly once, whether or not it got
     # as far as #to_io: one dropped without a #done hangs its waiter forever.
     abstract struct ControlPacket
+      # Records whose path starts with this carry an instruction, not file data.
+      # Never a real path, so nothing under it is created on disk or tracked.
+      PREFIX = "$ctrl/"
+
+      # True for a record that carries an instruction rather than file data,
+      # whether or not this build knows the instruction: an unknown one must
+      # still be recognised as a control record and skipped, not read as a
+      # delete of its path. Which instruction it is, .from_str answers.
+      def self.control?(path : String) : Bool
+        path.starts_with?(PREFIX)
+      end
+
       # The packet a received record's path stands for, nil for an instruction
       # only a newer leader knows. Deliberately returns the narrow union of the
       # packets with a wire form, not ControlPacket?, so a `case ... in` on it
@@ -70,7 +82,7 @@ module LavinMQ
     struct SyncControlPacket < ControlPacket
       # Names this instruction on the wire; the empty body means the record is
       # routed by prefix before its length is interpreted.
-      PATH = "#{CONTROL_PREFIX}sync"
+      PATH = "#{PREFIX}sync"
 
       # The whole record: filename framing plus a zero length, no body.
       RECORD = begin

--- a/src/lavinmq/clustering/control_packet.cr
+++ b/src/lavinmq/clustering/control_packet.cr
@@ -9,6 +9,16 @@ module LavinMQ
     # Whoever takes a packet must #done it exactly once, whether or not it got
     # as far as #to_io: one dropped without a #done hangs its waiter forever.
     abstract struct ControlPacket
+      # The packet a received record's path stands for, nil for an instruction
+      # only a newer leader knows. Deliberately returns the narrow union of the
+      # packets with a wire form, not ControlPacket?, so a `case ... in` on it
+      # stops compiling when a new one is added (see Client#control).
+      def self.from_str(str : String)
+        case str
+        when SYNC_CONTROL_PATH then SyncControlPacket.new
+        end
+      end
+
       # How many bytes #to_io writes. Counted into the follower's sent-byte
       # total at the position the record occupies on the wire.
       abstract def bytesize : Int64

--- a/src/lavinmq/clustering/control_packet.cr
+++ b/src/lavinmq/clustering/control_packet.cr
@@ -12,7 +12,7 @@ module LavinMQ
       # The symbol of every packet that can be sent. A record whose filename
       # starts with one carries that instruction instead of file data; what
       # follows the symbol is the instruction's argument.
-      SYMBOLS = {SyncControlPacket::SYMBOL}
+      SYMBOLS = {SyncPacket::SYMBOL}
 
       # True for a record that carries an instruction rather than file data.
       # Which instruction it is, .from_str answers.
@@ -26,7 +26,7 @@ module LavinMQ
       # stops compiling when a new one is added (see Client#control).
       def self.from_str(str : String)
         case str[0]?
-        when SyncControlPacket::SYMBOL then SyncControlPacket.new(str[1..])
+        when SyncPacket::SYMBOL then SyncPacket.new(str[1..])
         end
       end
 
@@ -80,7 +80,7 @@ module LavinMQ
     # No waiter of its own: the queue is FIFO, so waiting for a FlushPacket
     # queued after it covers this record too. Must always be followed by one, or
     # it sits in the compressor until ack_loop's fallback flush.
-    struct SyncControlPacket < ControlPacket
+    struct SyncPacket < ControlPacket
       # Names this instruction on the wire; `path` follows it as the argument.
       SYMBOL = '$'
 

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -159,10 +159,7 @@ module LavinMQ
       private def flush_loop
         while request = @flush_requested.receive?
           @write_lock.synchronize do
-            unless request.empty?
-              @sent_bytes.add(request.bytesize)
-              @lz4.write request
-            end
+            @lz4.write request unless request.empty?
             @lz4.flush
           rescue IO::Error | Socket::Error
           end
@@ -186,6 +183,7 @@ module LavinMQ
       # Never touches the socket, so it's safe from the publish confirm loop's
       # isolated thread (see flush_loop).
       def request_sync : Nil
+        @sent_bytes.add(SYNC_CONTROL_PACKET.bytesize)
         @flush_requested.send(SYNC_CONTROL_PACKET)
       rescue ::Channel::ClosedError
         # Dead follower; wait_for_confirm returns false instead of waiting.

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -187,7 +187,7 @@ module LavinMQ
 
       # Block until the follower has acked at least the bytes already sent at
       # call time. An ack means received and applied, not durable; a caller that
-      # needs durability queues a SyncControlPacket first, whose bytes are then
+      # needs durability queues a SyncPacket first, whose bytes are then
       # part of the count waited for here (see Clustering::Client#control).
       # Requests a flush first so the pending bytes reach the follower without
       # waiting for the ack_loop's 100ms flush timeout.

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -1,4 +1,5 @@
 require "./file_index"
+require "./control_packet"
 require "../config"
 require "../rate_limiter"
 require "socket"
@@ -28,15 +29,8 @@ module LavinMQ
       # sync lock forever.
       SYNC_WRITE_TIMEOUT = 60.seconds
 
-      # A whole $ctrl/sync record: filename framing plus a zero length, no
-      # body. Built once so a request can hand it over as a plain slice.
-      SYNC_CONTROL_PACKET = begin
-        io = IO::Memory.new
-        io.write_bytes SYNC_CONTROL_PATH.bytesize.to_i32, IO::ByteFormat::LittleEndian
-        io.write SYNC_CONTROL_PATH.to_slice
-        io.write_bytes 0i64 # empty body (endian-agnostic)
-        io.to_slice
-      end
+      # Packets that may be queued before a sender waits for control_loop.
+      CONTROL_QUEUE_CAPACITY = 5
 
       @acked_bytes = Atomic(Int64).new(0)
       @sent_bytes = Atomic(Int64).new(0)
@@ -44,10 +38,11 @@ module LavinMQ
       # when ack_loop ends, which doubles as the follower's death signal (see
       # #dead?).
       @ack_notify = ::Channel(Nil).new(1)
-      # Wakes flush_loop; capacity 1 so a burst of requests coalesces into one
-      # flush. Closed when ack_loop ends, stopping flush_loop. A `Bytes.empty` asks for
-      # a flush, a slice for a record to write first.
-      @flush_requested = ::Channel(Bytes).new(1)
+      # Instructions for control_loop, in order. Closed when ack_loop ends;
+      # packets already buffered are still delivered (receive? only reports a
+      # closed channel once the buffer is empty), so nothing queued is lost.
+      # Carries a struct, never nil, so a nil from receive? means close.
+      @control_packets = ::Channel(ControlPacket).new(CONTROL_QUEUE_CAPACITY)
       @write_lock = Mutex.new(:unchecked)
       @running = WaitGroup.new
       @state = State::Syncing
@@ -95,7 +90,7 @@ module LavinMQ
 
       def ack_loop(ack_timeout : Time::Span = ACK_TIMEOUT)
         @running.add
-        @running.spawn(name: "Clustering follower flush loop") { flush_loop }
+        @running.spawn(name: "Clustering follower control loop") { control_loop }
         # Tighten the write timeout for the streaming phase; full_sync relaxed it
         # to SYNC_WRITE_TIMEOUT for the bulk transfer.
         @socket.write_timeout = ACK_TIMEOUT
@@ -137,7 +132,7 @@ module LavinMQ
         # socket closed
       ensure
         @ack_notify.close      # unblock any waiter; this follower is gone
-        @flush_requested.close # stop flush_loop
+        @control_packets.close # stop control_loop
         @running.done
       end
 
@@ -150,48 +145,52 @@ module LavinMQ
         @ack_notify.closed?
       end
 
-      # Flushes on behalf of request_flush callers. Runs in its own fiber,
-      # spawned by ack_loop on the default execution context: the publish
-      # confirm loop runs on an isolated thread and must not write the socket
-      # itself — the socket's fd belongs to the default context's event loop
-      # (ack_loop keeps a read pending on it), and a write that blocks from
-      # another context raises instead of waiting.
-      private def flush_loop
-        while request = @flush_requested.receive?
+      # Carries out queued control packets. Runs in its own fiber, spawned by
+      # ack_loop on the default execution context: the socket's fd belongs to
+      # that context's event loop (ack_loop keeps a read pending on it), and a
+      # write that blocks from another context raises instead of waiting — so
+      # callers queue packets rather than write themselves.
+      private def control_loop
+        while packet = @control_packets.receive?
           @write_lock.synchronize do
-            @lz4.write request unless request.empty?
-            @lz4.flush
+            # Counted before writing: #done may release a waiter that then
+            # snapshots @sent_bytes at once.
+            @sent_bytes.add packet.bytesize
+            packet.to_io(@lz4)
           rescue IO::Error | Socket::Error
+            # ack_loop detects the broken socket and closes @ack_notify, so a
+            # wait_for_confirm waiter still unblocks.
+          ensure
+            packet.done # ours to release once taken, written or not
           end
         end
       end
 
-      # Ask flush_loop to push buffered bytes to the follower. Never blocks
-      # and never touches the socket, so it's safe to call from any execution
-      # context (see flush_loop).
+      # Push buffered bytes to the follower. Droppable: carries no waiter, and
+      # the packets that filled the queue flush those bytes anyway.
       def request_flush : Nil
-        @flush_requested.try_send(Bytes.empty)
+        @control_packets.try_send(FlushPacket.new)
       rescue ::Channel::ClosedError
       end
 
-      # Ask the follower to make everything replicated so far durable: hands a
-      # $ctrl/sync record to flush_loop, which counts, writes and flushes it.
-      # A plain flush can't tell the follower the leader is fencing on the data;
-      # this record does, and its ack is what a publish confirm waits for.
-      #
-      # A blocking send, not try_send: a dropped record silently skips the fence.
-      # Never touches the socket, so it's safe from the publish confirm loop's
-      # isolated thread (see flush_loop).
-      def request_sync : Nil
-        @sent_bytes.add(SYNC_CONTROL_PACKET.bytesize)
-        @flush_requested.send(SYNC_CONTROL_PACKET)
+      # Queue a packet that must land, so a blocking send — dropping it would
+      # hang its waiter and skip whatever it fences. Waits only for control_loop
+      # to free a slot and never touches the socket, so any execution context may
+      # call it (see control_loop).
+      def control(packet : ControlPacket) : Nil
+        packet.add
+        @control_packets.send(packet)
       rescue ::Channel::ClosedError
         # Dead follower; wait_for_confirm returns false instead of waiting.
+        packet.done
       end
 
       # Block until the follower has acked at least the bytes already sent at
-      # call time. Requests a flush first so the pending bytes reach the
-      # follower without waiting for the ack_loop's 100ms flush timeout.
+      # call time. An ack means received and applied, not durable; a caller that
+      # needs durability queues a SyncControlPacket first, whose bytes are then
+      # part of the count waited for here (see Clustering::Client#control).
+      # Requests a flush first so the pending bytes reach the follower without
+      # waiting for the ack_loop's 100ms flush timeout.
       # Returns true if the bytes were acked, false if the follower
       # disconnected. A follower that stops acking is disconnected by
       # ack_loop, which closes @ack_notify and unblocks us here.
@@ -396,7 +395,13 @@ module LavinMQ
         # must still read as dead and unblock any wait_for_confirm waiter,
         # or a publish confirm could hang on it forever.
         @ack_notify.close
-        @flush_requested.close
+        @control_packets.close
+        # A packet buffered with no control_loop to carry it out is released
+        # here; a closed channel still hands out what's in its buffer. Nothing
+        # races us: @running.wait above means control_loop is gone.
+        while packet = @control_packets.receive?
+          packet.done
+        end
       end
 
       def to_json(json : JSON::Builder)

--- a/src/lavinmq/clustering/follower.cr
+++ b/src/lavinmq/clustering/follower.cr
@@ -28,6 +28,16 @@ module LavinMQ
       # sync lock forever.
       SYNC_WRITE_TIMEOUT = 60.seconds
 
+      # A whole $ctrl/sync record: filename framing plus a zero length, no
+      # body. Built once so a request can hand it over as a plain slice.
+      SYNC_CONTROL_PACKET = begin
+        io = IO::Memory.new
+        io.write_bytes SYNC_CONTROL_PATH.bytesize.to_i32, IO::ByteFormat::LittleEndian
+        io.write SYNC_CONTROL_PATH.to_slice
+        io.write_bytes 0i64 # empty body (endian-agnostic)
+        io.to_slice
+      end
+
       @acked_bytes = Atomic(Int64).new(0)
       @sent_bytes = Atomic(Int64).new(0)
       # Wakes the publish-confirm waiter on each ack; closed (never replaced)
@@ -35,9 +45,9 @@ module LavinMQ
       # #dead?).
       @ack_notify = ::Channel(Nil).new(1)
       # Wakes flush_loop; capacity 1 so a burst of requests coalesces into one
-      # flush. Closed when ack_loop ends, stopping flush_loop. Carries Bool
-      # (not Nil) so receive? distinguishes a request (true) from close (nil).
-      @flush_requested = ::Channel(Bool).new(1)
+      # flush. Closed when ack_loop ends, stopping flush_loop. A `Bytes.empty` asks for
+      # a flush, a slice for a record to write first.
+      @flush_requested = ::Channel(Bytes).new(1)
       @write_lock = Mutex.new(:unchecked)
       @running = WaitGroup.new
       @state = State::Syncing
@@ -140,15 +150,6 @@ module LavinMQ
         @ack_notify.closed?
       end
 
-      # Flush the LZ4 buffer so pending bytes reach the follower without
-      # waiting for the ack_loop's 100ms flush timeout. Write errors are
-      # swallowed: a broken socket is detected by ack_loop, which closes
-      # @ack_notify so a wait_for_confirm waiter still unblocks.
-      private def flush : Nil
-        @write_lock.synchronize { @lz4.flush }
-      rescue IO::Error | Socket::Error
-      end
-
       # Flushes on behalf of request_flush callers. Runs in its own fiber,
       # spawned by ack_loop on the default execution context: the publish
       # confirm loop runs on an isolated thread and must not write the socket
@@ -156,8 +157,15 @@ module LavinMQ
       # (ack_loop keeps a read pending on it), and a write that blocks from
       # another context raises instead of waiting.
       private def flush_loop
-        while @flush_requested.receive?
-          flush
+        while request = @flush_requested.receive?
+          @write_lock.synchronize do
+            unless request.empty?
+              @sent_bytes.add(request.bytesize)
+              @lz4.write request
+            end
+            @lz4.flush
+          rescue IO::Error | Socket::Error
+          end
         end
       end
 
@@ -165,8 +173,22 @@ module LavinMQ
       # and never touches the socket, so it's safe to call from any execution
       # context (see flush_loop).
       def request_flush : Nil
-        @flush_requested.try_send(true)
+        @flush_requested.try_send(Bytes.empty)
       rescue ::Channel::ClosedError
+      end
+
+      # Ask the follower to make everything replicated so far durable: hands a
+      # $ctrl/sync record to flush_loop, which counts, writes and flushes it.
+      # A plain flush can't tell the follower the leader is fencing on the data;
+      # this record does, and its ack is what a publish confirm waits for.
+      #
+      # A blocking send, not try_send: a dropped record silently skips the fence.
+      # Never touches the socket, so it's safe from the publish confirm loop's
+      # isolated thread (see flush_loop).
+      def request_sync : Nil
+        @flush_requested.send(SYNC_CONTROL_PACKET)
+      rescue ::Channel::ClosedError
+        # Dead follower; wait_for_confirm returns false instead of waiting.
       end
 
       # Block until the follower has acked at least the bytes already sent at

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -1,4 +1,6 @@
 require "../mfile"
+require "./control_packet"
+require "wait_group"
 
 module LavinMQ
   module Clustering
@@ -23,12 +25,19 @@ module LavinMQ
       # Persister#wait_for_followers).
       abstract def isr_dirty? : Bool
       abstract def flush_isr : Nil
-      # Ask every in-sync follower to make everything replicated so far
-      # durable. Paired with #wait_for_followers: a follower acks received
-      # bytes, so only the ack of this request means they're persisted. Called
-      # once the operation is dispatched and locally fsynced, before the wait,
-      # so the followers persist while the leader does.
-      abstract def request_sync : Nil
+      # Push the bytes replicated so far to every in-sync follower. Never blocks.
+      abstract def request_flush : Nil
+      # Ask every in-sync follower to make everything replicated so far durable.
+      # Paired with #wait_for_followers: a follower acks received bytes, so only
+      # the ack of this request means they're persisted. Called once the
+      # operation is dispatched and locally fsynced, before the wait, so the
+      # followers persist while the leader does.
+      #
+      # `wg` is released per follower once the record is on its socket. Wait for
+      # it before #wait_for_followers: unless the record is counted in the
+      # follower's sent-byte total first, an append written ahead of it can
+      # carry that follower's acks past the target on its own.
+      abstract def request_sync(wg : WaitGroup) : Nil
       # Block until every in-sync follower has acked everything replicated so
       # far, then commit any pending ISR change. Called after a durable
       # operation has been dispatched and locally fsynced, before it is

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -23,6 +23,12 @@ module LavinMQ
       # Persister#wait_for_followers).
       abstract def isr_dirty? : Bool
       abstract def flush_isr : Nil
+      # Ask every in-sync follower to make everything replicated so far
+      # durable. Paired with #wait_for_followers: a follower acks received
+      # bytes, so only the ack of this request means they're persisted. Called
+      # once the operation is dispatched and locally fsynced, before the wait,
+      # so the followers persist while the leader does.
+      abstract def request_sync : Nil
       # Block until every in-sync follower has acked everything replicated so
       # far, then commit any pending ISR change. Called after a durable
       # operation has been dispatched and locally fsynced, before it is

--- a/src/lavinmq/clustering/replicator.cr
+++ b/src/lavinmq/clustering/replicator.cr
@@ -11,38 +11,25 @@ module LavinMQ
       abstract def replace_file(path : String) # regular files, re-read from disk
       abstract def replace_file(mfile : MFile) # mmap-backed files, read from the mmap (capped at mfile.size)
       abstract def append(path : String, pos : Int, length : Int)
-      # `offset` is the absolute byte position the value/bytes are written at on
-      # the leader; used to skip appends a just-joined follower already received
-      # via full_sync (see Server#append). Distinct names avoid colliding with
-      # the positional append(path, pos, length) overload.
+      # `offset` is where the value/bytes are written on the leader, so a
+      # just-joined follower can skip what full_sync already gave it.
       abstract def append_value(path : String, value : UInt32 | Int32, offset : Int64)
       abstract def append_bytes(path : String, bytes : Bytes, offset : Int64)
       abstract def delete_file(path : String)
       abstract def followers : Array(Follower)
       abstract def syncing_followers : Array(Follower)
-      # ISR bookkeeping for the publish-confirm path: a confirm may only be
-      # sent against an ISR that is committed to the coordinator (see
-      # Persister#wait_for_followers).
+      # True when the ISR last committed to the coordinator may be stale.
       abstract def isr_dirty? : Bool
+      # Commit the current ISR to the coordinator.
       abstract def flush_isr : Nil
-      # Push the bytes replicated so far to every in-sync follower. Never blocks.
+      # Push the bytes replicated so far to every in-sync follower.
       abstract def request_flush : Nil
       # Ask every in-sync follower to make everything replicated so far durable.
-      # Paired with #wait_for_followers: a follower acks received bytes, so only
-      # the ack of this request means they're persisted. Called once the
-      # operation is dispatched and locally fsynced, before the wait, so the
-      # followers persist while the leader does.
-      #
-      # `wg` is released per follower once the record is on its socket. Wait for
-      # it before #wait_for_followers: unless the record is counted in the
-      # follower's sent-byte total first, an append written ahead of it can
-      # carry that follower's acks past the target on its own.
+      # `wg` is released per follower once the request is on its socket; wait for
+      # it before #wait_for_followers.
       abstract def request_sync(wg : WaitGroup) : Nil
       # Block until every in-sync follower has acked everything replicated so
-      # far, then commit any pending ISR change. Called after a durable
-      # operation has been dispatched and locally fsynced, before it is
-      # acknowledged to a client (publish confirms via the Persister,
-      # definition changes via the DefinitionsStore).
+      # far, then commit any pending ISR change.
       abstract def wait_for_followers : Nil
       abstract def all_followers : Array(Follower)
       abstract def close

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -433,13 +433,19 @@ module LavinMQ
         end
       end
 
-      # Ask every in-sync follower to persist what's been replicated to it (see
-      # Follower#request_sync). Only synced followers: a syncing one has no
-      # flush_loop draining its requests yet, and the request would block. The
-      # request itself may block, so it's made outside @lock — #followers
-      # returns its own array.
-      def request_sync : Nil
-        followers.each &.request_sync
+      # Flush all synced followers io. A waitgroup can be passed to make
+      # this method synchronous.
+      def request_flush(wg : WaitGroup? = nil) : Nil
+        followers.each &.control(FlushPacket.new(wg))
+      end
+
+      # Send a sync frame to all followers. IO will be flushed. A waitgroup can
+      # be passed to make this method synchronous.
+      def request_sync(wg : WaitGroup? = nil) : Nil
+        followers.each do |f|
+          f.control SyncControlPacket.new
+          f.control FlushPacket.new(wg)
+        end
       end
 
       # Block until every in-sync follower has acked everything replicated so

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -443,7 +443,7 @@ module LavinMQ
       # be passed to make this method synchronous.
       def request_sync(wg : WaitGroup? = nil) : Nil
         followers.each do |f|
-          f.control SyncControlPacket.new
+          f.control SyncPacket.new
           f.control FlushPacket.new(wg)
         end
       end

--- a/src/lavinmq/clustering/server.cr
+++ b/src/lavinmq/clustering/server.cr
@@ -433,6 +433,15 @@ module LavinMQ
         end
       end
 
+      # Ask every in-sync follower to persist what's been replicated to it (see
+      # Follower#request_sync). Only synced followers: a syncing one has no
+      # flush_loop draining its requests yet, and the request would block. The
+      # request itself may block, so it's made outside @lock — #followers
+      # returns its own array.
+      def request_sync : Nil
+        followers.each &.request_sync
+      end
+
       # Block until every in-sync follower has acked everything replicated so
       # far, so a durable operation may be acknowledged to a client: once
       # this returns, every node etcd lists as a failover candidate has the

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -4,6 +4,7 @@ require "./event_type"
 require "./queue_factory"
 require "./amqp/exchange/*"
 require "./amqp/queue"
+require "wait_group"
 
 module LavinMQ
   class DefinitionsStore
@@ -34,11 +35,11 @@ module LavinMQ
     def fsync
       @definitions_lock.synchronize do
         @definitions_file.fsync
-        # The caller acknowledges the change right after this returns (a
-        # Declare-Ok, an import response), so a leader crash must not be able to
-        # elect a follower lacking it. An ack alone means received, hence the
-        # sync request first (see Replicator#request_sync).
-        @replicator.try &.request_sync
+        # The change is acknowledged right after this returns (Declare-Ok, an
+        # import response), so a leader crash must not elect a follower lacking
+        # it. An ack alone means received, hence the sync request first — and the
+        # wait for it before the acks (see Replicator#request_sync).
+        WaitGroup.wait { |wg| @replicator.try &.request_sync(wg) }
         @replicator.try &.wait_for_followers
       end
     end

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -394,8 +394,11 @@ module LavinMQ
         # returns (Declare-Ok etc.), so like a publish confirm it must be
         # durable on every in-sync follower first — otherwise a leader crash
         # could elect a follower lacking the acknowledged change. A follower
-        # that doesn't ack within its deadline is disconnected and its ISR
-        # removal committed before this returns.
+        # acks bytes it has received, so it's asked to persist them first and
+        # the wait covers that request's ack too. A follower that doesn't ack
+        # within its deadline is disconnected and its ISR removal committed
+        # before this returns.
+        @replicator.try &.request_sync
         @replicator.try &.wait_for_followers
       end
       if dirty

--- a/src/lavinmq/definitions_store.cr
+++ b/src/lavinmq/definitions_store.cr
@@ -28,13 +28,17 @@ module LavinMQ
       @definitions_deletes = 0
     end
 
-    # Flush buffered definition writes to disk. Used after a bulk operation
-    # (e.g. import) that stored its definitions with fsync: false; the whole
-    # batch is acknowledged after this, so it waits for follower acks like
-    # the per-frame path does.
+    # Make the definitions written so far durable, here and on every in-sync
+    # follower. Called per frame by store_definition, and once for the whole
+    # batch after a bulk import stored its definitions with fsync: false.
     def fsync
       @definitions_lock.synchronize do
         @definitions_file.fsync
+        # The caller acknowledges the change right after this returns (a
+        # Declare-Ok, an import response), so a leader crash must not be able to
+        # elect a follower lacking it. An ack alone means received, hence the
+        # sync request first (see Replicator#request_sync).
+        @replicator.try &.request_sync
         @replicator.try &.wait_for_followers
       end
     end
@@ -388,18 +392,9 @@ module LavinMQ
       # baseline instead of duplicating it.
       @definitions_file.write bytes
       @replicator.try &.append_bytes @definitions_file_path, bytes, offset
+
       if fsync
-        @definitions_file.fsync
-        # The caller acknowledges the change to the client right after this
-        # returns (Declare-Ok etc.), so like a publish confirm it must be
-        # durable on every in-sync follower first — otherwise a leader crash
-        # could elect a follower lacking the acknowledged change. A follower
-        # acks bytes it has received, so it's asked to persist them first and
-        # the wait covers that request's ack too. A follower that doesn't ack
-        # within its deadline is disconnected and its ISR removal committed
-        # before this returns.
-        @replicator.try &.request_sync
-        @replicator.try &.wait_for_followers
+        fsync()
       end
       if dirty
         if (@definitions_deletes += 1) >= Config.instance.max_deleted_definitions

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -90,7 +90,7 @@ module LavinMQ
       # follower sockets itself — their fds belong to the default execution
       # context's event loop (see Follower#flush_loop).
       if Config.instance.sync?
-        @replicator.try &.followers.each &.request_sync
+        @replicator.try &.request_sync
         begin
           sync
         rescue ex

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -4,6 +4,7 @@ require "./amqp/channel"
 require "./clustering/replicator"
 require "./clustering/follower"
 require "sync/exclusive"
+require "wait_group"
 
 module LavinMQ
   # Owns the filesystem fd used for syncfs(2) and the publish-confirm
@@ -85,20 +86,25 @@ module LavinMQ
       return unless acks
 
       # Ask each follower to push the pending replicated bytes and make them
-      # durable, so they persist and ack them while our own syncfs runs. Only a
-      # request: this loop runs on an isolated thread and must never write the
-      # follower sockets itself — their fds belong to the default execution
-      # context's event loop (see Follower#flush_loop).
+      # durable, so they persist while our own syncfs runs. Only a request: this
+      # loop runs on an isolated thread and must never write the follower sockets
+      # itself, their fds belong to the default execution context's event loop
+      # (see Follower#control_loop).
       if Config.instance.sync?
-        @replicator.try &.request_sync
-        begin
-          sync
-        rescue ex
-          Log.fatal(exception: ex) { "Failed to sync: #{ex.message}" }
-          exit 1
+        WaitGroup.wait do |wg|
+          # Sync implies flush. Both are handled by the "control packet" loop
+          # in the follower so we can be sure the sync packet is written before
+          # flush.
+          @replicator.try &.request_sync(wg)
+          begin
+            sync
+          rescue ex
+            Log.fatal(exception: ex) { "Failed to sync: #{ex.message}" }
+            exit 1
+          end
         end
       else
-        @replicator.try &.followers.each &.request_flush
+        @replicator.try &.request_flush
       end
       # Block until every in-sync follower has acked the replicated bytes and
       # any ISR shrink is committed to the coordinator, so a confirm means

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -84,19 +84,21 @@ module LavinMQ
       end
       return unless acks
 
-      # Ask each follower's flush fiber to push the pending replicated bytes,
-      # so they persist and ack them while our own syncfs runs. Only a
-      # request: this loop runs on an isolated thread and must never write
-      # the follower sockets itself — their fds belong to the default
-      # execution context's event loop (see Follower#flush_loop).
-      @replicator.try &.followers.each &.request_flush
+      # Ask each follower to push the pending replicated bytes and make them
+      # durable, so they persist and ack them while our own syncfs runs. Only a
+      # request: this loop runs on an isolated thread and must never write the
+      # follower sockets itself — their fds belong to the default execution
+      # context's event loop (see Follower#flush_loop).
       if Config.instance.sync?
+        @replicator.try &.followers.each &.request_sync
         begin
           sync
         rescue ex
           Log.fatal(exception: ex) { "Failed to sync: #{ex.message}" }
           exit 1
         end
+      else
+        @replicator.try &.followers.each &.request_flush
       end
       # Block until every in-sync follower has acked the replicated bytes and
       # any ISR shrink is committed to the coordinator, so a confirm means


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR introduces "control packets" in the clustering protocol. A control packets is just a "file delete" packet with a special filename. This means that it's backward compatible as an old follower would treat these packets as noop.

By introducing control packets the leader will now send a "sync" packet when it want to do a syncfs, meaning that that followers won't do it periodically anymore, only on demand. The leader will wait for the sync packet to be acked before sending confirms to its publishers.

Addresses #2177

### HOW can this pull request be tested?
Specs, but should be tested and benchmarked manually.
