### PR TITLE
Exit process if syncfs is blocked for 10 seconds

### DIFF
--- a/spec/clustering_client_syncfs_spec.cr
+++ b/spec/clustering_client_syncfs_spec.cr
@@ -1,0 +1,25 @@
+require "./spec_helper"
+require "../src/lavinmq/clustering/client"
+
+private class TimeoutSyncClient < LavinMQ::Clustering::Client
+  def wait_for_syncfs_public : Nil
+    wait_for_syncfs
+  end
+
+  protected def syncfs_timeout : Time::Span
+    1.millisecond
+  end
+end
+
+describe LavinMQ::Clustering::Client do
+  it "exits when syncfs is blocked past the timeout" do
+    config = LavinMQ::Config.instance
+    config.metrics_http_port = -1
+    client = TimeoutSyncClient.new(config, 1, "secret", proxy: false)
+
+    ex = expect_raises(SpecExit) { client.wait_for_syncfs_public }
+    ex.code.should eq 1
+  ensure
+    client.try &.close
+  end
+end

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -179,6 +179,7 @@ describe LavinMQ::Config do
           advertised_uri = lavinmq://localhost:5680
           on_leader_elected = echo "Leader elected"
           on_leader_lost = echo "Leader lost"
+          syncfs_timeout = 20
         CONFIG
     end
     config = LavinMQ::Config.new
@@ -263,6 +264,7 @@ describe LavinMQ::Config do
     config.clustering_advertised_uri.should eq "lavinmq://localhost:5680"
     config.clustering_on_leader_elected.should eq "echo \"Leader elected\""
     config.clustering_on_leader_lost.should eq "echo \"Leader lost\""
+    config.clustering_syncfs_timeout.should eq 20.seconds
   ensure
     # Reset log level to default for other specs
     Log.setup(:fatal)
@@ -308,6 +310,7 @@ describe LavinMQ::Config do
       "--clustering-etcd-prefix=cli-prefix",
       "--clustering-max-unsynced-actions=4096",
       "--clustering-port=5680",
+      "--clustering-syncfs-timeout=20",
     ]
     config.parse(argv)
 
@@ -347,6 +350,7 @@ describe LavinMQ::Config do
     config.clustering_etcd_endpoints.should eq "etcd1:2379,etcd2:2379"
     config.clustering_etcd_prefix.should eq "cli-prefix"
     config.clustering_port.should eq 5680
+    config.clustering_syncfs_timeout.should eq 20.seconds
   end
 
   it "can parse -d/--debug flag for verbose logging" do
@@ -381,6 +385,7 @@ describe LavinMQ::Config do
     ENV["LAVINMQ_CLUSTERING_ETCD_PREFIX"] = "env-prefix"
     ENV["LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS"] = "2048"
     ENV["LAVINMQ_CLUSTERING_PORT"] = "5681"
+    ENV["LAVINMQ_CLUSTERING_SYNCFS_TIMEOUT"] = "20"
     ENV["LAVINMQ_SYNC"] = "false"
     ENV["LAVINMQ_CONTROL_UNIX_PATH"] = "/tmp/lavinmqctl-env.sock"
     config = LavinMQ::Config.new
@@ -405,6 +410,7 @@ describe LavinMQ::Config do
     config.clustering_etcd_endpoints.should eq "env-etcd:2379"
     config.clustering_etcd_prefix.should eq "env-prefix"
     config.clustering_port.should eq 5681
+    config.clustering_syncfs_timeout.should eq 20.seconds
     config.control_unix_path.should eq "/tmp/lavinmqctl-env.sock"
   ensure
     ENV.delete("LAVINMQ_CONFIGURATION_DIRECTORY")
@@ -428,6 +434,7 @@ describe LavinMQ::Config do
     ENV.delete("LAVINMQ_CLUSTERING_ETCD_PREFIX")
     ENV.delete("LAVINMQ_CLUSTERING_MAX_UNSYNCED_ACTIONS")
     ENV.delete("LAVINMQ_CLUSTERING_PORT")
+    ENV.delete("LAVINMQ_CLUSTERING_SYNCFS_TIMEOUT")
     ENV.delete("LAVINMQ_CONTROL_UNIX_PATH")
   end
 

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -634,6 +634,23 @@ describe LavinMQ::Config do
     end
   end
 
+  describe "clustering_syncfs_timeout" do
+    it "rejects non-positive values" do
+      [0, -10].each do |seconds|
+        config_file = File.tempfile do |file|
+          file.print <<-CONFIG
+            [clustering]
+            syncfs_timeout = #{seconds}
+            CONFIG
+        end
+        config = LavinMQ::Config.new
+        expect_raises(LavinMQ::Config::Error, /clustering_syncfs_timeout/) do
+          config.parse(["-c", config_file.path])
+        end
+      end
+    end
+  end
+
   describe "reload" do
     it "keeps the running config when the new config has an invalid value" do
       config_file = File.tempfile("lavinmq-config", ".ini")

--- a/spec/persister_spec.cr
+++ b/spec/persister_spec.cr
@@ -59,4 +59,35 @@ describe LavinMQ::Persister do
   ensure
     persister.try &.close
   end
+
+  it "does not race when close runs while a sync is in flight" do
+    persister = BlockingPersister.new(LavinMQ::Config.instance.data_dir)
+    sync_result = Channel(Exception?).new(1)
+
+    spawn do
+      persister.sync
+      sync_result.send nil
+    rescue ex
+      sync_result.send ex
+    end
+    persister.sync_started.receive
+
+    # close's fd/@syncfs_ok teardown (in publish_confirm_loop's rescue) must
+    # queue behind @syncfs_lock, held by the in-flight sync above, instead of
+    # tearing down while that sync is still using @data_dir_fd/@syncfs_ok.
+    persister.close
+    # give the close-teardown fiber (a separate OS thread) a real chance to
+    # run while our sync is still blocked mid-syscall, holding the lock —
+    # without this, the race below is timing-dependent and rarely triggers.
+    sleep 50.milliseconds
+
+    persister.release_sync.send nil
+    sync_result.receive.should be_nil
+
+    wait_for { persister.closed? }
+
+    # A sync call arriving after the persister is fully closed must be a
+    # silent no-op — never a Channel::ClosedError from the closed @syncfs_ok.
+    persister.sync
+  end
 end

--- a/spec/persister_spec.cr
+++ b/spec/persister_spec.cr
@@ -1,0 +1,62 @@
+require "./spec_helper"
+
+private class BlockingPersister < LavinMQ::Persister
+  getter sync_started = Channel(Nil).new
+  getter release_sync = Channel(Nil).new
+
+  protected def sync_data_dir : Nil
+    @sync_started.send nil
+    @release_sync.receive
+  end
+end
+
+private class TimeoutPersister < LavinMQ::Persister
+  def wait_for_syncfs_public : Nil
+    wait_for_syncfs
+  end
+
+  protected def syncfs_timeout : Time::Span
+    1.millisecond
+  end
+end
+
+describe LavinMQ::Persister do
+  it "exits when syncfs exceeds the timeout" do
+    persister = TimeoutPersister.new(LavinMQ::Config.instance.data_dir)
+
+    ex = expect_raises(SpecExit) { persister.wait_for_syncfs_public }
+    ex.code.should eq 1
+  ensure
+    persister.try &.close
+  end
+
+  it "serializes concurrent sync calls" do
+    persister = BlockingPersister.new(LavinMQ::Config.instance.data_dir)
+    completed = Channel(Nil).new(2)
+
+    spawn do
+      persister.sync
+      completed.send nil
+    end
+    persister.sync_started.receive
+
+    spawn do
+      persister.sync
+      completed.send nil
+    end
+
+    select
+    when persister.sync_started.receive
+      fail "a second sync entered while the first was blocked"
+    when timeout(100.milliseconds)
+      # The second sync is waiting for the first to release the mutex.
+    end
+
+    persister.release_sync.send nil
+    persister.sync_started.receive
+    persister.release_sync.send nil
+    2.times { completed.receive }
+  ensure
+    persister.try &.close
+  end
+end

--- a/spec/persister_spec.cr
+++ b/spec/persister_spec.cr
@@ -76,6 +76,12 @@ private class BlockingPersister < LavinMQ::Persister
     @sync_started.send nil
     @release_sync.receive
   end
+
+  # `sync` is private (only called internally by the sync loop); expose it so
+  # specs can drive it directly instead of going through enqueue_ack/enqueue_tx_commit.
+  def sync_public : Nil
+    sync
+  end
 end
 
 private class TimeoutPersister < LavinMQ::Persister
@@ -114,7 +120,7 @@ describe LavinMQ::Persister do
     sync_result = Channel(Exception?).new(1)
 
     spawn do
-      persister.sync
+      persister.sync_public
       sync_result.send nil
     rescue ex
       sync_result.send ex
@@ -129,66 +135,5 @@ describe LavinMQ::Persister do
     sync_result.receive.should be_nil
   ensure
     persister.try &.close
-  end
-
-  it "serializes concurrent sync calls" do
-    persister = BlockingPersister.new(LavinMQ::Config.instance.data_dir)
-    completed = Channel(Nil).new(2)
-
-    spawn do
-      persister.sync
-      completed.send nil
-    end
-    persister.sync_started.receive
-
-    spawn do
-      persister.sync
-      completed.send nil
-    end
-
-    select
-    when persister.sync_started.receive
-      fail "a second sync entered while the first was blocked"
-    when timeout(100.milliseconds)
-      # The second sync is waiting for the first to release the mutex.
-    end
-
-    persister.release_sync.send nil
-    persister.sync_started.receive
-    persister.release_sync.send nil
-    2.times { completed.receive }
-  ensure
-    persister.try &.close
-  end
-
-  it "does not race when close runs while a sync is in flight" do
-    persister = BlockingPersister.new(LavinMQ::Config.instance.data_dir)
-    sync_result = Channel(Exception?).new(1)
-
-    spawn do
-      persister.sync
-      sync_result.send nil
-    rescue ex
-      sync_result.send ex
-    end
-    persister.sync_started.receive
-
-    # close's fd/@syncfs_ok teardown (in publish_confirm_loop's rescue) must
-    # queue behind @syncfs_lock, held by the in-flight sync above, instead of
-    # tearing down while that sync is still using @data_dir_fd/@syncfs_ok.
-    persister.close
-    # give the close-teardown fiber (a separate OS thread) a real chance to
-    # run while our sync is still blocked mid-syscall, holding the lock —
-    # without this, the race below is timing-dependent and rarely triggers.
-    sleep 50.milliseconds
-
-    persister.release_sync.send nil
-    sync_result.receive.should be_nil
-
-    wait_for { persister.closed? }
-
-    # A sync call arriving after the persister is fully closed must be a
-    # silent no-op — never a Channel::ClosedError from the closed @syncfs_ok.
-    persister.sync
   end
 end

--- a/spec/persister_spec.cr
+++ b/spec/persister_spec.cr
@@ -1,5 +1,73 @@
 require "./spec_helper"
 
+# Minimal no-op stand-in for a real replicator: only its presence matters
+# here (Persister treats a non-nil @replicator as "clustering is enabled").
+private class NullReplicator
+  include LavinMQ::Clustering::Replicator
+
+  def register_file(path : String)
+  end
+
+  def register_file(file : File)
+  end
+
+  def register_file(mfile : MFile)
+  end
+
+  def replace_file(path : String)
+  end
+
+  def replace_file(mfile : MFile)
+  end
+
+  def append(path : String, pos : Int, length : Int)
+  end
+
+  def append_value(path : String, value : UInt32 | Int32, offset : Int64)
+  end
+
+  def append_bytes(path : String, bytes : Bytes, offset : Int64)
+  end
+
+  def delete_file(path : String)
+  end
+
+  def followers : Array(LavinMQ::Clustering::Follower)
+    Array(LavinMQ::Clustering::Follower).new
+  end
+
+  def syncing_followers : Array(LavinMQ::Clustering::Follower)
+    Array(LavinMQ::Clustering::Follower).new
+  end
+
+  def all_followers : Array(LavinMQ::Clustering::Follower)
+    Array(LavinMQ::Clustering::Follower).new
+  end
+
+  def isr_dirty? : Bool
+    false
+  end
+
+  def flush_isr : Nil
+  end
+
+  def wait_for_followers : Nil
+  end
+
+  def close
+  end
+
+  def listen(server : TCPServer)
+  end
+
+  def clear
+  end
+
+  def password : String
+    ""
+  end
+end
+
 private class BlockingPersister < LavinMQ::Persister
   getter sync_started = Channel(Nil).new
   getter release_sync = Channel(Nil).new
@@ -20,12 +88,45 @@ private class TimeoutPersister < LavinMQ::Persister
   end
 end
 
+# Combines BlockingPersister's controllable sync_data_dir with a very short
+# timeout, so the real sync() -> @syncfs_ok -> background watchdog path can
+# be exercised end-to-end (a single producer/consumer pair on @syncfs_ok,
+# unlike calling wait_for_syncfs directly alongside the persister's own live
+# background watchdog fiber, which would race for the same signal).
+private class BlockingTimeoutPersister < BlockingPersister
+  protected def syncfs_timeout : Time::Span
+    1.millisecond
+  end
+end
+
 describe LavinMQ::Persister do
-  it "exits when syncfs exceeds the timeout" do
-    persister = TimeoutPersister.new(LavinMQ::Config.instance.data_dir)
+  it "exits when syncfs exceeds the timeout while clustering is enabled" do
+    persister = TimeoutPersister.new(LavinMQ::Config.instance.data_dir, NullReplicator.new)
 
     ex = expect_raises(SpecExit) { persister.wait_for_syncfs_public }
     ex.code.should eq 1
+  ensure
+    persister.try &.close
+  end
+
+  it "logs but does not exit when syncfs exceeds the timeout and clustering is disabled" do
+    persister = BlockingTimeoutPersister.new(LavinMQ::Config.instance.data_dir) # no replicator: standalone
+    sync_result = Channel(Exception?).new(1)
+
+    spawn do
+      persister.sync
+      sync_result.send nil
+    rescue ex
+      sync_result.send ex
+    end
+    persister.sync_started.receive
+
+    # Give the background watchdog time to notice the 1ms timeout, log, and
+    # settle into waiting for the real completion instead of exiting.
+    sleep 20.milliseconds
+
+    persister.release_sync.send nil
+    sync_result.receive.should be_nil
   ensure
     persister.try &.close
   end

--- a/spec/tx_spec.cr
+++ b/spec/tx_spec.cr
@@ -68,6 +68,46 @@ describe "Transactions" do
         end
       end
     end
+
+    it "commits quickly (no batching delay)" do
+      with_amqp_server do |s|
+        with_channel(s) do |ch|
+          ch.tx_select
+          q = ch.queue
+          q.publish "msg"
+          start = Time.instant
+          ch.tx_commit
+          duration = Time.instant - start
+          duration.should be < 100.milliseconds
+        end
+      end
+    end
+
+    it "commits from multiple channels concurrently without blocking each other" do
+      # Tx::CommitOk is sent asynchronously via the same batching loop as
+      # publish confirms (see Persister#enqueue_tx_commit); this exercises
+      # concurrent commits from many channels being drained together without
+      # cross-talk or deadlock.
+      with_amqp_server do |s|
+        conn = AMQP::Client.new(port: amqp_port(s)).connect
+        n = 20
+        channels = Array.new(n) { conn.channel }
+        queues = channels.map_with_index { |ch, i| ch.queue("tx_concurrent_#{i}") }
+        done = Channel(Nil).new(n)
+        channels.each_with_index do |ch, i|
+          spawn do
+            ch.tx_select
+            queues[i].publish "msg"
+            ch.tx_commit
+            done.send nil
+          end
+        end
+        n.times { done.receive }
+        queues.each(&.message_count.should(eq(1)))
+      ensure
+        conn.try &.close(no_wait: false)
+      end
+    end
   end
 
   describe "acks" do

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -50,6 +50,7 @@ module LavinMQ
       @confirm = false
       @confirm_total = 0_u64
       @confirm_ack_mailbox : ::Channel(UInt64)?
+      @tx_commit_mailbox : ::Channel(Bool)?
       @next_publish_mandatory = false
       @next_publish_immediate = false
       @next_publish_exchange_name : String?
@@ -351,6 +352,21 @@ module LavinMQ
       private def confirm_writer(mailbox : ::Channel(UInt64))
         while msgid = mailbox.receive?
           do_confirm_ack(msgid, multiple: true)
+        end
+      end
+
+      # Non-blocking. tx.commit has no no-wait variant, so the client never
+      # has more than one commit in flight on this channel — a plain 1-slot
+      # send is enough, no merging needed.
+      def enqueue_commit_ok : Nil
+        mailbox = @tx_commit_mailbox || return
+        mailbox.try_send true
+      rescue ::Channel::ClosedError
+      end
+
+      private def tx_commit_writer(mailbox : ::Channel(Bool))
+        while mailbox.receive?
+          send AMQP::Frame::Tx::CommitOk.new(@id)
         end
       end
 
@@ -717,6 +733,7 @@ module LavinMQ
         return false unless @running
         @running = false
         @confirm_ack_mailbox.try &.close
+        @tx_commit_mailbox.try &.close
         @consumers.each_with_index(1) do |consumer, i|
           consumer.close
           consumer.queue.rm_consumer(consumer)
@@ -821,16 +838,24 @@ module LavinMQ
           @client.send_precondition_failed(frame, "Channel already in confirm mode")
           return
         end
+        unless @tx
+          @tx_commit_mailbox = mailbox = ::Channel(Bool).new(1)
+          spawn tx_commit_writer(mailbox), name: "Channel##{@id} tx commit writer"
+        end
         @tx = true
         send AMQP::Frame::Tx::SelectOk.new(frame.channel)
       end
 
+      # Applies the tx's acks/publishes synchronously (so they're visible
+      # before the next frame on this channel is processed), then hands the
+      # commit off to the Persister — same as a publish confirm, the
+      # Tx::CommitOk is sent asynchronously once the batched syncfs (and
+      # follower wait) completes, see `Persister#enqueue_tx_commit`.
       def tx_commit(frame)
         return @client.send_precondition_failed(frame, "Not in transaction mode") unless @tx
         process_tx_acks
         process_tx_publishes
-        @client.vhost.sync
-        send AMQP::Frame::Tx::CommitOk.new(frame.channel)
+        @client.vhost.enqueue_tx_commit(self)
       end
 
       private def process_tx_publishes

--- a/src/lavinmq/clustering/client.cr
+++ b/src/lavinmq/clustering/client.cr
@@ -61,6 +61,14 @@ module LavinMQ
         Dir.mkdir_p @data_dir
         @data_dir_fd = LibC.open(@data_dir.check_no_null_byte, LibC::O_RDONLY)
         raise IO::Error.from_errno("Failed to open #{@data_dir}") if @data_dir_fd < 0
+        @syncfs_ok = Channel(Nil).new(2) # 2 slots: one for syncfs start, one for syncfs end
+        # A follower only exists while clustering, so unlike the leader's
+        # Persister (which also runs standalone) there's no case where dying
+        # on a blocked syncfs doesn't help: staying an unresponsive follower
+        # forever is strictly worse than exiting so the leader drops it from
+        # the in-sync set. See Persister#syncfs_timeout_loop for the same
+        # start/end signal protocol.
+        Fiber::ExecutionContext::Isolated.new("clustering syncfs timeout loop") { syncfs_timeout_loop }
         @data_dir_lock = DataDirLock.new(@data_dir).tap &.acquire
         backup_dir = File.join(@data_dir, "backups")
         FileUtils.rm_rf(backup_dir) if Dir.exists?(backup_dir)
@@ -611,7 +619,12 @@ module LavinMQ
       private def sync_to_disk : Nil
         return unless @config.sync?
 
-        sync_data_dir
+        @syncfs_ok.send nil
+        begin
+          sync_data_dir
+        ensure
+          @syncfs_ok.send nil
+        end
       rescue ex
         # Can't ack data that isn't durable; die fast so the leader drops us
         # from the in-sync set and stops confirming publishes on our acks.
@@ -619,13 +632,35 @@ module LavinMQ
         exit 1
       end
 
-      private def sync_data_dir : Nil
+      protected def sync_data_dir : Nil
         {% if flag?(:linux) %}
           ret = LibC.syncfs(@data_dir_fd)
           raise IO::Error.from_errno("syncfs") if ret != 0
         {% else %}
           LibC.sync
         {% end %}
+      end
+
+      private def syncfs_timeout_loop
+        loop do
+          @syncfs_ok.receive # syncfs is about to run
+          wait_for_syncfs
+        rescue Channel::ClosedError
+          break
+        end
+      end
+
+      private def wait_for_syncfs : Nil
+        select
+        when @syncfs_ok.receive     # syncfs completed
+        when timeout syncfs_timeout # syncfs blocked for too long
+          Log.fatal { "syncfs(2) is blocked, exiting so the leader can drop this follower" }
+          exit 1
+        end
+      end
+
+      protected def syncfs_timeout : Time::Span
+        Config.instance.clustering_syncfs_timeout
       end
 
       # Logs the streamed byte count until #stream_changes closes the done
@@ -687,6 +722,10 @@ module LavinMQ
         finalize_digests
         @checksums.store
         LibC.close(@data_dir_fd) if @data_dir_fd >= 0
+        # @ack_loops.wait above guarantees sync_to_disk (the only caller of
+        # sync_data_dir) has fully finished, so this can't race an in-flight
+        # start/end signal pair the way Persister#close has to guard against.
+        @syncfs_ok.close # close the syncfs timeout loop
         @data_dir_lock.release
         @metrics_server.try &.close
       end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -87,6 +87,9 @@ module LavinMQ
       unless @stats_interval.positive?
         raise Error.new("stats_interval must be positive (got #{@stats_interval})")
       end
+      unless @clustering_syncfs_timeout.positive?
+        raise Error.new("clustering_syncfs_timeout must be positive (got #{@clustering_syncfs_timeout})")
+      end
     end
 
     private def parse_config_from_cli(argv)

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -430,6 +430,17 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_CLUSTERING_PORT")]
       property clustering_port = 5679
 
+      # Used on both the leader (Persister) and a follower (Clustering::Client)
+      # to bound how long a blocked syncfs(2) is tolerated before exiting so a
+      # standby node can take over. Only enforced while clustering is enabled:
+      # a standalone node has no follower to fail over to, so it logs instead
+      # of exiting (see Persister#wait_for_syncfs).
+      @[CliOpt("", "--clustering-syncfs-timeout=SECONDS",
+        "Seconds to tolerate a blocked syncfs(2) before exiting (default: 10)", section: "clustering")]
+      @[IniOpt(ini_name: syncfs_timeout, section: "clustering")]
+      @[EnvOpt("LAVINMQ_CLUSTERING_SYNCFS_TIMEOUT")]
+      property clustering_syncfs_timeout : Time::Span = 10.seconds
+
       @[IniOpt(section: "amqp")]
       property max_consumers_per_channel = 0
 

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -21,6 +21,7 @@ module LavinMQ
     # follower only reaches the in-sync set after a full_sync that includes
     # every prior write.
     @pending_acks : Sync::Exclusive(Hash(AMQP::Channel, UInt64)) = Sync::Exclusive.new(Hash(AMQP::Channel, UInt64).new, :unchecked)
+    @syncfs_lock = Mutex.new # serialize all syncfs syscalls
 
     def initialize(data_dir : String, @replicator : Clustering::Replicator? = nil)
       @data_dir_fd = LibC.open(data_dir.check_no_null_byte, LibC::O_RDONLY)
@@ -36,16 +37,23 @@ module LavinMQ
     private def syncfs_timeout_loop
       loop do
         @syncfs_ok.receive # syncfs is about to run
-        select
-        when @syncfs_ok.receive # syncfs completed
-          next
-        when timeout 10.seconds # syncfs blocked for too long
-          Log.fatal { "syncfs(2) is blocked" }
-          exit 1
-        end
+        wait_for_syncfs
       rescue Channel::ClosedError
         break
       end
+    end
+
+    private def wait_for_syncfs : Nil
+      select
+      when @syncfs_ok.receive     # syncfs completed
+      when timeout syncfs_timeout # syncfs blocked for too long
+        Log.fatal { "syncfs(2) is blocked" }
+        exit 1
+      end
+    end
+
+    protected def syncfs_timeout : Time::Span
+      10.seconds
     end
 
     # Every confirm — sync, no-sync, and clustered alike — is routed through the
@@ -63,15 +71,23 @@ module LavinMQ
     end
 
     def sync : Nil
-      @syncfs_ok.send nil
+      @syncfs_lock.synchronize do
+        @syncfs_ok.send nil
+        begin
+          sync_data_dir
+        ensure
+          @syncfs_ok.send nil
+        end
+      end
+    end
+
+    protected def sync_data_dir : Nil
       {% if flag?(:linux) %}
         ret = LibC.syncfs(@data_dir_fd)
         raise IO::Error.from_errno("syncfs") if ret != 0
       {% else %}
         LibC.sync
       {% end %}
-    ensure
-      @syncfs_ok.send nil
     end
 
     def close : Nil

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -48,13 +48,21 @@ module LavinMQ
       select
       when @syncfs_ok.receive     # syncfs completed
       when timeout syncfs_timeout # syncfs blocked for too long
-        Log.fatal { "syncfs(2) is blocked" }
+        unless @replicator
+          # No follower to fail over to — dying doesn't help availability, it
+          # just turns a slow disk into a full outage. Log and keep waiting.
+          Log.error { "syncfs(2) is blocked" }
+          @syncfs_ok.receive # wait for the real completion so it isn't later
+          # mistaken for the *next* call's start signal (see #sync)
+          return
+        end
+        Log.fatal { "syncfs(2) is blocked, exiting so a follower can take over" }
         exit 1
       end
     end
 
     protected def syncfs_timeout : Time::Span
-      10.seconds
+      Config.instance.clustering_syncfs_timeout
     end
 
     # Every confirm — sync, no-sync, and clustered alike — is routed through the

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -21,7 +21,8 @@ module LavinMQ
     # follower only reaches the in-sync set after a full_sync that includes
     # every prior write.
     @pending_acks : Sync::Exclusive(Hash(AMQP::Channel, UInt64)) = Sync::Exclusive.new(Hash(AMQP::Channel, UInt64).new, :unchecked)
-    @syncfs_lock = Mutex.new # serialize all syncfs syscalls
+    @syncfs_lock = Mutex.new # serialize all syncfs syscalls, and guard @closed/@syncfs_ok/@data_dir_fd teardown
+    getter? closed = false
 
     def initialize(data_dir : String, @replicator : Clustering::Replicator? = nil)
       @data_dir_fd = LibC.open(data_dir.check_no_null_byte, LibC::O_RDONLY)
@@ -72,6 +73,10 @@ module LavinMQ
 
     def sync : Nil
       @syncfs_lock.synchronize do
+        # Persister is closing (or closed) on another fiber: @syncfs_ok and
+        # @data_dir_fd may already be torn down (see #close), so bail out
+        # instead of sending on a closed channel or syncing a closed fd.
+        return if @closed
         @syncfs_ok.send nil
         begin
           sync_data_dir
@@ -106,8 +111,15 @@ module LavinMQ
       # @publish_confirm_requested is closed; flush anything that was persisted
       # but not yet confirmed before exiting.
       drain_pending_acks
-      LibC.close(@data_dir_fd) if @data_dir_fd >= 0
-      @syncfs_ok.close # close the syncfs timeout loop
+      # Take the same lock `sync` uses so this can't race a concurrent (or
+      # about-to-start) sync() call: either it's already in flight and holds
+      # the lock — we wait for it to finish before tearing anything down —
+      # or it hasn't started yet and will see @closed and bail out below.
+      @syncfs_lock.synchronize do
+        @closed = true
+        LibC.close(@data_dir_fd) if @data_dir_fd >= 0
+        @syncfs_ok.close # close the syncfs timeout loop
+      end
     end
 
     private def drain_pending_acks

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -25,9 +25,27 @@ module LavinMQ
     def initialize(data_dir : String, @replicator : Clustering::Replicator? = nil)
       @data_dir_fd = LibC.open(data_dir.check_no_null_byte, LibC::O_RDONLY)
       raise IO::Error.from_errno("Failed to open #{data_dir}") if @data_dir_fd < 0
+      @syncfs_ok = Channel(Nil).new(2) # 2 slots: one for syncfs start, one for syncfs end
       # Run on a dedicated thread so the blocking syncfs(2) syscall only stalls
       # this thread, not the worker threads handling client connections.
       Fiber::ExecutionContext::Isolated.new("Publish confirm loop") { publish_confirm_loop }
+      # Timeout and exit process if syncfs doesn't respond in time
+      Fiber::ExecutionContext::Isolated.new("syncfs timeout loop") { syncfs_timeout_loop }
+    end
+
+    private def syncfs_timeout_loop
+      loop do
+        @syncfs_ok.receive # syncfs is about to run
+        select
+        when @syncfs_ok.receive # syncfs completed
+          next
+        when timeout 10.seconds # syncfs blocked for too long
+          Log.fatal { "syncfs(2) is blocked" }
+          exit 1
+        end
+      rescue Channel::ClosedError
+        break
+      end
     end
 
     # Every confirm — sync, no-sync, and clustered alike — is routed through the
@@ -45,12 +63,15 @@ module LavinMQ
     end
 
     def sync : Nil
+      @syncfs_ok.send nil
       {% if flag?(:linux) %}
         ret = LibC.syncfs(@data_dir_fd)
         raise IO::Error.from_errno("syncfs") if ret != 0
       {% else %}
         LibC.sync
       {% end %}
+    ensure
+      @syncfs_ok.send nil
     end
 
     def close : Nil
@@ -70,6 +91,7 @@ module LavinMQ
       # but not yet confirmed before exiting.
       drain_pending_acks
       LibC.close(@data_dir_fd) if @data_dir_fd >= 0
+      @syncfs_ok.close # close the syncfs timeout loop
     end
 
     private def drain_pending_acks

--- a/src/lavinmq/persister.cr
+++ b/src/lavinmq/persister.cr
@@ -6,22 +6,25 @@ require "./clustering/follower"
 require "sync/exclusive"
 
 module LavinMQ
-  # Owns the filesystem fd used for syncfs(2) and the publish-confirm
-  # batching loop. A single Persister is created per Server and shared
-  # between all VHosts — since they live on the same filesystem, one
-  # syncfs flushes data for every vhost in one syscall.
+  # Owns the filesystem fd used for syncfs(2) and the batching loop for
+  # publish confirms and tx.commit. A single Persister is created per Server
+  # and shared between all VHosts — since they live on the same filesystem,
+  # one syncfs flushes data for every vhost in one syscall.
   class Persister
     Log = LavinMQ::Log.for "persister"
 
     @data_dir_fd : Int32 = -1
-    @publish_confirm_requested = ::Channel(Bool).new(1)
+    @sync_requested = ::Channel(Bool).new(1)
     # Confirm acks accumulated since the last drain. The follower set is
     # decided at drain time against the in-sync set as it exists then (see
     # Clustering::Server#wait_for_followers), which is safe because a
     # follower only reaches the in-sync set after a full_sync that includes
     # every prior write.
     @pending_acks : Sync::Exclusive(Hash(AMQP::Channel, UInt64)) = Sync::Exclusive.new(Hash(AMQP::Channel, UInt64).new, :unchecked)
-    @syncfs_lock = Mutex.new # serialize all syncfs syscalls, and guard @closed/@syncfs_ok/@data_dir_fd teardown
+    # Channels with a Tx::CommitOk owed since the last drain. tx.commit has no
+    # no-wait variant, so a compliant client never has more than one commit in
+    # flight per channel — a Set is enough, no need to count.
+    @pending_tx_commits : Sync::Exclusive(Set(AMQP::Channel)) = Sync::Exclusive.new(Set(AMQP::Channel).new, :unchecked)
     getter? closed = false
 
     def initialize(data_dir : String, @replicator : Clustering::Replicator? = nil)
@@ -30,7 +33,7 @@ module LavinMQ
       @syncfs_ok = Channel(Nil).new(2) # 2 slots: one for syncfs start, one for syncfs end
       # Run on a dedicated thread so the blocking syncfs(2) syscall only stalls
       # this thread, not the worker threads handling client connections.
-      Fiber::ExecutionContext::Isolated.new("Publish confirm loop") { publish_confirm_loop }
+      Fiber::ExecutionContext::Isolated.new("Sync loop") { sync_loop }
       # Timeout and exit process if syncfs doesn't respond in time
       Fiber::ExecutionContext::Isolated.new("syncfs timeout loop") { syncfs_timeout_loop }
     end
@@ -66,31 +69,36 @@ module LavinMQ
     end
 
     # Every confirm — sync, no-sync, and clustered alike — is routed through the
-    # publish confirm loop so each channel has exactly one producer of ack
-    # frames. `sync` is a runtime-mutable INI option (SIGHUP reloads it); taking
+    # sync loop so each channel has exactly one producer of ack frames.
+    # `sync` is a runtime-mutable INI option (SIGHUP reloads it); taking
     # a shortcut here when it is disabled would let a later direct ack overtake
     # an earlier batched one after a mid-stream flip, sending cumulative
     # Basic.Ack frames out of delivery-tag order (see #2078). The loop skips the
-    # actual syncfs while sync is disabled (see drain_pending_acks), so no-sync
+    # actual syncfs while sync is disabled (see drain_pending), so no-sync
     # only pays a single hop to the loop, not a disk flush.
     def enqueue_ack(channel : AMQP::Channel, msgid : UInt64)
       @pending_acks.lock { |acks| acks[channel] = msgid }
-      @publish_confirm_requested.try_send true
+      @sync_requested.try_send true
     rescue ::Channel::ClosedError
     end
 
-    def sync : Nil
-      @syncfs_lock.synchronize do
-        # Persister is closing (or closed) on another fiber: @syncfs_ok and
-        # @data_dir_fd may already be torn down (see #close), so bail out
-        # instead of sending on a closed channel or syncing a closed fd.
-        return if @closed
+    # Routes tx.commit through the same loop as publish confirms: the
+    # syncfs(2) syscall must never run on a thread other than this loop's
+    # dedicated one, so `Channel#tx_commit` can't just call it inline. The
+    # Tx::CommitOk frame is sent asynchronously once the batched syncfs (and
+    # follower wait) completes.
+    def enqueue_tx_commit(channel : AMQP::Channel) : Nil
+      @pending_tx_commits.lock { |commits| commits << channel }
+      @sync_requested.try_send true
+    rescue ::Channel::ClosedError
+    end
+
+    private def sync : Nil
+      @syncfs_ok.send nil
+      begin
+        sync_data_dir
+      ensure
         @syncfs_ok.send nil
-        begin
-          sync_data_dir
-        ensure
-          @syncfs_ok.send nil
-        end
       end
     end
 
@@ -104,33 +112,30 @@ module LavinMQ
     end
 
     def close : Nil
-      @publish_confirm_requested.close
+      @sync_requested.close
     end
 
-    private def publish_confirm_loop
+    private def sync_loop
       loop do
-        # Wake on the first request, then sync + confirm everything pending.
-        # While syncfs runs, new requests accumulate in @pending_acks and are
-        # flushed by the next iteration — batching emerges without any delay.
-        @publish_confirm_requested.receive
-        drain_pending_acks
+        # Wake on the first request, then sync + confirm/commit everything
+        # pending. While syncfs runs, new requests accumulate in @pending_acks
+        # and @pending_tx_commits and are flushed by the next iteration —
+        # batching emerges without any delay.
+        @sync_requested.receive
+        drain_pending
       end
     rescue ::Channel::ClosedError
-      # @publish_confirm_requested is closed; flush anything that was persisted
-      # but not yet confirmed before exiting.
-      drain_pending_acks
-      # Take the same lock `sync` uses so this can't race a concurrent (or
-      # about-to-start) sync() call: either it's already in flight and holds
-      # the lock — we wait for it to finish before tearing anything down —
-      # or it hasn't started yet and will see @closed and bail out below.
-      @syncfs_lock.synchronize do
-        @closed = true
-        LibC.close(@data_dir_fd) if @data_dir_fd >= 0
-        @syncfs_ok.close # close the syncfs timeout loop
-      end
+      # @sync_requested is closed; flush anything that was persisted but not
+      # yet confirmed/committed before exiting. This runs in the same fiber as
+      # the loop above, so it can't race a sync() call — there isn't one in
+      # flight, and none can start after this point.
+      drain_pending
+      @closed = true
+      LibC.close(@data_dir_fd) if @data_dir_fd >= 0
+      @syncfs_ok.close # close the syncfs timeout loop
     end
 
-    private def drain_pending_acks
+    private def drain_pending
       acks : Hash(AMQP::Channel, UInt64)? = nil
       @pending_acks.replace do |current|
         if current.empty?
@@ -140,7 +145,18 @@ module LavinMQ
           Hash(AMQP::Channel, UInt64).new
         end
       end
-      return unless acks
+
+      tx_commits : Set(AMQP::Channel)? = nil
+      @pending_tx_commits.replace do |current|
+        if current.empty?
+          current
+        else
+          tx_commits = current
+          Set(AMQP::Channel).new
+        end
+      end
+
+      return if acks.nil? && tx_commits.nil?
 
       # Ask each follower's flush fiber to push the pending replicated bytes,
       # so they persist and ack them while our own syncfs runs. Only a
@@ -165,8 +181,11 @@ module LavinMQ
       # leader's lease expires and the process exits.
       @replicator.try &.wait_for_followers
 
-      acks.each do |channel, msgid|
+      acks.try &.each do |channel, msgid|
         channel.enqueue_confirm_ack(msgid)
+      end
+      tx_commits.try &.each do |channel|
+        channel.enqueue_commit_ok
       end
     end
   end

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -638,8 +638,8 @@ module LavinMQ
       @send_oct_count.add(bytes, :relaxed)
     end
 
-    def sync : Nil
-      @persister.sync
+    def enqueue_tx_commit(channel : AMQP::Channel) : Nil
+      @persister.enqueue_tx_commit(channel)
     end
 
     private def definitions : DefinitionsStore


### PR DESCRIPTION
### WHAT is this pull request doing?
`syncfs` can block, if it blocks for more than 10 seconds this PR exits the process so that another node in the cluster can take over. 

### HOW can this pull request be tested?

