### PR TITLE
Fix flaky macos specs 

### DIFF
--- a/spec/amqp/server_spec.cr
+++ b/spec/amqp/server_spec.cr
@@ -82,7 +82,7 @@ describe LavinMQ::AMQP::Server do
       amqp_server.close
       restart_server(server)
       amqp_server = LavinMQ::AMQP::Server.new(server)
-      tcp_server = 100.times do |i|
+      tcp_server = 100.times do
         break TCPServer.new("127.0.0.1", port)
       rescue Socket::BindError
         sleep 10.milliseconds

--- a/spec/amqp/server_spec.cr
+++ b/spec/amqp/server_spec.cr
@@ -82,7 +82,11 @@ describe LavinMQ::AMQP::Server do
       amqp_server.close
       restart_server(server)
       amqp_server = LavinMQ::AMQP::Server.new(server)
-      tcp_server = TCPServer.new("127.0.0.1", port)
+      tcp_server = 100.times do |i|
+        break TCPServer.new("127.0.0.1", port)
+      rescue Socket::BindError
+        sleep 10.milliseconds
+      end || raise "Address already in use 127.0.0.1:#{port}"
       amqp_server.bind_tcp(tcp_server)
       spawn(name: "amqp restart replacement listen spec") { amqp_server.listen }
       wait_for { amqp_server.@listeners.includes?(tcp_server) }

--- a/spec/mqtt/server_spec.cr
+++ b/spec/mqtt/server_spec.cr
@@ -48,7 +48,7 @@ describe LavinMQ::MQTT::Server do
       mqtt_server.close
       restart_server(server)
       mqtt_server = LavinMQ::MQTT::Server.new(server)
-      tcp_server = 100.times do |i|
+      tcp_server = 100.times do
         break TCPServer.new("127.0.0.1", port)
       rescue Socket::BindError
         sleep 10.milliseconds

--- a/spec/mqtt/server_spec.cr
+++ b/spec/mqtt/server_spec.cr
@@ -48,7 +48,11 @@ describe LavinMQ::MQTT::Server do
       mqtt_server.close
       restart_server(server)
       mqtt_server = LavinMQ::MQTT::Server.new(server)
-      tcp_server = TCPServer.new("127.0.0.1", port)
+      tcp_server = 100.times do |i|
+        break TCPServer.new("127.0.0.1", port)
+      rescue Socket::BindError
+        sleep 10.milliseconds
+      end || raise "Address already in use 127.0.0.1:#{port}"
       mqtt_server.bind_tcp(tcp_server)
       spawn(name: "mqtt restart replacement listen spec") { mqtt_server.listen }
       wait_for { mqtt_server.@listeners.includes?(tcp_server) }


### PR DESCRIPTION
They sometimes fails with "Address already in use" on macos. Let's retry a few times before failing.