### PR TITLE
Fix use-after-munmap segfault when dead-lettering races purge/queue delete

### DIFF
--- a/spec/message_store_spec.cr
+++ b/spec/message_store_spec.cr
@@ -123,6 +123,39 @@ def setup_orphaned_ack_scenario(dir)
 end
 
 describe LavinMQ::MessageStore do
+  describe "#copy" do
+    # Regression: dead-lettering routes a message after releasing the queue's
+    # @msg_store_lock, while a racing purge/queue delete can munmap the
+    # segment. A zero-copy `store[sp]` read would then segfault mid-copy;
+    # `#copy` must return a message that owns all its memory (body and
+    # headers included).
+    it "returns a message that stays valid after its segment is unmapped" do
+      mktmpdir do |dir|
+        body = "dead letter me"
+        headers = LavinMQ::AMQP::Table.new({"x-dead-letter-exchange" => "dlx"})
+        props = LavinMQ::AMQP::Properties.new(headers: headers)
+        store = LavinMQ::MessageStore.new(dir, nil)
+        msg = LavinMQ::Message.new(Time.utc.to_unix_ms, "ex", "rk", props,
+          body.bytesize.to_u64, IO::Memory.new(body))
+        sp = store.push(msg)
+        copy = store.copy(sp)
+        store.close # unmaps every segment
+        String.new(copy.body).should eq body
+        copy.exchange_name.should eq "ex"
+        copy.routing_key.should eq "rk"
+        copy.properties.headers.should eq headers
+      end
+    end
+
+    it "raises KeyError when the segment is gone" do
+      with_store do |store|
+        sp = store.push(LavinMQ::Message.new("ex", "rk", "body"))
+        gone = LavinMQ::SegmentPosition.new(sp.segment + 1, sp.position, sp.bytesize)
+        expect_raises(KeyError) { store.copy(gone) }
+      end
+    end
+  end
+
   it "deletes orphaned ack files" do
     mktmpdir do |dir|
       # Create a dummy msgs file

--- a/src/lavinmq/amqp/queue/priority_queue.cr
+++ b/src/lavinmq/amqp/queue/priority_queue.cr
@@ -167,6 +167,11 @@ module LavinMQ::AMQP
         store_for sp, &.[sp]
       end
 
+      def copy(sp : SegmentPosition) : BytesMessage
+        raise ClosedError.new if @closed
+        store_for sp, &.copy(sp)
+      end
+
       def delete(sp) : Nil
         raise ClosedError.new if @closed
         store_for sp, &.delete(sp)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -801,22 +801,29 @@ module LavinMQ::AMQP
       @log.info { "Expired #{i} messages" } if i > 0
     end
 
-    private def expire_msg(sp : SegmentPosition, reason : Symbol, dlx_tasks : Argument::DeadLettering::Tasks? = nil)
-      if sp.has_dlx? || @dead_letter.dlx
-        msg = @msg_store_lock.synchronize { @msg_store[sp] }
-        env = Envelope.new(sp, msg, false)
-        expire_msg(env, reason, dlx_tasks)
-      else
-        delete_message sp
-      end
+    private def expire_msg(env : Envelope, reason : Symbol, dlx_tasks : Argument::DeadLettering::Tasks? = nil)
+      expire_msg(env.segment_position, reason, dlx_tasks)
     end
 
-    private def expire_msg(env : Envelope, reason : Symbol, dlx_tasks : Argument::DeadLettering::Tasks? = nil)
-      sp = env.segment_position
-      msg = env.message
-      @log.debug { "Expiring #{sp} now due to #{reason}" }
-
-      @dead_letter.route(msg, reason, dlx_tasks) do
+    private def expire_msg(sp : SegmentPosition, reason : Symbol, dlx_tasks : Argument::DeadLettering::Tasks? = nil)
+      if sp.has_dlx? || @dead_letter.dlx
+        @log.debug { "Expiring #{sp} now due to #{reason}" }
+        # Dead-lettering escapes @msg_store_lock — the message is published
+        # into other queues after this method's lock hold — while a concurrent
+        # purge or queue/vhost delete can unmap the segment it lives in, so a
+        # zero-copy view (`@msg_store[sp]`) would be read after munmap. Route
+        # a copy that owns its memory instead.
+        msg = begin
+          @msg_store_lock.synchronize { @msg_store.copy(sp) }
+        rescue KeyError | MessageStore::ClosedError
+          # The segment (or whole store) is already gone: a racing purge or
+          # delete removed the message, so there is nothing left to route.
+          return
+        end
+        @dead_letter.route(msg, reason, dlx_tasks) do
+          delete_message sp
+        end
+      else
         delete_message sp
       end
     end

--- a/src/lavinmq/message_store.cr
+++ b/src/lavinmq/message_store.cr
@@ -173,6 +173,20 @@ module LavinMQ
       end
     end
 
+    # Like `#[]`, but the returned message owns all its memory: the record is
+    # copied out of the segment's mmap, so the message stays valid after the
+    # segment is deleted and unmapped. For messages that outlive the caller's
+    # @msg_store_lock hold, e.g. dead-lettering (see AMQP::Queue#expire_msg).
+    def copy(sp : SegmentPosition) : BytesMessage
+      raise ClosedError.new if @closed
+      segment = @segments[sp.segment]
+      begin
+        BytesMessage.from_bytes(segment.to_slice(sp.position.to_i64, sp.bytesize.to_i64).dup)
+      rescue ex
+        raise Error.new(segment, cause: ex)
+      end
+    end
+
     def delete(sp) : Nil
       raise ClosedError.new if @closed
       afile = @acks[sp.segment]


### PR DESCRIPTION
## What

`make stress` crashed with a SIGSEGV in `MFile#write` while dead-lettering:

```
#4  write ()            at src/lavinmq/mfile.cr  (memcpy fault)
#5  to_io ()            at src/lavinmq/message.cr:93
#7  write_to_disk ()    at src/lavinmq/message_store.cr
#8  push ()
#9  publish_internal () at src/lavinmq/amqp/queue/queue.cr
#10 drain_context ()    at src/lavinmq/amqp/argument/dead_lettering.cr
#11 route ()
#12 expire_msg ()       at src/lavinmq/amqp/queue/queue.cr
#14 reject ()
#15 do_reject ()        at src/lavinmq/amqp/channel.cr
```

## Root cause

`Queue#expire_msg` read the message under `@msg_store_lock` as a **zero-copy**
`BytesMessage` — its `body` is a slice pointing straight into the source
segment's mmap (`BytesMessage.from_bytes`) — then released the lock and handed
it to the dead-letter router, which publishes it into the target queues.

A concurrent `purge`, queue delete or vhost delete closes the source segment's
`MFile` (munmap) under the *source* queue's lock, which the dead-lettering fiber
no longer holds. When the target queue then copies the body into its own
segment (`MFile#write` → `Slice#copy_to`), it reads from unmapped memory and
segfaults. `extras/stress.cr` churns exactly these operations, which is why it
surfaced there.

This affects every dead-letter trigger, since they all route outside the lock:
reject, TTL expiry, max-length/bytes overflow drop, delivery-limit drop, and the
delayed-exchange queue.

## Fix

Route a message that **owns its memory**. New `MessageStore#copy(sp)` reads the
whole record out of the mmap (`to_slice(pos, bytesize).dup`) under the lock —
headers included, since the lazy `Table` also references the segment buffer — so
the dead-lettered `Message` stays valid after the source segment is unmapped.
Both `expire_msg` overloads now funnel through the `sp`-based one so every
dead-letter path is covered; if the segment is already gone (`KeyError` /
`ClosedError`) the message was removed with its queue data and there is nothing
to route.

## Testing

- New `spec/message_store_spec.cr` regression: `#copy` returns a message that
  stays valid after `store.close` unmaps every segment (body + exchange +
  routing key + headers), and raises `KeyError` when the segment is gone.
- Full suite green (2125 examples), lint clean.
- Reproduced the crash path by inspection against the backtrace; the race window
  is narrow (dead-letter routing must overlap a segment unmap), so a live stress
  repro is timing-dependent, but the copy-under-lock fix closes the window
  entirely and the unit test exercises the use-after-unmap deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)