### PR TITLE
WIP: MQTT5 support

### DIFF
--- a/MQTT5-INTEROP.md
+++ b/MQTT5-INTEROP.md
@@ -1,0 +1,653 @@
+# MQTT interop harness - how to re-run the external verification
+
+Companion to `MQTT5.md`. Section 7 there records *what* the 2026-08-19 external
+run found; this file is *how to run it again*. Nothing here is wired into `make`
+or CI on purpose: it needs a built binary, a network clone and a Docker pull, and
+it is a release-gate check, not a per-commit one.
+
+Re-run it after B / D / E / F land - most of the currently failing Paho tests are
+the grading function for exactly those items. The delivery-QoS and DISCONNECT
+`0x82` expectations below were updated when J1/J2 were fixed but have **not** been
+confirmed by a re-run yet.
+
+## What it exercises that our own specs cannot
+
+`spec/mqtt` drives the broker through `MQTT::Protocol::IO::V5` - the same codec
+the broker encodes with - so a self-consistent wire-format mistake is invisible to
+it. These tools bring their own codecs:
+
+| tool | what it is good for |
+|---|---|
+| Eclipse Paho interoperability suite | 27 v5 + 9 v3.1.1 broker conformance tests, written against the spec by the people who wrote the reference client |
+| paho-mqtt (Python) | property round-trips, capability inspection, wills |
+| mqtt.js (Node) | a third independent codec |
+| mosquitto clients | `-D` sets any v5 property by hand, so one command per row of the section 2 compliance table; prints the DISCONNECT reason code it receives |
+| hand-built raw packets | the byte-exact cases no library will let you send (packet id 0, a second CONNECT, a 5-byte Maximum Packet Size) |
+
+## Prerequisites
+
+`python3`, `node`/`npm`, `docker`, network access. No `sudo`: the mosquitto
+clients come from a container, and `paho-mqtt` goes in a venv (Debian's Python is
+PEP 668 externally-managed).
+
+## Setup
+
+Everything lives in a scratch directory - nothing is written into the repo.
+
+```sh
+export LMQ=/path/to/lavinmq-worktree
+export W=/tmp/mqtt-interop            # anything outside the repo
+mkdir -p "$W/results" && cd "$W"
+
+# 0. the binary under test
+( cd "$LMQ" && make bin/lavinmq CRYSTAL_FLAGS= )
+"$LMQ/bin/lavinmq" --version
+
+# 1. the conformance suite (stdlib only - the client it drives is vendored)
+git clone --depth 1 https://github.com/eclipse-paho/paho.mqtt.testing.git
+
+# 2. LavinMQ requires credentials on every CONNECT, and the suite sends none.
+#    Patch the two vendored clients' connect() defaults instead of ~27 call sites.
+sed -i 's/willRetain=False, username=None, password=None/willRetain=False, username="guest", password=b"guest"/' \
+  paho.mqtt.testing/interoperability/mqtt/clients/V5/main.py \
+  paho.mqtt.testing/interoperability/mqtt/clients/V311/main.py
+
+# 3. the real client libraries
+python3 -m venv venv && ./venv/bin/pip -q install 'paho-mqtt>=2,<3'
+mkdir -p node && ( cd node && npm init -y >/dev/null && npm install --silent mqtt )
+docker pull -q eclipse-mosquitto
+export NODE_PATH="$W/node/node_modules"
+```
+
+### The QoS-clamped copy of the suite
+
+The unmodified v5 suite cannot grade this broker: 22 of its 27 tests use QoS 2
+somewhere, and its client ignores our advertised `maximum_qos = 1` (a
+[MQTT-3.2.2-11] violation on the client's side). We correctly answer DISCONNECT
+`0x9B` and close, after which several tests spin forever on
+`while len(callback.messages) < 3`. Run the unmodified suite once to confirm that
+rejection path, then run this copy for everything else.
+
+```sh
+cp -a paho.mqtt.testing paho.qos1
+python3 - <<'EOF'
+import re
+p = "paho.qos1/interoperability/client_test5.py"
+s = open(p).read()
+s = s.replace("SubscribeOptions(2)", "SubscribeOptions(1)")
+s = re.sub(r"(\.publish\([^\n]*?),\s*2(\s*[,)])", r"\1, 1\2", s)
+s = s.replace("1 in qoss and 2 in qoss and 0 in qoss", "1 in qoss and 0 in qoss")
+open(p, "w").write(s)
+
+p = "paho.qos1/interoperability/client_test.py"
+s = open(p).read()
+s = re.sub(r"(\.publish\([^\n]*?),\s*2(\s*[,)])", r"\1, 1\2", s)
+s = s.replace(", [2])", ", [1])").replace(", [2, 2])", ", [1, 1])").replace(", [2, 1])", ", [1, 1])")
+s = s.replace("assert callback.messages[0][2] == 2", "assert callback.messages[0][2] == 1")
+s = s.replace("assert (callback.messages[0][2] == 2 and callback.messages[1][2] == 1) or \\",
+              "assert (callback.messages[0][2] == 1 and callback.messages[1][2] == 1) or \\")
+# client_test.py forgets to strip -p from argv, so unittest chokes on it
+old = '''    elif o in ("-p", "--port"):
+      port = int(a)'''
+s = s.replace(old, old + '''
+      sys.argv.remove("-p") if "-p" in sys.argv else sys.argv.remove("--port")
+      sys.argv.remove(a)''', 1)
+open(p, "w").write(s)
+
+# the vendored v5 client's connect() defaults to willQoS=2, so every test that
+# sets a will asks for one we advertise we cannot serve
+p = "paho.qos1/interoperability/mqtt/clients/V5/main.py"
+s = open(p).read().replace("willQoS=2", "willQoS=1")
+open(p, "w").write(s)
+EOF
+```
+
+Four kinds of edit, 96 lines in `client_test5.py`, all mechanical: `SubscribeOptions(2)`
+-> `(1)`, the third positional argument of `.publish()` from `2` to `1`, one
+`assertTrue(1 in qoss and 2 in qoss and 0 in qoss)` that can no longer hold, and
+the `willQoS` default. Nothing about what is being asserted changes.
+
+## The scripts
+
+Write these four files into `$W`.
+
+<details>
+<summary><code>broker.sh</code> - start/stop a broker on a fresh data dir</summary>
+
+```bash
+#!/usr/bin/env bash
+# usage: broker.sh start <logfile> | broker.sh stop
+set -u
+W="$(cd "$(dirname "$0")" && pwd)"
+BIN="${LMQ:?set LMQ to the lavinmq worktree}/bin/lavinmq"
+DATA="$W/data"
+PIDFILE="$W/broker.pid"
+
+case "${1:-}" in
+start)
+  LOG="${2:-$W/broker.log}"
+  "$0" stop
+  rm -rf "$DATA"; mkdir -p "$DATA"
+  "$BIN" --data-dir "$DATA" --bind 127.0.0.1 \
+         --mqtt-port 1883 --amqp-port 5673 --http-port 15673 \
+         --mqtts-port -1 --amqps-port -1 --debug > "$LOG" 2>&1 &
+  echo $! > "$PIDFILE"
+  for _ in $(seq 1 100); do
+    if (exec 3<>/dev/tcp/127.0.0.1/1883) 2>/dev/null; then
+      echo "broker up (pid $(cat "$PIDFILE")), log $LOG"; exit 0
+    fi
+    sleep 0.1
+  done
+  echo "broker failed to start"; tail -20 "$LOG"; exit 1
+  ;;
+stop)
+  if [ -f "$PIDFILE" ]; then
+    kill "$(cat "$PIDFILE")" 2>/dev/null
+    for _ in $(seq 1 50); do kill -0 "$(cat "$PIDFILE")" 2>/dev/null || break; sleep 0.1; done
+    rm -f "$PIDFILE"
+  fi
+  ;;
+*) echo "usage: $0 start [logfile] | $0 stop"; exit 2 ;;
+esac
+```
+
+`$LMQ` is the worktree exported during setup. Ports 1883 / 5673 / 15673 keep it clear of a
+default-port LavinMQ. A **fresh data dir per run** is not optional: retained
+messages and persisted sessions leak between suites otherwise.
+
+To run a second broker in parallel (useful: one suite on 1883 while you poke at
+1884), copy the script and change `DATA`, `PIDFILE`, all three ports, **and** give
+it its own `--metrics-http-port` plus `--control-unix-path`, `--amqp-unix-path`,
+`--http-unix-path`. Two instances otherwise fight over `/tmp/lavinmqctl.sock` and
+the second dies. Keep those socket paths short - a long path trips the 107-byte
+`sockaddr_un` limit.
+
+</details>
+
+<details>
+<summary><code>run_suite.sh</code> - the Paho suite, one test at a time</summary>
+
+```bash
+#!/usr/bin/env bash
+# usage: run_suite.sh <suite-dir> <client_test5.py|client_test.py> <out-dir>
+set -u
+W="$(cd "$(dirname "$0")" && pwd)"
+IOP="$W/$1/interoperability"; SUITE="$2"
+OUT="$(mkdir -p "$3" && cd "$3" && pwd)"   # absolute: we cd into the suite below
+TESTS=$(grep -o "  def test_[a-z0-9_]*" "$IOP/$SUITE" | sed 's/.*def //')
+for t in $TESTS; do
+  "$W/broker.sh" start "$OUT/$t.broker.log" >/dev/null || { echo "$t BROKER-FAIL"; continue; }
+  cd "$IOP"
+  timeout 180 python3 -u "$SUITE" "Test.$t" > "$OUT/$t.out" 2>&1
+  rc=$?
+  "$W/broker.sh" stop
+  if [ $rc -eq 0 ]; then st=PASS
+  elif [ $rc -eq 124 ]; then st=TIMEOUT
+  else st=FAIL; fi
+  crash=""
+  grep -qiE "unhandled exception|Invalid memory access|BUG:" "$OUT/$t.broker.log" && crash=" BROKER-CRASH"
+  printf "%-32s %s%s\n" "$t" "$st" "$crash" | tee -a "$OUT/summary.txt"
+done
+```
+
+One broker per test, so a test that wedges a session cannot contaminate the next
+one, and a hang costs 180s instead of the whole run. Usage:
+
+```sh
+./run_suite.sh paho.mqtt.testing client_test5.py results/v5        # as published
+./run_suite.sh paho.qos1        client_test5.py results/v5-qos1    # the useful run
+./run_suite.sh paho.qos1        client_test.py  results/v3-qos1    # 7/9 as of 2026-08-19
+```
+
+Each test leaves `results/<dir>/<test>.out` (client side) next to
+`<test>.broker.log` (server side, `--debug`). Read them as a pair: "client hung"
+plus `WARN Protocol violation ... QoSNotSupported` is a correct rejection, not a
+bug.
+
+</details>
+
+<details>
+<summary><code>interop.py</code> - paho-mqtt driver (capabilities, pub, sub)</summary>
+
+```python
+#!/usr/bin/env python3
+"""paho-mqtt driver for LavinMQ MQTT interop checks.
+
+  interop.py caps                                   # dump CONNACK capabilities
+  interop.py sub <topic> [count] [timeout] [5|311] [qos] [nl,rap,rh=N]
+  interop.py pub <topic> <payload> [qos] [retain|-] [5|311]
+
+Env: MQTT_PORT (default 1883). Credentials are always guest/guest.
+Subscriber prints one JSON line per event, so callers can grep for "props".
+"""
+import json, os, sys, threading, time
+import paho.mqtt.client as mqtt
+from paho.mqtt.enums import CallbackAPIVersion, MQTTProtocolVersion
+from paho.mqtt.properties import Properties
+from paho.mqtt.packettypes import PacketTypes
+from paho.mqtt.subscribeoptions import SubscribeOptions
+
+PORT = int(os.environ.get("MQTT_PORT", "1883"))
+PUB_PROPS = ("PayloadFormatIndicator", "MessageExpiryInterval", "ContentType",
+             "ResponseTopic", "CorrelationData", "UserProperty",
+             "SubscriptionIdentifier", "TopicAlias")
+CONNACK_PROPS = ("MaximumQoS", "RetainAvailable", "WildcardSubscriptionAvailable",
+                 "SubscriptionIdentifierAvailable", "SharedSubscriptionAvailable",
+                 "TopicAliasMaximum", "MaximumPacketSize", "ReceiveMaximum",
+                 "ServerKeepAlive", "SessionExpiryInterval",
+                 "AssignedClientIdentifier", "ResponseInformation", "ReasonString")
+
+def client(cid, ver):
+    proto = MQTTProtocolVersion.MQTTv5 if ver == "5" else MQTTProtocolVersion.MQTTv311
+    c = mqtt.Client(CallbackAPIVersion.VERSION2, client_id=cid, protocol=proto)
+    c.username_pw_set("guest", "guest")
+    return c, proto
+
+def dump(props, names):
+    out = {}
+    for n in names:
+        if props is not None and hasattr(props, n):
+            v = getattr(props, n)
+            out[n] = v.decode("utf-8", "replace") if isinstance(v, bytes) else v
+    return out
+
+cmd = sys.argv[1]
+
+if cmd == "caps":
+    c, _ = client("interop-caps", "5")
+    def on_connect(cl, u, flags, rc, props):
+        print(json.dumps({"reason_code": str(rc), "session_present": flags.session_present,
+                          "props": dump(props, CONNACK_PROPS)}, indent=2))
+        cl.disconnect()
+    c.on_connect = on_connect
+    c.connect("127.0.0.1", PORT, 30)
+    c.loop_forever()
+
+elif cmd == "sub":
+    topic = sys.argv[2]
+    count = int(sys.argv[3]) if len(sys.argv) > 3 else 1
+    timeout = float(sys.argv[4]) if len(sys.argv) > 4 else 10
+    ver = sys.argv[5] if len(sys.argv) > 5 else "5"
+    qos = int(sys.argv[6]) if len(sys.argv) > 6 else 1
+    opts = sys.argv[7] if len(sys.argv) > 7 else ""
+    got, done = [], threading.Event()
+    c, proto = client("interop-sub", ver)
+    def on_connect(cl, u, flags, rc, props=None):
+        print(json.dumps({"event": "connack", "rc": str(rc)}), flush=True)
+        if proto == MQTTProtocolVersion.MQTTv5:
+            cl.subscribe(topic, options=SubscribeOptions(
+                qos=qos, noLocal="nl" in opts, retainAsPublished="rap" in opts,
+                retainHandling=int(opts.split("rh=")[1][0]) if "rh=" in opts else 0))
+        else:
+            cl.subscribe(topic, qos)
+    def on_subscribe(cl, u, mid, rcs, props=None):
+        print(json.dumps({"event": "suback", "codes": [str(r) for r in rcs]}), flush=True)
+    def on_disconnect(cl, u, flags, rc, props=None):
+        print(json.dumps({"event": "disconnect", "rc": str(rc)}), flush=True)
+        done.set()
+    def on_message(cl, u, msg):
+        got.append(1)
+        print(json.dumps({"event": "message", "topic": msg.topic, "qos": msg.qos,
+                          "retain": msg.retain, "payload": msg.payload.decode("utf-8", "replace"),
+                          "props": dump(getattr(msg, "properties", None), PUB_PROPS)}), flush=True)
+        if len(got) >= count:
+            done.set()
+    c.on_connect, c.on_subscribe, c.on_disconnect, c.on_message = \
+        on_connect, on_subscribe, on_disconnect, on_message
+    c.connect("127.0.0.1", PORT, 30)
+    c.loop_start()
+    done.wait(timeout)
+    c.loop_stop()
+    print(json.dumps({"event": "end", "received": len(got)}), flush=True)
+
+elif cmd == "pub":
+    topic, payload = sys.argv[2], sys.argv[3]
+    qos = int(sys.argv[4]) if len(sys.argv) > 4 else 1
+    retain = len(sys.argv) > 5 and sys.argv[5] == "retain"
+    ver = sys.argv[6] if len(sys.argv) > 6 else "5"
+    c, proto = client("interop-pub", ver)
+    props = None
+    if proto == MQTTProtocolVersion.MQTTv5:
+        props = Properties(PacketTypes.PUBLISH)
+        props.PayloadFormatIndicator = 1
+        props.MessageExpiryInterval = 120
+        props.ContentType = "application/json"
+        props.ResponseTopic = "interop/response"
+        props.CorrelationData = b"corr-1234"
+        props.UserProperty = [("a", "1"), ("b", "two")]
+    c.on_connect = lambda cl, u, f, rc, p=None: print("connack", rc, flush=True)
+    c.connect("127.0.0.1", PORT, 30)
+    c.loop_start()
+    time.sleep(0.5)
+    c.publish(topic, payload, qos=qos, retain=retain, properties=props).wait_for_publish(10)
+    time.sleep(0.5)
+    c.disconnect(); c.loop_stop()
+
+else:
+    sys.exit(__doc__)
+```
+
+</details>
+
+<details>
+<summary><code>interop.js</code> - mqtt.js driver</summary>
+
+```javascript
+// mqtt.js driver.  usage:
+//   node interop.js sub <topic> [count] [timeout_ms] [5|4] [qos]
+//   node interop.js pub <topic> <payload> [qos] [retain|-] [5|4]
+// Env: MQTT_PORT (default 1883), NODE_PATH pointing at node_modules.
+const mqtt = require('mqtt');
+const [cmd, topic, a3, a4, a5, a6] = process.argv.slice(2);
+const version = ((cmd === 'sub' ? a5 : a6) || '5') === '5' ? 5 : 4;
+const conn = {protocolVersion: version, clientId: `node-${cmd}`, username: 'guest',
+              password: 'guest', clean: true, reconnectPeriod: 0};
+const c = mqtt.connect(`mqtt://127.0.0.1:${process.env.MQTT_PORT || 1883}`, conn);
+const say = (o) => console.log(JSON.stringify(o, (k, v) =>
+  (v && v.type === 'Buffer') ? Buffer.from(v.data).toString() : v));
+c.on('error', (e) => say({event: 'error', error: String(e)}));
+c.on('disconnect', (p) => say({event: 'disconnect', reasonCode: p.reasonCode}));
+
+if (cmd === 'sub') {
+  const count = parseInt(a3 || '1'), tmo = parseInt(a4 || '10000'), qos = parseInt(a6 || '1');
+  let got = 0;
+  const finish = () => { say({event: 'end', received: got}); c.end(true); process.exit(0); };
+  const timer = setTimeout(finish, tmo);
+  c.on('connect', (ack) => {
+    say({event: 'connack', rc: ack.reasonCode, props: ack.properties || null});
+    c.subscribe(topic, {qos}, (err, granted) =>
+      say({event: 'suback', err: err ? String(err) : null, granted}));
+  });
+  c.on('message', (t, payload, packet) => {
+    got++;
+    say({event: 'message', topic: t, qos: packet.qos, retain: packet.retain,
+         payload: payload.toString(), props: packet.properties || null});
+    if (got >= count) { clearTimeout(timer); setTimeout(finish, 200); }
+  });
+} else {
+  const qos = parseInt(a4 || '1'), retain = a5 === 'retain';
+  const props = version === 5 ? {properties: {
+    payloadFormatIndicator: true, messageExpiryInterval: 120,
+    contentType: 'application/json', responseTopic: 'interop/response',
+    correlationData: Buffer.from('corr-1234'), userProperties: {a: '1', b: 'two'}}} : {};
+  c.on('connect', (ack) => {
+    say({event: 'connack', rc: ack.reasonCode, props: ack.properties || null});
+    c.publish(topic, a3 || 'hello', Object.assign({qos, retain}, props), (err) => {
+      say({event: 'published', err: err ? String(err) : null});
+      setTimeout(() => { c.end(true); process.exit(0); }, 300);
+    });
+  });
+}
+```
+
+</details>
+
+<details>
+<summary><code>raw_v5.py</code> - hand-built packets for the byte-exact cases</summary>
+
+```python
+"""Hand-built v5 packets over a raw socket: exact-byte checks a library won't let us make."""
+import os, socket, sys, time
+
+PORT = int(os.environ.get("MQTT_PORT", "1883"))
+
+def s16(b): return len(b).to_bytes(2, "big") + b
+def varint(n):
+    out = b""
+    while True:
+        d = n % 128; n //= 128
+        out += bytes([d | (0x80 if n else 0)])
+        if not n: return out
+def pkt(t, flags, body): return bytes([(t << 4) | flags]) + varint(len(body)) + body
+
+def connect(client_id, props=b"", will=None):
+    flags = 0xC0  # username+password
+    body = s16(b"MQTT") + bytes([5])
+    if will:
+        wtopic, wpayload, wqos, wretain = will
+        flags |= 0x04 | (wqos << 3) | (0x20 if wretain else 0)
+    body += bytes([flags]) + (30).to_bytes(2, "big")
+    body += varint(len(props)) + props
+    body += s16(client_id.encode())
+    if will:
+        body += varint(0)  # no will properties
+        body += s16(wtopic.encode()) + s16(wpayload)
+    body += s16(b"guest") + s16(b"guest")
+    return pkt(1, 0, body)
+
+def read_packet(sock, timeout=3.0):
+    sock.settimeout(timeout)
+    try:
+        h = sock.recv(1)
+        if not h: return None
+        ln, mult = 0, 1
+        while True:
+            b = sock.recv(1)[0]
+            ln += (b & 127) * mult
+            if not (b & 128): break
+            mult *= 128
+        body = b"" if ln == 0 else sock.recv(ln)
+        return h + bytes([ln]) + body
+    except (socket.timeout, IndexError, ConnectionResetError):
+        return None
+
+def describe(p):
+    if p is None: return "no response / closed"
+    t = p[0] >> 4
+    names = {2: "CONNACK", 3: "PUBLISH", 4: "PUBACK", 9: "SUBACK", 11: "UNSUBACK", 13: "PINGRESP", 14: "DISCONNECT"}
+    return f"{names.get(t, t)} bytes={p.hex()}"
+
+def fresh(client_id, props=b"", will=None):
+    s = socket.create_connection(("127.0.0.1", PORT), timeout=5)
+    s.sendall(connect(client_id, props, will))
+    return s, describe(read_packet(s))
+
+case = sys.argv[1]
+
+if case == "disconnect_forms":
+    # subscriber that watches for a will
+    ws, wack = fresh("raw-will-watcher")
+    print("watcher connack:", wack)
+    ws.sendall(pkt(8, 2, (1).to_bytes(2, "big") + varint(0) + s16(b"raw/will") + bytes([0])))
+    print("watcher suback:", describe(read_packet(ws)))
+    forms = {
+        "no reason byte      (E0 00)": pkt(14, 0, b""),
+        "reason 0x00 only":            pkt(14, 0, bytes([0x00])),
+        "reason 0x00 + empty props":   pkt(14, 0, bytes([0x00]) + varint(0)),
+        "reason 0x00 + expiry=30":     pkt(14, 0, bytes([0x00]) + varint(5) + bytes([0x11]) + (30).to_bytes(4, "big")),
+        "reason 0x04 (with will)":     pkt(14, 0, bytes([0x04])),
+    }
+    for name, dp in forms.items():
+        s, ack = fresh("raw-disc", will=("raw/will", b"WILL-FIRED", 1, False))
+        s.sendall(dp)
+        time.sleep(0.6)
+        s.close()
+        got = read_packet(ws, 1.0)
+        print(f"  {name:30s} -> connack {ack[:8]}, will published: {'YES' if got else 'no'}")
+    ws.close()
+
+elif case == "empty_topic":
+    s, ack = fresh("raw-empty-topic")
+    print("connack:", ack)
+    s.sendall(pkt(3, 0x02, s16(b"") + (1).to_bytes(2, "big") + varint(0) + b"x"))
+    print("after empty-topic qos1 PUBLISH:", describe(read_packet(s)))
+    s.close()
+
+elif case == "tiny_max_packet_size":
+    # maximum packet size = 5: our CONNACK is larger than that -> [MQTT-3.1.2-24]
+    props = bytes([0x27]) + (5).to_bytes(4, "big")
+    s, ack = fresh("raw-tiny-mps", props=props)
+    print("connack with maximum-packet-size=5 requested:", ack)
+    print("  connack size:", "n/a" if ack.startswith("no") else len(bytes.fromhex(ack.split("bytes=")[1])))
+    s.close()
+
+elif case == "oversized_suback":
+    props = bytes([0x27]) + (12).to_bytes(4, "big")
+    s, ack = fresh("raw-suback-mps", props=props)
+    print("connack:", ack)
+    filters = b""
+    for i in range(10):
+        filters += s16(f"raw/filter/{i}".encode()) + bytes([0])
+    s.sendall(pkt(8, 2, (7).to_bytes(2, "big") + varint(0) + filters))
+    print("suback for 10 filters under maximum-packet-size=12:", describe(read_packet(s)))
+    s.close()
+
+elif case == "packet_id_zero":
+    s, ack = fresh("raw-pid-zero")
+    print("connack:", ack)
+    s.sendall(pkt(3, 0x02, s16(b"raw/pid") + (0).to_bytes(2, "big") + varint(0) + b"x"))
+    print("qos1 PUBLISH with packet id 0:", describe(read_packet(s)))
+    s.close()
+
+if case == "second_connect":
+    s, ack = fresh("raw-double-connect")
+    print("first connack:", ack)
+    s.sendall(connect("raw-double-connect"))
+    print("after a second CONNECT [MQTT-3.1.0-2]:", describe(read_packet(s)))
+    s.close()
+
+if case == "server_packet_from_client":
+    s, ack = fresh("raw-bad-packet")
+    print("connack:", ack)
+    s.sendall(pkt(13, 0, b""))  # PINGRESP: server-to-client only
+    print("after a client-sent PINGRESP:", describe(read_packet(s)))
+    s.close()
+
+if case == "auth_packet":
+    s, ack = fresh("raw-auth")
+    print("connack:", ack)
+    s.sendall(pkt(15, 0, bytes([0x18]) + varint(0)))  # AUTH, reason 0x18 continue
+    print("after an AUTH packet on a plain connection:", describe(read_packet(s)))
+    s.close()
+
+if case == "pubrel":
+    s, ack = fresh("raw-pubrel")
+    print("connack:", ack)
+    s.sendall(pkt(6, 2, (1).to_bytes(2, "big")))  # PUBREL
+    print("after a stray PUBREL:", describe(read_packet(s)))
+    s.close()
+```
+
+</details>
+
+## Running the checks
+
+### Capabilities
+
+```sh
+./broker.sh start results/broker.log
+MQTT_PORT=1883 ./venv/bin/python interop.py caps
+```
+
+Compare against `connection_factory.cr#build_server_capabilities`. Expected:
+`MaximumQoS 1`, `RetainAvailable 1`, `WildcardSubscriptionAvailable 1`,
+`TopicAliasMaximum 0`, `SubscriptionIdentifierAvailable 0`,
+`SharedSubscriptionAvailable 0`, `MaximumPacketSize 268435455`, and **no**
+`ReceiveMaximum` (we do not advertise one - section 6).
+
+### Property round-trips across codecs
+
+Each pair should show all six properties on the receiving side. Publisher and
+subscriber are deliberately different libraries.
+
+```sh
+p=./venv/bin/python
+# paho -> paho
+$p interop.py sub rt/1 1 12 5 1 & sleep 1.5; $p interop.py pub rt/1 hello 1 - 5; wait
+# paho -> mqtt.js
+node interop.js sub rt/2 1 12000 5 1 & sleep 1.5; $p interop.py pub rt/2 hello 1 - 5; wait
+# mqtt.js -> paho
+$p interop.py sub rt/3 1 12 5 1 & sleep 1.5; node interop.js pub rt/3 hello 1 - 5; wait
+# mosquitto -> paho
+$p interop.py sub rt/4 1 15 5 1 & sleep 1.5
+docker run --rm --network host eclipse-mosquitto mosquitto_pub \
+  -h 127.0.0.1 -p 1883 -u guest -P guest -V 5 -q 1 -t rt/4 -m hello \
+  -D publish payload-format-indicator 1 \
+  -D publish message-expiry-interval 120 \
+  -D publish content-type application/json \
+  -D publish response-topic interop/response \
+  -D publish correlation-data corr-1234 \
+  -D publish user-property a 1 -D publish user-property b two
+wait
+# cross-version: v5 publisher -> v3.1.1 subscriber (properties must vanish, payload must not)
+$p interop.py sub rt/5 1 12 311 1 & sleep 1.5; $p interop.py pub rt/5 hello 1 - 5; wait
+# retained: item F - the store keeps only the body, so props come back empty
+$p interop.py pub rt/6 retained 1 retain 5; $p interop.py sub rt/6 1 8 5 1
+```
+
+### One command per row of the compliance table
+
+`-D` puts an arbitrary property on the wire, and `-d` prints the reason code that
+comes back. `mos` below is
+`docker run --rm --network host eclipse-mosquitto`.
+
+| check | command | expected |
+|---|---|---|
+| QoS 2 publish | `mos mosquitto_pub ... -V 5 -d -q 2 -t x -m x` | mosquitto refuses client-side off our `maximum_qos`; force it past that and you get DISCONNECT 155 (`0x9B`) |
+| Topic Alias | `... mosquitto_pub -V 5 -d -q 1 -t x -m x -D publish topic-alias 1` | DISCONNECT 148 (`0x94`) |
+| Shared subscription | `... mosquitto_sub -V 5 -d -W 5 -t '$share/g1/x'` | DISCONNECT 158 (`0x9E`) |
+| Subscription Identifier | `... mosquitto_sub -V 5 -d -W 5 -t x -D subscribe subscription-identifier 1` | DISCONNECT 161 (`0xA1`) |
+| Enhanced auth | `... mosquitto_pub -V 5 -d -t x -m x -D connect authentication-method SCRAM-SHA-1` | CONNACK 140 (`0x8C`) |
+| No credentials | `... mosquitto_pub -V 5 -d -t x -m x` (drop `-u`/`-P`) | CONNACK 135 (`0x87`) |
+| Maximum Packet Size on delivery | `... mosquitto_sub -V 5 -d -W 8 -q 1 -t x -D connect maximum-packet-size 40`, then publish 200 bytes | no PUBLISH arrives, connection stays up |
+| Delivery QoS | `... mosquitto_sub -V 5 -d -W 8 -q 1 -t x`, then `mosquitto_pub -V 5 -q 0 -t x -m x` | the delivered PUBLISH is QoS **0**, not 1 [MQTT-3.8.4-8]. Repeat with `-V 311` |
+| Will QoS 2 | `interop.py` with `will_set(..., qos=2)` | CONNACK Success today - item I, spec 3.1.2.6 wants `0x9B` |
+| Session Expiry 0 | `... mosquitto_sub -V 5 -c -x 0 -i c1 -q 1 -t x`, publish while offline, reconnect | the message arrives, i.e. the session outlived its zero expiry - item J3 |
+
+### Byte-exact cases
+
+```sh
+for c in disconnect_forms empty_topic tiny_max_packet_size oversized_suback \
+         packet_id_zero second_connect server_packet_from_client auth_packet pubrel; do
+  echo "== $c"; MQTT_PORT=1883 python3 raw_v5.py "$c"
+done
+```
+
+`second_connect`, `server_packet_from_client`, `auth_packet` and `pubrel` each
+exercise the item J2 path and must now print a `DISCONNECT` whose last byte is
+`0x82`, where they used to print "no response / closed".
+
+`disconnect_forms` is the one to keep an eye on: it sends all five legal DISCONNECT
+encodings (no reason byte, reason only, reason plus empty properties, reason plus a
+session-expiry property, and `0x04`) and reports whether the will fired. Only
+`0x04` may publish it.
+
+### After every run
+
+```sh
+grep -ril "unhandled exception\|invalid memory access\|BUG:" results/   # must print nothing
+cat results/*/*.broker.log | grep -oE "(WARN|ERROR) .*" | sed 's/\[[^]]*\]//g' | sort | uniq -c | sort -rn
+```
+
+The second command is the fastest way to spot a bad rejection path: every
+`Protocol violation, disconnecting client: <ReasonCode>` line is a WARN by design,
+so an `ERROR ... Read Loop error` in that list is a packet we mishandle rather than
+reject. Since J2 landed there should be **none** - that count is now a regression
+check, not a known gap.
+
+## Interpreting the score
+
+Do not read the raw pass count. On 2026-08-19 the numbers were:
+
+| run | PASS | FAIL | TIMEOUT |
+|---|---|---|---|
+| v5 as published | 6 | 18 | 3 |
+| v5 QoS-clamped | 8 | 18 | 1 |
+| v3.1.1 as published | 3 | 6 | 0 |
+| v3.1.1 QoS-clamped | **7** | 2 | 0 |
+
+Every v5 failure mapped to a documented item (B, D, E, F, Receive Maximum, shard
+N3/O2), to a correct rejection the test client cannot cope with, or to one of
+these harness assumptions:
+
+- `test_subscribe_failure` wants an ACL denying `test/nosubscribe`;
+  `mqtt.permission_check_enabled` is false by default, so we grant it.
+- `test_server_keep_alive` wants a `ServerKeepAlive` property; a server MAY send
+  one and we do not.
+- `test_server_topic_alias` wants the server to use aliases; we advertise
+  `topic_alias_maximum = 0` and never do, which is legal.
+- `test_dollar_topics` wants `#` not to match `$`-prefixed topics; spec 4.7.2 is a
+  SHOULD NOT, and we do match. Pre-existing on v3 too.
+
+The v3.1.1 QoS-clamped row is the cleanest single signal: 7 of 9, with the two
+failures being `test_subscribe_failure` and `test_dollar_topics` from that list.

--- a/MQTT5-INTEROP.md
+++ b/MQTT5-INTEROP.md
@@ -5,10 +5,10 @@ run found; this file is *how to run it again*. Nothing here is wired into `make`
 or CI on purpose: it needs a built binary, a network clone and a Docker pull, and
 it is a release-gate check, not a per-commit one.
 
-Re-run it after B / D / E / F land - most of the currently failing Paho tests are
-the grading function for exactly those items. The delivery-QoS and DISCONNECT
-`0x82` expectations below were updated when J1/J2 were fixed but have **not** been
-confirmed by a re-run yet.
+Re-run it after B / E / F land - most of the currently failing Paho tests are the
+grading function for exactly those items. The delivery-QoS, DISCONNECT `0x82` and
+session-expiry expectations below were updated as J1/J2, item I and session expiry
+landed, but have **not** been confirmed by a re-run yet.
 
 ## What it exercises that our own specs cannot
 
@@ -592,7 +592,9 @@ comes back. `mos` below is
 | Maximum Packet Size on delivery | `... mosquitto_sub -V 5 -d -W 8 -q 1 -t x -D connect maximum-packet-size 40`, then publish 200 bytes | no PUBLISH arrives, connection stays up |
 | Delivery QoS | `... mosquitto_sub -V 5 -d -W 8 -q 1 -t x`, then `mosquitto_pub -V 5 -q 0 -t x -m x` | the delivered PUBLISH is QoS **0**, not 1 [MQTT-3.8.4-8]. Repeat with `-V 311` |
 | Will QoS 2 | `interop.py` with `will_set(..., qos=2)` | CONNACK Success today - item I, spec 3.1.2.6 wants `0x9B` |
-| Session Expiry 0 | `... mosquitto_sub -V 5 -c -x 0 -i c1 -q 1 -t x`, publish while offline, reconnect | the message arrives, i.e. the session outlived its zero expiry - item J3 |
+| Session Expiry 0 | `... mosquitto_sub -V 5 -c -x 0 -i c1 -q 1 -t x`, publish while offline, reconnect | **nothing arrives**: expiry 0 ends the session with the connection [MQTT-3.1.2-11] |
+| Session Expiry non-zero | same with `-x 60` | the message arrives, and `mqtt.c1` is still there between connections |
+| Clean Start 1 + expiry | `... mosquitto_sub -V 5 -C 1 -x 60 -i c2 -q 1 -t x` | old session discarded, new one persists - the case the Paho suite used to fail |
 
 ### Byte-exact cases
 
@@ -636,9 +638,11 @@ Do not read the raw pass count. On 2026-08-19 the numbers were:
 | v3.1.1 as published | 3 | 6 | 0 |
 | v3.1.1 QoS-clamped | **7** | 2 | 0 |
 
-Every v5 failure mapped to a documented item (B, D, E, F, Receive Maximum, shard
-N3/O2), to a correct rejection the test client cannot cope with, or to one of
-these harness assumptions:
+Those numbers are the 2026-08-19 run and have not been refreshed. Every v5 failure
+mapped to a documented item (B, D, E, F, Receive Maximum, shard N3/O2), to a
+correct rejection the test client cannot cope with, or to one of these harness
+assumptions. **D has since landed**, so the session-lifecycle failures in that
+column should pass on a re-run - which is the main reason to do one:
 
 - `test_subscribe_failure` wants an ACL denying `test/nosubscribe`;
   `mqtt.permission_check_enabled` is false by default, so we grant it.

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -3,7 +3,7 @@
 Status and design doc for the MQTT 5.0 work in LavinMQ, spanning both this repo
 and the `mqtt-protocol.cr` shard.
 
-Last reconciled against the code: **2026-08-19**.
+Last reconciled against the code: **2026-08-20**.
 
 ---
 
@@ -15,7 +15,7 @@ about 80% done**.
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 19 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 21 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
 intact, gets an accurate reason code on every ack, and gets a spec-correct
@@ -23,7 +23,7 @@ rejection for every feature we don't implement. What is missing is the rest of
 the *session-lifecycle* half of v5: session expiry, will properties and will
 delay, subscription options.
 
-**On `main` (`77c9ceb2`) and verified green on 2026-08-19: 2093 examples,
+**On `main` (`77c9ceb2`) and verified green on 2026-08-20: 2098 examples,
 0 failures, lint and format clean.** See section 7.
 
 ---
@@ -77,6 +77,7 @@ spec'd, which was the largest single risk in the project.
 QoS 2 (LavinMQ is QoS 0/1 throughout; PUBREC/PUBREL/PUBCOMP exist in the codec
 only), topic aliases, shared subscriptions, subscription identifiers, enhanced
 auth, will delay. All are advertised as unavailable per the table above.
+Section 9 sketches what QoS 2 would take, as follow-up work after this PR.
 
 ---
 
@@ -391,9 +392,36 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
   [MQTT-3.14.4-3]. We send nothing back - the receiver just closes
   [MQTT-3.14.4-2]
 
-**Specs:** 34 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
+**QoS and packet handling** (both from item J, both pre-existing on v3.1.1)
+- Delivery QoS is `Math.min(publish QoS, subscription QoS)` [MQTT-3.8.4-8] -
+  `exchange.cr#publish`. It was the subscription's QoS alone, so a QoS 0 publish
+  reached a QoS 1 subscriber as QoS 1: LavinMQ then waited for a PUBACK on a
+  fire-and-forget message, counted it against `max_inflight_messages`,
+  redelivered it on reconnect, and stored it for an offline subscriber. Retained
+  replay is unchanged and still delivers at the granted QoS - `broker.cr#subscribe`
+  bypasses `Exchange#publish` because the retain store never kept the publisher's
+  QoS. That is item F, not this.
+
+  The suite had encoded the bug: fourteen examples across `message_qos_spec.cr`,
+  `session_stats_spec.cr`, `various_spec.cr`, `unsubscribe_spec.cr` and this
+  branch's own `v5/puback_disconnect_spec.cr` published at QoS 0 and relied on the
+  upgrade for a packet id to ack, an inflight limit to hit, or an offline-stored
+  message - two of them commented "qos doesnt matter here". They now publish at
+  QoS 1; assertions are unchanged. The example that asserted the old behaviour was
+  titled "[LavinMQ non-normative]", so it had been written down as deliberate.
+- An unexpected packet raises `ProtocolViolation(ProtocolError)` instead of a bare
+  string exception - `client.cr#read_and_handle_packet`. It used to land in
+  `read_loop`'s catch-all `rescue`, which logged at ERROR *with a backtrace* and
+  closed with no DISCONNECT, so any client could fill the log on demand. Nine
+  decodable types reach it, including a second CONNECT [MQTT-3.1.0-2], a
+  client-sent PINGRESP and an AUTH packet on a plain connection. v5 now gets
+  DISCONNECT `0x82` and the log gets one WARN line; v3 still just closes.
+
+**Specs:** 33 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
 unsubscribe, puback/disconnect), plus the existing v3 suite adapted to the new
-shard API.
+shard API. (The previous reconciliation said 34 before three examples were added,
+so that figure was wrong by four; 33 is measured from
+`make test SPEC=spec/mqtt/v5`.)
 
 ---
 
@@ -531,6 +559,29 @@ introduced on this branch, so they are ours to fix before the PR.
   `IO::V3#write_properties` then discards. The session already reaches into the
   client for `max_packet_size`; the negotiated version could come the same way.
 
+### J. External interop findings
+
+Found on 2026-08-19 by running third-party tooling against the branch - the
+Eclipse Paho interoperability suite plus paho-mqtt, mqtt.js and the mosquitto
+clients. See `MQTT5-INTEROP.md` for the harness and how to re-run it. The rest of
+that run was clean: no crashes, and every deferred feature in the section 2 table
+was rejected with the promised reason code, confirmed by an independent
+implementation.
+
+All three lived on lines that predate the branch (`22445e0d`, the original MQTT
+support), so none was a regression. **J1 and J2 are fixed; see section 4.** J3 is
+the other direction of item D and is tracked there.
+
+- **J3. A zero Session Expiry Interval leaks the session** - the other direction
+  of item D, and the operationally sharper one. [MQTT-3.1.2-11]: expiry 0, or
+  absent (the spec default), means the session ends when the connection closes.
+  Clean Start = 0 with expiry 0 instead leaves `mqtt.<client-id>` behind durable
+  and not auto-delete, and delivers messages published while the client was away.
+  The mirror case is the one the Paho suite fails on: Clean Start = 1 with a
+  non-zero expiry - the v5 idiom for "discard any old session, persist this one" -
+  gets a transient session that is dropped at disconnect. Both fall out of D
+  treating clean-start as the only input.
+
 ---
 
 ## 6. Known limitations to state at release
@@ -538,7 +589,14 @@ introduced on this branch, so they are ours to fix before the PR.
 Things we will ship with, deliberately. These belong in the release notes and in
 the docs, not in a bug tracker.
 
-- **QoS 2 unsupported.** Advertised as Maximum QoS 1.
+- **Delivery QoS is now the minimum of the publish and subscription QoS on
+  v3.1.1 too**, not just v5. Spec-correct ([MQTT-3.8.4-6] in 3.1.1) and decided
+  deliberately rather than version-gating the publish hot path, but it is a
+  visible change for existing v3 users: a QoS 0 publish to a QoS 1 subscription
+  is no longer upgraded, so it is no longer stored while that subscriber is
+  offline. A spec titled "[LavinMQ non-normative]" used to assert the old
+  behaviour. **Release note.**
+- **QoS 2 unsupported.** Advertised as Maximum QoS 1. Follow-up work, section 9.
 - **Receive Maximum ignored.** We do not pace QoS 1 inflight against the
   client's advertised Receive Maximum, and we do not advertise our own (so
   clients assume the 65535 default). LavinMQ has its own
@@ -580,18 +638,19 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-08-19** after the PUBACK/DISCONNECT work, on `main`
-`77c9ceb2`:
+**LavinMQ, measured 2026-08-20** after the J1/J2 fixes, on `main` `77c9ceb2`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **248 examples, 0 failures, 0 errors, 0 pending** (18.0s) |
-| `make test TAGS=~etcd` | **2093 examples, 0 failures, 0 errors, 9 pending** (2:35) |
+| `make test SPEC=spec/mqtt` | **253 examples, 0 failures, 0 errors, 0 pending** (24.9s) |
+| `make test TAGS=~etcd` | **2098 examples, 0 failures, 0 errors, 9 pending** (2:38) |
 | `make lint` | 400 inspected, 0 failures |
 | `crystal tool format --check` | clean |
 
-(The previous reconciliation recorded 233 for `spec/mqtt`; the full-suite delta
-is exactly the 10 new examples, so that figure was mistyped, not a lost spec.)
+(The +5 over the previous 248/2093 is exactly the five examples added with J1 and
+J2 - two v3 QoS-minimum regressions, one v5 QoS-minimum, two v5 unexpected-packet.
+An earlier reconciliation recorded 233 for `spec/mqtt`; that figure was mistyped,
+not a lost spec.)
 
 The 9 pending are pre-existing and unrelated to MQTT (queue dead-lettering
 headers, kTLS, UNIX sockets, VHost GC segments). The etcd-tagged specs were
@@ -611,11 +670,37 @@ time. The other three `Packet.from_io(io)` call sites in that file are fine: the
 removed. Nothing else in `src/` or `spec/` constructs the abstract `IO`
 (verified by grep). Committed as `9e2f53f9`.
 
-**Gap worth closing before release:** all byte vectors are self-confirming
-round-trips. Nobody has cross-checked them against a real v5 client
-(`mosquitto_pub -V 5`, paho, MQTTX). That is the test that catches
-"consistently implemented my own wrong format." `mosquitto-clients` is
-apt-installable.
+**External verification, 2026-08-19.** The gap this section used to record - all
+byte vectors being self-confirming round-trips, never checked against a real v5
+client - is closed. The Eclipse Paho interoperability suite, paho-mqtt 2.1.0,
+mqtt.js 5.15.2 and the mosquitto 2.1.2 clients were all run against a debug build
+of `709a9f31`. `MQTT5-INTEROP.md` has the harness, the full result tables and how
+to re-run it; the short version:
+
+- No crashes, hangs or memory errors in ~75 broker starts.
+- The CONNACK capability bytes decode identically in three independent codecs, and
+  every rejection in the section 2 table produced its promised reason code on the
+  wire (`0x9B`, `0x94`, `0x9E`, `0xA1`, `0x8C`, `0x87`, `0x82`).
+- All six v5 PUBLISH properties survive paho -> paho, paho -> mqtt.js,
+  mqtt.js -> paho and mosquitto -> paho. A v5 publisher to a v3.1.1 subscriber
+  drops them cleanly, and the reverse works.
+- Both `[~]` rows in section 2 were confirmed from outside: a Will at QoS 2 is
+  accepted with CONNACK Success, and `maximum-packet-size 5` still gets a 23-byte
+  CONNACK (`maximum-packet-size 12` a 15-byte SUBACK).
+- Items B, D, E, F, the Receive Maximum limitation and shard items N3/O2 each
+  reproduced under a third-party client, so they are all real and correctly
+  described.
+- Three defects were new information: they were item J. J1 (delivery QoS) and J2
+  (unexpected packets) are now fixed, see section 4; J3 belongs to item D.
+
+The unmodified Paho v5 suite cannot grade this broker - 22 of its 27 tests use
+QoS 2 somewhere, and its client ignores our advertised `maximum_qos = 1`, which is
+itself a [MQTT-3.2.2-11] violation on the client's side. We correctly kill those
+connections, after which several tests spin forever on `while len(messages) < 3`.
+A mechanically QoS-clamped copy of the suite is the run worth reading; with QoS 2
+out of the picture the v3.1.1 suite goes 7/9, failing only on `$`-prefixed topics
+matching wildcards (spec 4.7.2 is a SHOULD NOT) and on a test that needs an ACL
+denying a topic.
 
 ---
 
@@ -624,7 +709,11 @@ apt-installable.
 1. Finish B / D / E (F and G in parallel, different people). The poison-message
    and hot-path-allocation findings in I should land before the PR regardless of
    who takes the feature work.
-2. External smoke test against a real v5 client.
+2. ~~External smoke test against a real v5 client.~~ Done 2026-08-19, see
+   section 7 and `MQTT5-INTEROP.md`. Re-run it once B/D/E/F land - the same
+   harness grades them. It has **not** been re-run since the J1/J2 fixes; the
+   interop doc's delivery-QoS and DISCONNECT `0x82` rows are the expectations to
+   confirm when it is.
 3. Tag the shard release (`1.0`), with 3.7's breaking changes in the changelog.
 4. Repoint `shard.yml` from `branch: feat/mqtt5` to the tag, update `shard.lock`.
 5. Merge back the v5 specs (section H).
@@ -639,6 +728,63 @@ Rebasing this work onto `main` is cheap today, with two standing hazards. The
 `shard.yml` / `shard.lock` v5 pin conflicts as soon as `main` bumps the shard
 again - step 3 above ends that permanently. And `connection_factory.cr#start`
 and `client.cr#details_tuple` are conflict magnets, for the reason in 3.7.
+
+---
+
+## 9. Deferred past this PR
+
+Scope discipline: this branch ships v5 with `maximum_qos = 1` and every deferral
+advertised and rejected per section 2. The items here are follow-up work, opened
+as their own issues once the PR lands. Nothing below blocks it.
+
+### QoS 2 (exactly-once delivery)
+
+The largest single item left in MQTT - bigger than B/D/E/F combined - and a
+*session-state and durability* project rather than a protocol one. Deliberately
+out of scope; see section 2 and the section 6 limitation.
+
+QoS 2 replaces the single PUBACK with a two-phase handshake:
+PUBLISH -> PUBREC -> PUBREL -> PUBCOMP. The exactly-once guarantee comes from the
+receiver remembering **packet ids**, not messages: between PUBREC and PUBREL it
+holds id N, so a re-sent PUBLISH with id N is answered with another PUBREC and not
+delivered a second time. That state must therefore survive a reconnect, because a
+resuming client resends PUBLISH N or PUBREL N depending on where it got to and
+expects an answer from persisted state.
+
+The codec is already done - `PubRec`/`PubRel`/`PubComp` exist in the shard with
+specs. What LavinMQ would need:
+
+1. **Inbound packet-id state per session**, checked on every PUBLISH and surviving
+   reconnect, with the message held *undelivered* until PUBREL. There is no home
+   for it today: `Session` is a `Queue` subclass, and `Exchange#publish` routes
+   straight into queues.
+2. **Outbound two-step state per subscriber** - awaiting PUBREC, then awaiting
+   PUBCOMP - with resend on reconnect. `@unacked` models one ack step, not two in
+   order, and the second must outlive the message body.
+3. **A different QoS carrier.** MQTT QoS currently rides on
+   `properties.delivery_mode`, which has two useful values. QoS 2 has no
+   `delivery_mode` to be.
+4. **A decision on cross-protocol semantics.** AMQP 0-9-1 has no equivalent
+   handshake, so exactly-once could only ever be a promise between two MQTT
+   endpoints.
+
+It also lands *on top of* item D: persisted QoS 2 state without a session lifetime
+is a leak by construction.
+
+Not urgent. The current position is fully spec-legal, and the external run
+confirmed real clients handle it gracefully - mosquitto refused a QoS 2 publish
+client-side off our advertised `maximum_qos = 1` without putting it on the wire.
+The usual answer for users who ask is an idempotent consumer on QoS 1, which is
+cheaper than four round-trips per message.
+
+### Others
+
+- Topic aliases, shared subscriptions, subscription identifiers, enhanced
+  authentication - each advertised as unavailable and rejected today (section 2),
+  each a standalone feature afterwards.
+- `$`-prefixed topics matching wildcard filters (spec 4.7.2, a SHOULD NOT).
+  Pre-existing on v3 as well; the Paho suite flags it. Cheap to fix, but it is a
+  behaviour change for existing v3 users, so it wants its own decision.
 
 ---
 

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -15,15 +15,15 @@ about 80% done**.
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 26 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 31 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
-intact, gets an accurate reason code on every ack, and gets a spec-correct
-rejection for every feature we don't implement. What is missing is the rest of
-the *session-lifecycle* half of v5: session expiry, will properties and will
-delay, subscription options.
+intact, gets an accurate reason code on every ack, gets a session whose lifetime
+it controls, and gets a spec-correct rejection for every feature we don't
+implement. What is missing is subscription options, will properties and will
+delay, and properties on retained messages.
 
-**On `main` (`77c9ceb2`) and verified green on 2026-08-20: 2105 examples,
+**On `main` (`77c9ceb2`) and verified green on 2026-08-20: 2121 examples,
 0 failures, lint and format clean.** See section 7.
 
 ---
@@ -299,6 +299,22 @@ trap.
   is redundant. #2139's three specs were kept and pass unchanged (only their
   `version:` arguments moved from `UInt8` to the `Version` enum). **Worth
   mentioning to whoever wrote #2139.**
+- **Session state rides AMQP queue arguments, deliberately but not happily.** A
+  session is persisted as a `Queue::Declare` frame, whose only field that can
+  hold a `UInt32` is `arguments` - so the Session Expiry Interval lives in
+  `x-mqtt-session-expiry`. `Session` had to start keeping per-instance arguments
+  for this; it previously returned a shared constant and silently dropped
+  whatever it was declared with. When the argument is absent the declare's
+  `auto_delete` flag is the fallback, because that is what carried this meaning
+  before - which is what keeps an older definitions file and a direct
+  `declare_queue` working. **Breaking MQTT away from AMQP-shaped persistence is
+  the refactor that removes this**; it is a consequence of how sessions are
+  stored, not a preference.
+- **Session expiry deliberately does not persist a deadline**, only the interval.
+  A restored session therefore starts its full interval from boot. MQTT leaves
+  restart behaviour implementation-defined, and this is the forgiving reading: it
+  never deletes something a client might still want, at the cost of a short
+  interval outliving a long outage.
 - **The v3 wire path is byte-for-byte unchanged.** On v3, properties are ignored
   on the wire, so the v3 CONNACK is identical to before. This is a hard
   constraint: the v3.1.1 suite must stay green throughout.
@@ -417,6 +433,31 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
   client-sent PINGRESP and an AUTH packet on a plain connection. v5 now gets
   DISCONNECT `0x82` and the log gets one WARN line; v3 still just closes.
 
+**Session expiry** (item D, and J3)
+- `Session#session_expiry_interval : UInt32` is the single input to a session's
+  lifetime; `durable?` and `auto_delete?` derive from it. `clean_session?` is
+  gone - it conflated two independent things.
+- Clean Start is a separate, connect-only input: it decides whether to discard
+  the stored session, the interval decides how long the one this connection ends
+  up with outlives it. That makes Clean Start 1 + a non-zero interval
+  expressible, which the old single bit could not represent.
+- Derived once at CONNECT: v5 reads the property, absent meaning 0
+  [MQTT-3.1.2-11]; v3 has no property, so `clean_session=1` is 0 and
+  `clean_session=0` is `UInt32::MAX`. A reconnecting client's interval is
+  adopted by the session it resumes.
+- DISCONNECT can name a new interval [MQTT-3.14.2.2.2], applied before
+  `remove_client` runs, so narrowing to 0 ends the session on that disconnect.
+  Absent there means keep the CONNECT value - the opposite default from CONNECT.
+  Non-zero after a CONNECT of 0 is `0x82` [MQTT-3.14.2], which needs no new code:
+  §3.14.2.2.2 says to answer it as a section 4.13 protocol error, which is exactly
+  what the `ProtocolViolation` handler does, will included.
+- The clock runs in the session's existing `deliver_loop`, not a new fiber - the
+  offline park became a `select` on `@has_client` versus a timeout. Reattaching
+  cancels it, so the interval is measured from each disconnect.
+- `session_present?` keeps an `auto_delete?` guard for takeover: it runs before
+  `add_client`, so a 0-interval session belonging to a still-connected client is
+  visible, and a takeover ends that session rather than resuming it (3.1.4).
+
 **Robustness and hot path** (item I)
 - `PublishHeaders.restore` tolerates any AMQP header. Four-byte ints go through
   one `fetch_u32?` and `response_topic` through `fetch_topic?`
@@ -438,18 +479,18 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
 - `Client#protocol_name` is an exhaustive `case/in` again, so a new `Version`
   member is a compile error rather than a silent "MQTT 3.1.1".
 
-**Specs:** 34 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
-unsubscribe, puback/disconnect) plus `spec/mqtt/publish_headers_spec.cr`, on top
-of the existing v3 suite adapted to the new shard API. Both figures are measured;
-an earlier reconciliation's "34 v5 examples" predated four of them and was wrong.
+**Specs:** 47 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
+unsubscribe, puback/disconnect, session expiry) plus
+`spec/mqtt/publish_headers_spec.cr` and `spec/mqtt/session_spec.cr`, on top of
+the existing v3 suite adapted to the new shard API. All figures here are
+measured, not counted by hand.
 
 ---
 
 ## 5. What is left
 
-Ordered roughly easiest-first. **B and D are independent of each other and of
-everything else** - these are the two clean hand-offs. (C is done; see
-section 4.)
+Ordered roughly easiest-first. **B is independent of everything else** and is
+the clean hand-off. (C, D and all of J are done; see section 4.)
 
 ### B. Honor subscription options
 
@@ -464,21 +505,6 @@ store. Pure LavinMQ behaviour, no shard work, well-bounded.
 - **Retain As Published** - preserve the publisher's retain flag on delivery
   instead of clearing it.
 - Files: `broker.cr#subscribe`, `session.cr#build_packet`, `client.cr#recieve_subscribe`.
-
-### D. Session expiry
-
-v5 replaces the clean-session boolean with Clean Start + Session Expiry
-Interval. We read `ConnectProperties#maximum_packet_size` and nothing else;
-`session_expiry_interval` is ignored, and DISCONNECT can also carry a new
-expiry value. Sessions are still clean-session-or-forever.
-
-C landed the DISCONNECT reason-code path, so the packet is now inspected in
-`read_loop`; reading `DisconnectProperties#session_expiry_interval` there is the
-natural next step. That also brings [MQTT-3.14.2]: a non-zero expiry on
-DISCONNECT when CONNECT sent zero is a Protocol Error (`0x82`), which we cannot
-enforce until the CONNECT value is stored.
-
-- Files: `connection_factory.cr`, `broker.cr#add_client`, `sessions.cr`, `session.cr`.
 
 ### E. Will properties and Will Delay
 
@@ -564,18 +590,8 @@ was rejected with the promised reason code, confirmed by an independent
 implementation.
 
 All three lived on lines that predate the branch (`22445e0d`, the original MQTT
-support), so none was a regression. **J1 and J2 are fixed; see section 4.** J3 is
-the other direction of item D and is tracked there.
-
-- **J3. A zero Session Expiry Interval leaks the session** - the other direction
-  of item D, and the operationally sharper one. [MQTT-3.1.2-11]: expiry 0, or
-  absent (the spec default), means the session ends when the connection closes.
-  Clean Start = 0 with expiry 0 instead leaves `mqtt.<client-id>` behind durable
-  and not auto-delete, and delivers messages published while the client was away.
-  The mirror case is the one the Paho suite fails on: Clean Start = 1 with a
-  non-zero expiry - the v5 idiom for "discard any old session, persist this one" -
-  gets a transient session that is dropped at disconnect. Both fall out of D
-  treating clean-start as the only input.
+support), so none was a regression, and **all three are now fixed** - J1 and J2
+directly, J3 as part of session expiry. See section 4.
 
 ---
 
@@ -584,6 +600,20 @@ the other direction of item D and is tracked there.
 Things we will ship with, deliberately. These belong in the release notes and in
 the docs, not in a bug tracker.
 
+- **A v5 client sending Clean Start 0 with no Session Expiry Interval now gets a
+  session that ends with its connection**, where it used to get one that persisted
+  forever. This is the normative reading of 3.1.2.11.2 - "if the Session Expiry
+  Interval is absent the value 0 is used ... the Session ends when the Network
+  Connection is closed" - and what mosquitto does. Note that the same section
+  contains a *non-normative* aside calling Clean Start 0 with no interval
+  "equivalent to setting CleanSession to 0 in 3.1.1", i.e. persistent. That
+  sentence is the one a user will cite when their session stops persisting, so
+  the decision to follow the normative text is recorded here on purpose. A client
+  that wants the old behaviour sends an explicit interval. v3.1.1 is unaffected.
+  **Release note.**
+- **Session expiry restarts its clock on a broker restart.** The interval
+  persists, the deadline does not, so a session restored from definitions gets
+  its full interval again from boot. MQTT leaves this implementation-defined.
 - **Delivery QoS is now the minimum of the publish and subscription QoS on
   v3.1.1 too**, not just v5. Spec-correct ([MQTT-3.8.4-6] in 3.1.1) and decided
   deliberately rather than version-gating the publish hot path, but it is a
@@ -633,21 +663,23 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-08-20** after the J1/J2 and item I fixes, on `main`
+**LavinMQ, measured 2026-08-20** after J1/J2, item I and item D, on `main`
 `77c9ceb2`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **260 examples, 0 failures, 0 errors, 0 pending** |
-| `make test TAGS=~etcd` | **2105 examples, 0 failures, 0 errors, 9 pending** (2:38) |
-| `make lint` | 401 inspected, 0 failures |
+| `make test SPEC=spec/mqtt` | **276 examples, 0 failures, 0 errors, 0 pending** |
+| `make test TAGS=~etcd` | **2121 examples, 0 failures, 0 errors, 9 pending** |
+| `make lint` | 403 inspected, 0 failures |
 | `crystal tool format --check` | clean |
 
-(The +12 over the 248/2093 of 2026-08-19 is exactly the twelve examples added
-since: five with J1/J2 - two v3 QoS-minimum, one v5 QoS-minimum, two v5
-unexpected-packet - and seven with item I - six `PublishHeaders.restore` unit
-examples and one end-to-end poison-message example. An earlier reconciliation
-recorded 233 for `spec/mqtt`; that figure was mistyped, not a lost spec.)
+(The +28 over the 248/2093 of 2026-08-19 breaks down as five with J1/J2, seven
+with item I, and sixteen with item D - thirteen in `v5/session_expiry_spec.cr`,
+two in the new `session_spec.cr` and one takeover case in `connect_spec.cr`. Two
+of the expiry specs are tagged `slow`: the interval's unit is seconds, so the
+shortest honest test of elapse and of reconnect-cancels-it is one second each. An
+earlier reconciliation recorded 233 for `spec/mqtt`; that figure was mistyped,
+not a lost spec.)
 
 The 9 pending are pre-existing and unrelated to MQTT (queue dead-lettering
 headers, kTLS, UNIX sockets, VHost GC segments). The etcd-tagged specs were
@@ -685,10 +717,11 @@ to re-run it; the short version:
   accepted with CONNACK Success, and `maximum-packet-size 5` still gets a 23-byte
   CONNACK (`maximum-packet-size 12` a 15-byte SUBACK).
 - Items B, D, E, F, the Receive Maximum limitation and shard items N3/O2 each
-  reproduced under a third-party client, so they are all real and correctly
-  described.
+  reproduced under a third-party client, so they were all real and correctly
+  described. D has since been fixed.
 - Three defects were new information: they were item J. J1 (delivery QoS) and J2
-  (unexpected packets) are now fixed, see section 4; J3 belongs to item D.
+  (unexpected packets) are now fixed, and J3 landed with session expiry - see
+  section 4.
 
 The unmodified Paho v5 suite cannot grade this broker - 22 of its 27 tests use
 QoS 2 somewhere, and its client ignores our advertised `maximum_qos = 1`, which is
@@ -703,12 +736,12 @@ denying a topic.
 
 ## 8. Sequencing to ship
 
-1. Finish B / D / E (F and G in parallel, different people). ~~The poison-message
+1. Finish B / E (F and G in parallel, different people). D is done. ~~The poison-message
    and hot-path-allocation findings in I should land before the PR regardless of
    who takes the feature work.~~ Done 2026-08-20, along with three of the other
    five; only the two section 2 `[~]` enforcement gaps remain in I.
 2. ~~External smoke test against a real v5 client.~~ Done 2026-08-19, see
-   section 7 and `MQTT5-INTEROP.md`. Re-run it once B/D/E/F land - the same
+   section 7 and `MQTT5-INTEROP.md`. Re-run it once B/E/F land - the same
    harness grades them. It has **not** been re-run since the J1/J2 and item I
    fixes; the interop doc's delivery-QoS and DISCONNECT `0x82` rows are the
    expectations to confirm when it is.
@@ -737,7 +770,7 @@ as their own issues once the PR lands. Nothing below blocks it.
 
 ### QoS 2 (exactly-once delivery)
 
-The largest single item left in MQTT - bigger than B/D/E/F combined - and a
+The largest single item left in MQTT - bigger than B/E/F combined - and a
 *session-state and durability* project rather than a protocol one. Deliberately
 out of scope; see section 2 and the section 6 limitation.
 
@@ -766,8 +799,9 @@ specs. What LavinMQ would need:
    handshake, so exactly-once could only ever be a promise between two MQTT
    endpoints.
 
-It also lands *on top of* item D: persisted QoS 2 state without a session lifetime
-is a leak by construction.
+It lands *on top of* session expiry, which is now in place - persisted QoS 2
+state without a session lifetime would have been a leak by construction, and the
+interval is what bounds it.
 
 Not urgent. The current position is fully spec-legal, and the external run
 confirmed real clients handle it gracefully - mosquitto refused a QoS 2 publish

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -15,7 +15,7 @@ about 80% done**.
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 21 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 26 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
 intact, gets an accurate reason code on every ack, and gets a spec-correct
@@ -23,7 +23,7 @@ rejection for every feature we don't implement. What is missing is the rest of
 the *session-lifecycle* half of v5: session expiry, will properties and will
 delay, subscription options.
 
-**On `main` (`77c9ceb2`) and verified green on 2026-08-20: 2098 examples,
+**On `main` (`77c9ceb2`) and verified green on 2026-08-20: 2105 examples,
 0 failures, lint and format clean.** See section 7.
 
 ---
@@ -417,11 +417,31 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
   client-sent PINGRESP and an AUTH packet on a plain connection. v5 now gets
   DISCONNECT `0x82` and the log gets one WARN line; v3 still just closes.
 
-**Specs:** 33 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
-unsubscribe, puback/disconnect), plus the existing v3 suite adapted to the new
-shard API. (The previous reconciliation said 34 before three examples were added,
-so that figure was wrong by four; 33 is measured from
-`make test SPEC=spec/mqtt/v5`.)
+**Robustness and hot path** (item I)
+- `PublishHeaders.restore` tolerates any AMQP header. Four-byte ints go through
+  one `fetch_u32?` and `response_topic` through `fetch_topic?`
+  ([MQTT-3.3.2-14], wildcards dropped). Previously `to_u32` on a negative
+  `mqtt.message_expiry_interval` raised inside `build_packet`, which requeued and
+  re-raised, force-closed the subscriber and re-poisoned on reconnect - an AMQP
+  client can reach this by binding `mqtt.<client-id>` to `amq.topic`, since
+  `definitions_store.cr` resolves a bind target as
+  `@queues[name]? || @sessions[name]?`.
+- `Session#get_packet`'s QoS>0 rescue is split in two: the inner one rolls back
+  the `@unacked_*` counters it incremented, the outer one requeues. It used to
+  subtract unconditionally, so a raise from `build_packet` drove both counters
+  negative.
+- `Exchange#publish` holds the decoded topic in a local instead of calling
+  `packet.topic` two or three times (3.7: the getter allocates per call).
+- `Session#build_packet` skips the property restore for a v3 subscriber, whose
+  `IO::V3#write_properties` discards them anyway. The version is read off the
+  client the same way `max_packet_size` already is.
+- `Client#protocol_name` is an exhaustive `case/in` again, so a new `Version`
+  member is a compile error rather than a silent "MQTT 3.1.1".
+
+**Specs:** 34 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
+unsubscribe, puback/disconnect) plus `spec/mqtt/publish_headers_spec.cr`, on top
+of the existing v3 suite adapted to the new shard API. Both figures are measured;
+an earlier reconciliation's "34 v5 examples" predated four of them and was wrong.
 
 ---
 
@@ -516,48 +536,23 @@ still uses `StringTokenIterator`, unlike the publish-path subscription tree.
 Parked from a full-branch review on 2026-08-19, ordered by severity. All were
 introduced on this branch, so they are ours to fix before the PR.
 
-- **Poison message via `mqtt.message_expiry_interval`.**
-  `publish_headers.cr#restore` does `i.to_u32` on a value read from an AMQP
-  header. `restore` is *not* only fed headers written by `store`:
-  `definitions_store.cr:217` resolves a bind target as
-  `@queues[name]? || @sessions[name]?`, so an AMQP client can bind
-  `mqtt.<client_id>` to `amq.topic` and publish
-  `mqtt.message_expiry_interval = -1_i32`. `.as?(Int)` succeeds, `to_u32` raises
-  `OverflowError` inside `build_packet`, the SP is requeued and re-raised, and
-  `deliver_loop` force-closes the subscriber - which re-poisons on reconnect, so
-  the queue can never drain. Every other field is nil-safe via `.as?`; this one
-  is not. Fix with `to_u32?`, and route every four-byte-int property through one
-  `fetch_u32?` helper so the next property added cannot get it wrong.
-  `response_topic` is also restored without wildcard validation.
-- **`packet.topic` allocates on the publish hot path.** The shard bump changed
-  `Publish#topic` from a stored `String` to `String.new(@topic)` per call (3.7,
-  and the shard says "hold the result or use `topic_bytes` on hot paths").
-  `exchange.cr#publish` calls it twice, three times with retain, so every MQTT
-  publish now allocates 2-3 throwaway Strings where `main` allocated none. Hoist
-  to a local. Documenting the cost in 3.7 did not prevent it - consider renaming
-  the getter to `topic_string` before the 1.0 tag so the cost is visible at the
-  call site.
+**Five of the seven are fixed** on 2026-08-20 - the poison message and its
+`@unacked_*` corruption, the hot-path allocation, `protocol_name` exhaustiveness,
+and the v3 property restore. See section 4. The two that remain are both
+enforcement gaps already tracked as the `[~]` rows in section 2:
+
 - **Will QoS 2 is accepted despite `maximum_qos = 1`** - section 2, first `[~]`
-  row.
+  row. `Connect.from_io` accepts any `will_qos < 3` and nothing rejects a Will at
+  QoS 2, where spec 3.1.2.6 wants CONNACK `0x9B`. Confirmed from outside by the
+  interop run.
 - **Maximum Packet Size is only enforced for outbound PUBLISH** - section 2,
   second `[~]` row. `Client#send` is the single outbound choke point and is the
   place to put it, so no future packet type can forget it.
-- **`session.cr`'s QoS>0 `rescue` can drive `@unacked_*` negative.** It
-  unconditionally subtracts, but the matching `add` calls sit *after* the
-  `exceeds_max_packet_size?` early-`next`, and `build_packet` (see the poison
-  message above) raises before them. Masked today only because `client=` resets
-  the counters. Move the `add` before the `begin`, or subtract only what was
-  added.
-- **`client.cr#protocol_name` lost a compiler check.** The removed
-  `ProtocolVersion` enum used `case/in`, so a new member was a compile error;
-  the replacement's `else "MQTT 3.1.1"` would silently mislabel a future
-  version in the management UI. `Version` has exactly three members, so
-  `case/in` restores exhaustiveness for free.
-- **`PublishHeaders.restore` runs for v3 subscribers too.** `build_packet` is
-  version-blind, so a v3-only deployment pays six `Table#fetch` linear scans
-  plus a `PublishProperties` construction per delivery, for properties
-  `IO::V3#write_properties` then discards. The session already reaches into the
-  client for `max_packet_size`; the negotiated version could come the same way.
+
+One follow-up the fixes did not take: the shard's `Publish#topic` still allocates
+per call, and documenting that in 3.7 did not stop a consumer from calling it
+three times on the hot path. Renaming it to `topic_string` before the 1.0 tag
+would make the cost visible at the call site.
 
 ### J. External interop findings
 
@@ -638,19 +633,21 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-08-20** after the J1/J2 fixes, on `main` `77c9ceb2`:
+**LavinMQ, measured 2026-08-20** after the J1/J2 and item I fixes, on `main`
+`77c9ceb2`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **253 examples, 0 failures, 0 errors, 0 pending** (24.9s) |
-| `make test TAGS=~etcd` | **2098 examples, 0 failures, 0 errors, 9 pending** (2:38) |
-| `make lint` | 400 inspected, 0 failures |
+| `make test SPEC=spec/mqtt` | **260 examples, 0 failures, 0 errors, 0 pending** |
+| `make test TAGS=~etcd` | **2105 examples, 0 failures, 0 errors, 9 pending** (2:38) |
+| `make lint` | 401 inspected, 0 failures |
 | `crystal tool format --check` | clean |
 
-(The +5 over the previous 248/2093 is exactly the five examples added with J1 and
-J2 - two v3 QoS-minimum regressions, one v5 QoS-minimum, two v5 unexpected-packet.
-An earlier reconciliation recorded 233 for `spec/mqtt`; that figure was mistyped,
-not a lost spec.)
+(The +12 over the 248/2093 of 2026-08-19 is exactly the twelve examples added
+since: five with J1/J2 - two v3 QoS-minimum, one v5 QoS-minimum, two v5
+unexpected-packet - and seven with item I - six `PublishHeaders.restore` unit
+examples and one end-to-end poison-message example. An earlier reconciliation
+recorded 233 for `spec/mqtt`; that figure was mistyped, not a lost spec.)
 
 The 9 pending are pre-existing and unrelated to MQTT (queue dead-lettering
 headers, kTLS, UNIX sockets, VHost GC segments). The etcd-tagged specs were
@@ -706,14 +703,15 @@ denying a topic.
 
 ## 8. Sequencing to ship
 
-1. Finish B / D / E (F and G in parallel, different people). The poison-message
+1. Finish B / D / E (F and G in parallel, different people). ~~The poison-message
    and hot-path-allocation findings in I should land before the PR regardless of
-   who takes the feature work.
+   who takes the feature work.~~ Done 2026-08-20, along with three of the other
+   five; only the two section 2 `[~]` enforcement gaps remain in I.
 2. ~~External smoke test against a real v5 client.~~ Done 2026-08-19, see
    section 7 and `MQTT5-INTEROP.md`. Re-run it once B/D/E/F land - the same
-   harness grades them. It has **not** been re-run since the J1/J2 fixes; the
-   interop doc's delivery-QoS and DISCONNECT `0x82` rows are the expectations to
-   confirm when it is.
+   harness grades them. It has **not** been re-run since the J1/J2 and item I
+   fixes; the interop doc's delivery-QoS and DISCONNECT `0x82` rows are the
+   expectations to confirm when it is.
 3. Tag the shard release (`1.0`), with 3.7's breaking changes in the changelog.
 4. Repoint `shard.yml` from `branch: feat/mqtt5` to the tag, update `shard.lock`.
 5. Merge back the v5 specs (section H).

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -15,7 +15,7 @@ about 80% done**.
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 18 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 19 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
 intact, gets an accurate reason code on every ack, and gets a spec-correct
@@ -41,22 +41,36 @@ This is what makes our deferrals legal rather than broken.
 
 | Property advertised in CONNACK | Value | Enforcement on use | Adv. | Enf. |
 |---|---|---|---|---|
-| `maximum_qos` | `1` | QoS 2 PUBLISH -> DISCONNECT `0x9B` QoSNotSupported | [x] | [x] |
+| `maximum_qos` | `1` | QoS 2 PUBLISH -> DISCONNECT `0x9B` QoSNotSupported | [x] | [~] |
 | `topic_alias_maximum` | `0` | PUBLISH with a Topic Alias -> DISCONNECT `0x94` TopicAliasInvalid | [x] | [x] |
 | `subscription_identifier_available` | `0` | SUBSCRIBE with a Subscription Identifier -> DISCONNECT `0xA1` | [x] | [x] |
 | `shared_subscription_available` | `0` | `$share/...` filter -> DISCONNECT `0x9E` | [x] | [x] |
 | `retain_available` | `1` | supported (LavinMQ has a retain store) | [x] | n/a |
 | `wildcard_subscription_available` | `1` | supported | [x] | n/a |
-| `maximum_packet_size` | `Config#mqtt_max_packet_size` | oversized inbound rejected by the codec; oversized outbound dropped | [x] | [x] |
+| `maximum_packet_size` | `Config#mqtt_max_packet_size` | oversized inbound rejected by the codec; oversized outbound dropped | [x] | [~] |
 | `receive_maximum` | omitted (default 65535) | **not enforced** - see limitations | [x] | [ ] |
 
 Plus: enhanced authentication (the AUTH-packet flow, [MQTT-4.12]) is rejected at
 CONNECT with CONNACK reason `0x8C` BadAuthenticationMethod, before
 username/password auth runs so the reason is accurate.
 
-Everything in this table is implemented and spec'd. **The advertise/enforce
-matrix is complete** - this was the largest single risk in the project and it is
-closed.
+**Two rows are `[~]`, not `[x]`** - the enforcement exists but does not cover
+every path the spec requires:
+
+- `maximum_qos`: inbound PUBLISH is checked in `client.cr#validate_v5_publish!`,
+  but the **Will QoS is not**. `Connect.from_io` accepts any `will_qos < 3`, and
+  nothing rejects a Will at QoS 2, so a v5 CONNECT that asks for one is accepted
+  where spec 3.1.2.6 wants CONNACK `0x9B`. The QoS is clamped at delivery in
+  `session.cr#build_packet`, so nothing breaks - but we accepted a connection we
+  advertised we could not serve.
+- `maximum_packet_size`: only the outbound **PUBLISH** path checks it
+  (`session.cr#exceeds_max_packet_size?`). [MQTT-3.1.2-24] covers *every* packet
+  the server sends, and a client may legally advertise any limit >= 1, so a very
+  small limit already gets an oversized capability CONNACK, and a SUBSCRIBE with
+  many filters gets an oversized SUBACK.
+
+Both are tracked as item I. Everything else in the table is implemented and
+spec'd, which was the largest single risk in the project.
 
 ### Deliberately out of scope for the first release
 
@@ -469,6 +483,54 @@ still uses `StringTokenIterator`, unlike the publish-path subscription tree.
   now pinned to `IO::V3` (section 7), so there is no load-testing path for v5
   at all. Optional, not a blocker.
 
+### I. Review findings
+
+Parked from a full-branch review on 2026-08-19, ordered by severity. All were
+introduced on this branch, so they are ours to fix before the PR.
+
+- **Poison message via `mqtt.message_expiry_interval`.**
+  `publish_headers.cr#restore` does `i.to_u32` on a value read from an AMQP
+  header. `restore` is *not* only fed headers written by `store`:
+  `definitions_store.cr:217` resolves a bind target as
+  `@queues[name]? || @sessions[name]?`, so an AMQP client can bind
+  `mqtt.<client_id>` to `amq.topic` and publish
+  `mqtt.message_expiry_interval = -1_i32`. `.as?(Int)` succeeds, `to_u32` raises
+  `OverflowError` inside `build_packet`, the SP is requeued and re-raised, and
+  `deliver_loop` force-closes the subscriber - which re-poisons on reconnect, so
+  the queue can never drain. Every other field is nil-safe via `.as?`; this one
+  is not. Fix with `to_u32?`, and route every four-byte-int property through one
+  `fetch_u32?` helper so the next property added cannot get it wrong.
+  `response_topic` is also restored without wildcard validation.
+- **`packet.topic` allocates on the publish hot path.** The shard bump changed
+  `Publish#topic` from a stored `String` to `String.new(@topic)` per call (3.7,
+  and the shard says "hold the result or use `topic_bytes` on hot paths").
+  `exchange.cr#publish` calls it twice, three times with retain, so every MQTT
+  publish now allocates 2-3 throwaway Strings where `main` allocated none. Hoist
+  to a local. Documenting the cost in 3.7 did not prevent it - consider renaming
+  the getter to `topic_string` before the 1.0 tag so the cost is visible at the
+  call site.
+- **Will QoS 2 is accepted despite `maximum_qos = 1`** - section 2, first `[~]`
+  row.
+- **Maximum Packet Size is only enforced for outbound PUBLISH** - section 2,
+  second `[~]` row. `Client#send` is the single outbound choke point and is the
+  place to put it, so no future packet type can forget it.
+- **`session.cr`'s QoS>0 `rescue` can drive `@unacked_*` negative.** It
+  unconditionally subtracts, but the matching `add` calls sit *after* the
+  `exceeds_max_packet_size?` early-`next`, and `build_packet` (see the poison
+  message above) raises before them. Masked today only because `client=` resets
+  the counters. Move the `add` before the `begin`, or subtract only what was
+  added.
+- **`client.cr#protocol_name` lost a compiler check.** The removed
+  `ProtocolVersion` enum used `case/in`, so a new member was a compile error;
+  the replacement's `else "MQTT 3.1.1"` would silently mislabel a future
+  version in the management UI. `Version` has exactly three members, so
+  `case/in` restores exhaustiveness for free.
+- **`PublishHeaders.restore` runs for v3 subscribers too.** `build_packet` is
+  version-blind, so a v3-only deployment pays six `Table#fetch` linear scans
+  plus a `PublishProperties` construction per delivery, for properties
+  `IO::V3#write_properties` then discards. The session already reaches into the
+  client for `max_packet_size`; the negotiated version could come the same way.
+
 ---
 
 ## 6. Known limitations to state at release
@@ -481,7 +543,7 @@ the docs, not in a bug tracker.
   client's advertised Receive Maximum, and we do not advertise our own (so
   clients assume the 65535 default). LavinMQ has its own
   `Config#max_inflight_messages` cap instead. This is the one line in the
-  compliance table with an unticked enforcement column.
+  compliance table with a fully unticked enforcement column.
 - **Topic aliases unsupported** in both directions.
 - **Shared subscriptions unsupported.**
 - **Subscription identifiers unsupported.**
@@ -559,7 +621,9 @@ apt-installable.
 
 ## 8. Sequencing to ship
 
-1. Finish B / D / E (F and G in parallel, different people).
+1. Finish B / D / E (F and G in parallel, different people). The poison-message
+   and hot-path-allocation findings in I should land before the PR regardless of
+   who takes the feature work.
 2. External smoke test against a real v5 client.
 3. Tag the shard release (`1.0`), with 3.7's breaking changes in the changelog.
 4. Repoint `shard.yml` from `branch: feat/mqtt5` to the tag, update `shard.lock`.

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -3,28 +3,28 @@
 Status and design doc for the MQTT 5.0 work in LavinMQ, spanning both this repo
 and the `mqtt-protocol.cr` shard.
 
-Last reconciled against the code: **2026-08-18**.
+Last reconciled against the code: **2026-08-19**.
 
 ---
 
 ## 1. TL;DR
 
 MQTT 5.0 spans two repos. The **wire codec is done**; the **broker semantics are
-about 70% done**.
+about 80% done**.
 
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 16 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 18 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
-intact, and gets a spec-correct rejection for every feature we don't implement.
-What is missing is the *session-lifecycle* half of v5: PUBACK reason codes,
-DISCONNECT handling, session expiry, will properties and will delay,
-subscription options.
+intact, gets an accurate reason code on every ack, and gets a spec-correct
+rejection for every feature we don't implement. What is missing is the rest of
+the *session-lifecycle* half of v5: session expiry, will properties and will
+delay, subscription options.
 
-**Rebased onto `main` (`77c9ceb2`) and verified green on 2026-08-18: 2083
-examples, 0 failures, lint and format clean.** See section 7.
+**On `main` (`77c9ceb2`) and verified green on 2026-08-19: 2093 examples,
+0 failures, lint and format clean.** See section 7.
 
 ---
 
@@ -361,15 +361,33 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
 - Per-topic reason codes, `Success` vs `NoSubscriptionExisted`;
   `Session#unsubscribe` now returns a Bool to drive that [MQTT-3.11.3]
 
-**Specs:** 24 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
-unsubscribe), plus the existing v3 suite adapted to the new shard API.
+**PUBACK / ack reason codes**
+- `NoMatchingSubscribers` (`0x10`) when the publish matched no session;
+  `Exchange#publish` already returned the match count [MQTT-3.4.2.1]
+- `NotAuthorized` (`0x87`) instead of a silent `close_socket`, via
+  `client.cr#refuse_publish`. QoS > 0 gets a PUBACK and keeps the connection;
+  QoS 0 has no ack, so it gets a server DISCONNECT `0x87` (spec 3.3.4)
+- SUBSCRIBE denial likewise answers a SUBACK of per-filter `NotAuthorized`
+- Inbound non-`Success` PUBACK is logged and still acks the message: a refused
+  QoS 1 delivery is finished, not retried [MQTT-3.4.2.1]
+
+**Client DISCONNECT**
+- The reason code is honoured: only `0x00` discards the will, so `0x04`
+  (Disconnect with Will Message) and every error code publish it
+  [MQTT-3.14.4-3]. We send nothing back - the receiver just closes
+  [MQTT-3.14.4-2]
+
+**Specs:** 34 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
+unsubscribe, puback/disconnect), plus the existing v3 suite adapted to the new
+shard API.
 
 ---
 
 ## 5. What is left
 
 Ordered roughly easiest-first. **B and D are independent of each other and of
-everything else** - these are the two clean hand-offs.
+everything else** - these are the two clean hand-offs. (C is done; see
+section 4.)
 
 ### B. Honor subscription options
 
@@ -385,16 +403,6 @@ store. Pure LavinMQ behaviour, no shard work, well-bounded.
   instead of clearing it.
 - Files: `broker.cr#subscribe`, `session.cr#build_packet`, `client.cr#recieve_subscribe`.
 
-### C. PUBACK + DISCONNECT
-
-- **PUBACK v5**: `client.cr:254` still sends a bare `PubAck.new(packet_id)`.
-  Needs a reason code and properties. Inbound PUBACK reason codes are ignored.
-- **Client DISCONNECT**: the packet is returned from `read_and_handle_packet`
-  unparsed. v5 needs its reason code read, and specifically reason `0x04`
-  ("Disconnect with Will Message") must **publish** the will, whereas a normal
-  `0x00` disconnect suppresses it. Today every clean disconnect suppresses it.
-- Files: `client.cr` (`recieve_puback`, `read_loop` DISCONNECT branch, `publish_will`).
-
 ### D. Session expiry
 
 v5 replaces the clean-session boolean with Clean Start + Session Expiry
@@ -402,8 +410,11 @@ Interval. We read `ConnectProperties#maximum_packet_size` and nothing else;
 `session_expiry_interval` is ignored, and DISCONNECT can also carry a new
 expiry value. Sessions are still clean-session-or-forever.
 
-Touches session lifecycle, so it pairs naturally with C (shared DISCONNECT
-path) or with whoever knows `sessions.cr` best.
+C landed the DISCONNECT reason-code path, so the packet is now inspected in
+`read_loop`; reading `DisconnectProperties#session_expiry_interval` there is the
+natural next step. That also brings [MQTT-3.14.2]: a non-zero expiry on
+DISCONNECT when CONNECT sent zero is a Protocol Error (`0x82`), which we cannot
+enforce until the CONNECT value is stored.
 
 - Files: `connection_factory.cr`, `broker.cr#add_client`, `sessions.cr`, `session.cr`.
 
@@ -449,7 +460,9 @@ still uses `StringTokenIterator`, unlike the publish-path subscription tree.
   matching `spec/mqtt/integrations/*_spec.cr` and delete the v5 file. **Except**
   the advertise-and-reject compliance matrix, which stays as its own standing
   file. Nothing has been merged back yet: connect, subscribe, unsubscribe,
-  publish, puback/disconnect all outstanding.
+  publish and puback/disconnect are all outstanding. The DISCONNECT/will
+  examples in `puback_disconnect_spec.cr` belong next to
+  `integrations/will_spec.cr`, not `publish_spec.cr`.
 - Consider moving `build_server_capabilities` into `consts.cr` or making it a
   constant, to make it obvious it is static.
 - Consider adding a v5 mode to the `lavinmqperf mqtt` throughput tool. It is
@@ -474,6 +487,16 @@ the docs, not in a bug tracker.
 - **Subscription identifiers unsupported.**
 - **Enhanced authentication unsupported.**
 - **Will delay interval ignored** (wills fire immediately).
+- **Payload Format Indicator is not validated.** Spec 3.3.2.3.2 only says a
+  server MAY check that a payload declared as UTF-8 really is, so we never
+  answer `0x99` PayloadFormatInvalid. Validating means a String allocation plus
+  a UTF-8 scan on the publish hot path for an optional check.
+- **No Reason Strings or User Properties on ack packets.** [MQTT-3.1.2-29]
+  makes them illegal on anything but PUBLISH / CONNACK / DISCONNECT when the
+  client set Request Problem Information to 0, and we never send them, so
+  `request_problem_information` needs no plumbing.
+- **UNSUBSCRIBE is not permission checked** (it never was, on v3 either), so
+  UNSUBACK never carries `0x87` NotAuthorized.
 - v5 PUBLISH properties are carried in `mqtt.*` AMQP headers and are **not**
   mapped onto AMQP-native properties, so an AMQP consumer of an MQTT-published
   message sees them as headers.
@@ -495,14 +518,18 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-08-18** on `9e2f53f9`, rebased onto `main` `77c9ceb2`:
+**LavinMQ, measured 2026-08-19** after the PUBACK/DISCONNECT work, on `main`
+`77c9ceb2`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **233 examples, 0 failures, 0 errors, 0 pending** (16.8s) |
-| `make test TAGS=~etcd` | **2083 examples, 0 failures, 0 errors, 9 pending** (2:41) |
-| `make lint` | 399 inspected, 0 failures |
+| `make test SPEC=spec/mqtt` | **248 examples, 0 failures, 0 errors, 0 pending** (18.0s) |
+| `make test TAGS=~etcd` | **2093 examples, 0 failures, 0 errors, 9 pending** (2:35) |
+| `make lint` | 400 inspected, 0 failures |
 | `crystal tool format --check` | clean |
+
+(The previous reconciliation recorded 233 for `spec/mqtt`; the full-suite delta
+is exactly the 10 new examples, so that figure was mistyped, not a lost spec.)
 
 The 9 pending are pre-existing and unrelated to MQTT (queue dead-lettering
 headers, kTLS, UNIX sockets, VHost GC segments). The etcd-tagged specs were
@@ -532,7 +559,7 @@ apt-installable.
 
 ## 8. Sequencing to ship
 
-1. Finish B / C / D / E (F and G in parallel, different people).
+1. Finish B / D / E (F and G in parallel, different people).
 2. External smoke test against a real v5 client.
 3. Tag the shard release (`1.0`), with 3.7's breaking changes in the changelog.
 4. Repoint `shard.yml` from `branch: feat/mqtt5` to the tag, update `shard.lock`.

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -1,0 +1,592 @@
+# MQTT 5.0 support - status, design, and remaining work
+
+Status and design doc for the MQTT 5.0 work in LavinMQ, spanning both this repo
+and the `mqtt-protocol.cr` shard.
+
+Last reconciled against the code: **2026-08-18**.
+
+---
+
+## 1. TL;DR
+
+MQTT 5.0 spans two repos. The **wire codec is done**; the **broker semantics are
+about 70% done**.
+
+| | branch | ahead of main | PR | state |
+|---|---|---|---|---|
+| `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
+| `lavinmq` | `feat/implement-mqtt5-support` | 16 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + full compliance contract |
+
+A v5 client can today connect, subscribe, publish and receive with properties
+intact, and gets a spec-correct rejection for every feature we don't implement.
+What is missing is the *session-lifecycle* half of v5: PUBACK reason codes,
+DISCONNECT handling, session expiry, will properties and will delay,
+subscription options.
+
+**Rebased onto `main` (`77c9ceb2`) and verified green on 2026-08-18: 2083
+examples, 0 failures, lint and format clean.** See section 7.
+
+---
+
+## 2. Scope and the compliance contract
+
+**Read this section first. It is the correctness anchor for the whole project.**
+
+MQTT 5.0 lets a server omit optional features **only if it advertises their
+absence in CONNACK** and then rejects clients that use them anyway. Advertising
+alone is not compliance, and enforcing alone is not compliance. Both columns
+must be ticked, because a client can send anything regardless of what we said.
+
+This is what makes our deferrals legal rather than broken.
+
+| Property advertised in CONNACK | Value | Enforcement on use | Adv. | Enf. |
+|---|---|---|---|---|
+| `maximum_qos` | `1` | QoS 2 PUBLISH -> DISCONNECT `0x9B` QoSNotSupported | [x] | [x] |
+| `topic_alias_maximum` | `0` | PUBLISH with a Topic Alias -> DISCONNECT `0x94` TopicAliasInvalid | [x] | [x] |
+| `subscription_identifier_available` | `0` | SUBSCRIBE with a Subscription Identifier -> DISCONNECT `0xA1` | [x] | [x] |
+| `shared_subscription_available` | `0` | `$share/...` filter -> DISCONNECT `0x9E` | [x] | [x] |
+| `retain_available` | `1` | supported (LavinMQ has a retain store) | [x] | n/a |
+| `wildcard_subscription_available` | `1` | supported | [x] | n/a |
+| `maximum_packet_size` | `Config#mqtt_max_packet_size` | oversized inbound rejected by the codec; oversized outbound dropped | [x] | [x] |
+| `receive_maximum` | omitted (default 65535) | **not enforced** - see limitations | [x] | [ ] |
+
+Plus: enhanced authentication (the AUTH-packet flow, [MQTT-4.12]) is rejected at
+CONNECT with CONNACK reason `0x8C` BadAuthenticationMethod, before
+username/password auth runs so the reason is accurate.
+
+Everything in this table is implemented and spec'd. **The advertise/enforce
+matrix is complete** - this was the largest single risk in the project and it is
+closed.
+
+### Deliberately out of scope for the first release
+
+QoS 2 (LavinMQ is QoS 0/1 throughout; PUBREC/PUBREL/PUBCOMP exist in the codec
+only), topic aliases, shared subscriptions, subscription identifiers, enhanced
+auth, will delay. All are advertised as unavailable per the table above.
+
+---
+
+## 3. Architecture
+
+### 3.1 Division of responsibility
+
+```
+MQTT 5.0 = [ wire codec ] + [ broker semantics ]
+             mqtt-protocol.cr    lavinmq
+```
+
+The shard is a **pure codec with zero semantics**. Its job ends at the wire:
+encode and decode every v5 packet correctly, and hand the consumer a reason code
+when bytes are invalid. Everything stateful is LavinMQ's: sessions, expiry, flow
+control, topic-alias maps, shared subscriptions, capability advertisement,
+QoS 2 state machines.
+
+This split is load-bearing. It means anyone can build an MQTT 5 server on the
+shard, and it means **every v5 behaviour decision lives in LavinMQ**, which is
+why the LavinMQ half is where the remaining work is.
+
+### 3.2 Shard: the version is the IO's *type*
+
+The single most important design decision. All v3-vs-v5 wire differences are
+isolated into ~9 framing hooks on an abstract `IO`, with concrete `IO::V3` and
+`IO::V5` subclasses. Packet structs are version-agnostic and never branch on the
+version.
+
+```mermaid
+classDiagram
+    class Packet {
+        <<abstract struct>>
+        +to_io(io)*
+        +remaining_length(version) UInt32*
+        +bytesize(version) UInt32
+        +from_io(io) Packet$
+    }
+    Packet <|-- Connect
+    Packet <|-- Connack
+    Packet <|-- Publish
+    Packet <|-- PubAck_PubRec_PubRel_PubComp
+    Packet <|-- Subscribe
+    Packet <|-- SubAck
+    Packet <|-- Unsubscribe
+    Packet <|-- UnsubAck
+    Packet <|-- Disconnect
+    Packet <|-- Auth
+    Packet <|-- PingReq_PingResp
+
+    class IO {
+        <<abstract class>>
+        +version() Version*
+        +read_byte() / read_int() / read_string()
+        +variable_byte_int(max)
+        +consume(remaining, n)  // checked
+        ~read_properties(klass, remaining)*
+        ~write_properties(props)*
+        ~read_ack_tail() / write_ack()*
+        ~read_reason_tail() / write_reason_tail()*
+        ~validate_subscription_options()*
+        ~read_connack_reason() / write_connack_body()*
+        ~allow_empty_topic?()*
+        +for(version, socket)$ IO
+        +read_connect(socket)$ {Connect, IO}
+    }
+    IO <|-- V3
+    IO <|-- V5
+
+    class V3 {
+        version = V3_1 / V3_1_1
+        read_properties -> {empty, 0}
+        write_properties -> no-op
+        read_ack_tail -> {nil, empty}
+        write_connack_body -> session+return_code byte
+        allow_empty_topic? -> false
+    }
+    class V5 {
+        version = V5
+        read_properties -> parse property section
+        write_properties -> length-prefixed section
+        read_ack_tail -> {reason_byte?, props}
+        write_connack_body -> session+reason+props
+        allow_empty_topic? -> true
+    }
+
+    Packet ..> IO : from_io / to_io call hooks
+    note for Packet "Packets are VERSION-AGNOSTIC.\nNo `if version.v5?` on the wire path\n(except UnsubAck: genuine structural diff)."
+```
+
+**Why it replaced the original mutable `io.version` field:** the field defaulted
+to `V3_1_1`, so decoding a CONNACK on a fresh IO silently took the v3 path, and
+every packet had to remember an `if io.version.v5?` branch. That is exactly how
+the PUBREL/PUBCOMP gate bug crept in. Type dispatch makes the branch impossible
+to forget, and a future protocol version becomes a third subclass rather than a
+third branch in twelve places.
+
+Two acknowledged exceptions:
+- `UnsubAck` is the one packet that checks `io.version` directly, because v3 is a
+  bare packet id with no payload at all - a structural difference, not a framing
+  one.
+- `remaining_length(version)` takes the version as a parameter, because there is
+  no IO object at size-computation time.
+
+### 3.3 Version negotiation
+
+CONNECT is the only packet that *reveals* the version, via its protocol-level
+byte. The flow:
+
+```
+socket
+  -> IO::V3.new(socket, max)          # bootstrap reader
+  -> io.read_connect                  # reads CONNECT, reframes to the negotiated version
+  -> {Connect, IO::V3 | IO::V5}       # every subsequent packet uses this IO
+```
+
+The instance method `io.read_connect` (not the class method) is what a
+*rejecting* server needs: it only rebinds `io` on success, so if the CONNECT is
+malformed the v3 bootstrap IO survives and can still frame a rejection CONNACK.
+LavinMQ uses this at `connection_factory.cr:31`. The class-method
+`IO.read_connect(socket, max)` builds its IO internally and raises before
+returning, leaving a rejecting server with nothing to answer on. That instance
+method was added to the shard specifically because a LavinMQ test caught the
+trap.
+
+### 3.4 Other shard design decisions
+
+- **Typed properties struct per packet context.** `ConnectProperties`,
+  `PublishProperties`, `ConnackProperties` etc., generated by a
+  `define_properties` macro. A property that is illegal in a packet is
+  *structurally absent* (no field), not a runtime table lookup. User Property is
+  always present as an ordered `Array(StringPair)` since it is legal everywhere.
+  Value ranges are declared in the macro spec table, so "it is a Protocol Error
+  if value is 0" is enforced by the generated decoder **and** the setter - the
+  shard can never construct a packet its own decoder would reject.
+- **Repeatable properties are nil-backed** so a packet without them allocates
+  nothing on the hot path. The getters deliberately do **not** memoize: these are
+  value structs, and a memo set on one copy is lost through the next copy, which
+  would break `==`. Build the array and assign it whole.
+- **Per-packet reason-code enums.** `Connack::ReasonCode`,
+  `Disconnect::ReasonCode`, `SubAck::ReasonCode`, ... Each lists only the codes
+  legal for that packet, with contextually correct names, because the same byte
+  `0x00` means "Success" / "Normal disconnection" / "Granted QoS 0" depending on
+  the packet. The v3 `Connack::ReturnCode` stays as the v3 wire format; the
+  IO hooks pick which byte goes on the wire.
+- **Decode errors carry the reason code.** `Error::ProtocolError` carries the v5
+  reason byte the consumer must respond with, so "which violation maps to which
+  reason code" stays protocol knowledge owned by the shard instead of being
+  re-derived in every consumer. `PacketDecode` remains the just-close case.
+- **Validation split.** The codec rejects only bytes that can never be valid in
+  *any* connection state. Empty PUBLISH topic is version-gated (illegal in v3,
+  legal in v5 where a Topic Alias substitutes). Topic-alias limits, receive
+  maximum and alias resolution are all consumer-side because they depend on state
+  the codec does not hold.
+- **`remaining_length` by arithmetic precompute, per version, on demand.** No
+  serialize-then-measure. It is not frozen at construction, because a frozen
+  value matched only one version - that was a real review finding.
+- **An IO-owned byte budget bounds every read.** Every length-prefixed field read
+  is charged against the packet's remaining length, and `consume(remaining, n)`
+  raises `PacketDecode` rather than letting a `UInt32` subtraction underflow.
+  This was the single highest-leverage hardening change; it fixed a class of
+  malformed-packet DoS bugs (uncaught `OverflowError` / `EOFError`) rather than
+  individual instances. `forward_missing_to` was removed from IO so no read can
+  bypass the budget.
+
+### 3.5 Per-packet v3 -> v5 differences
+
+| Packet | Change in v5 |
+|---|---|
+| `Connect` | protocol level `0x05`; `ConnectProperties`; `Will` gains `WillProperties` |
+| `Connack` | `ConnackProperties`; `ReasonCode` (v3 `ReturnCode` on the wire for v3) |
+| `Publish` | `PublishProperties`; empty topic legal (Topic Alias substitutes) |
+| `PubAck`/`PubRec`/`PubRel`/`PubComp` | reason-code byte + properties, omittable when reason is `0x00` and there are no properties (3.4.2.1) |
+| `Subscribe` | `SubscribeProperties`; per-filter options: No Local, Retain As Published, Retain Handling |
+| `SubAck`/`UnsubAck` | per-entry `ReasonCode` + properties |
+| `Unsubscribe` | properties |
+| `Disconnect` | promoted out of `SimplePacket`: optional reason code + properties, **bidirectional** |
+| `Auth` | **new** packet type `0x0F` |
+| `PingReq`/`PingResp` | unchanged |
+
+### 3.6 LavinMQ-side design decisions
+
+- **`ProtocolViolation` exception -> server DISCONNECT.** Packet handlers raise
+  `MQTT::ProtocolViolation` carrying a `Disconnect::ReasonCode`; `read_loop`
+  catches it centrally, sends a v5 DISCONNECT with that reason, and publishes the
+  will. v3 has no server DISCONNECT packet, so it just closes. Shard
+  `Protocol::Error::ProtocolError` is caught in the same place and its reason
+  byte mapped through `disconnect_reason`. One place decides how a violation
+  reaches the wire.
+- **Capability set built once in `initialize`.** The advertised properties depend
+  only on config, which is fixed after startup. The one per-connection variant
+  (`assigned_client_identifier`) builds a fresh copy rather than mutating the
+  shared struct.
+- **v5 PUBLISH properties round-trip through AMQP headers**
+  (`publish_headers.cr`). Header-only mapping under an `mqtt.*` prefix, no
+  mapping onto AMQP-native slots like `content_type` / `reply_to`; that
+  cross-protocol mapping is a separate concern and a separate decision. User
+  Properties are stored as an **array of `{key, value}` tables**, not a flat
+  table, because [MQTT-3.3.2-18] requires order and duplicate keys to survive and
+  a Hash would lose both.
+- **`MAX_QOS = 1u8` in `consts.cr`** is the single source for "QoS 2 is not
+  implemented": advertised in CONNACK, enforced on inbound v5 PUBLISH, and used
+  to clamp granted and delivered QoS.
+- **Granted QoS is clamped at subscribe time, not delivery time.** SUBACK reports
+  the clamped value per [MQTT-3.8.4-7], and the session stores and delivers at
+  that same value, so the granted QoS and the actual QoS cannot drift apart.
+- **Oversized outbound PUBLISH is dropped, not requeued.** A message exceeding
+  the subscriber's Maximum Packet Size is deleted and the delivery completed
+  without entering `@unacked`, so it is never redelivered [MQTT-3.1.2-25].
+  Requeuing would loop forever, since the packet will be exactly as oversized
+  next time.
+- **`main`'s `MQTT::ProtocolVersion` enum was removed during the rebase.** #2139
+  landed on `main` while this branch was paused and solved the same problem
+  (reporting the real protocol in connection details) with a LavinMQ-local enum
+  holding only levels 3 and 4. It cannot represent v5, and `Broker#add_client`
+  called `ProtocolVersion.from_value(packet.version)`, which **raises on a v5
+  connection**. Our `Client#protocol_name` derives the string from the shard's
+  `Version` instead, which already covers all three versions, so the local enum
+  is redundant. #2139's three specs were kept and pass unchanged (only their
+  `version:` arguments moved from `UInt8` to the `Version` enum). **Worth
+  mentioning to whoever wrote #2139.**
+- **The v3 wire path is byte-for-byte unchanged.** On v3, properties are ignored
+  on the wire, so the v3 CONNACK is identical to before. This is a hard
+  constraint: the v3.1.1 suite must stay green throughout.
+
+### 3.7 Breaking API changes in the shard vs 0.3.1
+
+These are why the shard needs a major-ish release, and what any other consumer
+would have to fix:
+
+- `Protocol::IO` is now **abstract**. `IO.new(socket)` and the
+  `Packet.from_io(io : ::IO)` raw-IO overload are gone. Construct `IO::V3` /
+  `IO::V5`, or use `read_connect`.
+- `Packet#bytesize` / `#remaining_length` lost their no-arg form and now take a
+  `Version`.
+- `SubAck` uses `ReasonCode` / `reason_codes` (was `ReturnCode` /
+  `return_codes`). No compat shim. `Connack` **is** back-compat: the
+  `(Bool, ReturnCode)` overload and `return_code` getter are retained.
+- `Connect#version` is now the `Version` enum, was `UInt8`. **Silent hazard:**
+  in Crystal, comparing a `UInt8`-backed enum to an Int compiles and is always
+  `false`, so a consumer doing `if connect.version == 4` keeps compiling and
+  routes everything into the else branch. Decided (2026-07-02) to keep the enum
+  and call it out in the PR rather than rename, since LavinMQ is the only
+  consumer and both sides are ours. **This must be in the shard release notes.**
+- `Publish#topic` is stored as `Bytes` but `topic` still returns a decoded
+  `String`, so routing code is unchanged. It allocates on **every** call
+  (memoization is unreliable through struct copies) - hold the result or use
+  `topic_bytes` on hot paths. Decided to keep the name and document the cost.
+- `PubComp` fixed-header flags corrected `0b0010` -> `0b0000`; the old value was
+  a pre-existing v3 wire bug ([MQTT-2.2.2-1]). Strict rejection kept by decision
+  (2026-07-02): nothing in use involves PUBCOMP, since LavinMQ is QoS 0/1, and a
+  leniency shim would tolerate a wire form nobody emits. **Note it in the
+  changelog.**
+
+---
+
+## 4. What is done in LavinMQ
+
+All of this is committed on `feat/implement-mqtt5-support` with specs.
+
+**Foundation**
+- Version negotiation on a single listener (3.1 / 3.1.1 / 5) via
+  `io.read_connect` - `connection_factory.cr:25-40`
+- Version carried onto `Client`; `details_tuple` reports the real protocol name
+  instead of the hardcoded `"MQTT 3.1.1"` - `client.cr#protocol_name`
+- `packet.bytesize` -> `@io.bytesize(packet)` everywhere (read accounting, send
+  accounting)
+- Client's Maximum Packet Size plumbed CONNECT -> `Broker#add_client` -> `Client`
+
+**CONNECT / CONNACK**
+- Full capability advertisement - `connection_factory.cr#build_server_capabilities`
+- `assigned_client_identifier` echoed when we generate a client id
+  [MQTT-3.2.2-16]; refactored from rebuilding the packet to
+  `Connect#copy_with` - `connection_factory.cr#generated_client_id`
+- Enhanced auth rejected with `0x8C` before authentication runs
+- `Connack::ReasonCode.from_v3_return_code` bridges the v3 accept path
+
+**Error handling**
+- `ProtocolViolation` + central `read_loop` handling -> v5 server DISCONNECT
+- Shard `ProtocolError` reason byte mapped to a DISCONNECT reason code
+
+**PUBLISH**
+- v5 property passthrough end to end, publisher -> store -> subscriber, via
+  `publish_headers.cr` (new file): payload format indicator, message expiry
+  interval, response topic, correlation data, content type, user properties
+- Maximum Packet Size enforced on delivery - `session.cr#exceeds_max_packet_size?`
+- QoS 2 rejected `0x9B`; Topic Alias rejected `0x94`; empty topic rejected
+  `0x82` by the codec
+
+**SUBSCRIBE / SUBACK**
+- Granted QoS clamped to `MAX_QOS`, reported in SUBACK as a `ReasonCode`
+- Subscription Identifier rejected `0xA1`; `$share/` rejected `0x9E`, including
+  when mixed with valid filters (the whole packet fails)
+
+**UNSUBSCRIBE / UNSUBACK**
+- Per-topic reason codes, `Success` vs `NoSubscriptionExisted`;
+  `Session#unsubscribe` now returns a Bool to drive that [MQTT-3.11.3]
+
+**Specs:** 24 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
+unsubscribe), plus the existing v3 suite adapted to the new shard API.
+
+---
+
+## 5. What is left
+
+Ordered roughly easiest-first. **B and D are independent of each other and of
+everything else** - these are the two clean hand-offs.
+
+### B. Honor subscription options
+
+The shard already parses the per-filter options byte and exposes `no_local`,
+`retain_as_published` and `retain_handling` on `TopicFilter`.
+`Broker#subscribe` currently reads only `tf.qos` and always replays the retain
+store. Pure LavinMQ behaviour, no shard work, well-bounded.
+
+- **Retain Handling** (0 = send retained on subscribe, 1 = only if the
+  subscription is new, 2 = never). We currently always behave as 0.
+- **No Local** - do not deliver a message back to the client that published it.
+- **Retain As Published** - preserve the publisher's retain flag on delivery
+  instead of clearing it.
+- Files: `broker.cr#subscribe`, `session.cr#build_packet`, `client.cr#recieve_subscribe`.
+
+### C. PUBACK + DISCONNECT
+
+- **PUBACK v5**: `client.cr:254` still sends a bare `PubAck.new(packet_id)`.
+  Needs a reason code and properties. Inbound PUBACK reason codes are ignored.
+- **Client DISCONNECT**: the packet is returned from `read_and_handle_packet`
+  unparsed. v5 needs its reason code read, and specifically reason `0x04`
+  ("Disconnect with Will Message") must **publish** the will, whereas a normal
+  `0x00` disconnect suppresses it. Today every clean disconnect suppresses it.
+- Files: `client.cr` (`recieve_puback`, `read_loop` DISCONNECT branch, `publish_will`).
+
+### D. Session expiry
+
+v5 replaces the clean-session boolean with Clean Start + Session Expiry
+Interval. We read `ConnectProperties#maximum_packet_size` and nothing else;
+`session_expiry_interval` is ignored, and DISCONNECT can also carry a new
+expiry value. Sessions are still clean-session-or-forever.
+
+Touches session lifecycle, so it pairs naturally with C (shared DISCONNECT
+path) or with whoever knows `sessions.cr` best.
+
+- Files: `connection_factory.cr`, `broker.cr#add_client`, `sessions.cr`, `session.cr`.
+
+### E. Will properties and Will Delay
+
+`client.cr#publish_will` constructs a `Protocol::Publish` with **no properties
+at all**, so every v5 Will Property (payload format, message expiry, content
+type, response topic, correlation data, user properties) is silently dropped.
+`WillProperties#will_delay_interval` is also unread; will delay is currently in
+the deferred list but is not advertised as unavailable, because MQTT has no
+capability flag for it.
+
+- Files: `client.cr#publish_will`, plus the `Will` plumbing through `Broker`.
+
+### F. Retained messages lose v5 properties
+
+The retain store keeps only the body (`retain_store.cr#retain` takes topic +
+body + size). A retained v5 message therefore reaches a later subscriber with
+its properties stripped. Needs a store-format change, so it is the most invasive
+of the remaining items. `topic_tree.cr` (which backs the retain store) also
+still uses `StringTokenIterator`, unlike the publish-path subscription tree.
+
+### G. Shard release and open items
+
+- **Cut a tagged release.** `shard.yml` currently pins `branch: feat/mqtt5`,
+  which cannot ship. Given the breaking changes in 3.7, `1.0` was the intended
+  target. `main` is at `0.3.1`.
+- Decide **U1**: v5 CONNACK with a non-zero reason but `session_present = 1` is
+  accepted at decode. Arguably a server-side semantic rather than a codec rule.
+- Optional low-severity conformance gaps, none blocking: **N3** packet
+  identifier `0` accepted where a non-zero id is required; **O1** zero-entry
+  SUBSCRIBE / UNSUBSCRIBE / SUBACK accepted at decode; **O2** AUTH accepted on a
+  v3 connection; **O3** some receiver-side property value validations missing.
+- Optional test gaps: **N5** no malformed property-*value* test (the UTF-8 / NUL
+  validation branch has zero coverage); **N6** the `consumed != total`
+  intra-section property guard is untested; **U2** v3 CONNACK return-code byte
+  `>= 6` rejection untested.
+
+### H. Cross-cutting cleanup
+
+- **Merge the v5 specs back.** `spec/mqtt/v5/*_spec.cr` were kept separate so
+  each chunk's diff stayed self-contained. Before the PR, fold each into the
+  matching `spec/mqtt/integrations/*_spec.cr` and delete the v5 file. **Except**
+  the advertise-and-reject compliance matrix, which stays as its own standing
+  file. Nothing has been merged back yet: connect, subscribe, unsubscribe,
+  publish, puback/disconnect all outstanding.
+- Consider moving `build_server_capabilities` into `consts.cr` or making it a
+  constant, to make it obvious it is static.
+- Consider adding a v5 mode to the `lavinmqperf mqtt` throughput tool. It is
+  now pinned to `IO::V3` (section 7), so there is no load-testing path for v5
+  at all. Optional, not a blocker.
+
+---
+
+## 6. Known limitations to state at release
+
+Things we will ship with, deliberately. These belong in the release notes and in
+the docs, not in a bug tracker.
+
+- **QoS 2 unsupported.** Advertised as Maximum QoS 1.
+- **Receive Maximum ignored.** We do not pace QoS 1 inflight against the
+  client's advertised Receive Maximum, and we do not advertise our own (so
+  clients assume the 65535 default). LavinMQ has its own
+  `Config#max_inflight_messages` cap instead. This is the one line in the
+  compliance table with an unticked enforcement column.
+- **Topic aliases unsupported** in both directions.
+- **Shared subscriptions unsupported.**
+- **Subscription identifiers unsupported.**
+- **Enhanced authentication unsupported.**
+- **Will delay interval ignored** (wills fire immediately).
+- v5 PUBLISH properties are carried in `mqtt.*` AMQP headers and are **not**
+  mapped onto AMQP-native properties, so an AMQP consumer of an MQTT-published
+  message sees them as headers.
+
+---
+
+## 7. Testing
+
+**Strategy:** the shard has exhaustive codec specs, so LavinMQ tests
+**behaviour**, not framing. Per packet: a v5 client connects, exercises the
+feature, and we assert the broker's response and reason codes. The v3.1.1 suite
+must stay green throughout, since the v3 wire path is unchanged.
+
+**Shard:** 259 examples, 0 failures as of 2026-06-30, `crystal tool format
+--check` clean. Exact-byte vectors are the backbone, with round-trip tests
+focused on properties and a version matrix for the genuinely ambiguous cases
+(PUBREL/PUBCOMP remaining-length 2 vs a reason tail; CONNACK return code vs
+reason code). A blanket version matrix was deliberately dropped as redundant:
+the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
+structurally hard to even express.
+
+**LavinMQ, measured 2026-08-18** on `9e2f53f9`, rebased onto `main` `77c9ceb2`:
+
+| what | result |
+|---|---|
+| `make test SPEC=spec/mqtt` | **233 examples, 0 failures, 0 errors, 0 pending** (16.8s) |
+| `make test TAGS=~etcd` | **2083 examples, 0 failures, 0 errors, 9 pending** (2:41) |
+| `make lint` | 399 inspected, 0 failures |
+| `crystal tool format --check` | clean |
+
+The 9 pending are pre-existing and unrelated to MQTT (queue dead-lettering
+headers, kTLS, UNIX sockets, VHost GC segments). The etcd-tagged specs were
+skipped because no etcd is running locally, not because they fail.
+
+**The v5 work is green and has not regressed anything on the AMQP side.**
+
+One shard-bump miss was found and fixed during this run:
+`src/lavinmqperf/mqtt/throughput.cr:101` still called
+`LavinMQ::MQTT::Protocol::IO.new(socket)`, which stopped compiling when the
+shard made `IO` abstract (breaking change A in section 3.7). Changed to
+`Protocol::IO::V3.new(socket)`, since the perf tool speaks 3.1.1. It hid for a
+while because `spec/mqtt` never requires `lavinmqperf` - only the full suite
+does, so a targeted MQTT spec run looked green while `make test` died at compile
+time. The other three `Packet.from_io(io)` call sites in that file are fine: the
+`from_io(io : Protocol::IO)` overload survived, only the raw-`::IO` one was
+removed. Nothing else in `src/` or `spec/` constructs the abstract `IO`
+(verified by grep). Committed as `9e2f53f9`.
+
+**Gap worth closing before release:** all byte vectors are self-confirming
+round-trips. Nobody has cross-checked them against a real v5 client
+(`mosquitto_pub -V 5`, paho, MQTTX). That is the test that catches
+"consistently implemented my own wrong format." `mosquitto-clients` is
+apt-installable.
+
+---
+
+## 8. Sequencing to ship
+
+1. Finish B / C / D / E (F and G in parallel, different people).
+2. External smoke test against a real v5 client.
+3. Tag the shard release (`1.0`), with 3.7's breaking changes in the changelog.
+4. Repoint `shard.yml` from `branch: feat/mqtt5` to the tag, update `shard.lock`.
+5. Merge back the v5 specs (section H).
+6. Open the LavinMQ PR as draft.
+
+The per-feature commit granularity is deliberate: each rejection in the
+section 2 compliance table is its own commit with its spec citation and its
+test, which is the unit a reviewer checks and the template for the remaining
+work.
+
+Rebasing this work onto `main` is cheap today, with two standing hazards. The
+`shard.yml` / `shard.lock` v5 pin conflicts as soon as `main` bumps the shard
+again - step 3 above ends that permanently. And `connection_factory.cr#start`
+and `client.cr#details_tuple` are conflict magnets, for the reason in 3.7.
+
+---
+
+## Appendix: parked PUBLISH topic perf investigation
+
+Kept because the conclusion is non-obvious and someone will suggest it again.
+
+A colleague proposed reading the PUBLISH topic as `Bytes` instead of `String`.
+Prototyped off shard `main` (commit `e16e186`, never pushed). Isolated
+microbenchmark showed 1.8x-3.0x faster topic decode.
+
+**It does not help LavinMQ.** The topic must become an AMQP `String`
+routing_key anyway - `routing_key : String` is load-bearing across the shared
+AMQP core (message store on-disk format, bindings, dead-lettering, management
+API). So LavinMQ would call `String.new(packet.topic)` regardless, making the
+change net-negative: a Bytes alloc in the shard *plus* a String alloc in
+LavinMQ, saving only the UTF-8 validation we arguably want.
+
+**The real win was elsewhere and it already landed.** The subscription-tree
+match allocated one throwaway `String` per topic level on every publish. Byte
+slicing the tokenizer makes that zero-allocation, needs no shard change, and is
+**already on `main`** via `bytes_token_iterator.cr` (#1920) -
+`subscription_tree.cr` uses `BytesTokenIterator` today. `topic_tree.cr` (retain
+store) still uses `StringTokenIterator`, but it is off the publish hot path.
+
+`feat/mqtt5` has the Bytes-topic change baked into its `publish.cr` already, so
+the two branches conflict. Park the breaking version until MQTT is decoupled
+from the AMQP core and `routing_key` no longer has to be a String.
+
+**Dead end, do not repeat:** a `Char::Reader` single-pass UTF-8 validation in
+`read_string` benchmarked **5-17x slower** than the stdlib two-scan
+(`includes?('\0') || !valid_encoding?`). It was reverted.
+
+---
+
+## Doc hygiene
+
+- Status claims here are only as fresh as the "last reconciled" date at the
+  top. Re-derive from the code before trusting a checkbox.
+- To verify reason codes and behaviour, keep a local untracked copy of the full
+  OASIS spec text (`MQTT-v5.0-spec.txt`, ~311KB) in the repo root and grep it.
+  The OASIS HTML truncates before chapter 3 in most fetchers.

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -3,7 +3,7 @@
 Status and design doc for the MQTT 5.0 work in LavinMQ, spanning both this repo
 and the `mqtt-protocol.cr` shard.
 
-Last reconciled against the code: **2026-08-20**.
+Last reconciled against the code: **2026-08-21**.
 
 ---
 
@@ -15,7 +15,7 @@ about 80% done**.
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 31 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 33 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
 intact, gets an accurate reason code on every ack, gets a session whose lifetime
@@ -23,7 +23,7 @@ it controls, and gets a spec-correct rejection for every feature we don't
 implement. What is missing is subscription options, will properties and will
 delay, and properties on retained messages.
 
-**On `main` (`77c9ceb2`) and verified green on 2026-08-20: 2121 examples,
+**On `main` (`77c9ceb2`) and verified green on 2026-08-21: 2125 examples,
 0 failures, lint and format clean.** See section 7.
 
 ---
@@ -435,8 +435,15 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
 
 **Session expiry** (item D, and J3)
 - `Session#session_expiry_interval : UInt32` is the single input to a session's
-  lifetime; `durable?` and `auto_delete?` derive from it. `clean_session?` is
-  gone - it conflated two independent things.
+  lifetime; `auto_delete?` and the expiry clock derive from it. `clean_session?`
+  is gone from both `Session` and `Client` - it conflated two independent things.
+- `durable?` deliberately does **not** follow the interval. It is derived from it
+  once, at construction, because it selects the message store's data dir,
+  replicator and durability, which cannot be re-derived later. A resuming client
+  that narrows a 3600s session to 0 would otherwise flip `durable?` to false
+  while its files sit in the durable dir - and the `Queue::Delete` frame is only
+  written for a durable queue, so nothing would record the deletion and the
+  original declare would replay into a ghost session on the next boot.
 - Clean Start is a separate, connect-only input: it decides whether to discard
   the stored session, the interval decides how long the one this connection ends
   up with outlives it. That makes Clean Start 1 + a non-zero interval
@@ -453,10 +460,19 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
   what the `ProtocolViolation` handler does, will included.
 - The clock runs in the session's existing `deliver_loop`, not a new fiber - the
   offline park became a `select` on `@has_client` versus a timeout. Reattaching
-  cancels it, so the interval is measured from each disconnect.
+  cancels it, so the interval is measured from each disconnect. A 0-interval
+  session with no client therefore expires on its first pass, so one declared
+  straight through `declare_queue` with `auto_delete` deletes itself immediately -
+  which is why the `expiry_from` specs declare with `auto_delete: false`.
 - `session_present?` keeps an `auto_delete?` guard for takeover: it runs before
   `add_client`, so a 0-interval session belonging to a still-connected client is
   visible, and a takeover ends that session rather than resuming it (3.1.4).
+- An interval changed on a reconnect is in-memory until the next definitions
+  compaction; the log has no update frame for a name it already holds. Section 6
+  records it. Narrowing to 0 is exempt, since it ends in a persisted deletion.
+- `Session.expiry_from` warns instead of silently falling back when the argument
+  is present but unusable (negative, out of range, not an integer), because an
+  AMQP client can declare `mqtt.<id>` by hand.
 
 **Robustness and hot path** (item I)
 - `PublishHeaders.restore` tolerates any AMQP header. Four-byte ints go through
@@ -479,7 +495,7 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
 - `Client#protocol_name` is an exhaustive `case/in` again, so a new `Version`
   member is a compile error rather than a silent "MQTT 3.1.1".
 
-**Specs:** 47 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
+**Specs:** 49 examples in `spec/mqtt/v5/` (connect, publish, subscribe,
 unsubscribe, puback/disconnect, session expiry) plus
 `spec/mqtt/publish_headers_spec.cr` and `spec/mqtt/session_spec.cr`, on top of
 the existing v3 suite adapted to the new shard API. All figures here are
@@ -559,13 +575,14 @@ still uses `StringTokenIterator`, unlike the publish-path subscription tree.
 
 ### I. Review findings
 
-Parked from a full-branch review on 2026-08-19, ordered by severity. All were
-introduced on this branch, so they are ours to fix before the PR.
+Two review rounds. Everything listed was introduced on this branch, so it is
+ours to fix before the PR.
 
-**Five of the seven are fixed** on 2026-08-20 - the poison message and its
-`@unacked_*` corruption, the hot-path allocation, `protocol_name` exhaustiveness,
-and the v3 property restore. See section 4. The two that remain are both
-enforcement gaps already tracked as the `[~]` rows in section 2:
+**Round 1 - full branch, 2026-08-19.** Seven findings, ordered by severity.
+**Five are fixed** on 2026-08-20 - the poison message and its `@unacked_*`
+corruption, the hot-path allocation, `protocol_name` exhaustiveness, and the v3
+property restore. See section 4. The two that remain are both enforcement gaps
+already tracked as the `[~]` rows in section 2:
 
 - **Will QoS 2 is accepted despite `maximum_qos = 1`** - section 2, first `[~]`
   row. `Connect.from_io` accepts any `will_qos < 3` and nothing rejects a Will at
@@ -575,7 +592,33 @@ enforcement gaps already tracked as the `[~]` rows in section 2:
   second `[~]` row. `Client#send` is the single outbound choke point and is the
   place to put it, so no future packet type can forget it.
 
-One follow-up the fixes did not take: the shard's `Publish#topic` still allocates
+**Round 2 - item D only, 2026-08-21. All five are fixed**, in one commit with
+specs; each new spec was first run against the unfixed code to confirm it failed.
+
+- **`durable?` followed the interval, so narrowing to 0 lost the deletion.** The
+  one that mattered, and worse than the review first scored it. `apply
+  Queue::Delete` only appends the frame `if q.durable?`, and `compact!` only keeps
+  sessions `select(&.durable?)` - so a durable session narrowed to 0 by a resuming
+  client was deleted in memory with its files removed while **neither** path
+  recorded it, and the original declare replayed into a ghost session with an
+  empty store on the next boot. Fixed by deriving `durable?` once at
+  construction; see section 4.
+- **A runtime interval change never reaches disk without a compaction.** Not
+  fixable in this log format: `apply Queue::Declare` returns early on a name it
+  already holds, so there is no update frame to append, and forcing a `compact!`
+  per reconnect is far too expensive. Documented in section 6 instead.
+- **`Client#clean_session` was dead state** once the broker switched to reading
+  `packet.clean_session?` directly. Removed with its ctor parameter; that call
+  site now passes named arguments, so the next removal cannot silently shift an
+  argument past a same-typed neighbour.
+- **The takeover spec only asserted the CONNACK bit**, so it would have passed on
+  the actually-broken outcome - client told to discard its state while the server
+  keeps the subscription. It now asserts the session is gone, after a PINGREQ
+  round-trip, because the CONNACK is written before `add_client` runs.
+- **`expiry_from` swallowed an unusable argument.** It warns now, and the fallback
+  has specs for negative, out-of-range and non-integer values.
+
+One follow-up neither round took: the shard's `Publish#topic` still allocates
 per call, and documenting that in 3.7 did not stop a consumer from calling it
 three times on the hot path. Renaming it to `topic_string` before the 1.0 tag
 would make the cost visible at the call site.
@@ -614,6 +657,13 @@ the docs, not in a bug tracker.
 - **Session expiry restarts its clock on a broker restart.** The interval
   persists, the deadline does not, so a session restored from definitions gets
   its full interval again from boot. MQTT leaves this implementation-defined.
+- **An interval changed on a reconnect reaches disk only at the next definitions
+  compaction.** The definitions log has no update frame for an existing queue -
+  `apply Queue::Declare` returns early on a name it already holds - so a restart
+  can restore the interval the session was first declared with. Bounded by a
+  value the same client chose earlier, and the clock resets on restart anyway.
+  Narrowing to 0 is unaffected: it ends the session, and the deletion frame *is*
+  persisted.
 - **Delivery QoS is now the minimum of the publish and subscription QoS on
   v3.1.1 too**, not just v5. Spec-correct ([MQTT-3.8.4-6] in 3.1.1) and decided
   deliberately rather than version-gating the publish hot path, but it is a
@@ -663,19 +713,20 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-08-20** after J1/J2, item I and item D, on `main`
-`77c9ceb2`:
+**LavinMQ, measured 2026-08-21** after J1/J2, item I, item D and the item D
+review fixes, on `main` `77c9ceb2`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **276 examples, 0 failures, 0 errors, 0 pending** |
-| `make test TAGS=~etcd` | **2121 examples, 0 failures, 0 errors, 9 pending** |
+| `make test SPEC=spec/mqtt` | **280 examples, 0 failures, 0 errors, 0 pending** |
+| `make test TAGS=~etcd` | **2125 examples, 0 failures, 0 errors, 9 pending** |
 | `make lint` | 403 inspected, 0 failures |
 | `crystal tool format --check` | clean |
 
-(The +28 over the 248/2093 of 2026-08-19 breaks down as five with J1/J2, seven
-with item I, and sixteen with item D - thirteen in `v5/session_expiry_spec.cr`,
-two in the new `session_spec.cr` and one takeover case in `connect_spec.cr`. Two
+(The +32 over the 248/2093 of 2026-08-19 breaks down as five with J1/J2, seven
+with item I, sixteen with item D - thirteen in `v5/session_expiry_spec.cr`, two
+in the new `session_spec.cr` and one takeover case in `connect_spec.cr` - and
+four with the item D review fixes, two more in each of those two new files. Two
 of the expiry specs are tagged `slow`: the interval's unit is seconds, so the
 shortest honest test of elapse and of reconnect-cancels-it is one second each. An
 earlier reconciliation recorded 233 for `spec/mqtt`; that figure was mistyped,
@@ -739,7 +790,8 @@ denying a topic.
 1. Finish B / E (F and G in parallel, different people). D is done. ~~The poison-message
    and hot-path-allocation findings in I should land before the PR regardless of
    who takes the feature work.~~ Done 2026-08-20, along with three of the other
-   five; only the two section 2 `[~]` enforcement gaps remain in I.
+   five; only the two section 2 `[~]` enforcement gaps remain in I. Item I's
+   second round, the item D review, is done as of 2026-08-21.
 2. ~~External smoke test against a real v5 client.~~ Done 2026-08-19, see
    section 7 and `MQTT5-INTEROP.md`. Re-run it once B/E/F land - the same
    harness grades them. It has **not** been re-run since the J1/J2 and item I

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -535,11 +535,13 @@ capability flag for it.
 
 ### F. Retained messages lose v5 properties
 
-The retain store keeps only the body (`retain_store.cr#retain` takes topic +
-body + size). A retained v5 message therefore reaches a later subscriber with
-its properties stripped. Needs a store-format change, so it is the most invasive
-of the remaining items. `topic_tree.cr` (which backs the retain store) also
-still uses `StringTokenIterator`, unlike the publish-path subscription tree.
+The retain store keeps only the body: `retain_store.cr#retain` takes the whole
+`Publish` but writes just `packet.payload` to the file. A retained v5 message
+therefore reaches a later subscriber with its properties stripped. The call
+already has `packet.properties` in hand, so the work is entirely in the store
+format, which is still the most invasive of the remaining items. `topic_tree.cr`
+(which backs the retain store) also still uses `StringTokenIterator`, unlike the
+publish-path subscription tree.
 
 ### G. Shard release and open items
 

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -10,20 +10,20 @@ Last reconciled against the code: **2026-08-21**.
 ## 1. TL;DR
 
 MQTT 5.0 spans two repos. The **wire codec is done**; the **broker semantics are
-about 80% done**.
+about 90% done**.
 
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 33 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 36 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + subscription options + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
 intact, gets an accurate reason code on every ack, gets a session whose lifetime
-it controls, and gets a spec-correct rejection for every feature we don't
-implement. What is missing is subscription options, will properties and will
-delay, and properties on retained messages.
+it controls, gets its subscription options honoured, and gets a spec-correct
+rejection for every feature we don't implement. What is missing is will
+properties and will delay, and properties on retained messages.
 
-**On `main` (`77c9ceb2`) and verified green on 2026-08-21: 2125 examples,
+**On `main` (`02e97d70`) and verified green on 2026-09-07: 2216 examples,
 0 failures, lint and format clean.** See section 7.
 
 ---
@@ -388,6 +388,66 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
 - Subscription Identifier rejected `0xA1`; `$share/` rejected `0x9E`, including
   when mixed with valid filters (the whole packet fails)
 
+**Subscription options** (item B)
+- All three per-filter options are honoured. They are **not** advertisable
+  features: v5 CONNACK has no flag for any of them, so unlike QoS 2 or shared
+  subscriptions this was a real compliance gap rather than a legal deferral.
+- **No Local** - `Exchange#publish` takes the publishing client's session name
+  and skips a matching subscription that set the bit [MQTT-3.8.3-3]. Identity is
+  the ClientID, and a session's name is `mqtt.<client_id>`, so a name compare is
+  the spec's test. One Bool test per matched entry; the string compare is paid
+  for only by a subscription that asked for it. Applies to the will too, whose
+  publisher is the connection that died - so a takeover suppresses the
+  predecessor's will if it had such a subscription, since the will is published
+  while that session is still attached.
+- **Retain As Published** - the retain flag is resolved per matched entry in
+  `Exchange#publish`, next to the `delivery_mode` it already varies there, and
+  read back unchanged by `build_packet`. Written for *every* matched entry, not
+  just the ones that set it, or a `true` leaks into every later subscriber in
+  the same tree walk. Skipped entirely unless the publish is retained, so the
+  ordinary path is untouched. Safe only because `MessageStore#push` serializes
+  properties synchronously - the same invariant `delivery_mode` already relies
+  on, and worth knowing before anyone makes that store lazy.
+- **Retain Handling** - gates the existing retain-store replay in
+  `Broker#subscribe`. `Session#subscribe` returns whether the filter was new.
+  Existence is by **topic filter alone** [MQTT-3.8.4-3], so a re-subscribe that
+  changes the QoS or the options is a replacement, not a new subscription.
+  Value 1 sends retained messages only for a subscription that did **not**
+  already exist. Worth knowing before you verify that by grepping, since the
+  documented workflow here is to grep the local spec text: our
+  `MQTT-v5.0-spec.txt` has an **Appendix B row for [MQTT-3.3.1-10] that states
+  the value-1 case inverted**, contradicting the four body locations that agree
+  with each other - §3.3.1.3 (where the statement is defined), §3.8.3.1's value
+  list, and §3.8.4's separate new-vs-replaced rules, which match this
+  implementation clause for clause. The body governs. Whether the inversion is
+  a defect in the OASIS document itself or an artifact of our local text
+  extraction was **not** determined: the OASIS HTML truncates before chapter 3
+  and the PDF resists text extraction. Third-party restatements of
+  [MQTT-3.3.1-10] agree with the body text.
+- Persisted in binding arguments as `mqtt.no-local` and
+  `mqtt.retain-as-published`, **omitted when false** - so a default
+  subscription's arguments table stays byte-identical to what LavinMQ has always
+  written, older definitions files load unchanged, and the shared
+  `QOS0_ARGUMENTS`/`QOS1_ARGUMENTS` constants remain the zero-allocation path.
+  `SubscriptionKey#arguments` renders them, which is required rather than
+  cosmetic: `compact!` re-derives every binding from that method instead of
+  replaying frames, so anything it cannot reconstruct survives a restart and
+  then vanishes at the first compaction.
+- `SubscriptionOptions` carries QoS plus the two delivery-time options through
+  the subscription tree, replacing the bare `UInt8`. Stored inline as a `Hash`
+  value, so no extra allocation. Retain Handling is deliberately not in it: it
+  is consulted only during the SUBSCRIBE.
+- **v3.1.1 is unaffected by construction, not by convention.**
+  `IO::V3#validate_subscription_options` rejects a v3 SUBSCRIBE with any of bits
+  7-2 set, so these paths are unreachable from v3 and need no version gating.
+- Two things fixed on the way, both prerequisites: `Session#find_binding`
+  matched a **synthetic default-exchange binding** whose routing key is the
+  queue's own name, so a client subscribing to the literal filter
+  `mqtt.<its own client id>` looked like an existing subscription - a spurious
+  unbind before, a wrong Retain Handling answer after. And `MQTT.granted_qos` now
+  replaces three different spellings of the same clamp, one of which bypassed
+  `MAX_QOS` entirely.
+
 **UNSUBSCRIBE / UNSUBACK**
 - Per-topic reason codes, `Success` vs `NoSubscriptionExisted`;
   `Session#unsubscribe` now returns a Bool to drive that [MQTT-3.11.3]
@@ -505,22 +565,8 @@ measured, not counted by hand.
 
 ## 5. What is left
 
-Ordered roughly easiest-first. **B is independent of everything else** and is
-the clean hand-off. (C, D and all of J are done; see section 4.)
-
-### B. Honor subscription options
-
-The shard already parses the per-filter options byte and exposes `no_local`,
-`retain_as_published` and `retain_handling` on `TopicFilter`.
-`Broker#subscribe` currently reads only `tf.qos` and always replays the retain
-store. Pure LavinMQ behaviour, no shard work, well-bounded.
-
-- **Retain Handling** (0 = send retained on subscribe, 1 = only if the
-  subscription is new, 2 = never). We currently always behave as 0.
-- **No Local** - do not deliver a message back to the client that published it.
-- **Retain As Published** - preserve the publisher's retain flag on delivery
-  instead of clearing it.
-- Files: `broker.cr#subscribe`, `session.cr#build_packet`, `client.cr#recieve_subscribe`.
+Ordered roughly easiest-first. **E is the clean hand-off** now that B has
+landed. (B, C, D and all of J are done; see section 4.)
 
 ### E. Will properties and Will Delay
 
@@ -554,6 +600,11 @@ publish-path subscription tree.
   identifier `0` accepted where a non-zero id is required; **O1** zero-entry
   SUBSCRIBE / UNSUBSCRIBE / SUBACK accepted at decode; **O2** AUTH accepted on a
   v3 connection; **O3** some receiver-side property value validations missing.
+- **Retain Handling 3** is a Protocol Error (spec 3.8.3.1), so v5 wants a
+  DISCONNECT. The shard raises `ArgumentError` in the `TopicFilter` constructor
+  and `Subscribe.from_io` maps it to `Error::PacketDecode`, which is the
+  just-close case, so the client gets no reason code. Low severity; belongs with
+  N3/O1/O2/O3 above.
 - Optional test gaps: **N5** no malformed property-*value* test (the UTF-8 / NUL
   validation branch has zero coverage); **N6** the `consumed != total`
   intra-section property guard is untested; **U2** v3 CONNACK return-code byte
@@ -673,6 +724,22 @@ the docs, not in a bug tracker.
   is no longer upgraded, so it is no longer stored while that subscriber is
   offline. A spec titled "[LavinMQ non-normative]" used to assert the old
   behaviour. **Release note.**
+- **Replacing a subscription has a message-loss window.** [MQTT-3.8.4-4] says
+  Application Messages MUST NOT be lost when a subscription is replaced, but
+  `Session#subscribe` unbinds before it binds and each call can reach disk and
+  therefore yield, so a publish landing in between is lost. Pre-existing - it
+  already triggered on a QoS change - and now reachable by changing a
+  subscription option too. Not fixed here because bind-then-unbind does not
+  work: `SubscriptionTree#unsubscribe` removes by (filter, session) and would
+  delete the entry the bind just wrote, so a correct fix needs the tree's
+  removal to become options-aware.
+- **An UNSUBSCRIBE of a non-canonically stored binding can be undone by a
+  restart.** Definitions replay cancels a stored `Queue::Bind` only on exact
+  argument-table equality, while `Session#unsubscribe` sends the canonical table
+  from `SubscriptionKey#arguments`. A binding an operator created with, say,
+  `{mqtt.qos: 2i32}` is therefore removed in memory but restored on the next
+  boot. Pre-existing and QoS-only until now; the two option keys multiply the
+  permutations.
 - **QoS 2 unsupported.** Advertised as Maximum QoS 1. Follow-up work, section 9.
 - **Receive Maximum ignored.** We do not pace QoS 1 inflight against the
   client's advertised Receive Maximum, and we do not advertise our own (so
@@ -715,24 +782,33 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-08-21** after J1/J2, item I, item D and the item D
-review fixes, on `main` `77c9ceb2`:
+**LavinMQ, measured 2026-09-07** after J1/J2, item I, item D, the item D review
+fixes and item B, on `main` `02e97d70`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **280 examples, 0 failures, 0 errors, 0 pending** |
-| `make test TAGS=~etcd` | **2125 examples, 0 failures, 0 errors, 9 pending** |
-| `make lint` | 403 inspected, 0 failures |
+| `make test SPEC=spec/mqtt` | **348 examples, 0 failures, 0 errors, 0 pending** |
+| `make test TAGS=~etcd` | **2220 examples, 0 failures, 0 errors, 9 pending** |
+| `make lint` | 412 inspected, 0 failures |
 | `crystal tool format --check` | clean |
 
-(The +32 over the 248/2093 of 2026-08-19 breaks down as five with J1/J2, seven
-with item I, sixteen with item D - thirteen in `v5/session_expiry_spec.cr`, two
-in the new `session_spec.cr` and one takeover case in `connect_spec.cr` - and
-four with the item D review fixes, two more in each of those two new files. Two
-of the expiry specs are tagged `slow`: the interval's unit is seconds, so the
-shortest honest test of elapse and of reconnect-cancels-it is one second each. An
-earlier reconciliation recorded 233 for `spec/mqtt`; that figure was mistyped,
-not a lost spec.)
+(The 2026-08-21 figures were 280/2125 against the older `main`; the rebase onto
+`02e97d70` itself added 31 to `spec/mqtt` - `main`'s new `retain_store_spec.cr`
+and some auth specs - taking the pre-item-B baseline to 311/2183, re-measured on
+2026-09-07 rather than carried over. Item B adds the remaining 37: 19 in the new
+`v5/subscription_options_spec.cr`, 11 in `consts_spec.cr` for `granted_qos` and
+the arguments round-trip, four in `subscription_key_spec.cr` for the compaction
+guard, two in `exchange_spec.cr` for out-of-band binds, and one will/takeover
+case in `integrations/will_spec.cr`. Two of the expiry specs are tagged `slow`:
+the interval's unit is seconds, so the shortest honest test of elapse and of
+reconnect-cancels-it is one second each.)
+
+Every item B spec was run against the unfixed code first, and each failed for
+the intended reason. That check earned its keep twice: the restart spec passed
+even with the options stripped from `SubscriptionKey#arguments`, because the
+restart path reads the stored frame rather than the key - which is exactly the
+compaction gap, so it needed its own unit spec. And the retain-flag leak is
+caught in only one of the two subscriber orders, which is why both are asserted.
 
 The 9 pending are pre-existing and unrelated to MQTT (queue dead-lettering
 headers, kTLS, UNIX sockets, VHost GC segments). The etcd-tagged specs were
@@ -789,13 +865,13 @@ denying a topic.
 
 ## 8. Sequencing to ship
 
-1. Finish B / E (F and G in parallel, different people). D is done. ~~The poison-message
+1. Finish E (F and G in parallel, different people). B and D are done. ~~The poison-message
    and hot-path-allocation findings in I should land before the PR regardless of
    who takes the feature work.~~ Done 2026-08-20, along with three of the other
    five; only the two section 2 `[~]` enforcement gaps remain in I. Item I's
    second round, the item D review, is done as of 2026-08-21.
 2. ~~External smoke test against a real v5 client.~~ Done 2026-08-19, see
-   section 7 and `MQTT5-INTEROP.md`. Re-run it once B/E/F land - the same
+   section 7 and `MQTT5-INTEROP.md`. Re-run it once E/F land - the same
    harness grades them. It has **not** been re-run since the J1/J2 and item I
    fixes; the interop doc's delivery-QoS and DISCONNECT `0x82` rows are the
    expectations to confirm when it is.

--- a/MQTT5.md
+++ b/MQTT5.md
@@ -3,25 +3,26 @@
 Status and design doc for the MQTT 5.0 work in LavinMQ, spanning both this repo
 and the `mqtt-protocol.cr` shard.
 
-Last reconciled against the code: **2026-08-21**.
+Last reconciled against the code: **2026-09-08**.
 
 ---
 
 ## 1. TL;DR
 
 MQTT 5.0 spans two repos. The **wire codec is done**; the **broker semantics are
-about 90% done**.
+about 92% done**.
 
 | | branch | ahead of main | PR | state |
 |---|---|---|---|---|
 | `mqtt-protocol.cr` | `feat/mqtt5` | 29 commits | none | complete v5 codec, reviewed twice, needs a release tag |
-| `lavinmq` | `feat/implement-mqtt5-support` | 36 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + subscription options + full compliance contract |
+| `lavinmq` | `feat/implement-mqtt5-support` | 37 commits, on current `main` | none | foundation + PUBLISH + SUBSCRIBE/UNSUBSCRIBE + PUBACK/DISCONNECT + delivery QoS + session expiry + subscription options + will properties + full compliance contract |
 
 A v5 client can today connect, subscribe, publish and receive with properties
 intact, gets an accurate reason code on every ack, gets a session whose lifetime
-it controls, gets its subscription options honoured, and gets a spec-correct
-rejection for every feature we don't implement. What is missing is will
-properties and will delay, and properties on retained messages.
+it controls, gets its subscription options honoured, gets its will published
+with its properties intact, and gets a spec-correct rejection for every feature
+we don't implement. What is missing is the Will Delay Interval and properties on
+retained messages.
 
 **On `main` (`02e97d70`) and verified green on 2026-09-07: 2216 examples,
 0 failures, lint and format clean.** See section 7.
@@ -41,7 +42,7 @@ This is what makes our deferrals legal rather than broken.
 
 | Property advertised in CONNACK | Value | Enforcement on use | Adv. | Enf. |
 |---|---|---|---|---|
-| `maximum_qos` | `1` | QoS 2 PUBLISH -> DISCONNECT `0x9B` QoSNotSupported | [x] | [~] |
+| `maximum_qos` | `1` | QoS 2 PUBLISH -> DISCONNECT `0x9B`; QoS 2 Will -> CONNACK `0x9B` | [x] | [x] |
 | `topic_alias_maximum` | `0` | PUBLISH with a Topic Alias -> DISCONNECT `0x94` TopicAliasInvalid | [x] | [x] |
 | `subscription_identifier_available` | `0` | SUBSCRIBE with a Subscription Identifier -> DISCONNECT `0xA1` | [x] | [x] |
 | `shared_subscription_available` | `0` | `$share/...` filter -> DISCONNECT `0x9E` | [x] | [x] |
@@ -54,23 +55,20 @@ Plus: enhanced authentication (the AUTH-packet flow, [MQTT-4.12]) is rejected at
 CONNECT with CONNACK reason `0x8C` BadAuthenticationMethod, before
 username/password auth runs so the reason is accurate.
 
-**Two rows are `[~]`, not `[x]`** - the enforcement exists but does not cover
+**One row is `[~]`, not `[x]`** - the enforcement exists but does not cover
 every path the spec requires:
 
-- `maximum_qos`: inbound PUBLISH is checked in `client.cr#validate_v5_publish!`,
-  but the **Will QoS is not**. `Connect.from_io` accepts any `will_qos < 3`, and
-  nothing rejects a Will at QoS 2, so a v5 CONNECT that asks for one is accepted
-  where spec 3.1.2.6 wants CONNACK `0x9B`. The QoS is clamped at delivery in
-  `session.cr#build_packet`, so nothing breaks - but we accepted a connection we
-  advertised we could not serve.
 - `maximum_packet_size`: only the outbound **PUBLISH** path checks it
   (`session.cr#exceeds_max_packet_size?`). [MQTT-3.1.2-24] covers *every* packet
   the server sends, and a client may legally advertise any limit >= 1, so a very
   small limit already gets an oversized capability CONNACK, and a SUBSCRIBE with
   many filters gets an oversized SUBACK.
 
-Both are tracked as item I. Everything else in the table is implemented and
-spec'd, which was the largest single risk in the project.
+It is tracked as item I. `maximum_qos` was the other one until the Will QoS
+check landed with item E; both of its paths - inbound PUBLISH in
+`client.cr#validate_v5_publish!` and the Will at CONNECT - are now enforced.
+Everything else in the table is implemented and spec'd, which was the largest
+single risk in the project.
 
 ### Deliberately out of scope for the first release
 
@@ -448,6 +446,24 @@ All of this is committed on `feat/implement-mqtt5-support` with specs.
   replaces three different spellings of the same clamp, one of which bypassed
   `MAX_QOS` entirely.
 
+**Will properties** (item E, first half)
+- The six Will Properties that are also PUBLISH properties - payload format
+  indicator, message expiry interval, content type, response topic, correlation
+  data and user properties - are carried onto the message the will becomes.
+  `client.cr#publish_will` previously built a `Protocol::Publish` with no
+  properties at all, so every one was dropped. `will_delay_interval` is
+  deliberately not mapped: it is server behaviour, not wire content.
+- No version gate: v3 CONNECT has no will properties, so they are all nil there
+  and `IO::V3#write_properties` discards them regardless.
+- A will at QoS 2 is now refused with CONNACK `0x9B` QoSNotSupported rather
+  than quietly clamped (3.1.2.6), which closes the first of the two `[~]` rows
+  in the section 2 table. **v5 only, deliberately**: v3 has no return code
+  meaning "QoS not supported", so refusing there would mean a misleading code or
+  a bare close. A v3 will at QoS 2 stays accepted and clamped at delivery, as it
+  always was, and there is a spec pinning that asymmetry down.
+- A **retained** will inherits item F: its properties reach live subscribers but
+  not later ones, because the retain store keeps only the payload.
+
 **UNSUBSCRIBE / UNSUBACK**
 - Per-topic reason codes, `Success` vs `NoSubscriptionExisted`;
   `Session#unsubscribe` now returns a Bool to drive that [MQTT-3.11.3]
@@ -568,16 +584,35 @@ measured, not counted by hand.
 Ordered roughly easiest-first. **E is the clean hand-off** now that B has
 landed. (B, C, D and all of J are done; see section 4.)
 
-### E. Will properties and Will Delay
+### E. Will Delay Interval
 
-`client.cr#publish_will` constructs a `Protocol::Publish` with **no properties
-at all**, so every v5 Will Property (payload format, message expiry, content
-type, response topic, correlation data, user properties) is silently dropped.
-`WillProperties#will_delay_interval` is also unread; will delay is currently in
-the deferred list but is not advertised as unavailable, because MQTT has no
-capability flag for it.
+Will *properties* are done; see section 4. What remains is
+`WillProperties#will_delay_interval`, still unread. Like subscription options
+and unlike QoS 2, it has **no capability flag**, so it cannot be advertised as
+unavailable - shipping without it is a real gap, not a legal deferral.
 
-- Files: `client.cr#publish_will`, plus the `Will` plumbing through `Broker`.
+It is a bigger piece than the properties half was, and not a tweak:
+
+- **The will has to outlive its owner.** `@will` lives on `Client`, and all
+  seven `publish_will` call sites are inside `read_loop`'s rescues, so today the
+  will is always published by the dying connection's own fiber. A delayed will
+  must fire after that fiber is gone.
+- **Nothing downstream can publish it.** `Session` holds no reference to the
+  `Broker`, and `Broker#publish` is what applies the retain store, so a retained
+  delayed will routed straight through `@vhost.mqtt_exchange` would silently
+  skip retention.
+- **It belongs in the session-expiry timer, not a second one.** [MQTT-3.1.2-8]
+  and [MQTT-3.1.3-9] make it "the delay elapses **or** the session ends,
+  whichever first", cancelled by a reconnect - the exact shape of
+  `Session#wait_for_client`'s existing select. Spec 3.1.3.2.2 explicitly
+  supports a delay longer than the expiry as a way to be told the session
+  expired, so session-end has to win.
+- **Takeover has its own rule** (3.1.4): a takeover publishes the predecessor's
+  will *unless* the new connection has Clean Start 0 **and** will delay > 0. We
+  currently always publish on takeover.
+- A delayed will need not survive a broker restart: 3.1.3.2.2 lets a server
+  defer publication until after a restart, and session expiry already sets the
+  precedent of persisting no deadlines.
 
 ### F. Retained messages lose v5 properties
 
@@ -634,16 +669,18 @@ ours to fix before the PR.
 **Round 1 - full branch, 2026-08-19.** Seven findings, ordered by severity.
 **Five are fixed** on 2026-08-20 - the poison message and its `@unacked_*`
 corruption, the hot-path allocation, `protocol_name` exhaustiveness, and the v3
-property restore. See section 4. The two that remain are both enforcement gaps
-already tracked as the `[~]` rows in section 2:
+property restore. See section 4. **Six of seven are now fixed** - the Will QoS 2
+gap landed with item E's will properties. The one that remains is the
+enforcement gap still tracked as the `[~]` row in section 2:
 
-- **Will QoS 2 is accepted despite `maximum_qos = 1`** - section 2, first `[~]`
-  row. `Connect.from_io` accepts any `will_qos < 3` and nothing rejects a Will at
-  QoS 2, where spec 3.1.2.6 wants CONNACK `0x9B`. Confirmed from outside by the
-  interop run.
-- **Maximum Packet Size is only enforced for outbound PUBLISH** - section 2,
-  second `[~]` row. `Client#send` is the single outbound choke point and is the
-  place to put it, so no future packet type can forget it.
+- **Maximum Packet Size is only enforced for outbound PUBLISH** - section 2's
+  remaining `[~]` row. `Client#send` is the single outbound choke point and is
+  the place to put it, so no future packet type can forget it.
+
+~~**Will QoS 2 is accepted despite `maximum_qos = 1`**~~ - fixed with item E.
+`Connect.from_io` accepts any `will_qos < 3`, so nothing had rejected a Will at
+QoS 2 where spec 3.1.2.6 wants CONNACK `0x9B`. It was confirmed from outside by
+the interop run, so that run's expectation for it has changed.
 
 **Round 2 - item D only, 2026-08-21. All five are fixed**, in one commit with
 specs; each new spec was first run against the unfixed code to confirm it failed.
@@ -750,7 +787,9 @@ the docs, not in a bug tracker.
 - **Shared subscriptions unsupported.**
 - **Subscription identifiers unsupported.**
 - **Enhanced authentication unsupported.**
-- **Will delay interval ignored** (wills fire immediately).
+- **Will Delay Interval ignored** (wills fire immediately). Not advertisable -
+  MQTT has no capability flag for it - so this is a real gap rather than a
+  legal deferral. Section 5 item E has the shape of the work.
 - **Payload Format Indicator is not validated.** Spec 3.3.2.3.2 only says a
   server MAY check that a payload declared as UTF-8 really is, so we never
   answer `0x99` PayloadFormatInvalid. Validating means a String allocation plus
@@ -782,13 +821,13 @@ reason code). A blanket version matrix was deliberately dropped as redundant:
 the `IO::V3`/`IO::V5` split makes "a v5 packet parsed with v3 framing"
 structurally hard to even express.
 
-**LavinMQ, measured 2026-09-07** after J1/J2, item I, item D, the item D review
-fixes and item B, on `main` `02e97d70`:
+**LavinMQ, measured 2026-09-08** after J1/J2, item I, item D, the item D review
+fixes, item B and item E's will properties, on `main` `02e97d70`:
 
 | what | result |
 |---|---|
-| `make test SPEC=spec/mqtt` | **348 examples, 0 failures, 0 errors, 0 pending** |
-| `make test TAGS=~etcd` | **2220 examples, 0 failures, 0 errors, 9 pending** |
+| `make test SPEC=spec/mqtt` | **353 examples, 0 failures, 0 errors, 0 pending** |
+| `make test TAGS=~etcd` | **2225 examples, 0 failures, 0 errors, 9 pending** |
 | `make lint` | 412 inspected, 0 failures |
 | `crystal tool format --check` | clean |
 
@@ -799,7 +838,10 @@ and some auth specs - taking the pre-item-B baseline to 311/2183, re-measured on
 `v5/subscription_options_spec.cr`, 11 in `consts_spec.cr` for `granted_qos` and
 the arguments round-trip, four in `subscription_key_spec.cr` for the compaction
 guard, two in `exchange_spec.cr` for out-of-band binds, and one will/takeover
-case in `integrations/will_spec.cr`. Two of the expiry specs are tagged `slow`:
+case in `integrations/will_spec.cr`. Item E's will properties add five more in
+that same file: three regression tests for the properties and the QoS 2
+refusal, plus two invariant guards for the deliberate v3 asymmetry, which pass
+before and after by design. Two of the expiry specs are tagged `slow`:
 the interval's unit is seconds, so the shortest honest test of elapse and of
 reconnect-cancels-it is one second each.)
 
@@ -842,12 +884,14 @@ to re-run it; the short version:
 - All six v5 PUBLISH properties survive paho -> paho, paho -> mqtt.js,
   mqtt.js -> paho and mosquitto -> paho. A v5 publisher to a v3.1.1 subscriber
   drops them cleanly, and the reverse works.
-- Both `[~]` rows in section 2 were confirmed from outside: a Will at QoS 2 is
-  accepted with CONNACK Success, and `maximum-packet-size 5` still gets a 23-byte
-  CONNACK (`maximum-packet-size 12` a 15-byte SUBACK).
+- Both of the then-`[~]` rows in section 2 were confirmed from outside: a Will at
+  QoS 2 was accepted with CONNACK Success, and `maximum-packet-size 5` still gets
+  a 23-byte CONNACK (`maximum-packet-size 12` a 15-byte SUBACK). The Will QoS one
+  has since been fixed with item E, so a re-run should now see CONNACK `0x9B`.
 - Items B, D, E, F, the Receive Maximum limitation and shard items N3/O2 each
   reproduced under a third-party client, so they were all real and correctly
-  described. D has since been fixed.
+  described. B, D and E's will properties have since been fixed; E's Will Delay
+  half and F have not.
 - Three defects were new information: they were item J. J1 (delivery QoS) and J2
   (unexpected packets) are now fixed, and J3 landed with session expiry - see
   section 4.
@@ -865,7 +909,7 @@ denying a topic.
 
 ## 8. Sequencing to ship
 
-1. Finish E (F and G in parallel, different people). B and D are done. ~~The poison-message
+1. Finish E's Will Delay half (F and G in parallel, different people). B, D and E's will properties are done. ~~The poison-message
    and hot-path-allocation findings in I should land before the PR regardless of
    who takes the feature work.~~ Done 2026-08-20, along with three of the other
    five; only the two section 2 `[~]` enforcement gaps remain in I. Item I's

--- a/shard.lock
+++ b/shard.lock
@@ -18,7 +18,7 @@ shards:
 
   mqtt-protocol:
     git: https://github.com/84codes/mqtt-protocol.cr.git
-    version: 0.3.1
+    version: 0.3.1+git.commit.348af7ab4daa5a81a20abab10fcba0f55018fc12
 
   systemd:
     git: https://github.com/84codes/systemd.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -35,6 +35,7 @@ dependencies:
     github: 84codes/lz4.cr
   mqtt-protocol:
     github: 84codes/mqtt-protocol.cr
+    branch: feat/mqtt5
 
 development_dependencies:
   ameba:

--- a/spec/mqtt/client_id_validation_spec.cr
+++ b/spec/mqtt/client_id_validation_spec.cr
@@ -60,6 +60,24 @@ module MqttSpecs
           end
         end
       end
+
+      it "assigns the username as client_id on v5 and echoes it back" do
+        with_server do |server|
+          with_client_socket(server) do |socket|
+            io = MQTT::Protocol::IO::V5.new(socket)
+            connack = connect(io, version: MQTT::Protocol::Version::V5,
+              client_id: "", clean_session: true).as(MQTT::Protocol::Connack)
+            connack.return_code.should eq MQTT::Protocol::Connack::ReturnCode::Accepted
+            # The assigned id must be the username, and it must survive the
+            # rebuild of the CONNECT packet intact so the broker registers it.
+            connack.properties.assigned_client_identifier.should eq("guest")
+            registered = wait_for do
+              server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first?.try(&.client_id)
+            end
+            registered.should eq("guest")
+          end
+        end
+      end
     end
 
     describe "none mode (default)" do

--- a/spec/mqtt/consts_spec.cr
+++ b/spec/mqtt/consts_spec.cr
@@ -1,53 +1,139 @@
 require "./spec_helper"
 
+private def opts(qos, no_local = false, retain_as_published = false)
+  LavinMQ::MQTT::SubscriptionOptions.new(qos.to_u8, no_local, retain_as_published)
+end
+
+private def table(hash)
+  LavinMQ::AMQP::Table.new(hash)
+end
+
 describe LavinMQ::MQTT do
-  describe ".qos_arguments" do
-    it "returns the QoS 0 constant for QoS 0" do
-      LavinMQ::MQTT.qos_arguments(0u8).should be(LavinMQ::MQTT::QOS0_ARGUMENTS)
+  describe ".granted_qos" do
+    it "passes through the QoS levels it can deliver" do
+      LavinMQ::MQTT.granted_qos(0u8).should eq 0u8
+      LavinMQ::MQTT.granted_qos(1u8).should eq 1u8
     end
 
-    it "returns the QoS 1 constant for QoS 1" do
-      LavinMQ::MQTT.qos_arguments(1u8).should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+    it "grants QoS 2 as QoS 1 [MQTT-3.9.3-1]" do
+      LavinMQ::MQTT.granted_qos(2u8).should eq 1u8
     end
 
-    it "returns the QoS 1 constant for QoS 2, which is granted as QoS 1" do
-      LavinMQ::MQTT.qos_arguments(2u8).should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+    it "accepts any integer type, since a binding argument is not parsed by MQTT" do
+      LavinMQ::MQTT.granted_qos(1).should eq 1u8
+      LavinMQ::MQTT.granted_qos(2i64).should eq 1u8
+      LavinMQ::MQTT.granted_qos(Int64::MAX).should eq 1u8
     end
 
-    it "carries the QoS under the QoS header" do
-      LavinMQ::MQTT.qos_arguments(0u8)[LavinMQ::MQTT::QOS_HEADER].should eq 0u8
-      LavinMQ::MQTT.qos_arguments(1u8)[LavinMQ::MQTT::QOS_HEADER].should eq 1u8
+    it "is QoS 0 for a missing or negative value" do
+      LavinMQ::MQTT.granted_qos(nil).should eq 0u8
+      LavinMQ::MQTT.granted_qos(-1).should eq 0u8
+      LavinMQ::MQTT.granted_qos(Int64::MIN).should eq 0u8
     end
   end
 
-  describe ".qos" do
-    it "reads the QoS back from the arguments of qos_arguments" do
-      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(0u8)).should eq 0u8
-      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(1u8)).should eq 1u8
-      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(2u8)).should eq 1u8
+  describe ".session_name" do
+    it "prefixes the client id" do
+      LavinMQ::MQTT.session_name("sub").should eq "mqtt.sub"
+    end
+  end
+
+  describe ".subscription_arguments" do
+    it "returns the QoS 0 constant for QoS 0" do
+      LavinMQ::MQTT.subscription_arguments(opts(0)).should be(LavinMQ::MQTT::QOS0_ARGUMENTS)
+    end
+
+    it "returns the QoS 1 constant for QoS 1" do
+      LavinMQ::MQTT.subscription_arguments(opts(1)).should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+    end
+
+    it "returns the QoS 1 constant for QoS 2, which is granted as QoS 1" do
+      LavinMQ::MQTT.subscription_arguments(opts(2)).should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+    end
+
+    it "carries the QoS under the QoS header" do
+      LavinMQ::MQTT.subscription_arguments(opts(0))[LavinMQ::MQTT::QOS_HEADER].should eq 0u8
+      LavinMQ::MQTT.subscription_arguments(opts(1))[LavinMQ::MQTT::QOS_HEADER].should eq 1u8
+    end
+
+    it "omits the option keys entirely when both are false" do
+      arguments = LavinMQ::MQTT.subscription_arguments(opts(1))
+      arguments[LavinMQ::MQTT::NO_LOCAL_HEADER]?.should be_nil
+      arguments[LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER]?.should be_nil
+    end
+
+    it "carries No Local when set" do
+      arguments = LavinMQ::MQTT.subscription_arguments(opts(1, no_local: true))
+      arguments[LavinMQ::MQTT::QOS_HEADER].should eq 1u8
+      arguments[LavinMQ::MQTT::NO_LOCAL_HEADER].should be_true
+      arguments[LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER]?.should be_nil
+    end
+
+    it "carries Retain As Published when set" do
+      arguments = LavinMQ::MQTT.subscription_arguments(opts(0, retain_as_published: true))
+      arguments[LavinMQ::MQTT::QOS_HEADER].should eq 0u8
+      arguments[LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER].should be_true
+      arguments[LavinMQ::MQTT::NO_LOCAL_HEADER]?.should be_nil
+    end
+
+    it "carries both when both are set" do
+      arguments = LavinMQ::MQTT.subscription_arguments(
+        opts(1, no_local: true, retain_as_published: true))
+      arguments[LavinMQ::MQTT::NO_LOCAL_HEADER].should be_true
+      arguments[LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER].should be_true
+    end
+
+    it "allocates a fresh table only when an option is set" do
+      # The default case must keep returning the shared constant, or every
+      # subscription starts allocating on a path that never did.
+      LavinMQ::MQTT.subscription_arguments(opts(1))
+        .should be(LavinMQ::MQTT.subscription_arguments(opts(1)))
+      LavinMQ::MQTT.subscription_arguments(opts(1, no_local: true))
+        .should_not be(LavinMQ::MQTT.subscription_arguments(opts(1, no_local: true)))
+    end
+  end
+
+  describe ".subscription_options" do
+    it "round-trips everything subscription_arguments writes" do
+      [opts(0), opts(1), opts(1, no_local: true),
+       opts(0, retain_as_published: true),
+       opts(1, no_local: true, retain_as_published: true)].each do |options|
+        LavinMQ::MQTT.subscription_options(
+          LavinMQ::MQTT.subscription_arguments(options)).should eq options
+      end
     end
 
     it "grants QoS 2 as QoS 1" do
-      arguments = LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2u8})
-      LavinMQ::MQTT.qos(arguments).should eq 1u8
+      LavinMQ::MQTT.subscription_options(table({LavinMQ::MQTT::QOS_HEADER => 2u8})).qos.should eq 1u8
     end
 
     it "accepts any integer type, not just UInt8" do
-      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 1})).should eq 1u8
-      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2i64})).should eq 1u8
+      LavinMQ::MQTT.subscription_options(table({LavinMQ::MQTT::QOS_HEADER => 1})).qos.should eq 1u8
+      LavinMQ::MQTT.subscription_options(table({LavinMQ::MQTT::QOS_HEADER => 2i64})).qos.should eq 1u8
     end
 
-    it "is QoS 0 without arguments" do
-      LavinMQ::MQTT.qos(nil).should eq 0u8
-      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new).should eq 0u8
+    it "is all-defaults without arguments" do
+      LavinMQ::MQTT.subscription_options(nil).should eq opts(0)
+      LavinMQ::MQTT.subscription_options(LavinMQ::AMQP::Table.new).should eq opts(0)
     end
 
     it "is QoS 0 for a non-integer value" do
-      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => "1"})).should eq 0u8
+      LavinMQ::MQTT.subscription_options(table({LavinMQ::MQTT::QOS_HEADER => "1"})).qos.should eq 0u8
     end
 
     it "is QoS 0 for a negative value" do
-      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => -1})).should eq 0u8
+      LavinMQ::MQTT.subscription_options(table({LavinMQ::MQTT::QOS_HEADER => -1})).qos.should eq 0u8
+    end
+
+    it "reads a non-true option value as false rather than raising" do
+      # An operator or a definitions import can put anything here, and this runs
+      # during load!, so a raise would be a boot failure.
+      LavinMQ::MQTT.subscription_options(
+        table({LavinMQ::MQTT::NO_LOCAL_HEADER => "yes"})).no_local?.should be_false
+      LavinMQ::MQTT.subscription_options(
+        table({LavinMQ::MQTT::NO_LOCAL_HEADER => 1})).no_local?.should be_false
+      LavinMQ::MQTT.subscription_options(
+        table({LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER => false})).retain_as_published?.should be_false
     end
   end
 end

--- a/spec/mqtt/exchange_spec.cr
+++ b/spec/mqtt/exchange_spec.cr
@@ -46,6 +46,55 @@ module MqttSpecs
       end
     end
 
+    it "reads subscription options from a binding made outside the MQTT protocol" do
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        exchange = vhost.mqtt_exchange
+        vhost.declare_queue("mqtt.sub", true, false,
+          LavinMQ::AMQP::Table.new({"x-queue-type" => "mqtt"}))
+
+        arguments = LavinMQ::AMQP::Table.new({
+          LavinMQ::MQTT::QOS_HEADER                 => 1,
+          LavinMQ::MQTT::NO_LOCAL_HEADER            => true,
+          LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER => true,
+        })
+        vhost.bind_queue("mqtt.sub", LavinMQ::MQTT::EXCHANGE, "a/b", arguments)
+
+        options = exchange.bindings_details.first
+          .binding_key.as(LavinMQ::MQTT::SubscriptionKey).options
+        options.qos.should eq 1u8
+        options.no_local?.should be_true
+        options.retain_as_published?.should be_true
+
+        # Same symmetry requirement as the QoS above: bind and unbind must read
+        # the options identically, or the unbind misses the binding it targets.
+        vhost.unbind_queue("mqtt.sub", LavinMQ::MQTT::EXCHANGE, "a/b", arguments)
+        exchange.bindings_details.should be_empty
+      end
+    end
+
+    it "ignores an unusable subscription option value rather than raising" do
+      # Exchange#bind runs during definitions load!, so a raise here is a boot
+      # failure. An operator can put anything in these keys.
+      with_server do |server|
+        vhost = server.vhosts["/"]
+        exchange = vhost.mqtt_exchange
+        vhost.declare_queue("mqtt.sub", true, false,
+          LavinMQ::AMQP::Table.new({"x-queue-type" => "mqtt"}))
+
+        vhost.bind_queue("mqtt.sub", LavinMQ::MQTT::EXCHANGE, "a/b",
+          LavinMQ::AMQP::Table.new({
+            LavinMQ::MQTT::QOS_HEADER      => 1,
+            LavinMQ::MQTT::NO_LOCAL_HEADER => "yes",
+          }))
+
+        options = exchange.bindings_details.first
+          .binding_key.as(LavinMQ::MQTT::SubscriptionKey).options
+        options.qos.should eq 1u8
+        options.no_local?.should be_false
+      end
+    end
+
     it "exposes subscriptions as MQTT::SubscriptionDetails sharing the binding details interface" do
       with_server do |server|
         exchange = server.vhosts["/"].exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -138,6 +138,20 @@ module MqttSpecs
           end
         end
 
+        it "negotiates the protocol version from CONNECT and replies with a v5 CONNACK" do
+          with_server do |server|
+            with_client_socket(server) do |socket|
+              io = MQTT::Protocol::IO::V5.new(socket)
+              # A v5 CONNECT must be answered with a v5-framed CONNACK; if the
+              # broker kept v3 framing the reply would be unparseable here.
+              connack = connect(io, version: MQTT::Protocol::Version::V5)
+              connack.should be_a(MQTT::Protocol::Connack)
+              connack = connack.as(MQTT::Protocol::Connack)
+              connack.reason_code.should eq(MQTT::Protocol::Connack::ReasonCode::Success)
+            end
+          end
+        end
+
         # pending "for invalid credentials" do
         #   auth = SpecAuth.new({"a" => {password: "b", acls: ["a", "a/b", "/", "/a"] of String}})
         #   with_server(auth: auth) do |server|
@@ -157,7 +171,7 @@ module MqttSpecs
           with_server do |server|
             with_client_io(server) do |io|
               temp_io = IO::Memory.new
-              temp_mqtt_io = MQTT::Protocol::IO.new(temp_io)
+              temp_mqtt_io = MQTT::Protocol::IO::V3.new(temp_io)
               connect(temp_mqtt_io, expect_response: false)
               temp_io.rewind
               connect_pkt = temp_io.to_slice
@@ -230,16 +244,19 @@ module MqttSpecs
         it "for password flag set without username flag set [MQTT-3.1.2-22]" do
           with_server do |server|
             with_client_io(server) do |io|
+              # The shard forbids constructing a v3 password-without-username
+              # CONNECT, so craft the malformed packet: build a valid
+              # username+password CONNECT and clear the username flag (bit 7),
+              # leaving the password flag set.
               connect = MQTT::Protocol::Connect.new(
                 client_id: "client_id",
                 clean_session: true,
                 keepalive: 30u16,
-                username: nil,
+                username: "valid_user",
                 password: "valid_password".to_slice,
                 will: nil
               ).to_slice
-              # Set password flag
-              connect[9] |= 0b0100_0000
+              connect[9] &= 0b0111_1111
               io.write_bytes_raw connect
 
               # Verify that connection is closed [MQTT-3.1.4-1]

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -138,20 +138,6 @@ module MqttSpecs
           end
         end
 
-        it "negotiates the protocol version from CONNECT and replies with a v5 CONNACK" do
-          with_server do |server|
-            with_client_socket(server) do |socket|
-              io = MQTT::Protocol::IO::V5.new(socket)
-              # A v5 CONNECT must be answered with a v5-framed CONNACK; if the
-              # broker kept v3 framing the reply would be unparseable here.
-              connack = connect(io, version: MQTT::Protocol::Version::V5)
-              connack.should be_a(MQTT::Protocol::Connack)
-              connack = connack.as(MQTT::Protocol::Connack)
-              connack.reason_code.should eq(MQTT::Protocol::Connack::ReasonCode::Success)
-            end
-          end
-        end
-
         # pending "for invalid credentials" do
         #   auth = SpecAuth.new({"a" => {password: "b", acls: ["a", "a/b", "/", "/a"] of String}})
         #   with_server(auth: auth) do |server|

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -124,6 +124,27 @@ module MqttSpecs
             end
           end
         end
+
+        it "no session present when taking over a session that ends with its connection" do
+          # session_present? runs before add_client, so the previous connection's
+          # 0-interval session is still visible here - but the takeover ends it,
+          # so the new connection must not be told it resumed one.
+          with_server do |server|
+            with_client_io(server) do |first|
+              connect(first, clean_session: true)
+              subscribe(first,
+                topic_filters: [subtopic("a/topic", 0u8)],
+                packet_id: 1u16
+              )
+
+              with_client_io(server) do |second|
+                connack = connect(second, clean_session: false).as(MQTT::Protocol::Connack)
+                connack.session_present?.should be_false
+                disconnect(second)
+              end
+            end
+          end
+        end
       end
 
       describe "with expected return code" do

--- a/spec/mqtt/integrations/connect_spec.cr
+++ b/spec/mqtt/integrations/connect_spec.cr
@@ -128,7 +128,8 @@ module MqttSpecs
         it "no session present when taking over a session that ends with its connection" do
           # session_present? runs before add_client, so the previous connection's
           # 0-interval session is still visible here - but the takeover ends it,
-          # so the new connection must not be told it resumed one.
+          # so the new connection must not be told it resumed one, and must not
+          # inherit the subscription either.
           with_server do |server|
             with_client_io(server) do |first|
               connect(first, clean_session: true)
@@ -140,6 +141,10 @@ module MqttSpecs
               with_client_io(server) do |second|
                 connack = connect(second, clean_session: false).as(MQTT::Protocol::Connack)
                 connack.session_present?.should be_false
+                # The CONNACK is written before add_client runs; a PINGREQ
+                # round-trip proves the takeover has been applied.
+                pingpong(second)
+                server.vhosts["/"].session?("mqtt.client_id").should be_nil
                 disconnect(second)
               end
             end

--- a/spec/mqtt/integrations/message_qos_spec.cr
+++ b/spec/mqtt/integrations/message_qos_spec.cr
@@ -19,6 +19,20 @@ module MqttSpecs
       end
     end
 
+    it "accepts a QoS 2 publish on v3 (downgraded, not disconnected)" do
+      # v3.1.1 has no Maximum QoS contract, so a QoS 2 PUBLISH is accepted and
+      # PubAck'd (delivery is clamped to QoS 1). Only v5 rejects it. Guards the
+      # version gate in Client#recieve_publish.
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          ack = publish(io, topic: "a/b", qos: 2u8)
+          ack.should be_a(MQTT::Protocol::PubAck)
+          io.should_not be_closed
+        end
+      end
+    end
+
     it "qos is set according to subscription qos [LavinMQ non-normative]" do
       with_server do |server|
         with_client_io(server) do |io|

--- a/spec/mqtt/integrations/message_qos_spec.cr
+++ b/spec/mqtt/integrations/message_qos_spec.cr
@@ -33,11 +33,10 @@ module MqttSpecs
       end
     end
 
-    it "qos is set according to subscription qos [LavinMQ non-normative]" do
+    it "downgrades to the subscription qos [MQTT-3.8.4-8]" do
       with_server do |server|
         with_client_io(server) do |io|
           connect(io)
-          # Subscribe with qos=0 means downgrade messages to qos=0
           topic_filters = mk_topic_filters({"a/b", 0u8})
           subscribe(io, topic_filters: topic_filters)
 
@@ -60,6 +59,56 @@ module MqttSpecs
       end
     end
 
+    it "does not upgrade to the subscription qos [MQTT-3.8.4-8]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+          with_client_io(server) do |publisher_io|
+            connect(publisher_io, client_id: "publisher")
+            publish(publisher_io, topic: "a/b", qos: 0u8)
+            publish(publisher_io, topic: "a/b", qos: 1u8)
+            disconnect(publisher_io)
+          end
+
+          # A qos0 publish stays qos0, so it carries no packet id and is not
+          # tracked as inflight; only the qos1 publish is ackable.
+          pub1 = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::Publish)
+          pub1.qos.should eq(0u8)
+          pub1.packet_id.should be_nil
+          pub2 = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::Publish)
+          pub2.qos.should eq(1u8)
+          pub2.packet_id.should_not be_nil
+          puback(io, pub2.packet_id)
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "does not store a qos0 publish for an offline qos1 subscription [MQTT-3.8.4-8]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, clean_session: false)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+          disconnect(io)
+        end
+
+        with_client_io(server) do |publisher_io|
+          connect(publisher_io, client_id: "publisher")
+          publish(publisher_io, topic: "a/b", qos: 0u8)
+          disconnect(publisher_io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, clean_session: false)
+          read_packet(io).should be_nil
+          disconnect(io)
+        end
+      end
+    end
+
     it "qos1 messages are stored for offline sessions [MQTT-3.1.2-5]" do
       with_server do |server|
         with_client_io(server) do |io|
@@ -72,8 +121,7 @@ module MqttSpecs
         with_client_io(server) do |publisher_io|
           connect(publisher_io, client_id: "publisher")
           100.times do
-            # qos doesnt matter here
-            publish(publisher_io, topic: "a/b", qos: 0u8)
+            publish(publisher_io, topic: "a/b", qos: 1u8)
           end
           disconnect(publisher_io)
         end
@@ -101,8 +149,8 @@ module MqttSpecs
 
           with_client_io(server) do |publisher_io|
             connect(publisher_io, client_id: "publisher")
-            publish(publisher_io, topic: "a/b", payload: "1".to_slice, qos: 0u8)
-            publish(publisher_io, topic: "a/b", payload: "2".to_slice, qos: 0u8)
+            publish(publisher_io, topic: "a/b", payload: "1".to_slice, qos: 1u8)
+            publish(publisher_io, topic: "a/b", payload: "2".to_slice, qos: 1u8)
             pingpong(publisher_io)
             disconnect(publisher_io)
           end
@@ -142,7 +190,7 @@ module MqttSpecs
           with_client_io(server) do |publisher_io|
             connect(publisher_io, client_id: "publisher")
             10.times do |i|
-              publish(publisher_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8)
+              publish(publisher_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8)
             end
             pingpong(publisher_io)
             disconnect(publisher_io)
@@ -193,7 +241,7 @@ module MqttSpecs
 
           with_client_io(server) do |publisher_io|
             connect(publisher_io, client_id: "publisher")
-            publish(publisher_io, topic: "a/b", qos: 0u8)
+            publish(publisher_io, topic: "a/b", qos: 1u8)
             disconnect(publisher_io)
           end
 
@@ -226,8 +274,7 @@ module MqttSpecs
             number_of_messages.times do |i|
               data = Bytes.new(sizeof(UInt16))
               IO::ByteFormat::SystemEndian.encode(i, data)
-              # qos doesnt matter here
-              publish(publisher_io, topic: "a/b", payload: data, qos: 0u8)
+              publish(publisher_io, topic: "a/b", payload: data, qos: 1u8)
             end
             disconnect(publisher_io)
           end
@@ -292,7 +339,7 @@ module MqttSpecs
 
             with_client_io(server) do |pub_io|
               connect(pub_io, client_id: "publisher")
-              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8) }
+              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8) }
               disconnect(pub_io)
             end
 
@@ -315,7 +362,7 @@ module MqttSpecs
 
             with_client_io(server) do |pub_io|
               connect(pub_io, client_id: "publisher")
-              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8) }
+              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8) }
               disconnect(pub_io)
             end
 

--- a/spec/mqtt/integrations/message_qos_spec.cr
+++ b/spec/mqtt/integrations/message_qos_spec.cr
@@ -9,10 +9,10 @@ module MqttSpecs
         with_client_io(server) do |io|
           connect(io)
           temp_io = IO::Memory.new
-          publish(MQTT::Protocol::IO.new(temp_io), topic: "a/b", qos: 1u8, expect_response: false)
+          publish(MQTT::Protocol::IO::V3.new(temp_io), topic: "a/b", qos: 1u8, expect_response: false)
           pub_pkt = temp_io.to_slice
           pub_pkt[0] |= 0b0000_0110u8
-          io.write pub_pkt
+          io.io.write pub_pkt
 
           io.should be_closed
         end

--- a/spec/mqtt/integrations/retain_store_spec.cr
+++ b/spec/mqtt/integrations/retain_store_spec.cr
@@ -141,17 +141,21 @@ module MqttSpecs
 
     it "subscribing to topic with retained message does not crash" do
       with_server(clean_dir: false) do |server|
-        # First, publish a retained message
+        # clean_session and QoS 1 are load-bearing. A persistent session keeps
+        # its binding across connections, so the subscriber would get this
+        # message live as well as from the retain store; and QoS 0 is
+        # unacknowledged, so nothing would order the publish before the next
+        # connection. Either way a live delivery can precede the SUBACK, which
+        # is legal (spec 3.8.4) and which read_packet would misread below.
         with_client_io(server) do |io|
-          connect(io, client_id: "publisher")
-          # Use a larger payload to increase chances of triggering copy_file_range
-          subscribe(io, topic_filters: [subtopic("test/retain")])
+          connect(io, client_id: "publisher", clean_session: true)
+          # A larger payload increases the chances of triggering copy_file_range
           large_payload = "retained_message_" + ("x" * 8192)
-          publish(io, topic: "test/retain", payload: large_payload.to_slice, qos: 0u8, retain: true)
+          publish(io, topic: "test/retain", payload: large_payload.to_slice, qos: 1u8, retain: true)
           disconnect(io)
         end
         with_client_io(server) do |io|
-          connect(io, client_id: "subscriber")
+          connect(io, client_id: "subscriber", clean_session: true)
           subscribe(io, topic_filters: [subtopic("test/retain")])
 
           # Should receive the retained message without crashing
@@ -165,17 +169,17 @@ module MqttSpecs
       end
 
       with_server do |server|
-        # First, publish a retained message
+        # Same server dir as the block above, so this asserts the retained
+        # message survived the restart. Same clean_session/QoS 1 reasoning.
         with_client_io(server) do |io|
-          connect(io, client_id: "publisher")
-          # Use a larger payload to increase chances of triggering copy_file_range
-          subscribe(io, topic_filters: [subtopic("test/retain")])
+          connect(io, client_id: "publisher", clean_session: true)
+          # A larger payload increases the chances of triggering copy_file_range
           large_payload = "retained_message_" + ("x" * 8192)
-          publish(io, topic: "test/retain", payload: large_payload.to_slice, qos: 0u8, retain: true)
+          publish(io, topic: "test/retain", payload: large_payload.to_slice, qos: 1u8, retain: true)
           disconnect(io)
         end
         with_client_io(server) do |io|
-          connect(io, client_id: "subscriber")
+          connect(io, client_id: "subscriber", clean_session: true)
           subscribe(io, topic_filters: [subtopic("test/retain")])
 
           # Should receive the retained message without crashing

--- a/spec/mqtt/integrations/session_limit_spec.cr
+++ b/spec/mqtt/integrations/session_limit_spec.cr
@@ -14,7 +14,7 @@ module MqttSpecs
           connect(io, client_id: "a")
           ack = subscribe(io, topic_filters: mk_topic_filters({"a/b", 0}))
             .should be_a(MQTT::Protocol::SubAck)
-          ack.return_codes.should eq [MQTT::Protocol::SubAck::ReturnCode::QoS0]
+          ack.reason_codes.should eq [MQTT::Protocol::SubAck::ReasonCode::GrantedQoS0]
         end
 
         with_client_io(server) do |io|
@@ -22,8 +22,8 @@ module MqttSpecs
           ack = subscribe(io, topic_filters: mk_topic_filters({"c/d", 0}, {"e/f", 1}))
             .should be_a(MQTT::Protocol::SubAck)
           # One return code per topic filter [MQTT-3.8.4-5]
-          ack.return_codes.should eq [MQTT::Protocol::SubAck::ReturnCode::Failure,
-                                      MQTT::Protocol::SubAck::ReturnCode::Failure]
+          ack.reason_codes.should eq [MQTT::Protocol::SubAck::ReasonCode::UnspecifiedError,
+                                      MQTT::Protocol::SubAck::ReasonCode::UnspecifiedError]
         end
 
         vhost.sessions_size.should eq 1
@@ -42,7 +42,7 @@ module MqttSpecs
           vhost.max_queues = 1
           ack = subscribe(io, topic_filters: mk_topic_filters({"c/d", 1}))
             .should be_a(MQTT::Protocol::SubAck)
-          ack.return_codes.should eq [MQTT::Protocol::SubAck::ReturnCode::QoS1]
+          ack.reason_codes.should eq [MQTT::Protocol::SubAck::ReasonCode::GrantedQoS1]
           disconnect(io)
         end
 
@@ -52,7 +52,7 @@ module MqttSpecs
           connect(io, client_id: "a", clean_session: false)
           ack = subscribe(io, topic_filters: mk_topic_filters({"e/f", 0}))
             .should be_a(MQTT::Protocol::SubAck)
-          ack.return_codes.should eq [MQTT::Protocol::SubAck::ReturnCode::QoS0]
+          ack.reason_codes.should eq [MQTT::Protocol::SubAck::ReasonCode::GrantedQoS0]
         end
       end
     end
@@ -67,7 +67,7 @@ module MqttSpecs
           connect(io, client_id: "a")
           ack = subscribe(io, topic_filters: mk_topic_filters({"a/b", 0}))
             .should be_a(MQTT::Protocol::SubAck)
-          ack.return_codes.should eq [MQTT::Protocol::SubAck::ReturnCode::Failure]
+          ack.reason_codes.should eq [MQTT::Protocol::SubAck::ReasonCode::UnspecifiedError]
         end
 
         vhost.sessions_size.should eq 0
@@ -90,7 +90,7 @@ module MqttSpecs
           connect(io, client_id: "b", clean_session: true)
           ack = subscribe(io, topic_filters: mk_topic_filters({"a/b", 0}))
             .should be_a(MQTT::Protocol::SubAck)
-          ack.return_codes.should eq [MQTT::Protocol::SubAck::ReturnCode::QoS0]
+          ack.reason_codes.should eq [MQTT::Protocol::SubAck::ReasonCode::GrantedQoS0]
         end
       end
     end

--- a/spec/mqtt/integrations/session_stats_spec.cr
+++ b/spec/mqtt/integrations/session_stats_spec.cr
@@ -61,7 +61,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 
@@ -87,7 +87,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 
@@ -115,7 +115,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 
@@ -138,7 +138,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -42,7 +42,7 @@ module MqttSpecs
 
           temp_io = IO::Memory.new
           topic_filters = mk_topic_filters({"a/b", 0})
-          subscribe(MQTT::Protocol::IO.new(temp_io), topic_filters: topic_filters, expect_response: false)
+          subscribe(MQTT::Protocol::IO::V3.new(temp_io), topic_filters: topic_filters, expect_response: false)
           temp_io.rewind
           subscribe_pkt = temp_io.to_slice
           # This will overwrite the protocol level byte
@@ -62,7 +62,7 @@ module MqttSpecs
 
           topic_filters = mk_topic_filters({"a/b", 0})
           temp_io = IO::Memory.new
-          subscribe(MQTT::Protocol::IO.new(temp_io), topic_filters: topic_filters, expect_response: false)
+          subscribe(MQTT::Protocol::IO::V3.new(temp_io), topic_filters: topic_filters, expect_response: false)
           temp_io.rewind
           sub_pkt = temp_io.to_slice
           sub_pkt[1] = 2u8 # Override remaning length
@@ -81,7 +81,7 @@ module MqttSpecs
 
           topic_filters = mk_topic_filters({"a/b", 0})
           temp_io = IO::Memory.new
-          subscribe(MQTT::Protocol::IO.new(temp_io), topic_filters: topic_filters, expect_response: false)
+          subscribe(MQTT::Protocol::IO::V3.new(temp_io), topic_filters: topic_filters, expect_response: false)
           temp_io.rewind
           sub_pkt = temp_io.to_slice
           sub_pkt[sub_pkt.size - 1] |= 0b1010_0100u8
@@ -103,7 +103,7 @@ module MqttSpecs
           suback.should be_a(MQTT::Protocol::SubAck)
           suback = suback.as(MQTT::Protocol::SubAck)
           # Verify that we subscribed as qos0
-          suback.return_codes.first.should eq(MQTT::Protocol::SubAck::ReturnCode::QoS0)
+          suback.reason_codes.first.should eq(MQTT::Protocol::SubAck::ReasonCode::GrantedQoS0)
 
           # Publish something to the topic we're subscribed to...
           publish(io, topic: "a/b", payload: "a".to_slice, qos: 1u8)
@@ -118,7 +118,7 @@ module MqttSpecs
           suback.should be_a(MQTT::Protocol::SubAck)
           suback = suback.as(MQTT::Protocol::SubAck)
           # Verify that we subscribed as qos1
-          suback.return_codes.should eq([MQTT::Protocol::SubAck::ReturnCode::QoS1])
+          suback.reason_codes.should eq([MQTT::Protocol::SubAck::ReasonCode::GrantedQoS1])
 
           # Publish something to the topic we're subscribed to...
           publish(io, topic: "a/b", payload: "a".to_slice, qos: 1u8)

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -144,7 +144,7 @@ module MqttSpecs
           suback = subscribe(io, topic_filters: topic_filters)
           suback.should be_a(MQTT::Protocol::SubAck)
           suback = suback.as(MQTT::Protocol::SubAck)
-          suback.return_codes.should eq([MQTT::Protocol::SubAck::ReturnCode::QoS1])
+          suback.reason_codes.should eq([MQTT::Protocol::SubAck::ReasonCode::GrantedQoS1])
 
           # Publish something to the topic we're subscribed to...
           publish(io, topic: "a/b", payload: "a".to_slice, qos: 1u8)

--- a/spec/mqtt/integrations/unsubscribe_spec.cr
+++ b/spec/mqtt/integrations/unsubscribe_spec.cr
@@ -55,7 +55,7 @@ module MqttSpecs
           end
 
           # Publish messages that will be stored for the subscriber
-          2.times { |i| publish(pubio, topic: "a/b", payload: i.to_s.to_slice, qos: 0u8) }
+          2.times { |i| publish(pubio, topic: "a/b", payload: i.to_s.to_slice, qos: 1u8) }
 
           # Let the subscriber connect and read the messages, but don't ack. Then unsubscribe.
           # We must read the Publish packets before unsubscribe, else the "suback" will be stuck.
@@ -72,7 +72,7 @@ module MqttSpecs
           end
 
           # Publish more messages
-          2.times { |i| publish(pubio, topic: "a/b", payload: (2 + i).to_s.to_slice, qos: 0u8) }
+          2.times { |i| publish(pubio, topic: "a/b", payload: (2 + i).to_s.to_slice, qos: 1u8) }
 
           # Now, if unsubscribed worked, the last two publish packets shouldn't be held for the
           # session. Read the two we expect, then test that there is nothing more to read.

--- a/spec/mqtt/integrations/unsubscribe_spec.cr
+++ b/spec/mqtt/integrations/unsubscribe_spec.cr
@@ -11,7 +11,7 @@ module MqttSpecs
           connect(io)
 
           temp_io = IO::Memory.new
-          unsubscribe(MQTT::Protocol::IO.new(temp_io), topics: ["a/b"], expect_response: false)
+          unsubscribe(MQTT::Protocol::IO::V3.new(temp_io), topics: ["a/b"], expect_response: false)
           temp_io.rewind
           unsubscribe_pkt = temp_io.to_slice
           # This will overwrite the protocol level byte
@@ -29,7 +29,7 @@ module MqttSpecs
           connect(io)
 
           temp_io = IO::Memory.new
-          unsubscribe(MQTT::Protocol::IO.new(temp_io), topics: ["a/b"], expect_response: false)
+          unsubscribe(MQTT::Protocol::IO::V3.new(temp_io), topics: ["a/b"], expect_response: false)
           temp_io.rewind
           unsubscribe_pkt = temp_io.to_slice
           # Overwrite remaining length

--- a/spec/mqtt/integrations/various_spec.cr
+++ b/spec/mqtt/integrations/various_spec.cr
@@ -15,7 +15,7 @@ module MqttSpecs
 
         with_client_io(server) do |io|
           connect(io, clean_session: false, client_id: "pub")
-          publish(io, topic: "a/b/c", qos: 0u8)
+          publish(io, topic: "a/b/c", qos: 1u8)
         end
 
         with_client_io(server) do |io|

--- a/spec/mqtt/integrations/will_spec.cr
+++ b/spec/mqtt/integrations/will_spec.cr
@@ -67,10 +67,10 @@ module MqttSpecs
               connect(io2, client_id: "will_client", will: will, keepalive: 20u16)
 
               broken_packet_io = IO::Memory.new
-              publish(MQTT::Protocol::IO.new(broken_packet_io), topic: "foo", qos: 1u8, expect_response: false)
+              publish(MQTT::Protocol::IO::V3.new(broken_packet_io), topic: "foo", qos: 1u8, expect_response: false)
               broken_packet = broken_packet_io.to_slice
               broken_packet[0] |= 0b0000_0110u8 # set both qos bits to 1
-              io2.write broken_packet
+              io2.io.write broken_packet
             end
 
             pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
@@ -135,11 +135,11 @@ module MqttSpecs
       with_server do |server|
         with_client_io(server) do |io|
           temp_io = IO::Memory.new
-          connect(MQTT::Protocol::IO.new(temp_io), client_id: "will_client", keepalive: 1u16, expect_response: false)
+          connect(MQTT::Protocol::IO::V3.new(temp_io), client_id: "will_client", keepalive: 1u16, expect_response: false)
           temp_io.rewind
           connect_pkt = temp_io.to_slice
           connect_pkt[9] |= 0b0001_0000u8
-          io.write connect_pkt
+          io.io.write connect_pkt
 
           expect_raises(IO::Error) do
             read_packet(io)
@@ -154,11 +154,11 @@ module MqttSpecs
           temp_io = IO::Memory.new
           will = MQTT::Protocol::Will.new(
             topic: "will/t", payload: "dead".to_slice, qos: 0u8, retain: false)
-          connect(MQTT::Protocol::IO.new(temp_io), will: will, client_id: "will_client", keepalive: 1u16, expect_response: false)
+          connect(MQTT::Protocol::IO::V3.new(temp_io), will: will, client_id: "will_client", keepalive: 1u16, expect_response: false)
           temp_io.rewind
           connect_pkt = temp_io.to_slice
           connect_pkt[9] |= 0b0001_1000u8
-          io.write connect_pkt
+          io.io.write connect_pkt
 
           expect_raises(IO::Error) do
             read_packet(io)
@@ -171,11 +171,11 @@ module MqttSpecs
       with_server do |server|
         with_client_io(server) do |io|
           temp_io = IO::Memory.new
-          connect(MQTT::Protocol::IO.new(temp_io), client_id: "will_client", keepalive: 1u16, expect_response: false)
+          connect(MQTT::Protocol::IO::V3.new(temp_io), client_id: "will_client", keepalive: 1u16, expect_response: false)
           temp_io.rewind
           connect_pkt = temp_io.to_slice
           connect_pkt[9] |= 0b0010_0000u8
-          io.write connect_pkt
+          io.io.write connect_pkt
 
           expect_raises(IO::Error) do
             read_packet(io)

--- a/spec/mqtt/integrations/will_spec.cr
+++ b/spec/mqtt/integrations/will_spec.cr
@@ -167,6 +167,142 @@ module MqttSpecs
       end
     end
 
+    it "carries the Will Properties onto the published message" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("will/t", 1u8)])
+
+          with_client_socket(server) do |dying_socket|
+            dying = MQTT::Protocol::IO::V5.new(dying_socket)
+            props = MQTT::Protocol::WillProperties.new
+            props.payload_format_indicator = true
+            props.message_expiry_interval = 120u32
+            props.content_type = "text/plain"
+            props.response_topic = "reply/here"
+            props.correlation_data = "cid".to_slice
+            props.user_properties = [{"a", "1"}, {"b", "2"}]
+            # will_delay_interval is set but ignored for now: it is server
+            # behaviour, not wire content, and must not reach the subscriber.
+            props.will_delay_interval = 0u32
+            will = MQTT::Protocol::Will.new(topic: "will/t", payload: "bye".to_slice,
+              qos: 1u8, retain: false, properties: props)
+            connect(dying, version: MQTT::Protocol::Version::V5,
+              client_id: "dying", will: will)
+            # 0x04 publishes the will without an error path [MQTT-3.14.4-3]
+            MQTT::Protocol::Disconnect.new(
+              MQTT::Protocol::Disconnect::ReasonCode::DisconnectWithWillMessage).to_io(dying)
+            dying.flush
+          end
+
+          pub = read_packet(sub).as(MQTT::Protocol::Publish)
+          pub.topic.should eq "will/t"
+          String.new(pub.payload).should eq "bye"
+          pub.properties.payload_format_indicator.should be_true
+          pub.properties.message_expiry_interval.should eq 120u32
+          pub.properties.content_type.should eq "text/plain"
+          pub.properties.response_topic.should eq "reply/here"
+          String.new(pub.properties.correlation_data.not_nil!).should eq "cid"
+          pub.properties.user_properties.should eq [{"a", "1"}, {"b", "2"}]
+        end
+      end
+    end
+
+    it "keeps Will user property order and duplicate keys [MQTT-3.3.2-18]" do
+      # The reason they are an array of {key, value} tables rather than a flat
+      # table: a Hash would lose both.
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("will/t", 1u8)])
+
+          with_client_socket(server) do |dying_socket|
+            dying = MQTT::Protocol::IO::V5.new(dying_socket)
+            props = MQTT::Protocol::WillProperties.new
+            props.user_properties = [{"k", "1"}, {"k", "2"}, {"a", "3"}]
+            will = MQTT::Protocol::Will.new(topic: "will/t", payload: "x".to_slice,
+              qos: 1u8, retain: false, properties: props)
+            connect(dying, version: MQTT::Protocol::Version::V5,
+              client_id: "dying", will: will)
+            MQTT::Protocol::Disconnect.new(
+              MQTT::Protocol::Disconnect::ReasonCode::DisconnectWithWillMessage).to_io(dying)
+            dying.flush
+          end
+
+          pub = read_packet(sub).as(MQTT::Protocol::Publish)
+          pub.properties.user_properties.should eq [{"k", "1"}, {"k", "2"}, {"a", "3"}]
+        end
+      end
+    end
+
+    it "drops the Will Properties cleanly for a v3 subscriber" do
+      with_server do |server|
+        with_client_io(server) do |sub|
+          connect(sub, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("will/t", 1u8)])
+
+          with_client_socket(server) do |dying_socket|
+            dying = MQTT::Protocol::IO::V5.new(dying_socket)
+            props = MQTT::Protocol::WillProperties.new
+            props.content_type = "text/plain"
+            props.user_properties = [{"a", "1"}]
+            will = MQTT::Protocol::Will.new(topic: "will/t", payload: "bye".to_slice,
+              qos: 1u8, retain: false, properties: props)
+            connect(dying, version: MQTT::Protocol::Version::V5,
+              client_id: "dying", will: will)
+            MQTT::Protocol::Disconnect.new(
+              MQTT::Protocol::Disconnect::ReasonCode::DisconnectWithWillMessage).to_io(dying)
+            dying.flush
+          end
+
+          pub = read_packet(sub).as(MQTT::Protocol::Publish)
+          String.new(pub.payload).should eq "bye"
+          pub.properties.content_type.should be_nil
+          pub.properties.user_properties.should be_empty
+        end
+      end
+    end
+
+    it "refuses a v5 Will above maximum_qos with QoSNotSupported (0x9B)" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          will = MQTT::Protocol::Will.new(topic: "will/t", payload: "x".to_slice,
+            qos: 2u8, retain: false)
+          connect(io, false, version: MQTT::Protocol::Version::V5,
+            client_id: "qos2will", will: will)
+          io.flush
+          connack = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::Connack)
+          connack.reason_code.should eq MQTT::Protocol::Connack::ReasonCode::QoSNotSupported
+          io.should be_closed
+        end
+      end
+    end
+
+    it "still accepts a v3 Will at QoS 2, clamped at delivery" do
+      # Deliberate asymmetry: v3 has no return code meaning "QoS not
+      # supported", so refusing would mean a misleading code or a bare close.
+      with_server do |server|
+        with_client_io(server) do |sub|
+          connect(sub, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("will/t", 1u8)])
+
+          with_client_io(server) do |dying|
+            will = MQTT::Protocol::Will.new(topic: "will/t", payload: "bye".to_slice,
+              qos: 2u8, retain: false)
+            connect(dying, client_id: "dying", will: will)
+            dying.io.close # ungraceful, so the will fires
+          end
+
+          pub = read_packet(sub).as(MQTT::Protocol::Publish)
+          String.new(pub.payload).should eq "bye"
+          pub.qos.should eq 1u8
+        end
+      end
+    end
+
     it "No Local suppresses a will sent to the dying client's own session" do
       # The will's publisher is the connection that died, so [MQTT-3.8.3-3]
       # applies to it like any other publish. Worth pinning down because the

--- a/spec/mqtt/integrations/will_spec.cr
+++ b/spec/mqtt/integrations/will_spec.cr
@@ -167,6 +167,36 @@ module MqttSpecs
       end
     end
 
+    it "No Local suppresses a will sent to the dying client's own session" do
+      # The will's publisher is the connection that died, so [MQTT-3.8.3-3]
+      # applies to it like any other publish. Worth pinning down because the
+      # ordering is not obvious: a takeover closes the previous connection
+      # (publishing its will) while that connection's session is still
+      # attached and still holds the no_local binding, so the will is dropped.
+      with_server do |server|
+        will = MQTT::Protocol::Will.new(
+          topic: "last/words", payload: "bye".to_slice, qos: 1u8, retain: false)
+
+        props = MQTT::Protocol::ConnectProperties.new
+        props.session_expiry_interval = 3600u32
+        with_client_socket(server) do |first_socket|
+          first = MQTT::Protocol::IO::V5.new(first_socket)
+          connect(first, version: MQTT::Protocol::Version::V5, client_id: "sub",
+            clean_session: false, will: will, properties: props)
+          subscribe(first, topic_filters: [subtopic("last/words", 1u8, no_local: true)])
+
+          # A second connection with the same client id takes over, which closes
+          # the first and publishes its will.
+          with_client_socket(server) do |second_socket|
+            second = MQTT::Protocol::IO::V5.new(second_socket)
+            connect(second, version: MQTT::Protocol::Version::V5, client_id: "sub",
+              clean_session: false, properties: props)
+            second.should be_drained
+          end
+        end
+      end
+    end
+
     it "retain can't be set of will flag is unset [MQTT-3.1.2-15]" do
       with_server do |server|
         with_client_io(server) do |io|

--- a/spec/mqtt/oauth_expiration_spec.cr
+++ b/spec/mqtt/oauth_expiration_spec.cr
@@ -10,7 +10,7 @@ module MqttSpecs
       with_server do |server|
         # Create a pipe pair to simulate the MQTT socket
         reader, writer = IO.pipe
-        mqtt_io = MQTT::Protocol::IO.new(reader)
+        mqtt_io = MQTT::Protocol::IO::V3.new(reader)
         conn_info = LavinMQ::ConnectionInfo.local
 
         # Create OAuthUser with a very short-lived token
@@ -43,7 +43,7 @@ module MqttSpecs
     it "does not disconnect client when token is still valid" do
       with_server do |server|
         reader, writer = IO.pipe
-        mqtt_io = MQTT::Protocol::IO.new(reader)
+        mqtt_io = MQTT::Protocol::IO::V3.new(reader)
         conn_info = LavinMQ::ConnectionInfo.local
 
         # Create OAuthUser with a long-lived token

--- a/spec/mqtt/oauth_spec.cr
+++ b/spec/mqtt/oauth_spec.cr
@@ -9,7 +9,7 @@ module MqttSpecs
     it "allows connection with wildcard vhost permissions" do
       with_server do |server|
         reader, writer = IO.pipe
-        mqtt_io = MQTT::Protocol::IO.new(reader)
+        mqtt_io = MQTT::Protocol::IO::V3.new(reader)
         conn_info = LavinMQ::ConnectionInfo.local
 
         # OAuthUser with wildcard vhost "*" should match default vhost "/"
@@ -41,7 +41,7 @@ module MqttSpecs
     it "allows connection with exact vhost permissions" do
       with_server do |server|
         reader, writer = IO.pipe
-        mqtt_io = MQTT::Protocol::IO.new(reader)
+        mqtt_io = MQTT::Protocol::IO::V3.new(reader)
         conn_info = LavinMQ::ConnectionInfo.local
 
         permissions = {"/" => {config: /.*/, read: /.*/, write: /.*/}}
@@ -71,7 +71,7 @@ module MqttSpecs
     it "cleans up OAuthUser on disconnect" do
       with_server do |server|
         reader, writer = IO.pipe
-        mqtt_io = MQTT::Protocol::IO.new(reader)
+        mqtt_io = MQTT::Protocol::IO::V3.new(reader)
         conn_info = LavinMQ::ConnectionInfo.local
 
         permissions = {"/" => {config: /.*/, read: /.*/, write: /.*/}}

--- a/spec/mqtt/protocol_version_spec.cr
+++ b/spec/mqtt/protocol_version_spec.cr
@@ -6,7 +6,7 @@ module MqttSpecs
     it "reports MQTT 3.1.1 for protocol level 4" do
       with_server do |server|
         with_client_io(server) do |io|
-          connect(io, version: 4u8)
+          connect(io, version: MQTT::Protocol::Version::V3_1_1)
           conn = wait_for { server.connections.first?.as?(LavinMQ::MQTT::Client) }
           conn.details_tuple[:protocol].should eq "MQTT 3.1.1"
         end
@@ -16,7 +16,7 @@ module MqttSpecs
     it "reports MQTT 3.1 for protocol level 3 (MQIsdp)" do
       with_server do |server|
         with_client_io(server) do |io|
-          connect(io, version: 3u8)
+          connect(io, version: MQTT::Protocol::Version::V3_1)
           conn = wait_for { server.connections.first?.as?(LavinMQ::MQTT::Client) }
           conn.details_tuple[:protocol].should eq "MQTT 3.1"
         end
@@ -26,7 +26,7 @@ module MqttSpecs
     it "keeps the negotiated version when the client id is auto-assigned" do
       with_server do |server|
         with_client_io(server) do |io|
-          connect(io, version: 3u8, client_id: "", clean_session: true)
+          connect(io, version: MQTT::Protocol::Version::V3_1, client_id: "", clean_session: true)
           conn = wait_for { server.connections.first?.as?(LavinMQ::MQTT::Client) }
           conn.details_tuple[:protocol].should eq "MQTT 3.1"
         end

--- a/spec/mqtt/publish_headers_spec.cr
+++ b/spec/mqtt/publish_headers_spec.cr
@@ -1,0 +1,58 @@
+require "./spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+
+  # `restore` is not only fed headers that `store` wrote: definitions_store
+  # resolves a bind target as `@queues[name]? || @sessions[name]?`, so an AMQP
+  # client can bind `mqtt.<client-id>` to `amq.topic` and publish anything. A
+  # raise in here is requeued and re-raised by Session#get_packet, which poisons
+  # the queue permanently, so every field has to degrade instead.
+  describe LavinMQ::MQTT::PublishHeaders do
+    describe ".restore" do
+      it "drops a message_expiry_interval that is negative" do
+        headers = LavinMQ::AMQP::Table.new({"mqtt.message_expiry_interval" => -1_i32})
+        props = LavinMQ::MQTT::PublishHeaders.restore(headers)
+        props.message_expiry_interval.should be_nil
+      end
+
+      it "drops a message_expiry_interval that overflows UInt32" do
+        headers = LavinMQ::AMQP::Table.new({"mqtt.message_expiry_interval" => Int64::MAX})
+        props = LavinMQ::MQTT::PublishHeaders.restore(headers)
+        props.message_expiry_interval.should be_nil
+      end
+
+      it "keeps a valid message_expiry_interval" do
+        headers = LavinMQ::AMQP::Table.new({"mqtt.message_expiry_interval" => 3600_i32})
+        props = LavinMQ::MQTT::PublishHeaders.restore(headers)
+        props.message_expiry_interval.should eq 3600u32
+      end
+
+      it "drops a response_topic containing wildcards [MQTT-3.3.2-14]" do
+        %w[a/# a/+/b # +].each do |topic|
+          headers = LavinMQ::AMQP::Table.new({"mqtt.response_topic" => topic})
+          LavinMQ::MQTT::PublishHeaders.restore(headers).response_topic.should be_nil
+        end
+      end
+
+      it "keeps a wildcard-free response_topic" do
+        headers = LavinMQ::AMQP::Table.new({"mqtt.response_topic" => "reply/here"})
+        LavinMQ::MQTT::PublishHeaders.restore(headers).response_topic.should eq "reply/here"
+      end
+
+      it "round-trips what store wrote" do
+        stored = MQTT::Protocol::PublishProperties.new
+        stored.payload_format_indicator = true
+        stored.message_expiry_interval = 120u32
+        stored.response_topic = "reply/here"
+        stored.correlation_data = Bytes[1, 2, 3]
+        stored.content_type = "application/json"
+        stored.user_properties = [{"a", "1"}, {"b", "2"}, {"a", "3"}]
+
+        headers = LavinMQ::AMQP::Table.new
+        LavinMQ::MQTT::PublishHeaders.store(stored, headers)
+        LavinMQ::MQTT::PublishHeaders.restore(headers).should eq stored
+      end
+    end
+  end
+end

--- a/spec/mqtt/server_spec.cr
+++ b/spec/mqtt/server_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 private def connect_mqtt(port : Int32, client_id = "mqtt-server-spec")
   socket = TCPSocket.new("127.0.0.1", port, connect_timeout: 5)
-  mqtt_io = MQTT::Protocol::IO.new(socket)
+  mqtt_io = MQTT::Protocol::IO::V3.new(socket)
   MQTT::Protocol::Connect.new(
     client_id: client_id,
     clean_session: true,

--- a/spec/mqtt/session_spec.cr
+++ b/spec/mqtt/session_spec.cr
@@ -3,6 +3,15 @@ require "./spec_helper"
 module MqttSpecs
   extend MqttHelpers
 
+  # Sessions are only rebuilt as sessions when x-queue-type is present, so every
+  # hand-declared session needs it alongside whatever is under test.
+  private def self.session_args(expiry : ::AMQ::Protocol::Field = nil)
+    args = LavinMQ::AMQP::Table.new
+    args["x-queue-type"] = "mqtt"
+    args[LavinMQ::MQTT::SESSION_EXPIRY_ARG] = expiry unless expiry.nil?
+    args
+  end
+
   describe LavinMQ::MQTT::Session do
     describe "#arguments" do
       it "reports the arguments the session was declared with" do
@@ -25,6 +34,30 @@ module MqttSpecs
             server.vhosts["/"].session("mqtt.client_id")
               .arguments["x-queue-type"]?.should eq "mqtt"
             disconnect(io)
+          end
+        end
+      end
+    end
+
+    describe "#session_expiry_interval" do
+      it "is read from the queue arguments" do
+        with_server do |server|
+          vhost = server.vhosts["/"]
+          vhost.declare_queue("mqtt.expiry", true, false, session_args(60))
+          vhost.session("mqtt.expiry").session_expiry_interval.should eq 60u32
+        end
+      end
+
+      it "falls back to the declare flag when the argument is unusable" do
+        # Reachable from an AMQP client declaring mqtt.<id> by hand, so every
+        # branch has to land somewhere sane rather than raise.
+        with_server do |server|
+          vhost = server.vhosts["/"]
+          [-5, Int64::MAX, "3600"].each_with_index do |value, i|
+            name = "mqtt.bad#{i}"
+            vhost.declare_queue(name, true, false, session_args(value))
+            # auto_delete false, so the pre-expiry meaning of the flag: forever.
+            vhost.session(name).session_expiry_interval.should eq UInt32::MAX
           end
         end
       end

--- a/spec/mqtt/session_spec.cr
+++ b/spec/mqtt/session_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+
+  describe LavinMQ::MQTT::Session do
+    describe "#arguments" do
+      it "reports the arguments the session was declared with" do
+        with_server do |server|
+          vhost = server.vhosts["/"]
+          args = LavinMQ::AMQP::Table.new({"x-queue-type" => "mqtt", "x-spec" => "kept"})
+          vhost.declare_queue("mqtt.args", true, false, args)
+          vhost.session("mqtt.args").arguments["x-spec"]?.should eq "kept"
+        end
+      end
+
+      it "carries x-queue-type so a persisted session is rebuilt as a session" do
+        # definitions_store compaction writes `s.arguments` into the replayed
+        # Queue::Declare frame, and QueueFactory decides Session vs AMQP::Queue
+        # by looking for this key in it.
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, clean_session: false)
+            subscribe(io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+            server.vhosts["/"].session("mqtt.client_id")
+              .arguments["x-queue-type"]?.should eq "mqtt"
+            disconnect(io)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/spec_helper/mqtt_client_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_client_spec.cr
@@ -12,7 +12,7 @@ module MqttHelpers
 
     def initialize(io : IO)
       @client_id = ""
-      @io = MQTT::Protocol::IO.new(io)
+      @io = MQTT::Protocol::IO::V3.new(io)
       @packet_id_generator = (0u16..).each
     end
 

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -56,12 +56,12 @@ module MqttHelpers
 
   def with_client_io(server)
     socket = with_client_socket(server)
-    MQTT::Protocol::IO.new(socket)
+    MQTT::Protocol::IO::V3.new(socket)
   end
 
   def with_client_io(server, &)
     with_client_socket(server) do |io|
-      with MqttHelpers yield MQTT::Protocol::IO.new(io)
+      with MqttHelpers yield MQTT::Protocol::IO::V3.new(io)
     end
   end
 

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -97,8 +97,10 @@ module MqttHelpers
     MQTT::Protocol::Packet.from_io(io) if expect_response
   end
 
-  def subtopic(topic : String, qos = 0)
-    MQTT::Protocol::Subscribe::TopicFilter.new(topic, qos.to_u8)
+  def subtopic(topic : String, qos = 0, no_local = false,
+               retain_as_published = false, retain_handling = 0)
+    MQTT::Protocol::Subscribe::TopicFilter.new(topic, qos.to_u8,
+      no_local, retain_as_published, retain_handling.to_u8)
   end
 
   def publish_packet(**args) : MQTT::Protocol::Publish

--- a/spec/mqtt/spec_helper/mqtt_protocol_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_protocol_spec.cr
@@ -3,7 +3,7 @@ module MQTT
     abstract struct Packet
       def to_slice
         io = ::IO::Memory.new
-        to_io(IO.new(io))
+        to_io(IO::V3.new(io))
         io.rewind
         io.to_slice
       end

--- a/spec/mqtt/subscription_key_spec.cr
+++ b/spec/mqtt/subscription_key_spec.cr
@@ -18,6 +18,37 @@ describe LavinMQ::MQTT::SubscriptionKey do
     end
   end
 
+  describe "#arguments with subscription options" do
+    # This is the definitions-compaction guard. `compact!` does not replay the
+    # original Queue::Bind frames, it re-derives every binding from
+    # `bindings_details` -> `SubscriptionKey#arguments`, so anything this
+    # method cannot reconstruct survives a plain restart and then vanishes at
+    # the first compaction.
+    it "renders No Local" do
+      key = LavinMQ::MQTT::SubscriptionKey.new("a/b",
+        LavinMQ::MQTT::SubscriptionOptions.new(1u8, no_local: true))
+      key.arguments.not_nil![LavinMQ::MQTT::NO_LOCAL_HEADER].should be_true
+    end
+
+    it "renders Retain As Published" do
+      key = LavinMQ::MQTT::SubscriptionKey.new("a/b",
+        LavinMQ::MQTT::SubscriptionOptions.new(1u8, retain_as_published: true))
+      key.arguments.not_nil![LavinMQ::MQTT::RETAIN_AS_PUBLISHED_HEADER].should be_true
+    end
+
+    it "round-trips through subscription_options" do
+      options = LavinMQ::MQTT::SubscriptionOptions.new(1u8,
+        no_local: true, retain_as_published: true)
+      key = LavinMQ::MQTT::SubscriptionKey.new("a/b", options)
+      LavinMQ::MQTT.subscription_options(key.arguments).should eq options
+    end
+
+    it "still returns the shared constant for a subscription with no options" do
+      LavinMQ::MQTT::SubscriptionKey.new("a/b", 1u8).arguments
+        .should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+    end
+  end
+
   describe "#properties_key" do
     it "returns ~ for an empty topic filter" do
       LavinMQ::MQTT::SubscriptionKey.new("", 0u8).properties_key.should eq "~"

--- a/spec/mqtt/subscription_tree_spec.cr
+++ b/spec/mqtt/subscription_tree_spec.cr
@@ -194,8 +194,8 @@ describe LavinMQ::MQTT::SubscriptionTree do
     end
 
     calls = 0
-    tree.each_entry "a/b" do |_session, qos, _filter|
-      qos.should eq 0u8
+    tree.each_entry "a/b" do |_session, options, _filter|
+      options.qos.should eq 0u8
       calls += 1
     end
     calls.should eq 4
@@ -223,7 +223,7 @@ describe LavinMQ::MQTT::SubscriptionTree do
       end
     end
     calls = 0
-    tree.each_entry "a/b" do |_session, _qos, _filter|
+    tree.each_entry "a/b" do |_session, _options, _filter|
       calls += 1
     end
     calls.should eq 2
@@ -233,9 +233,9 @@ describe LavinMQ::MQTT::SubscriptionTree do
     tree = LavinMQ::MQTT::SubscriptionTree(String).new
     session = "session"
     tree.subscribe("a/b", session, 0u8)
-    tree.each_entry "a/b" { |_sess, qos, _filter| qos.should eq 0u8 }
+    tree.each_entry "a/b" { |_sess, options, _filter| options.qos.should eq 0u8 }
     tree.subscribe("a/b", session, 1u8)
-    tree.each_entry "a/b" { |_sess, qos, _filter| qos.should eq 1u8 }
+    tree.each_entry "a/b" { |_sess, options, _filter| options.qos.should eq 1u8 }
   end
 
   it "matches topic levels with multibyte UTF-8 characters" do
@@ -272,7 +272,7 @@ describe LavinMQ::MQTT::SubscriptionTree do
     end
 
     calls = 0
-    tree.each_entry do |_session, _qos, _filter|
+    tree.each_entry do |_session, _options, _filter|
       calls += 1
     end
     calls.should eq 7

--- a/spec/mqtt/v5/connect_spec.cr
+++ b/spec/mqtt/v5/connect_spec.cr
@@ -4,6 +4,21 @@ module MqttSpecs
   extend MqttHelpers
   extend MqttMatchers
   describe "MQTT 5.0 connect" do
+    it "rejects enhanced authentication with BadAuthenticationMethod (0x8C)" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          # A CONNECT carrying an Authentication Method wants the AUTH-packet
+          # flow, which we don't support -> CONNACK 0x8C [MQTT-4.12].
+          props = MQTT::Protocol::ConnectProperties.new
+          props.authentication_method = "SCRAM-SHA-1"
+          connack = connect(io, version: MQTT::Protocol::Version::V5,
+            properties: props).as(MQTT::Protocol::Connack)
+          connack.reason_code.should eq(MQTT::Protocol::Connack::ReasonCode::BadAuthenticationMethod)
+        end
+      end
+    end
+
     it "negotiates the protocol version from CONNECT and replies with a v5 CONNACK" do
       with_server do |server|
         with_client_socket(server) do |socket|

--- a/spec/mqtt/v5/connect_spec.cr
+++ b/spec/mqtt/v5/connect_spec.cr
@@ -34,5 +34,35 @@ module MqttSpecs
         end
       end
     end
+
+    it "echoes a server-assigned client id via assigned_client_identifier [MQTT-3.2.2-16]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connack = connect(io, version: MQTT::Protocol::Version::V5,
+            client_id: "", clean_session: true).as(MQTT::Protocol::Connack)
+          assigned = connack.properties.assigned_client_identifier
+          assigned.should_not be_nil
+          assigned = assigned.not_nil!
+          assigned.should_not be_empty
+          # The advertised id must be the one the broker actually registered.
+          registered = wait_for do
+            server.vhosts["/"].connections.select(LavinMQ::MQTT::Client).first?.try(&.client_id)
+          end
+          registered.should eq(assigned)
+        end
+      end
+    end
+
+    it "does not set assigned_client_identifier when the client supplies a client id" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connack = connect(io, version: MQTT::Protocol::Version::V5,
+            client_id: "supplied-id").as(MQTT::Protocol::Connack)
+          connack.properties.assigned_client_identifier.should be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/v5/connect_spec.cr
+++ b/spec/mqtt/v5/connect_spec.cr
@@ -1,0 +1,38 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+  describe "MQTT 5.0 connect" do
+    it "negotiates the protocol version from CONNECT and replies with a v5 CONNACK" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          # A v5 CONNECT must be answered with a v5-framed CONNACK; if the
+          # broker kept v3 framing the reply would be unparseable here.
+          connack = connect(io, version: MQTT::Protocol::Version::V5)
+          connack.should be_a(MQTT::Protocol::Connack)
+          connack = connack.as(MQTT::Protocol::Connack)
+          connack.reason_code.should eq(MQTT::Protocol::Connack::ReasonCode::Success)
+        end
+      end
+    end
+
+    it "advertises server capabilities in the v5 CONNACK" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connack = connect(io, version: MQTT::Protocol::Version::V5).as(MQTT::Protocol::Connack)
+          props = connack.properties
+          props.maximum_qos.should eq(1u8)
+          props.retain_available.should be_true
+          props.wildcard_subscription_available.should be_true
+          props.topic_alias_maximum.should eq(0u16)
+          props.subscription_identifier_available.should be_false
+          props.shared_subscription_available.should be_false
+          props.maximum_packet_size.should eq(LavinMQ::Config.instance.mqtt_max_packet_size)
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/v5/puback_disconnect_spec.cr
+++ b/spec/mqtt/v5/puback_disconnect_spec.cr
@@ -1,0 +1,218 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  private def self.v5_connect(socket, **args)
+    io = MQTT::Protocol::IO::V5.new(socket)
+    connect(io, **{version: MQTT::Protocol::Version::V5}.merge(args))
+    io
+  end
+
+  private def self.send_disconnect(io, reason : MQTT::Protocol::Disconnect::ReasonCode)
+    MQTT::Protocol::Disconnect.new(reason).to_io(io)
+    io.flush
+  end
+
+  private def self.will(topic = "will/t", payload = "dead")
+    MQTT::Protocol::Will.new(topic: topic, payload: payload.to_slice, qos: 0u8, retain: false)
+  end
+
+  describe "MQTT 5.0 PUBACK" do
+    it "answers NoMatchingSubscribers when nothing is subscribed [MQTT-3.4.2.1]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket)
+          publish(io, false, topic: "no/subs", qos: 1u8, packet_id: 1u16)
+          io.flush
+          ack = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::PubAck)
+          ack.packet_id.should eq 1u16
+          ack.reason_code.should eq MQTT::Protocol::PubAck::ReasonCode::NoMatchingSubscribers
+        end
+      end
+    end
+
+    it "answers Success when the message matched a subscriber" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = v5_connect(sub_socket, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("has/subs", 1)], packet_id: 1u16)
+
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, false, topic: "has/subs", qos: 1u8, packet_id: 2u16)
+            pub.flush
+            ack = MQTT::Protocol::Packet.from_io(pub).as(MQTT::Protocol::PubAck)
+            ack.reason_code.should eq MQTT::Protocol::PubAck::ReasonCode::Success
+          end
+        end
+      end
+    end
+
+    it "keeps the v3 PUBACK a bare packet id on the wire" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V3.new(socket)
+          connect(io)
+          publish(io, false, topic: "no/subs", qos: 1u8, packet_id: 7u16)
+          io.flush
+          # 0x40, remaining length 2, packet id - no reason byte, no property
+          # length. A v5-only reason code must never leak onto a v3 connection.
+          buf = Bytes.new(4)
+          socket.read_fully(buf)
+          buf.should eq Bytes[0x40, 0x02, 0x00, 0x07]
+        end
+      end
+    end
+
+    it "acks the message even when the client PUBACK carries an error reason" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = v5_connect(sub_socket, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+
+          with_client_io(server) do |pub|
+            connect(pub, client_id: "publisher")
+            publish(pub, topic: "a/b", qos: 0u8)
+            disconnect(pub)
+          end
+
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          packet_id = delivered.packet_id.should_not be_nil
+          MQTT::Protocol::PubAck.new(
+            packet_id, MQTT::Protocol::PubAck::ReasonCode::UnspecifiedError).to_io(sub)
+          sub.flush
+          pingpong(sub)
+
+          session = server.vhosts["/"].session("mqtt.sub")
+          session.ack_count.should eq 1
+          session.unacked_count.should eq 0
+        end
+      end
+    end
+  end
+
+  describe "MQTT 5.0 client DISCONNECT" do
+    it "publishes the will on reason 0x04 DisconnectWithWillMessage [MQTT-3.14.4-3]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"will/t", 0}))
+
+          with_client_socket(server) do |socket|
+            v5 = v5_connect(socket, client_id: "will_client", will: will)
+            send_disconnect(v5, MQTT::Protocol::Disconnect::ReasonCode::DisconnectWithWillMessage)
+          end
+
+          pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
+          pub.topic.should eq "will/t"
+          pub.payload.should eq "dead".to_slice
+          disconnect(io)
+        end
+      end
+    end
+
+    it "publishes the will on an error reason code" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"will/t", 0}))
+
+          with_client_socket(server) do |socket|
+            v5 = v5_connect(socket, client_id: "will_client", will: will)
+            send_disconnect(v5, MQTT::Protocol::Disconnect::ReasonCode::UnspecifiedError)
+          end
+
+          pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
+          pub.topic.should eq "will/t"
+          pub.payload.should eq "dead".to_slice
+          disconnect(io)
+        end
+      end
+    end
+
+    it "discards the will on reason 0x00 NormalDisconnection [MQTT-3.14.4-3]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"#", 0}))
+
+          with_client_socket(server) do |socket|
+            v5 = v5_connect(socket, client_id: "will_client", will: will)
+            send_disconnect(v5, MQTT::Protocol::Disconnect::ReasonCode::NormalDisconnection)
+          end
+
+          # A published will would arrive before this sentinel
+          publish(io, topic: "a/b", payload: "alive".to_slice)
+
+          pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
+          pub.topic.should eq "a/b"
+          pub.payload.should eq "alive".to_slice
+          disconnect(io)
+        end
+      end
+    end
+  end
+
+  describe "MQTT 5.0 NotAuthorized reason codes" do
+    before_each do
+      LavinMQ::Config.instance.mqtt_permission_check_enabled = true
+    end
+
+    after_each do
+      LavinMQ::Config.instance.mqtt_permission_check_enabled = false
+    end
+
+    it "answers PUBACK NotAuthorized and keeps the connection open" do
+      with_server do |server|
+        server.users.create("no_write", "pass")
+        server.users.add_permission("no_write", "/", /.*/, /.*/, /^$/)
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, username: "no_write", password: "pass".to_slice)
+          publish(io, false, topic: "test/topic", qos: 1u8, packet_id: 1u16)
+          io.flush
+          ack = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::PubAck)
+          ack.reason_code.should eq MQTT::Protocol::PubAck::ReasonCode::NotAuthorized
+          # 3.3.4 lets us refuse a single PUBLISH without tearing down the session
+          pingpong(io)
+        end
+      end
+    end
+
+    it "answers DISCONNECT NotAuthorized for a QoS 0 publish, which has no ack" do
+      with_server do |server|
+        server.users.create("no_write", "pass")
+        server.users.add_permission("no_write", "/", /.*/, /.*/, /^$/)
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, username: "no_write", password: "pass".to_slice)
+          publish(io, false, topic: "test/topic", qos: 0u8)
+          io.flush
+          disc = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::Disconnect)
+          disc.reason_code.should eq MQTT::Protocol::Disconnect::ReasonCode::NotAuthorized
+        end
+      end
+    end
+
+    it "answers SUBACK NotAuthorized per topic filter" do
+      with_server do |server|
+        server.users.create("no_read", "pass")
+        server.users.add_permission("no_read", "/", /.*/, /^$/, /^$/)
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, username: "no_read", password: "pass".to_slice)
+          subscribe(io, false, topic_filters: [subtopic("a/b", 0), subtopic("c/d", 1)], packet_id: 1u16)
+          io.flush
+          suback = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::SubAck)
+          suback.packet_id.should eq 1u16
+          suback.reason_codes.should eq [
+            MQTT::Protocol::SubAck::ReasonCode::NotAuthorized,
+            MQTT::Protocol::SubAck::ReasonCode::NotAuthorized,
+          ]
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/v5/puback_disconnect_spec.cr
+++ b/spec/mqtt/v5/puback_disconnect_spec.cr
@@ -74,7 +74,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub|
             connect(pub, client_id: "publisher")
-            publish(pub, topic: "a/b", qos: 0u8)
+            publish(pub, topic: "a/b", qos: 1u8)
             disconnect(pub)
           end
 

--- a/spec/mqtt/v5/puback_disconnect_spec.cr
+++ b/spec/mqtt/v5/puback_disconnect_spec.cr
@@ -215,4 +215,39 @@ module MqttSpecs
       end
     end
   end
+
+  describe "MQTT 5.0 unexpected packets" do
+    it "answers DISCONNECT ProtocolError (0x82) to a client-sent PINGRESP" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket)
+
+          # PINGRESP is server-to-client only, so a client sending one is a
+          # protocol error rather than something we should log a backtrace for.
+          MQTT::Protocol::PingResp.new.to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::ProtocolError)
+        end
+      end
+    end
+
+    it "answers DISCONNECT ProtocolError (0x82) to a second CONNECT [MQTT-3.1.0-2]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket)
+          connect(io, expect_response: false, version: MQTT::Protocol::Version::V5)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::ProtocolError)
+        end
+      end
+    end
+  end
 end

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -124,11 +124,10 @@ module MqttSpecs
           io = MQTT::Protocol::IO::V5.new(socket)
           connect(io, version: MQTT::Protocol::Version::V5)
 
-          # An empty topic is only valid with an alias to resolve it; we allow none.
-          MQTT::Protocol::Publish.new(
-            topic: "", payload: "x".to_slice,
-            packet_id: 1u16, dup: false, qos: 1u8, retain: false,
-          ).to_io(io)
+          # The shard refuses to encode an empty-topic PUBLISH, so send raw bytes
+          # for a v5 QoS 0 PUBLISH with an empty topic, empty properties, payload
+          # "x": [0x30, remaining=4, topic-len=0x0000, props-len=0x00, 'x'].
+          io.write_bytes_raw(Bytes[0x30, 0x04, 0x00, 0x00, 0x00, 0x78])
           io.flush
 
           pkt = MQTT::Protocol::Packet.from_io(io)

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -4,6 +4,75 @@ module MqttSpecs
   extend MqttHelpers
   extend MqttMatchers
   describe "MQTT 5.0 publish" do
+    it "passes v5 PUBLISH properties through to a v5 subscriber, preserving user-property order" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("test/topic", 1)], packet_id: 1u16)
+
+          props = MQTT::Protocol::PublishProperties.new
+          props.payload_format_indicator = true
+          props.message_expiry_interval = 3600u32
+          props.response_topic = "reply/here"
+          props.correlation_data = Bytes[1, 2, 3]
+          props.content_type = "application/json"
+          # order + a duplicate key, both of which must survive [MQTT-3.3.2-17/18]
+          props.user_properties = [{"a", "1"}, {"b", "2"}, {"a", "3"}]
+
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            MQTT::Protocol::Publish.new(
+              topic: "test/topic", payload: "hello".to_slice,
+              packet_id: 2u16, dup: false, qos: 1u8, retain: false, properties: props,
+            ).to_io(pub)
+            pub.flush
+            MQTT::Protocol::Packet.from_io(pub).should be_a(MQTT::Protocol::PubAck)
+          end
+
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          dp = delivered.properties
+          dp.payload_format_indicator.should be_true
+          dp.message_expiry_interval.should eq(3600u32)
+          dp.response_topic.should eq("reply/here")
+          dp.correlation_data.should eq(Bytes[1, 2, 3])
+          dp.content_type.should eq("application/json")
+          dp.user_properties.should eq([{"a", "1"}, {"b", "2"}, {"a", "3"}])
+        end
+      end
+    end
+
+    it "delivers a v5-published message to a v3 subscriber without leaking v5 properties" do
+      with_server do |server|
+        with_client_io(server) do |sub| # v3 subscriber
+          connect(sub)
+          subscribe(sub, topic_filters: [subtopic("test/topic", 1)], packet_id: 1u16)
+
+          props = MQTT::Protocol::PublishProperties.new
+          props.content_type = "application/json"
+          props.user_properties = [{"a", "1"}]
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            MQTT::Protocol::Publish.new(
+              topic: "test/topic", payload: "hi".to_slice,
+              packet_id: 2u16, dup: false, qos: 1u8, retain: false, properties: props,
+            ).to_io(pub)
+            pub.flush
+            MQTT::Protocol::Packet.from_io(pub).should be_a(MQTT::Protocol::PubAck)
+          end
+
+          # v3 framing carries no properties section; the packet must still be
+          # well-formed with the right payload/topic (properties must not corrupt it).
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          String.new(delivered.payload).should eq("hi")
+          delivered.topic.should eq("test/topic")
+          delivered.properties.user_properties.should be_empty
+        end
+      end
+    end
+
     it "disconnects with QoSNotSupported (0x9B) when a client publishes QoS 2" do
       with_server do |server|
         with_client_socket(server) do |socket|

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -246,5 +246,32 @@ module MqttSpecs
         end
       end
     end
+
+    it "delivers at the minimum of publish and subscription qos [MQTT-3.8.4-8]" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("test/topic", 1)], packet_id: 1u16)
+
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            publish(pub, topic: "test/topic", qos: 0u8)
+            publish(pub, topic: "test/topic", qos: 1u8, packet_id: 2u16)
+          end
+
+          # The qos1 subscription must not upgrade the qos0 publish, so the first
+          # delivery carries no packet id and is not ackable.
+          first = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          first.qos.should eq(0u8)
+          first.packet_id.should be_nil
+          second = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          second.qos.should eq(1u8)
+          second.packet_id.should_not be_nil
+          puback(sub, second.packet_id)
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+  describe "MQTT 5.0 publish" do
+    it "disconnects with QoSNotSupported (0x9B) when a client publishes QoS 2" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # We advertised maximum_qos=1, so a QoS 2 PUBLISH is a protocol error
+          # [MQTT-3.2.2] -> the server must answer with DISCONNECT 0x9B and close.
+          MQTT::Protocol::Publish.new(
+            topic: "test/topic", payload: "x".to_slice,
+            packet_id: 1u16, dup: false, qos: 2u8, retain: false,
+          ).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::QoSNotSupported)
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -73,6 +73,115 @@ module MqttSpecs
       end
     end
 
+    it "does not deliver a PUBLISH exceeding the subscriber's Maximum Packet Size" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          props = MQTT::Protocol::ConnectProperties.new
+          props.maximum_packet_size = 50u32
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub", properties: props)
+          subscribe(sub, topic_filters: [subtopic("t", 1)], packet_id: 1u16)
+
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            publish(pub, topic: "t", payload: Bytes.new(200, 0u8), qos: 1u8) # over 50 -> dropped
+            publish(pub, topic: "t", payload: "ok".to_slice, qos: 1u8)       # under 50 -> delivered
+          end
+
+          # The oversized message is discarded [MQTT-3.1.2-25]; the subscriber
+          # receives only the small one, and the big one is not redelivered.
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          String.new(delivered.payload).should eq("ok")
+          read_packet(sub).should be_nil
+        end
+      end
+    end
+
+    it "does not deliver an oversized QoS 0 PUBLISH exceeding the subscriber's Maximum Packet Size" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          props = MQTT::Protocol::ConnectProperties.new
+          props.maximum_packet_size = 50u32
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub", properties: props)
+          subscribe(sub, topic_filters: [subtopic("t", 0)], packet_id: 1u16)
+
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            publish(pub, topic: "t", payload: Bytes.new(200, 0u8), qos: 0u8) # over 50 -> dropped
+            publish(pub, topic: "t", payload: "ok".to_slice, qos: 0u8)       # under 50 -> delivered
+          end
+
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          String.new(delivered.payload).should eq("ok")
+        end
+      end
+    end
+
+    it "keeps the Maximum Packet Size of a subscriber that connected without a client id" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          props = MQTT::Protocol::ConnectProperties.new
+          props.maximum_packet_size = 50u32
+          # Empty client id: the server assigns one and rebuilds the CONNECT.
+          # The rebuild must carry the properties over, or the limit is lost.
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "",
+            clean_session: true, properties: props)
+          subscribe(sub, topic_filters: [subtopic("t", 1)], packet_id: 1u16)
+
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            publish(pub, topic: "t", payload: Bytes.new(200, 0u8), qos: 1u8) # over 50 -> dropped
+            publish(pub, topic: "t", payload: "ok".to_slice, qos: 1u8)       # under 50 -> delivered
+          end
+
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          String.new(delivered.payload).should eq("ok")
+          read_packet(sub).should be_nil
+        end
+      end
+    end
+
+    it "delivers an oversized PUBLISH when the subscriber sets no Maximum Packet Size (v5)" do
+      with_server do |server|
+        with_client_socket(server) do |sub_socket|
+          sub = MQTT::Protocol::IO::V5.new(sub_socket)
+          connect(sub, version: MQTT::Protocol::Version::V5, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("t", 1)], packet_id: 1u16)
+
+          with_client_socket(server) do |pub_socket|
+            pub = MQTT::Protocol::IO::V5.new(pub_socket)
+            connect(pub, version: MQTT::Protocol::Version::V5, client_id: "pub")
+            publish(pub, topic: "t", payload: Bytes.new(200, 7u8), qos: 1u8)
+          end
+
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          delivered.payload.size.should eq(200)
+        end
+      end
+    end
+
+    it "delivers a large PUBLISH to a v3 subscriber (no Maximum Packet Size in v3)" do
+      with_server do |server|
+        with_client_io(server) do |sub| # v3
+          connect(sub, client_id: "sub")
+          subscribe(sub, topic_filters: [subtopic("t", 1)], packet_id: 1u16)
+
+          with_client_io(server) do |pub|
+            connect(pub, client_id: "pub")
+            publish(pub, topic: "t", payload: Bytes.new(200, 3u8), qos: 1u8)
+          end
+
+          delivered = MQTT::Protocol::Packet.from_io(sub).as(MQTT::Protocol::Publish)
+          delivered.payload.size.should eq(200)
+        end
+      end
+    end
+
     it "disconnects with QoSNotSupported (0x9B) when a client publishes QoS 2" do
       with_server do |server|
         with_client_socket(server) do |socket|

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -273,5 +273,39 @@ module MqttSpecs
         end
       end
     end
+    it "delivers a message whose mqtt.* header is out of range instead of poisoning the queue" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+
+          # An AMQP client can bind mqtt.<client-id> to amq.topic and publish
+          # anything, so a header `store` would never write must not raise inside
+          # build_packet - that requeues and re-raises, force-closing the
+          # subscriber, which re-poisons on reconnect.
+          headers = LavinMQ::AMQP::Table.new({
+            "mqtt.message_expiry_interval" => -1_i32,
+            "mqtt.response_topic"          => "reply/#",
+          })
+          props = LavinMQ::AMQP::Properties.new(headers: headers, delivery_mode: 1u8)
+          body = "poison"
+          msg = LavinMQ::Message.new(RoughTime.unix_ms, LavinMQ::MQTT::EXCHANGE, "a/b",
+            props, body.bytesize.to_u64, ::IO::Memory.new(body))
+          server.vhosts["/"].session("mqtt.sub").publish(msg)
+
+          delivered = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::Publish)
+          delivered.payload.should eq("poison".to_slice)
+          delivered.properties.message_expiry_interval.should be_nil
+          delivered.properties.response_topic.should be_nil
+          puback(io, delivered.packet_id)
+          pingpong(io)
+
+          session = server.vhosts["/"].session("mqtt.sub")
+          session.unacked_count.should eq 0
+          session.message_count.should eq 0
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/v5/publish_spec.cr
+++ b/spec/mqtt/v5/publish_spec.cr
@@ -25,5 +25,49 @@ module MqttSpecs
         end
       end
     end
+
+    it "disconnects with TopicAliasInvalid (0x94) when a client sends a Topic Alias" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # We advertised topic_alias_maximum=0, so any Topic Alias is invalid.
+          props = MQTT::Protocol::PublishProperties.new
+          props.topic_alias = 1u16
+          MQTT::Protocol::Publish.new(
+            topic: "test/topic", payload: "x".to_slice,
+            packet_id: 1u16, dup: false, qos: 1u8, retain: false, properties: props,
+          ).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::TopicAliasInvalid)
+        end
+      end
+    end
+
+    it "disconnects with ProtocolError (0x82) on an empty topic with no alias" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # An empty topic is only valid with an alias to resolve it; we allow none.
+          MQTT::Protocol::Publish.new(
+            topic: "", payload: "x".to_slice,
+            packet_id: 1u16, dup: false, qos: 1u8, retain: false,
+          ).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::ProtocolError)
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/v5/session_expiry_spec.cr
+++ b/spec/mqtt/v5/session_expiry_spec.cr
@@ -114,6 +114,55 @@ module MqttSpecs
       end
     end
 
+    it "deletes the session once the interval elapses", tags: "slow" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 1u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        server.vhosts["/"].session?("mqtt.sub").should_not be_nil
+        wait_for { server.vhosts["/"].session?("mqtt.sub").nil? }
+      end
+    end
+
+    it "cancels the expiry when the client reconnects", tags: "slow" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 1u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        with_client_socket(server) do |socket|
+          v5_connect(socket, 1u32, clean_session: false, client_id: "sub")
+          # Past the interval, but attached the whole time, so the timer the
+          # previous disconnect started must have been cancelled.
+          sleep 1.5.seconds
+          server.vhosts["/"].session?("mqtt.sub").should_not be_nil
+        end
+      end
+    end
+
+    it "restores the interval and restarts the clock after a restart" do
+      # The interval persists via the queue arguments; the deadline deliberately
+      # does not, so a restored session gets its full interval again from boot.
+      with_server(clean_dir: false) do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+      end
+
+      with_server do |server|
+        session = server.vhosts["/"].session?("mqtt.sub").should_not be_nil
+        session.session_expiry_interval.should eq 3600u32
+        session.durable?.should be_true
+      end
+    end
+
     it "keeps a v3 non-clean session forever" do
       with_server do |server|
         with_client_io(server) do |io|

--- a/spec/mqtt/v5/session_expiry_spec.cr
+++ b/spec/mqtt/v5/session_expiry_spec.cr
@@ -1,0 +1,131 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  private def self.v5_connect(socket, expiry : UInt32?, **args)
+    io = MQTT::Protocol::IO::V5.new(socket)
+    props = MQTT::Protocol::ConnectProperties.new
+    props.session_expiry_interval = expiry if expiry
+    connect(io, **{version: MQTT::Protocol::Version::V5, properties: props}.merge(args))
+    io
+  end
+
+  describe "MQTT 5.0 Session Expiry Interval" do
+    it "ends the session with the connection when the interval is 0 [MQTT-3.1.2-11]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 0u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        with_client_io(server) do |pub|
+          connect(pub, client_id: "publisher")
+          publish(pub, topic: "a/b", qos: 1u8)
+          disconnect(pub)
+        end
+
+        wait_for { server.vhosts["/"].session?("mqtt.sub").nil? }
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 0u32, clean_session: false, client_id: "sub")
+          read_packet(io).should be_nil
+        end
+      end
+    end
+
+    it "ends the session with the connection when the interval is absent [MQTT-3.1.2-11]" do
+      # Absent means 0, so Clean Start = 0 alone is not enough to persist.
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, nil, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        wait_for { server.vhosts["/"].session?("mqtt.sub").nil? }
+      end
+    end
+
+    it "persists the session when Clean Start is 1 and the interval is non-zero" do
+      # The v5 idiom for "discard any old session, but persist this one". Under
+      # the old clean-session bit this got a transient session.
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: true, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        session = server.vhosts["/"].session?("mqtt.sub").should_not be_nil
+        session.durable?.should be_true
+        session.session_expiry_interval.should eq 3600u32
+
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          props = MQTT::Protocol::ConnectProperties.new
+          props.session_expiry_interval = 3600u32
+          connack = connect(io, version: MQTT::Protocol::Version::V5,
+            clean_session: false, client_id: "sub", properties: props)
+            .as(MQTT::Protocol::Connack)
+          connack.session_present?.should be_true
+        end
+      end
+    end
+
+    it "delivers messages published while a non-zero-interval session was offline" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        with_client_io(server) do |pub|
+          connect(pub, client_id: "publisher")
+          publish(pub, topic: "a/b", payload: "stored".to_slice, qos: 1u8)
+          disconnect(pub)
+        end
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          pub = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::Publish)
+          pub.payload.should eq "stored".to_slice
+          puback(io, pub.packet_id)
+        end
+      end
+    end
+
+    it "adopts the interval named by a reconnecting client" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 60u32, clean_session: false, client_id: "sub")
+          server.vhosts["/"].session("mqtt.sub").session_expiry_interval.should eq 60u32
+          disconnect(io)
+        end
+      end
+    end
+
+    it "keeps a v3 non-clean session forever" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, clean_session: false, client_id: "v3sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        session = server.vhosts["/"].session?("mqtt.v3sub").should_not be_nil
+        session.session_expiry_interval.should eq UInt32::MAX
+        session.durable?.should be_true
+      end
+    end
+  end
+end

--- a/spec/mqtt/v5/session_expiry_spec.cr
+++ b/spec/mqtt/v5/session_expiry_spec.cr
@@ -163,6 +163,30 @@ module MqttSpecs
       end
     end
 
+    it "does not resurrect a session narrowed to 0 before a restart" do
+      # The deletion frame is only written for a durable session, so durable?
+      # must not follow the interval down - otherwise nothing records the delete
+      # and the original declare replays.
+      with_server(clean_dir: false) do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 0u32, clean_session: false, client_id: "sub")
+          disconnect(io)
+        end
+
+        wait_for { server.vhosts["/"].session?("mqtt.sub").nil? }
+      end
+
+      with_server do |server|
+        server.vhosts["/"].session?("mqtt.sub").should be_nil
+      end
+    end
+
     it "adopts a new interval from DISCONNECT [MQTT-3.14.2.2.2]" do
       with_server do |server|
         with_client_socket(server) do |socket|
@@ -239,6 +263,32 @@ module MqttSpecs
           pub.payload.should eq "dead".to_slice
           read_packet(watcher).should be_nil
         end
+      end
+    end
+
+    it "stays durable when a resuming client narrows the interval to 0" do
+      # durable? was fixed when the message store was built; only auto_delete?
+      # and the clock follow the narrowed interval.
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 0u32, clean_session: false, client_id: "sub")
+          # Round-trip a SUBSCRIBE so the server is known to be past add_client,
+          # which is where the narrowed interval is adopted.
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 2u16)
+
+          session = server.vhosts["/"].session("mqtt.sub")
+          session.session_expiry_interval.should eq 0u32
+          session.auto_delete?.should be_true
+          session.durable?.should be_true
+        end
+
+        wait_for { server.vhosts["/"].session?("mqtt.sub").nil? }
       end
     end
 

--- a/spec/mqtt/v5/session_expiry_spec.cr
+++ b/spec/mqtt/v5/session_expiry_spec.cr
@@ -163,6 +163,85 @@ module MqttSpecs
       end
     end
 
+    it "adopts a new interval from DISCONNECT [MQTT-3.14.2.2.2]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+
+          # Narrowing to 0 on the way out ends the session with this connection,
+          # which is how a client says it is done with it.
+          props = MQTT::Protocol::DisconnectProperties.new
+          props.session_expiry_interval = 0u32
+          MQTT::Protocol::Disconnect.new(
+            MQTT::Protocol::Disconnect::ReasonCode::NormalDisconnection, props).to_io(io)
+          io.flush
+        end
+
+        wait_for { server.vhosts["/"].session?("mqtt.sub").nil? }
+      end
+    end
+
+    it "keeps the CONNECT interval when DISCONNECT omits it [MQTT-3.14.2.2.2]" do
+      # Absent on DISCONNECT means "keep the CONNECT value", not 0.
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 3600u32, clean_session: false, client_id: "sub")
+          subscribe(io, topic_filters: [subtopic("a/b", 1)], packet_id: 1u16)
+          disconnect(io)
+        end
+
+        session = server.vhosts["/"].session?("mqtt.sub").should_not be_nil
+        session.session_expiry_interval.should eq 3600u32
+      end
+    end
+
+    it "answers 0x82 to a non-zero DISCONNECT interval after a zero CONNECT [MQTT-3.14.2]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = v5_connect(socket, 0u32, clean_session: false, client_id: "sub")
+
+          props = MQTT::Protocol::DisconnectProperties.new
+          props.session_expiry_interval = 60u32
+          MQTT::Protocol::Disconnect.new(
+            MQTT::Protocol::Disconnect::ReasonCode::NormalDisconnection, props).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::ProtocolError)
+        end
+      end
+    end
+
+    it "publishes the will when a DISCONNECT is rejected as a protocol error" do
+      # An invalid DISCONNECT is not a graceful one, so the will fires - and it
+      # must fire exactly once. Reason 0x04 is the case that matters: it publishes
+      # the will on its own, so handling the expiry after it would publish twice.
+      with_server do |server|
+        with_client_io(server) do |watcher|
+          connect(watcher, client_id: "watcher")
+          subscribe(watcher, topic_filters: [subtopic("will/t", 0u8)], packet_id: 9u16)
+
+          with_client_socket(server) do |socket|
+            io = v5_connect(socket, 0u32, clean_session: false, client_id: "willer",
+              will: MQTT::Protocol::Will.new(topic: "will/t", payload: "dead".to_slice,
+                qos: 0u8, retain: false))
+            props = MQTT::Protocol::DisconnectProperties.new
+            props.session_expiry_interval = 60u32
+            MQTT::Protocol::Disconnect.new(
+              MQTT::Protocol::Disconnect::ReasonCode::DisconnectWithWillMessage, props).to_io(io)
+            io.flush
+          end
+
+          pub = read_packet(watcher).as(MQTT::Protocol::Publish)
+          pub.payload.should eq "dead".to_slice
+          read_packet(watcher).should be_nil
+        end
+      end
+    end
+
     it "keeps a v3 non-clean session forever" do
       with_server do |server|
         with_client_io(server) do |io|

--- a/spec/mqtt/v5/subscribe_spec.cr
+++ b/spec/mqtt/v5/subscribe_spec.cr
@@ -25,5 +25,48 @@ module MqttSpecs
         end
       end
     end
+
+    it "disconnects with SharedSubscriptionsNotSupported (0x9E) on a $share/ filter" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # We advertised shared_subscription_available=0 [MQTT-3.2.2.3.13].
+          tf = MQTT::Protocol::Subscribe::TopicFilter.new("$share/group/test/topic", 0u8)
+          MQTT::Protocol::Subscribe.new([tf], 1u16).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::SharedSubscriptionsNotSupported)
+        end
+      end
+    end
+
+    it "disconnects on a $share/ filter even when mixed with a normal filter" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # A Shared Subscription anywhere in the packet is a packet-level
+          # protocol error -> the whole connection is disconnected, not a
+          # per-filter SUBACK reason code.
+          tfs = [
+            MQTT::Protocol::Subscribe::TopicFilter.new("plain/topic", 0u8),
+            MQTT::Protocol::Subscribe::TopicFilter.new("$share/group/test/topic", 0u8),
+          ]
+          MQTT::Protocol::Subscribe.new(tfs, 1u16).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::SharedSubscriptionsNotSupported)
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/v5/subscribe_spec.cr
+++ b/spec/mqtt/v5/subscribe_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+  describe "MQTT 5.0 subscribe" do
+    it "disconnects with SubscriptionIdentifiersNotSupported (0xA1) on a Subscription Identifier" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # We advertised subscription_identifier_available=0, so any Subscription
+          # Identifier is a protocol error -> DISCONNECT 0xA1.
+          props = MQTT::Protocol::SubscribeProperties.new
+          props.subscription_identifier = 1u32
+          tf = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+          MQTT::Protocol::Subscribe.new([tf], 1u16, props).to_io(io)
+          io.flush
+
+          pkt = MQTT::Protocol::Packet.from_io(io)
+          pkt.should be_a(MQTT::Protocol::Disconnect)
+          pkt.as(MQTT::Protocol::Disconnect).reason_code
+            .should eq(MQTT::Protocol::Disconnect::ReasonCode::SubscriptionIdentifiersNotSupported)
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/v5/subscribe_spec.cr
+++ b/spec/mqtt/v5/subscribe_spec.cr
@@ -68,5 +68,23 @@ module MqttSpecs
         end
       end
     end
+
+    it "clamps the granted QoS in SUBACK to the server maximum" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+
+          # We only deliver up to QoS 1, so a QoS 2 request is granted QoS 1
+          # [MQTT-3.8.4-7] - the SUBACK must report the granted max, not requested.
+          tf = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 2u8)
+          MQTT::Protocol::Subscribe.new([tf], 1u16).to_io(io)
+          io.flush
+
+          suback = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::SubAck)
+          suback.reason_codes.should eq([MQTT::Protocol::SubAck::ReasonCode::GrantedQoS1])
+        end
+      end
+    end
   end
 end

--- a/spec/mqtt/v5/subscription_options_spec.cr
+++ b/spec/mqtt/v5/subscription_options_spec.cr
@@ -1,0 +1,378 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  private def self.v5_connect(socket, **args)
+    io = MQTT::Protocol::IO::V5.new(socket)
+    connect(io, **{version: MQTT::Protocol::Version::V5}.merge(args))
+    io
+  end
+
+  describe "MQTT 5.0 subscription options" do
+    describe "No Local [MQTT-3.8.3-3]" do
+      it "does not deliver a message back to the client that published it" do
+        with_server do |server|
+          with_client_socket(server) do |socket|
+            io = v5_connect(socket, client_id: "self")
+            subscribe(io, topic_filters: [subtopic("a/b", 1u8, no_local: true)])
+            # QoS 1 so the PUBACK proves the publish was fully handled before
+            # we assert that nothing came back.
+            publish(io, topic: "a/b", qos: 1u8)
+            io.should be_drained
+          end
+        end
+      end
+
+      it "still delivers the message to other subscribers of the same filter" do
+        with_server do |server|
+          with_client_socket(server) do |other_socket|
+            other = v5_connect(other_socket, client_id: "other")
+            subscribe(other, topic_filters: [subtopic("a/b", 1u8)])
+
+            with_client_socket(server) do |socket|
+              io = v5_connect(socket, client_id: "self")
+              subscribe(io, topic_filters: [subtopic("a/b", 1u8, no_local: true)])
+              publish(io, topic: "a/b", qos: 1u8, payload: "hello".to_slice)
+              io.should be_drained
+            end
+
+            delivered = read_packet(other).as(MQTT::Protocol::Publish)
+            delivered.topic.should eq "a/b"
+            String.new(delivered.payload).should eq "hello"
+          end
+        end
+      end
+
+      it "delivers a client its own message when No Local is not set" do
+        # The guard against over-suppressing: this is the pre-existing
+        # behaviour and it must survive.
+        with_server do |server|
+          with_client_socket(server) do |socket|
+            io = v5_connect(socket, client_id: "self")
+            subscribe(io, topic_filters: [subtopic("a/b", 1u8)])
+            publish(io, topic: "a/b", qos: 1u8, payload: "mine".to_slice)
+            delivered = read_packet(io).as(MQTT::Protocol::Publish)
+            String.new(delivered.payload).should eq "mine"
+          end
+        end
+      end
+
+      it "suppresses only the publisher when two clients both set No Local" do
+        with_server do |server|
+          with_client_socket(server) do |a_socket|
+            a = v5_connect(a_socket, client_id: "a")
+            subscribe(a, topic_filters: [subtopic("a/b", 1u8, no_local: true)])
+
+            with_client_socket(server) do |b_socket|
+              b = v5_connect(b_socket, client_id: "b")
+              subscribe(b, topic_filters: [subtopic("a/b", 1u8, no_local: true)])
+
+              publish(b, topic: "a/b", qos: 1u8, payload: "from-b".to_slice)
+              b.should be_drained
+
+              from_b = read_packet(a).as(MQTT::Protocol::Publish)
+              String.new(from_b.payload).should eq "from-b"
+              puback(a, from_b.packet_id)
+
+              publish(a, topic: "a/b", qos: 1u8, payload: "from-a".to_slice)
+              a.should be_drained
+
+              from_a = read_packet(b).as(MQTT::Protocol::Publish)
+              String.new(from_a.payload).should eq "from-a"
+            end
+          end
+        end
+      end
+
+      it "answers NoMatchingSubscribers when the only subscriber was itself" do
+        # A visible v5 consequence: PubAck 0x10 comes from the routed count,
+        # which No Local can now legitimately drive to zero. The spec makes
+        # this reason code a MAY, so it is legal - but assert it on purpose.
+        with_server do |server|
+          with_client_socket(server) do |socket|
+            io = v5_connect(socket, client_id: "self")
+            subscribe(io, topic_filters: [subtopic("a/b", 1u8, no_local: true)])
+            publish(io, false, topic: "a/b", qos: 1u8, packet_id: 1u16)
+            io.flush
+            ack = MQTT::Protocol::Packet.from_io(io).as(MQTT::Protocol::PubAck)
+            ack.reason_code.should eq MQTT::Protocol::PubAck::ReasonCode::NoMatchingSubscribers
+          end
+        end
+      end
+    end
+
+    describe "Retain As Published" do
+      it "keeps the publisher's retain flag when set" do
+        with_server do |server|
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_as_published: true)])
+
+            with_client_socket(server) do |pub_socket|
+              pub = v5_connect(pub_socket, client_id: "pub")
+              publish(pub, topic: "a/b", qos: 1u8, retain: true)
+            end
+
+            read_packet(sub).as(MQTT::Protocol::Publish).retain?.should be_true
+          end
+        end
+      end
+
+      it "clears the retain flag when not set [MQTT-3.3.1-9]" do
+        with_server do |server|
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8)])
+
+            with_client_socket(server) do |pub_socket|
+              pub = v5_connect(pub_socket, client_id: "pub")
+              publish(pub, topic: "a/b", qos: 1u8, retain: true)
+            end
+
+            read_packet(sub).as(MQTT::Protocol::Publish).retain?.should be_false
+          end
+        end
+      end
+
+      it "does not set the retain flag for a publish that was not retained" do
+        with_server do |server|
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_as_published: true)])
+
+            with_client_socket(server) do |pub_socket|
+              pub = v5_connect(pub_socket, client_id: "pub")
+              publish(pub, topic: "a/b", qos: 1u8, retain: false)
+            end
+
+            read_packet(sub).as(MQTT::Protocol::Publish).retain?.should be_false
+          end
+        end
+      end
+
+      # The leak: the retain flag is varied per matched subscription inside one
+      # walk of the subscription tree, so writing it only for the subscriptions
+      # that asked for it would let a `true` bleed into every later subscriber.
+      # Both orders, because only one of them catches that and the tree is
+      # walked in an order these specs must not depend on.
+      it "does not leak the retain flag to a later plain subscriber" do
+        with_server do |server|
+          with_client_socket(server) do |rap_socket|
+            with_client_socket(server) do |plain_socket|
+              rap = v5_connect(rap_socket, client_id: "rap")
+              plain = v5_connect(plain_socket, client_id: "plain")
+              subscribe(rap, topic_filters: [subtopic("a/b", 1u8, retain_as_published: true)])
+              subscribe(plain, topic_filters: [subtopic("a/b", 1u8)])
+
+              with_client_socket(server) do |pub_socket|
+                pub = v5_connect(pub_socket, client_id: "pub")
+                publish(pub, topic: "a/b", qos: 1u8, retain: true)
+              end
+
+              read_packet(rap).as(MQTT::Protocol::Publish).retain?.should be_true
+              read_packet(plain).as(MQTT::Protocol::Publish).retain?.should be_false
+            end
+          end
+        end
+      end
+
+      it "does not leak the retain flag to a later RAP subscriber" do
+        with_server do |server|
+          with_client_socket(server) do |plain_socket|
+            with_client_socket(server) do |rap_socket|
+              plain = v5_connect(plain_socket, client_id: "plain")
+              rap = v5_connect(rap_socket, client_id: "rap")
+              subscribe(plain, topic_filters: [subtopic("a/b", 1u8)])
+              subscribe(rap, topic_filters: [subtopic("a/b", 1u8, retain_as_published: true)])
+
+              with_client_socket(server) do |pub_socket|
+                pub = v5_connect(pub_socket, client_id: "pub")
+                publish(pub, topic: "a/b", qos: 1u8, retain: true)
+              end
+
+              read_packet(plain).as(MQTT::Protocol::Publish).retain?.should be_false
+              read_packet(rap).as(MQTT::Protocol::Publish).retain?.should be_true
+            end
+          end
+        end
+      end
+
+      it "still sends retained messages with retain=1 at subscribe time" do
+        # Retain As Published governs forwarded messages only; a replay from the
+        # retain store always carries retain=1 [MQTT-3.3.1-8].
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "a/b", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_as_published: false)])
+            read_packet(sub).as(MQTT::Protocol::Publish).retain?.should be_true
+          end
+        end
+      end
+    end
+
+    # Beware when checking these against MQTT-v5.0-spec.txt: the body text at
+    # line 1502 governs; the Appendix B copy of [MQTT-3.3.1-10] at line 3278
+    # states the value-1 case inverted. That is an OASIS erratum.
+    describe "Retain Handling" do
+      it "sends retained messages at subscribe when 0 [MQTT-3.3.1-9]" do
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "a/b", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 0)])
+            read_packet(sub).as(MQTT::Protocol::Publish).topic.should eq "a/b"
+          end
+        end
+      end
+
+      it "never sends retained messages when 2 [MQTT-3.3.1-11]" do
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "a/b", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 2)])
+            sub.should be_drained
+            # Still nothing on a re-subscribe, new or not.
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 2)])
+            sub.should be_drained
+          end
+        end
+      end
+
+      it "sends retained messages when 1 and the subscription is new [MQTT-3.3.1-10]" do
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "a/b", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 1)])
+            read_packet(sub).as(MQTT::Protocol::Publish).topic.should eq "a/b"
+          end
+        end
+      end
+
+      it "does not send them again when 1 and the subscription exists [MQTT-3.3.1-10]" do
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "a/b", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 1)])
+            first = read_packet(sub).as(MQTT::Protocol::Publish)
+            puback(sub, first.packet_id)
+
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 1)])
+            sub.should be_drained
+          end
+        end
+      end
+
+      it "treats a re-subscribe with a different QoS as existing, not new" do
+        # [MQTT-3.8.4-3] replaces a subscription whose topic filter is
+        # identical, so a changed QoS is a replacement and not a new
+        # subscription - the subtle case, since the binding arguments differ.
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "a/b", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("a/b", 0u8, retain_handling: 1)])
+            read_packet(sub).as(MQTT::Protocol::Publish).topic.should eq "a/b"
+
+            subscribe(sub, topic_filters: [subtopic("a/b", 1u8, retain_handling: 1)])
+            sub.should be_drained
+          end
+        end
+      end
+
+      it "treats a filter equal to the session's own queue name as new" do
+        # queue_bindings prepends a synthetic default-exchange binding whose
+        # routing key is the queue name, so a client subscribing to
+        # `mqtt.<its own client id>` used to look like an existing subscription.
+        with_server do |server|
+          with_client_socket(server) do |pub_socket|
+            pub = v5_connect(pub_socket, client_id: "pub")
+            publish(pub, topic: "mqtt.sub", qos: 1u8, retain: true)
+          end
+
+          with_client_socket(server) do |sub_socket|
+            sub = v5_connect(sub_socket, client_id: "sub")
+            subscribe(sub, topic_filters: [subtopic("mqtt.sub", 1u8, retain_handling: 1)])
+            read_packet(sub).as(MQTT::Protocol::Publish).topic.should eq "mqtt.sub"
+          end
+        end
+      end
+    end
+
+    describe "persistence" do
+      it "keeps the options of a durable session's subscription across a restart" do
+        with_server do |server|
+          with_client_socket(server) do |socket|
+            io = MQTT::Protocol::IO::V5.new(socket)
+            props = MQTT::Protocol::ConnectProperties.new
+            props.session_expiry_interval = 3600u32
+            connect(io, version: MQTT::Protocol::Version::V5,
+              client_id: "sub", clean_session: false, properties: props)
+            subscribe(io, topic_filters: [
+              subtopic("a/b", 1u8, no_local: true, retain_as_published: true),
+            ])
+            disconnect(io)
+          end
+
+          restart_server(server)
+
+          exchange = server.vhosts["/"].mqtt_exchange
+          binding = exchange.bindings_details.first
+          binding.binding_key.routing_key.should eq "a/b"
+          options = binding.binding_key.as(LavinMQ::MQTT::SubscriptionKey).options
+          options.qos.should eq 1u8
+          options.no_local?.should be_true
+          options.retain_as_published?.should be_true
+        end
+      end
+    end
+
+    describe "MQTT 3.1.1" do
+      it "is unaffected: a v3 client still receives its own published messages" do
+        # The v3 wire has no options byte at all - IO::V3 rejects a SUBSCRIBE
+        # with any of bits 7-2 set - so the new code paths are structurally
+        # unreachable from v3 rather than merely defaulted.
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, client_id: "v3")
+            subscribe(io, topic_filters: [subtopic("a/b", 1u8)])
+            publish(io, topic: "a/b", qos: 1u8, retain: true)
+            delivered = read_packet(io).as(MQTT::Protocol::Publish)
+            delivered.topic.should eq "a/b"
+            # retain cleared on a forwarded message, retained replay untouched
+            delivered.retain?.should be_false
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/v5/unsubscribe_spec.cr
+++ b/spec/mqtt/v5/unsubscribe_spec.cr
@@ -1,0 +1,27 @@
+require "../spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+  describe "MQTT 5.0 unsubscribe" do
+    it "UNSUBACK carries a reason code per topic filter, in order [MQTT-3.11.3-1]" do
+      with_server do |server|
+        with_client_socket(server) do |socket|
+          io = MQTT::Protocol::IO::V5.new(socket)
+          connect(io, version: MQTT::Protocol::Version::V5)
+          subscribe(io, topic_filters: [subtopic("a/b", 0)], packet_id: 1u16)
+
+          # "a/b" was subscribed -> Success (0x00); "x/y" never was ->
+          # NoSubscriptionExisted (0x11). Order matches the topic filters.
+          unsuback = unsubscribe(io, topics: ["a/b", "x/y"], packet_id: 2u16)
+            .as(MQTT::Protocol::UnsubAck)
+          unsuback.packet_id.should eq(2u16)
+          unsuback.reason_codes.should eq([
+            MQTT::Protocol::UnsubAck::ReasonCode::Success,
+            MQTT::Protocol::UnsubAck::ReasonCode::NoSubscriptionExisted,
+          ])
+        end
+      end
+    end
+  end
+end

--- a/spec/websocket_spec.cr
+++ b/spec/websocket_spec.cr
@@ -111,7 +111,7 @@ describe "Websocket support" do
 
           ch = Channel(Nil).new
           websocket.on_binary do |bytes|
-            pkt = MQTT::Protocol::Packet.from_io(IO::Memory.new(bytes))
+            pkt = MQTT::Protocol::Packet.from_io(MQTT::Protocol::IO::V3.new(IO::Memory.new(bytes)))
             fail("received unexpected #{pkt}")
           rescue
             ch.close # close to signal "failure"
@@ -121,7 +121,7 @@ describe "Websocket support" do
           end
           spawn { websocket.run }
 
-          websocket.stream { |io| connect.to_io(MQTT::Protocol::IO.new(io)) }
+          websocket.stream { |io| connect.to_io(MQTT::Protocol::IO::V3.new(io)) }
 
           expect_raises(Channel::ClosedError) do
             select
@@ -179,7 +179,7 @@ describe "Websocket support" do
 
             ch = Channel(Nil).new
             websocket.on_binary do |bytes|
-              pkt = MQTT::Protocol::Packet.from_io(IO::Memory.new(bytes))
+              pkt = MQTT::Protocol::Packet.from_io(MQTT::Protocol::IO::V3.new(IO::Memory.new(bytes)))
               fail("received unexpected #{pkt}")
             rescue
               ch.close # close to signal "failure"
@@ -189,7 +189,7 @@ describe "Websocket support" do
             end
             spawn { websocket.run }
 
-            websocket.stream { |io| connect.to_io(MQTT::Protocol::IO.new(io)) }
+            websocket.stream { |io| connect.to_io(MQTT::Protocol::IO::V3.new(io)) }
 
             expect_raises(Channel::ClosedError) do
               select
@@ -239,12 +239,12 @@ describe "Websocket support" do
 
             ch = Channel(MQTT::Protocol::Packet).new
             websocket.on_binary do |bytes|
-              ch.send MQTT::Protocol::Packet.from_io(IO::Memory.new(bytes))
+              ch.send MQTT::Protocol::Packet.from_io(MQTT::Protocol::IO::V3.new(IO::Memory.new(bytes)))
               websocket.close
             end
             spawn { websocket.run }
 
-            websocket.stream { |io| connect.to_io(MQTT::Protocol::IO.new(io)) }
+            websocket.stream { |io| connect.to_io(MQTT::Protocol::IO::V3.new(io)) }
 
             select
             when pkt = ch.receive

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -30,11 +30,25 @@ module LavinMQ
         @vhost.register_exchange(@exchange)
       end
 
-      def session_present?(client_id : String, clean_session) : Bool
-        return false if clean_session
+      # Clean Start = 1 always reports no session, because the stored one is about
+      # to be discarded [MQTT-3.1.2-4].
+      #
+      # The auto_delete? guard is for takeover: this runs before add_client, so a
+      # 0-interval session belonging to a still-connected client is visible here,
+      # and that session is ended by the takeover rather than resumed (3.1.4).
+      def session_present?(client_id : String, clean_start) : Bool
+        return false if clean_start
         session = sessions[client_id]? || return false
-        return false if session.clean_session?
-        true
+        !session.auto_delete?
+      end
+
+      # v3 has no expiry property, so its clean-session bit carries both meanings:
+      # 1 ends the session with the connection, 0 keeps it forever, which is what
+      # LavinMQ has always done. v5 reads the property, absent meaning 0
+      # [MQTT-3.1.2-11].
+      private def session_expiry_interval(packet : Protocol::Connect) : UInt32
+        return packet.clean_session? ? 0u32 : UInt32::MAX unless packet.version.v5?
+        packet.properties.session_expiry_interval || 0u32
       end
 
       def add_client(io, connection_info, user, packet) : Client
@@ -52,13 +66,20 @@ module LavinMQ
           packet.clean_session?,
           packet.keepalive,
           packet.will,
-          packet.properties.maximum_packet_size)
-        if client.clean_session?
+          packet.properties.maximum_packet_size,
+          session_expiry_interval(packet))
+        # Clean Start and the expiry are separate inputs: the first decides
+        # whether to discard the stored session, the second how long the session
+        # this connection ends up with will outlive it.
+        if packet.clean_session?
           sessions[client.client_id]?.try &.delete
         else
-          # If an existing session exists, reuse it. If no session exists
-          # it will be created on first subscribe
-          sessions[client.client_id]?.try &.client = client
+          # Reuse an existing session, adopting this connection's interval. No
+          # session yet means it is created on first subscribe.
+          if session = sessions[client.client_id]?
+            session.session_expiry_interval = client.session_expiry_interval
+            session.client = client
+          end
         end
         @clients[packet.client_id] = client
         @vhost.add_connection client
@@ -80,7 +101,7 @@ module LavinMQ
         if session = sessions[client_id]?
           if session.client.nil? || (session.client == client)
             session.client = nil
-            session.delete if session.clean_session?
+            session.delete if session.auto_delete?
           end
         end
         @clients.delete(client_id) if @clients[client_id]? == client

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -77,8 +77,11 @@ module LavinMQ
           # Reuse an existing session, adopting this connection's interval. No
           # session yet means it is created on first subscribe.
           if session = sessions[client.client_id]?
-            session.session_expiry_interval = client.session_expiry_interval
+            # Attach first: while the session has a client, wait_for_client
+            # cannot run, so narrowing the interval here can never expire the
+            # session this connection is about to resume.
             session.client = client
+            session.session_expiry_interval = client.session_expiry_interval
           end
         end
         @clients[packet.client_id] = client

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -51,7 +51,8 @@ module LavinMQ
           packet.client_id,
           packet.clean_session?,
           packet.keepalive,
-          packet.will)
+          packet.will,
+          packet.properties.maximum_packet_size)
         if client.clean_session?
           sessions[client.client_id]?.try &.delete
         else

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -109,10 +109,14 @@ module LavinMQ
         end
       end
 
-      def unsubscribe(client_id, topics)
+      def unsubscribe(client_id, topics) : Array(Protocol::UnsubAck::ReasonCode)
         session = sessions[client_id]
-        topics.each do |tf|
-          session.unsubscribe(tf)
+        topics.map do |tf|
+          if session.unsubscribe(tf)
+            Protocol::UnsubAck::ReasonCode::Success
+          else
+            Protocol::UnsubAck::ReasonCode::NoSubscriptionExisted
+          end
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -94,14 +94,17 @@ module LavinMQ
         session = sessions.declare(client)
         headers = AMQP::Table.new({RETAIN_HEADER => true})
         topics.map do |tf|
-          session.subscribe(tf.topic, tf.qos)
+          # We only deliver up to MAX_QOS, so grant (and store/deliver at) the
+          # clamped QoS - the SUBACK must report the granted max [MQTT-3.8.4-7].
+          granted = Math.min(tf.qos, MAX_QOS)
+          session.subscribe(tf.topic, granted)
           ts = RoughTime.unix_ms
           @retain_store.each(tf.topic) do |topic, body_io, body_bytesize|
-            props = AMQP::Properties.new(headers: headers, delivery_mode: tf.qos)
+            props = AMQP::Properties.new(headers: headers, delivery_mode: granted)
             msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
             session.publish(msg)
           end
-          Protocol::SubAck::ReasonCode.from_value(tf.qos)
+          Protocol::SubAck::ReasonCode.from_value(granted)
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -49,7 +49,6 @@ module LavinMQ
           user,
           self,
           packet.client_id,
-          ProtocolVersion.from_value(packet.version),
           packet.clean_session?,
           packet.keepalive,
           packet.will)
@@ -102,7 +101,7 @@ module LavinMQ
             msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
             session.publish(msg)
           end
-          Protocol::SubAck::ReturnCode.from_int(tf.qos)
+          Protocol::SubAck::ReasonCode.from_value(tf.qos)
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -62,12 +62,11 @@ module LavinMQ
           connection_info,
           user,
           self,
-          packet.client_id,
-          packet.clean_session?,
-          packet.keepalive,
-          packet.will,
-          packet.properties.maximum_packet_size,
-          session_expiry_interval(packet))
+          client_id: packet.client_id,
+          keepalive: packet.keepalive,
+          will: packet.will,
+          max_packet_size: packet.properties.maximum_packet_size,
+          session_expiry_interval: session_expiry_interval(packet))
         # Clean Start and the expiry are separate inputs: the first decides
         # whether to discard the stored session, the second how long the session
         # this connection ends up with will outlive it.

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -69,12 +69,11 @@ module LavinMQ
           connection_info,
           user,
           self,
-          packet.client_id,
-          packet.clean_session?,
-          packet.keepalive,
-          packet.will,
-          packet.properties.maximum_packet_size,
-          session_expiry_interval(packet))
+          client_id: packet.client_id,
+          keepalive: packet.keepalive,
+          will: packet.will,
+          max_packet_size: packet.properties.maximum_packet_size,
+          session_expiry_interval: session_expiry_interval(packet))
         # Clean Start and the expiry are separate inputs: the first decides
         # whether to discard the stored session, the second how long the session
         # this connection ends up with will outlive it.

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -58,7 +58,8 @@ module LavinMQ
           packet.client_id,
           packet.clean_session?,
           packet.keepalive,
-          packet.will)
+          packet.will,
+          packet.properties.maximum_packet_size)
         if client.clean_session?
           sessions[client.client_id]?.try &.delete
         else

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -117,9 +117,24 @@ module LavinMQ
         @vhost.rm_connection(client)
       end
 
-      def publish(packet : Protocol::Publish)
+      def publish(packet : Protocol::Publish, publisher : String)
         @retain_store.retain(packet) if packet.retain?
-        @exchange.publish(packet)
+        @exchange.publish(packet, publisher)
+      end
+
+      # Retain Handling [MQTT-3.3.1-9/10/11], spelled as the spec words it.
+      #
+      # Careful if you check this against the local MQTT-v5.0-spec.txt: its
+      # Appendix B row for [MQTT-3.3.1-10] states the value-1 case inverted.
+      # Four body locations agree against it - §3.3.1.3's definition of that
+      # statement, §3.8.3.1's list of the three values, and §3.8.4's separate
+      # new-vs-replaced rules - so the body governs.
+      private def replay_retained?(retain_handling : UInt8, new_subscription : Bool) : Bool
+        case retain_handling
+        when 0 then true             # always send at subscribe
+        when 1 then new_subscription # only for a subscription that did not exist
+        else        false            # 2: never send at subscribe
+        end
       end
 
       def subscribe(client, topics) : Array(Protocol::SubAck::ReasonCode)
@@ -131,13 +146,16 @@ module LavinMQ
         topics.map do |tf|
           # We only deliver up to MAX_QOS, so grant (and store/deliver at) the
           # clamped QoS - the SUBACK must report the granted max [MQTT-3.8.4-7].
-          options = SubscriptionOptions.new(MQTT.granted_qos(tf.qos))
-          session.subscribe(tf.topic, options)
-          ts = RoughTime.unix_ms
-          @retain_store.each(tf.topic) do |topic, body_io, body_bytesize|
-            props = AMQP::Properties.new(headers: RETAINED_HEADERS, delivery_mode: options.qos)
-            msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
-            session.publish(msg)
+          options = SubscriptionOptions.new(
+            MQTT.granted_qos(tf.qos), tf.no_local?, tf.retain_as_published?)
+          new_subscription = session.subscribe(tf.topic, options)
+          if replay_retained?(tf.retain_handling, new_subscription)
+            ts = RoughTime.unix_ms
+            @retain_store.each(tf.topic) do |topic, body_io, body_bytesize|
+              props = AMQP::Properties.new(headers: RETAINED_HEADERS, delivery_mode: options.qos)
+              msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
+              session.publish(msg)
+            end
           end
           Protocol::SubAck::ReasonCode.from_value(options.qos)
         end

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -128,19 +128,18 @@ module LavinMQ
           Log.warn { "Rejecting subscribe from client_id=#{client.client_id}, queue limit in vhost '#{@vhost.name}' (#{@vhost.max_queues}) is reached" }
           return topics.map { Protocol::SubAck::ReasonCode::UnspecifiedError }
         end
-        headers = AMQP::Table.new({RETAIN_HEADER => true})
         topics.map do |tf|
           # We only deliver up to MAX_QOS, so grant (and store/deliver at) the
           # clamped QoS - the SUBACK must report the granted max [MQTT-3.8.4-7].
-          granted = Math.min(tf.qos, MAX_QOS)
-          session.subscribe(tf.topic, granted)
+          options = SubscriptionOptions.new(MQTT.granted_qos(tf.qos))
+          session.subscribe(tf.topic, options)
           ts = RoughTime.unix_ms
           @retain_store.each(tf.topic) do |topic, body_io, body_bytesize|
-            props = AMQP::Properties.new(headers: headers, delivery_mode: granted)
+            props = AMQP::Properties.new(headers: RETAINED_HEADERS, delivery_mode: options.qos)
             msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
             session.publish(msg)
           end
-          Protocol::SubAck::ReasonCode.from_value(granted)
+          Protocol::SubAck::ReasonCode.from_value(options.qos)
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -121,10 +121,18 @@ module LavinMQ
         end
       end
 
-      def unsubscribe(client_id, topics)
-        session = sessions[client_id]? || return
-        topics.each do |tf|
-          session.unsubscribe(tf)
+      def unsubscribe(client_id, topics) : Array(Protocol::UnsubAck::ReasonCode)
+        # A client with no session has no matching filter for anything it names,
+        # and [MQTT-3.11.3-2] still wants a code per filter received.
+        unless session = sessions[client_id]?
+          return topics.map { Protocol::UnsubAck::ReasonCode::NoSubscriptionExisted }
+        end
+        topics.map do |tf|
+          if session.unsubscribe(tf)
+            Protocol::UnsubAck::ReasonCode::Success
+          else
+            Protocol::UnsubAck::ReasonCode::NoSubscriptionExisted
+          end
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -56,7 +56,6 @@ module LavinMQ
           user,
           self,
           packet.client_id,
-          ProtocolVersion.from_value(packet.version),
           packet.clean_session?,
           packet.keepalive,
           packet.will)
@@ -115,7 +114,7 @@ module LavinMQ
             msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
             session.publish(msg)
           end
-          Protocol::SubAck::ReturnCode.from_int(qos)
+          Protocol::SubAck::ReasonCode.from_value(tf.qos)
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -30,11 +30,25 @@ module LavinMQ
         @exchange = @vhost.mqtt_exchange
       end
 
-      def session_present?(client_id : String, clean_session) : Bool
-        return false if clean_session
+      # Clean Start = 1 always reports no session, because the stored one is about
+      # to be discarded [MQTT-3.1.2-4].
+      #
+      # The auto_delete? guard is for takeover: this runs before add_client, so a
+      # 0-interval session belonging to a still-connected client is visible here,
+      # and that session is ended by the takeover rather than resumed (3.1.4).
+      def session_present?(client_id : String, clean_start) : Bool
+        return false if clean_start
         session = sessions[client_id]? || return false
-        return false if session.clean_session?
-        true
+        !session.auto_delete?
+      end
+
+      # v3 has no expiry property, so its clean-session bit carries both meanings:
+      # 1 ends the session with the connection, 0 keeps it forever, which is what
+      # LavinMQ has always done. v5 reads the property, absent meaning 0
+      # [MQTT-3.1.2-11].
+      private def session_expiry_interval(packet : Protocol::Connect) : UInt32
+        return packet.clean_session? ? 0u32 : UInt32::MAX unless packet.version.v5?
+        packet.properties.session_expiry_interval || 0u32
       end
 
       # A reconnecting client_id displaces the existing connection in
@@ -59,13 +73,20 @@ module LavinMQ
           packet.clean_session?,
           packet.keepalive,
           packet.will,
-          packet.properties.maximum_packet_size)
-        if client.clean_session?
+          packet.properties.maximum_packet_size,
+          session_expiry_interval(packet))
+        # Clean Start and the expiry are separate inputs: the first decides
+        # whether to discard the stored session, the second how long the session
+        # this connection ends up with will outlive it.
+        if packet.clean_session?
           sessions[client.client_id]?.try &.delete
         else
-          # If an existing session exists, reuse it. If no session exists
-          # it will be created on first subscribe
-          sessions[client.client_id]?.try &.client = client
+          # Reuse an existing session, adopting this connection's interval. No
+          # session yet means it is created on first subscribe.
+          if session = sessions[client.client_id]?
+            session.session_expiry_interval = client.session_expiry_interval
+            session.client = client
+          end
         end
         @clients[packet.client_id] = client
         @vhost.add_connection client
@@ -87,7 +108,7 @@ module LavinMQ
         if session = sessions[client_id]?
           if session.client.nil? || (session.client == client)
             session.client = nil
-            session.delete if session.clean_session?
+            session.delete if session.auto_delete?
           end
         end
         @clients.delete(client_id) if @clients[client_id]? == client

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -98,23 +98,25 @@ module LavinMQ
         @exchange.publish(packet)
       end
 
-      def subscribe(client, topics) : Array(Protocol::SubAck::ReturnCode)
+      def subscribe(client, topics) : Array(Protocol::SubAck::ReasonCode)
         session = sessions.declare(client)
         unless session
           Log.warn { "Rejecting subscribe from client_id=#{client.client_id}, queue limit in vhost '#{@vhost.name}' (#{@vhost.max_queues}) is reached" }
-          return topics.map { Protocol::SubAck::ReturnCode::Failure }
+          return topics.map { Protocol::SubAck::ReasonCode::UnspecifiedError }
         end
         headers = AMQP::Table.new({RETAIN_HEADER => true})
         topics.map do |tf|
-          qos = tf.qos.zero? ? 0u8 : 1u8 # downgrade to 1 if > 1
-          session.subscribe(tf.topic, qos)
+          # We only deliver up to MAX_QOS, so grant (and store/deliver at) the
+          # clamped QoS - the SUBACK must report the granted max [MQTT-3.8.4-7].
+          granted = Math.min(tf.qos, MAX_QOS)
+          session.subscribe(tf.topic, granted)
           ts = RoughTime.unix_ms
           @retain_store.each(tf.topic) do |topic, body_io, body_bytesize|
-            props = AMQP::Properties.new(headers: headers, delivery_mode: qos)
+            props = AMQP::Properties.new(headers: headers, delivery_mode: granted)
             msg = Message.new(ts, EXCHANGE, topic, props, body_bytesize, body_io)
             session.publish(msg)
           end
-          Protocol::SubAck::ReasonCode.from_value(tf.qos)
+          Protocol::SubAck::ReasonCode.from_value(granted)
         end
       end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -84,8 +84,11 @@ module LavinMQ
           # Reuse an existing session, adopting this connection's interval. No
           # session yet means it is created on first subscribe.
           if session = sessions[client.client_id]?
-            session.session_expiry_interval = client.session_expiry_interval
+            # Attach first: while the session has a client, wait_for_client
+            # cannot run, so narrowing the interval here can never expire the
+            # session this connection is about to resume.
             session.client = client
+            session.session_expiry_interval = client.session_expiry_interval
           end
         end
         @clients[packet.client_id] = client

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -178,7 +178,12 @@ module LavinMQ
         when Protocol::Unsubscribe then recieve_unsubscribe(packet)
         when Protocol::PingReq     then receive_pingreq(packet)
         when Protocol::Disconnect  then return {packet, bytesize}
-        else                            raise "received unexpected packet: #{packet}"
+        else
+          # Every remaining decodable type is either server-to-client only or
+          # illegal after CONNECT (a second CONNECT is [MQTT-3.1.0-2]), so this
+          # is the client's protocol error, not an internal one to backtrace.
+          @log.debug { "Unexpected packet: #{packet.inspect}" }
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::ProtocolError)
         end
         {packet, bytesize}
       end

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -90,11 +90,13 @@ module LavinMQ
         "mqtt-client-#{@client_id}"
       end
 
+      # Exhaustive `case/in` on purpose: a new Version member must be a compile
+      # error here, not silently reported as 3.1.1 in the management UI.
       private def protocol_name : String
         case @io.version
-        when .v5?   then "MQTT 5.0"
-        when .v3_1? then "MQTT 3.1"
-        else             "MQTT 3.1.1"
+        in .v5?     then "MQTT 5.0"
+        in .v3_1?   then "MQTT 3.1"
+        in .v3_1_1? then "MQTT 3.1.1"
         end
       end
 

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -204,13 +204,28 @@ module LavinMQ
         send Protocol::PingResp.new
       end
 
-      def recieve_publish(packet : Protocol::Publish)
-        # We advertise maximum_qos=1, so a v5 QoS 2 PUBLISH is a protocol error
-        # [MQTT-3.2.2] -> DISCONNECT 0x9B. v3 has no such contract; its QoS 2 is
-        # accepted and downgraded to QoS 1 on delivery (session.cr).
-        if @io.version.v5? && packet.qos > MAX_QOS
+      # Enforce the v5 limits we advertised in CONNACK. A conformant client
+      # honours them, so a violation is a protocol error -> server DISCONNECT
+      # (raised as ProtocolViolation, handled in read_loop). v3 has no such
+      # contract and is unaffected.
+      private def validate_v5_publish!(packet : Protocol::Publish)
+        return unless @io.version.v5?
+        # maximum_qos=1: QoS 2 is not supported (v3 downgrades on delivery instead).
+        if packet.qos > MAX_QOS
           raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::QoSNotSupported)
         end
+        # topic_alias_maximum=0: we accept no Topic Aliases.
+        if packet.properties.topic_alias
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::TopicAliasInvalid)
+        end
+        # An empty topic is only resolvable via a Topic Alias, which we don't allow.
+        if packet.topic_bytes.empty?
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::ProtocolError)
+        end
+      end
+
+      def recieve_publish(packet : Protocol::Publish)
+        validate_v5_publish!(packet)
         if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
           Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
           close_socket

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -39,6 +39,10 @@ module LavinMQ
       end
 
       getter? clean_session
+
+      # The interval named on CONNECT. Kept because [MQTT-3.14.2] makes a
+      # non-zero interval on DISCONNECT a Protocol Error when this one was 0.
+      getter session_expiry_interval : UInt32
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
       @session : MQTT::Session?
@@ -74,7 +78,8 @@ module LavinMQ
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
                      @will : Protocol::Will? = nil,
-                     @max_packet_size : UInt32? = nil)
+                     @max_packet_size : UInt32? = nil,
+                     @session_expiry_interval : UInt32 = 0u32)
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -11,10 +11,10 @@ require "../stats"
 
 module LavinMQ
   module MQTT
-    # Raised by a packet handler when the client violates the protocol in a way
-    # that must tear the connection down with a reason code. Caught centrally in
-    # Client#read_loop, which sends a v5 DISCONNECT carrying the reason (v3 has
-    # no server DISCONNECT, so it just closes).
+    # Raised by a packet handler when the connection must be torn down with a
+    # reason code. Caught centrally in Client#read_loop, which sends a v5
+    # DISCONNECT carrying the reason (v3 has no server DISCONNECT, so it just
+    # closes).
     class ProtocolViolation < Exception
       getter reason : Protocol::Disconnect::ReasonCode
 
@@ -118,7 +118,10 @@ module LavinMQ
           # The disconnect packet has been handled and the socket has been closed.
           # If we dont breakt the loop here we'll get a IO/Error on next read.
           if packet.is_a?(Protocol::Disconnect)
-            @log.debug { "Received disconnect" }
+            @log.debug { "Received disconnect: #{packet.reason_code}" }
+            # Only reason 0x00 discards the will [MQTT-3.14.4-3]. 0x04
+            # (DisconnectWithWillMessage) and every error code publish it.
+            publish_will unless packet.reason_code.normal_disconnection?
             break
           end
         end
@@ -244,18 +247,40 @@ module LavinMQ
         validate_v5_publish!(packet)
         if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
           Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
-          close_socket
-          return
+          return refuse_publish(packet)
         end
-        @broker.publish(packet)
+        matched = @broker.publish(packet)
         vhost.event_tick(EventType::ClientPublish)
         # Ok to not send anything if qos = 0 (fire and forget)
         if packet.qos > 0 && (packet_id = packet.packet_id)
-          send(Protocol::PubAck.new(packet_id))
+          # 0x10 lets the publisher see that nothing was subscribed (3.4.2.1).
+          # The shard drops the reason tail on v3, so no version branch here.
+          reason = matched.zero? ? Protocol::PubAck::ReasonCode::NoMatchingSubscribers : Protocol::PubAck::ReasonCode::Success
+          send(Protocol::PubAck.new(packet_id, reason))
+        end
+      end
+
+      # An unauthorized PUBLISH gets a reason code instead of a bare TCP close:
+      # PUBACK 0x87 when there is an ack to carry it, otherwise a server
+      # DISCONNECT 0x87 (spec 3.3.4). v3 has no way to say why, so it just closes.
+      private def refuse_publish(packet : Protocol::Publish) : Nil
+        unless @io.version.v5?
+          close_socket
+          return
+        end
+        if packet.qos > 0 && (packet_id = packet.packet_id)
+          send(Protocol::PubAck.new(packet_id, Protocol::PubAck::ReasonCode::NotAuthorized))
+        else
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::NotAuthorized)
         end
       end
 
       def recieve_puback(packet : Protocol::PubAck)
+        # A non-success PUBACK still terminates the QoS 1 delivery (3.4.2.1), so
+        # the message is acked either way and the code is purely diagnostic.
+        unless packet.reason_code.success?
+          @log.warn { "PUBACK for packet id #{packet.packet_id} with reason #{packet.reason_code}" }
+        end
         @broker.sessions[@client_id].ack(packet)
         vhost.event_tick(EventType::ClientAck)
       end
@@ -280,7 +305,14 @@ module LavinMQ
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
-            close_socket
+            # A v3 SUBACK can only say 0x00-0x02 or 0x80, so v3 keeps closing
+            # without an explanation.
+            if @io.version.v5?
+              codes = Array.new(packet.topic_filters.size, Protocol::SubAck::ReasonCode::NotAuthorized)
+              send(Protocol::SubAck.new(codes, packet.packet_id))
+            else
+              close_socket
+            end
             return
           end
         end

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -245,6 +245,11 @@ module LavinMQ
       end
 
       def recieve_subscribe(packet : Protocol::Subscribe)
+        # subscription_identifier_available=0: a Subscription Identifier is a
+        # packet-level protocol error [MQTT-3.8.2] -> DISCONNECT 0xA1.
+        if @io.version.v5? && packet.properties.subscription_identifier
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::SubscriptionIdentifiersNotSupported)
+        end
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -289,8 +289,10 @@ module LavinMQ
       end
 
       def recieve_unsubscribe(packet : Protocol::Unsubscribe)
-        @broker.unsubscribe(client_id, packet.topics)
-        send(Protocol::UnsubAck.new(packet.packet_id))
+        reason_codes = @broker.unsubscribe(client_id, packet.topics)
+        # v5 UNSUBACK carries a reason code per topic filter; the shard drops
+        # the payload on v3, so no version branch is needed here.
+        send(Protocol::UnsubAck.new(packet.packet_id, reason_codes))
       end
 
       def details_tuple

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -38,8 +38,6 @@ module LavinMQ
         @io.version
       end
 
-      getter? clean_session
-
       # The interval named on CONNECT. Kept because [MQTT-3.14.2] makes a
       # non-zero interval on DISCONNECT a Protocol Error when this one was 0.
       getter session_expiry_interval : UInt32
@@ -75,7 +73,6 @@ module LavinMQ
                      @user : Auth::BaseUser,
                      @broker : MQTT::Broker,
                      @client_id : String,
-                     @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
                      @will : Protocol::Will? = nil,
                      @max_packet_size : UInt32? = nil,

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -11,20 +11,6 @@ require "../stats"
 
 module LavinMQ
   module MQTT
-    # Protocol level from the CONNECT packet:
-    # level 3 is MQTT 3.1 (MQIsdp), level 4 is MQTT 3.1.1 (MQTT).
-    enum ProtocolVersion : UInt8
-      V3_1   = 3
-      V3_1_1 = 4
-
-      def name
-        case self
-        in .v3_1?   then "MQTT 3.1"
-        in .v3_1_1? then "MQTT 3.1.1"
-        end
-      end
-    end
-
     class Client < LavinMQ::Client
       include Stats
       include SortableJSON
@@ -34,7 +20,6 @@ module LavinMQ
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
       @session : MQTT::Session?
-      @protocol : String
       rate_stats({"send_oct", "recv_oct"})
       Log = LavinMQ::Log.for "mqtt.client"
 
@@ -64,11 +49,9 @@ module LavinMQ
                      @user : Auth::BaseUser,
                      @broker : MQTT::Broker,
                      @client_id : String,
-                     protocol_version : ProtocolVersion,
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
                      @will : Protocol::Will? = nil)
-        @protocol = protocol_version.name
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
@@ -91,6 +74,14 @@ module LavinMQ
         "mqtt-client-#{@client_id}"
       end
 
+      private def protocol_name : String
+        case @io.version
+        when .v5?   then "MQTT 5.0"
+        when .v3_1? then "MQTT 3.1"
+        else             "MQTT 3.1.1"
+        end
+      end
+
       private def read_loop
         received_bytes = 0_u32
         socket = @io.io
@@ -100,8 +91,8 @@ module LavinMQ
         end
         loop do
           @log.trace { "waiting for packet" }
-          packet = read_and_handle_packet
-          if (received_bytes &+= packet.bytesize) > Config.instance.yield_each_received_bytes
+          packet, bytesize = read_and_handle_packet
+          if (received_bytes &+= bytesize) > Config.instance.yield_each_received_bytes
             received_bytes = 0_u32
             Fiber.yield
           end
@@ -143,8 +134,9 @@ module LavinMQ
       def read_and_handle_packet
         packet = @io.read_packet
         @log.trace { "Received packet:  #{packet.inspect}" }
-        @recv_oct_count.add(packet.bytesize, :relaxed)
-        vhost.add_recv_bytes(packet.bytesize.to_u64)
+        bytesize = @io.bytesize(packet)
+        @recv_oct_count.add(bytesize, :relaxed)
+        vhost.add_recv_bytes(bytesize.to_u64)
 
         case packet
         when Protocol::Publish     then recieve_publish(packet)
@@ -152,18 +144,19 @@ module LavinMQ
         when Protocol::Subscribe   then recieve_subscribe(packet)
         when Protocol::Unsubscribe then recieve_unsubscribe(packet)
         when Protocol::PingReq     then receive_pingreq(packet)
-        when Protocol::Disconnect  then return packet
+        when Protocol::Disconnect  then return {packet, bytesize}
         else                            raise "received unexpected packet: #{packet}"
         end
-        packet
+        {packet, bytesize}
       end
 
       def send(packet)
         @lock.synchronize do
           @io.write_packet(packet)
           @io.flush
-          @send_oct_count.add(packet.bytesize, :relaxed)
-          vhost.add_send_bytes(packet.bytesize.to_u64)
+          bytesize = @io.bytesize(packet)
+          @send_oct_count.add(bytesize, :relaxed)
+          vhost.add_send_bytes(bytesize.to_u64)
         end
         case packet
         when Protocol::Publish
@@ -222,7 +215,7 @@ module LavinMQ
         {
           vhost:             @broker.vhost.name,
           user:              @user.name,
-          protocol:          @protocol,
+          protocol:          protocol_name,
           client_id:         @client_id,
           name:              @name,
           timeout:           @keepalive,
@@ -290,7 +283,7 @@ module LavinMQ
       end
 
       private def close_socket
-        socket = @io
+        socket = @io.io
         if socket.responds_to?(:"write_timeout=")
           socket.write_timeout = 1.seconds
         end

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -11,6 +11,18 @@ require "../stats"
 
 module LavinMQ
   module MQTT
+    # Raised by a packet handler when the client violates the protocol in a way
+    # that must tear the connection down with a reason code. Caught centrally in
+    # Client#read_loop, which sends a v5 DISCONNECT carrying the reason (v3 has
+    # no server DISCONNECT, so it just closes).
+    class ProtocolViolation < Exception
+      getter reason : Protocol::Disconnect::ReasonCode
+
+      def initialize(@reason : Protocol::Disconnect::ReasonCode)
+        super(@reason.to_s)
+      end
+    end
+
     class Client < LavinMQ::Client
       include Stats
       include SortableJSON
@@ -82,13 +94,16 @@ module LavinMQ
         end
       end
 
+      private def apply_keepalive_timeout
+        socket = @io.io
+        return unless socket.responds_to?(:"read_timeout=")
+        # 50% grace period according to [MQTT-3.1.2-24]
+        socket.read_timeout = @keepalive.zero? ? nil : (@keepalive * 1.5).seconds
+      end
+
       private def read_loop
         received_bytes = 0_u32
-        socket = @io.io
-        if socket.responds_to?(:"read_timeout=")
-          # 50% grace period according to [MQTT-3.1.2-24]
-          socket.read_timeout = @keepalive.zero? ? nil : (@keepalive * 1.5).seconds
-        end
+        apply_keepalive_timeout
         loop do
           @log.trace { "waiting for packet" }
           packet, bytesize = read_and_handle_packet
@@ -103,6 +118,10 @@ module LavinMQ
             break
           end
         end
+      rescue ex : ProtocolViolation
+        @log.warn { "Protocol violation, disconnecting client: #{ex.reason}" }
+        disconnect(ex.reason)
+        publish_will
       rescue ex : Protocol::Error::PacketDecode
         @log.warn(exception: ex) { "Packet decode error" }
         publish_will
@@ -171,11 +190,27 @@ module LavinMQ
         end
       end
 
+      # Server-initiated disconnect. v5 clients get a DISCONNECT carrying the
+      # reason code; v3 has no server DISCONNECT packet, so we just let the
+      # caller's cleanup close the socket. The socket close itself happens in
+      # read_loop's ensure block.
+      private def disconnect(reason : Protocol::Disconnect::ReasonCode)
+        send(Protocol::Disconnect.new(reason)) if @io.version.v5?
+      rescue ::IO::Error
+        # peer may already be gone; read_loop's ensure still closes the socket
+      end
+
       def receive_pingreq(packet : Protocol::PingReq)
         send Protocol::PingResp.new
       end
 
       def recieve_publish(packet : Protocol::Publish)
+        # We advertise maximum_qos=1, so a v5 QoS 2 PUBLISH is a protocol error
+        # [MQTT-3.2.2] -> DISCONNECT 0x9B. v3 has no such contract; its QoS 2 is
+        # accepted and downgraded to QoS 1 on delivery (session.cr).
+        if @io.version.v5? && packet.qos > MAX_QOS
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::QoSNotSupported)
+        end
         if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
           Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
           close_socket

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -28,6 +28,9 @@ module LavinMQ
       include SortableJSON
 
       getter log, name, user, client_id, socket, connection_info
+      # The client's advertised Maximum Packet Size (v5); nil = no limit. Used to
+      # enforce [MQTT-3.1.2-24] on outbound packets in the session delivery path.
+      getter max_packet_size : UInt32?
       getter? clean_session
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
@@ -63,7 +66,8 @@ module LavinMQ
                      @client_id : String,
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
-                     @will : Protocol::Will? = nil)
+                     @will : Protocol::Will? = nil,
+                     @max_packet_size : UInt32? = nil)
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -122,6 +122,13 @@ module LavinMQ
         @log.warn { "Protocol violation, disconnecting client: #{ex.reason}" }
         disconnect(ex.reason)
         publish_will
+      rescue ex : Protocol::Error::ProtocolError
+        # The shard raises this (with a reason byte) for codec-level protocol
+        # violations, e.g. an empty PUBLISH topic with no alias (0x82). Map it to
+        # a v5 server DISCONNECT; v3 just closes.
+        @log.warn { "Protocol error, disconnecting client: #{ex.message}" }
+        disconnect(disconnect_reason(ex.reason_code))
+        publish_will
       rescue ex : Protocol::Error::PacketDecode
         @log.warn(exception: ex) { "Packet decode error" }
         publish_will
@@ -200,6 +207,13 @@ module LavinMQ
         # peer may already be gone; read_loop's ensure still closes the socket
       end
 
+      # Map a shard reason byte to a DISCONNECT reason code, defaulting to a
+      # generic protocol error if it isn't a known DISCONNECT code.
+      private def disconnect_reason(reason_byte : UInt8) : Protocol::Disconnect::ReasonCode
+        Protocol::Disconnect::ReasonCode.from_value?(reason_byte) ||
+          Protocol::Disconnect::ReasonCode::ProtocolError
+      end
+
       def receive_pingreq(packet : Protocol::PingReq)
         send Protocol::PingResp.new
       end
@@ -218,10 +232,8 @@ module LavinMQ
         if packet.properties.topic_alias
           raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::TopicAliasInvalid)
         end
-        # An empty topic is only resolvable via a Topic Alias, which we don't allow.
-        if packet.topic_bytes.empty?
-          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::ProtocolError)
-        end
+        # (An empty topic with no alias is rejected by the shard on decode with a
+        # ProtocolError 0x82, mapped to a server DISCONNECT in read_loop.)
       end
 
       def recieve_publish(packet : Protocol::Publish)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -133,6 +133,9 @@ module LavinMQ
           # If we dont breakt the loop here we'll get a IO/Error on next read.
           if packet.is_a?(Protocol::Disconnect)
             @log.debug { "Received disconnect: #{packet.reason_code}" }
+            # Before the will decision: on a protocol error the rescue publishes
+            # the will itself, so doing it here first would publish it twice.
+            apply_disconnect_expiry(packet)
             # Only reason 0x00 discards the will [MQTT-3.14.4-3]. 0x04
             # (DisconnectWithWillMessage) and every error code publish it.
             publish_will unless packet.reason_code.normal_disconnection?
@@ -170,6 +173,24 @@ module LavinMQ
         @waitgroup.done
         close_socket
         @log.info { "Connection disconnected for user=#{@user.name} duration=#{duration}" }
+      end
+
+      # A DISCONNECT may name a new Session Expiry Interval [MQTT-3.14.2.2.2].
+      # Absent means keep the CONNECT value, not 0.
+      #
+      # A non-zero interval when CONNECT sent 0 is a Protocol Error, and the spec
+      # is explicit that the server does not treat it as a valid DISCONNECT but
+      # answers 0x82 as in section 4.13 [MQTT-3.14.2] - which is exactly what the
+      # ProtocolViolation handler already does, will included.
+      private def apply_disconnect_expiry(packet : Protocol::Disconnect) : Nil
+        interval = packet.properties.session_expiry_interval || return
+        if @session_expiry_interval.zero? && !interval.zero?
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::ProtocolError)
+        end
+        @session_expiry_interval = interval
+        # The session picks it up before read_loop's ensure runs remove_client, so
+        # narrowing to 0 deletes the session on this disconnect.
+        @broker.sessions[@client_id]?.try &.session_expiry_interval = interval
       end
 
       private def duration

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -31,6 +31,13 @@ module LavinMQ
       # The client's advertised Maximum Packet Size (v5); nil = no limit. Used to
       # enforce [MQTT-3.1.2-24] on outbound packets in the session delivery path.
       getter max_packet_size : UInt32?
+
+      # The negotiated protocol version. Session reads it to skip v5-only work
+      # for a v3 subscriber, the same way it reads max_packet_size.
+      def version : Protocol::Version
+        @io.version
+      end
+
       getter? clean_session
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -244,12 +244,23 @@ module LavinMQ
         vhost.event_tick(EventType::ClientAck)
       end
 
-      def recieve_subscribe(packet : Protocol::Subscribe)
-        # subscription_identifier_available=0: a Subscription Identifier is a
-        # packet-level protocol error [MQTT-3.8.2] -> DISCONNECT 0xA1.
-        if @io.version.v5? && packet.properties.subscription_identifier
+      # Enforce the v5 SUBSCRIBE limits we advertised in CONNACK. Both are
+      # packet-level protocol errors -> server DISCONNECT (spec 3.2.2.3.12 /
+      # 3.2.2.3.13), raised via ProtocolViolation and handled in read_loop.
+      private def validate_v5_subscribe!(packet : Protocol::Subscribe)
+        return unless @io.version.v5?
+        # subscription_identifier_available=0
+        if packet.properties.subscription_identifier
           raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::SubscriptionIdentifiersNotSupported)
         end
+        # shared_subscription_available=0: any $share/ filter fails the whole packet.
+        if packet.topic_filters.any?(&.topic.starts_with?("$share/"))
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::SharedSubscriptionsNotSupported)
+        end
+      end
+
+      def recieve_subscribe(packet : Protocol::Subscribe)
+        validate_v5_subscribe!(packet)
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -295,8 +295,10 @@ module LavinMQ
       end
 
       def recieve_unsubscribe(packet : Protocol::Unsubscribe)
-        @broker.unsubscribe(client_id, packet.topics)
-        send(Protocol::UnsubAck.new(packet.packet_id))
+        reason_codes = @broker.unsubscribe(client_id, packet.topics)
+        # v5 UNSUBACK carries a reason code per topic filter; the shard drops
+        # the payload on v3, so no version branch is needed here.
+        send(Protocol::UnsubAck.new(packet.packet_id, reason_codes))
       end
 
       def details_tuple

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -28,7 +28,8 @@ module LavinMQ
       include SortableJSON
 
       getter log, name, user, client_id, socket, connection_info
-      # This client's session queue name, built once rather than per use.
+      # This client's session queue name, built once. Read on every publish to
+      # resolve No Local, so it must not allocate per message.
       getter session_name : String
       # The client's advertised Maximum Packet Size (v5); nil = no limit. Used to
       # enforce [MQTT-3.1.2-24] on outbound packets in the session delivery path.
@@ -289,7 +290,7 @@ module LavinMQ
           Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
           return refuse_publish(packet)
         end
-        matched = @broker.publish(packet)
+        matched = @broker.publish(packet, session_name)
         vhost.event_tick(EventType::ClientPublish)
         # Ok to not send anything if qos = 0 (fire and forget)
         if packet.qos > 0 && (packet_id = packet.packet_id)
@@ -414,6 +415,8 @@ module LavinMQ
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
             return
           end
+          # The will's publisher is this client, so No Local applies to it by
+          # the same rule as any other publish [MQTT-3.8.3-3].
           @broker.publish(Protocol::Publish.new(
             topic: will.topic,
             payload: will.payload,
@@ -421,7 +424,7 @@ module LavinMQ
             qos: will.qos,
             retain: will.retain?,
             dup: false,
-          ))
+          ), session_name)
         end
       rescue ex
         @log.warn { "Failed to publish will: #{ex.message}" }

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -250,12 +250,23 @@ module LavinMQ
         vhost.event_tick(EventType::ClientAck)
       end
 
-      def recieve_subscribe(packet : Protocol::Subscribe)
-        # subscription_identifier_available=0: a Subscription Identifier is a
-        # packet-level protocol error [MQTT-3.8.2] -> DISCONNECT 0xA1.
-        if @io.version.v5? && packet.properties.subscription_identifier
+      # Enforce the v5 SUBSCRIBE limits we advertised in CONNACK. Both are
+      # packet-level protocol errors -> server DISCONNECT (spec 3.2.2.3.12 /
+      # 3.2.2.3.13), raised via ProtocolViolation and handled in read_loop.
+      private def validate_v5_subscribe!(packet : Protocol::Subscribe)
+        return unless @io.version.v5?
+        # subscription_identifier_available=0
+        if packet.properties.subscription_identifier
           raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::SubscriptionIdentifiersNotSupported)
         end
+        # shared_subscription_available=0: any $share/ filter fails the whole packet.
+        if packet.topic_filters.any?(&.topic.starts_with?("$share/"))
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::SharedSubscriptionsNotSupported)
+        end
+      end
+
+      def recieve_subscribe(packet : Protocol::Subscribe)
+        validate_v5_subscribe!(packet)
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -28,6 +28,8 @@ module LavinMQ
       include SortableJSON
 
       getter log, name, user, client_id, socket, connection_info
+      # This client's session queue name, built once rather than per use.
+      getter session_name : String
       # The client's advertised Maximum Packet Size (v5); nil = no limit. Used to
       # enforce [MQTT-3.1.2-24] on outbound packets in the session delivery path.
       getter max_packet_size : UInt32?
@@ -80,6 +82,7 @@ module LavinMQ
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
+        @session_name = MQTT.session_name(@client_id)
         metadata = ::Log::Metadata.new(nil, {vhost: @broker.vhost.name, address: @connection_info.remote_address.to_s, client_id: client_id})
         @log = Logger.new(Log, metadata)
       end
@@ -346,7 +349,7 @@ module LavinMQ
       def recieve_subscribe(packet : Protocol::Subscribe)
         validate_v5_subscribe!(packet)
         if Config.instance.mqtt_permission_check_enabled?
-          unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
+          unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, session_name)
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
             # A v3 SUBACK can only say 0x00-0x02 or 0x80, so v3 keeps closing
             # without an explanation.

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -11,20 +11,6 @@ require "../stats"
 
 module LavinMQ
   module MQTT
-    # Protocol level from the CONNECT packet:
-    # level 3 is MQTT 3.1 (MQIsdp), level 4 is MQTT 3.1.1 (MQTT).
-    enum ProtocolVersion : UInt8
-      V3_1   = 3
-      V3_1_1 = 4
-
-      def name
-        case self
-        in .v3_1?   then "MQTT 3.1"
-        in .v3_1_1? then "MQTT 3.1.1"
-        end
-      end
-    end
-
     class Client < LavinMQ::Client
       include Stats
       include SortableJSON
@@ -34,7 +20,6 @@ module LavinMQ
       @connected_at = RoughTime.unix_ms
       @channels = Hash(UInt16, Client::Channel).new
       @session : MQTT::Session?
-      @protocol : String
       rate_stats({"send_oct", "recv_oct"})
       Log = LavinMQ::Log.for "mqtt.client"
 
@@ -64,11 +49,9 @@ module LavinMQ
                      @user : Auth::BaseUser,
                      @broker : MQTT::Broker,
                      @client_id : String,
-                     protocol_version : ProtocolVersion,
                      @clean_session : Bool = false,
                      @keepalive : UInt16 = 30,
                      @will : Protocol::Will? = nil)
-        @protocol = protocol_version.name
         @lock = Mutex.new
         @waitgroup = WaitGroup.new(1)
         @name = "#{@connection_info.remote_address} -> #{@connection_info.local_address}"
@@ -91,6 +74,14 @@ module LavinMQ
         "mqtt-client-#{@client_id}"
       end
 
+      private def protocol_name : String
+        case @io.version
+        when .v5?   then "MQTT 5.0"
+        when .v3_1? then "MQTT 3.1"
+        else             "MQTT 3.1.1"
+        end
+      end
+
       private def read_loop
         received_bytes = 0_u32
         socket = @io.io
@@ -100,8 +91,8 @@ module LavinMQ
         end
         loop do
           @log.trace { "waiting for packet" }
-          packet = read_and_handle_packet
-          if (received_bytes &+= packet.bytesize) > Config.instance.yield_each_received_bytes
+          packet, bytesize = read_and_handle_packet
+          if (received_bytes &+= bytesize) > Config.instance.yield_each_received_bytes
             received_bytes = 0_u32
             Fiber.yield
           end
@@ -143,8 +134,9 @@ module LavinMQ
       def read_and_handle_packet
         packet = @io.read_packet
         @log.trace { "Received packet:  #{packet.inspect}" }
-        @recv_oct_count.add(packet.bytesize, :relaxed)
-        vhost.add_recv_bytes(packet.bytesize.to_u64)
+        bytesize = @io.bytesize(packet)
+        @recv_oct_count.add(bytesize, :relaxed)
+        vhost.add_recv_bytes(bytesize.to_u64)
 
         case packet
         when Protocol::Publish     then recieve_publish(packet)
@@ -152,18 +144,19 @@ module LavinMQ
         when Protocol::Subscribe   then recieve_subscribe(packet)
         when Protocol::Unsubscribe then recieve_unsubscribe(packet)
         when Protocol::PingReq     then receive_pingreq(packet)
-        when Protocol::Disconnect  then return packet
+        when Protocol::Disconnect  then return {packet, bytesize}
         else                            raise "received unexpected packet: #{packet}"
         end
-        packet
+        {packet, bytesize}
       end
 
       def send(packet)
         @lock.synchronize do
           @io.write_packet(packet)
           @io.flush
-          @send_oct_count.add(packet.bytesize, :relaxed)
-          vhost.add_send_bytes(packet.bytesize.to_u64)
+          bytesize = @io.bytesize(packet)
+          @send_oct_count.add(bytesize, :relaxed)
+          vhost.add_send_bytes(bytesize.to_u64)
         end
         case packet
         when Protocol::Publish
@@ -228,7 +221,7 @@ module LavinMQ
         {
           vhost:             @broker.vhost.name,
           user:              @user.name,
-          protocol:          @protocol,
+          protocol:          protocol_name,
           client_id:         @client_id,
           name:              @name,
           timeout:           @keepalive,
@@ -296,7 +289,7 @@ module LavinMQ
       end
 
       private def close_socket
-        socket = @io
+        socket = @io.io
         if socket.responds_to?(:"write_timeout=")
           socket.write_timeout = 1.seconds
         end

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -424,10 +424,32 @@ module LavinMQ
             qos: will.qos,
             retain: will.retain?,
             dup: false,
+            properties: will_properties(will.properties),
           ), session_name)
         end
       rescue ex
         @log.warn { "Failed to publish will: #{ex.message}" }
+      end
+
+      # The six Will Properties that are also PUBLISH properties, carried onto
+      # the message the will becomes. `will_delay_interval` is deliberately not
+      # among them: it is server behaviour, not wire content.
+      #
+      # Needs no version gate - v3 CONNECT has no will properties, so these are
+      # all nil there and `IO::V3#write_properties` would discard them anyway.
+      private def will_properties(will : Protocol::WillProperties) : Protocol::PublishProperties
+        properties = Protocol::PublishProperties.new
+        properties.payload_format_indicator = will.payload_format_indicator
+        properties.message_expiry_interval = will.message_expiry_interval
+        properties.content_type = will.content_type
+        properties.response_topic = will.response_topic
+        properties.correlation_data = will.correlation_data
+        # Nilable reader, and assigned whole: the repeatable-property getters
+        # don't memoize, so appending to one is not supported.
+        if user_properties = will.user_properties?
+          properties.user_properties = user_properties
+        end
+        properties
       end
 
       # should only be used when server needs to froce close client

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -251,6 +251,11 @@ module LavinMQ
       end
 
       def recieve_subscribe(packet : Protocol::Subscribe)
+        # subscription_identifier_available=0: a Subscription Identifier is a
+        # packet-level protocol error [MQTT-3.8.2] -> DISCONNECT 0xA1.
+        if @io.version.v5? && packet.properties.subscription_identifier
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::SubscriptionIdentifiersNotSupported)
+        end
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -11,10 +11,10 @@ require "../stats"
 
 module LavinMQ
   module MQTT
-    # Raised by a packet handler when the client violates the protocol in a way
-    # that must tear the connection down with a reason code. Caught centrally in
-    # Client#read_loop, which sends a v5 DISCONNECT carrying the reason (v3 has
-    # no server DISCONNECT, so it just closes).
+    # Raised by a packet handler when the connection must be torn down with a
+    # reason code. Caught centrally in Client#read_loop, which sends a v5
+    # DISCONNECT carrying the reason (v3 has no server DISCONNECT, so it just
+    # closes).
     class ProtocolViolation < Exception
       getter reason : Protocol::Disconnect::ReasonCode
 
@@ -118,7 +118,10 @@ module LavinMQ
           # The disconnect packet has been handled and the socket has been closed.
           # If we dont breakt the loop here we'll get a IO/Error on next read.
           if packet.is_a?(Protocol::Disconnect)
-            @log.debug { "Received disconnect" }
+            @log.debug { "Received disconnect: #{packet.reason_code}" }
+            # Only reason 0x00 discards the will [MQTT-3.14.4-3]. 0x04
+            # (DisconnectWithWillMessage) and every error code publish it.
+            publish_will unless packet.reason_code.normal_disconnection?
             break
           end
         end
@@ -244,18 +247,40 @@ module LavinMQ
         validate_v5_publish!(packet)
         if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
           Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
-          close_socket
-          return
+          return refuse_publish(packet)
         end
-        @broker.publish(packet)
+        matched = @broker.publish(packet)
         vhost.event_tick(EventType::ClientPublish)
         # Ok to not send anything if qos = 0 (fire and forget)
         if packet.qos > 0 && (packet_id = packet.packet_id)
-          send(Protocol::PubAck.new(packet_id))
+          # 0x10 lets the publisher see that nothing was subscribed (3.4.2.1).
+          # The shard drops the reason tail on v3, so no version branch here.
+          reason = matched.zero? ? Protocol::PubAck::ReasonCode::NoMatchingSubscribers : Protocol::PubAck::ReasonCode::Success
+          send(Protocol::PubAck.new(packet_id, reason))
+        end
+      end
+
+      # An unauthorized PUBLISH gets a reason code instead of a bare TCP close:
+      # PUBACK 0x87 when there is an ack to carry it, otherwise a server
+      # DISCONNECT 0x87 (spec 3.3.4). v3 has no way to say why, so it just closes.
+      private def refuse_publish(packet : Protocol::Publish) : Nil
+        unless @io.version.v5?
+          close_socket
+          return
+        end
+        if packet.qos > 0 && (packet_id = packet.packet_id)
+          send(Protocol::PubAck.new(packet_id, Protocol::PubAck::ReasonCode::NotAuthorized))
+        else
+          raise ProtocolViolation.new(Protocol::Disconnect::ReasonCode::NotAuthorized)
         end
       end
 
       def recieve_puback(packet : Protocol::PubAck)
+        # A non-success PUBACK still terminates the QoS 1 delivery (3.4.2.1), so
+        # the message is acked either way and the code is purely diagnostic.
+        unless packet.reason_code.success?
+          @log.warn { "PUBACK for packet id #{packet.packet_id} with reason #{packet.reason_code}" }
+        end
         # No session means we never delivered anything to ack
         unless session = @broker.sessions[@client_id]?
           @log.warn { "Received PubAck from client without a session" }
@@ -286,7 +311,14 @@ module LavinMQ
         if Config.instance.mqtt_permission_check_enabled?
           unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
             Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
-            close_socket
+            # A v3 SUBACK can only say 0x00-0x02 or 0x80, so v3 keeps closing
+            # without an explanation.
+            if @io.version.v5?
+              codes = Array.new(packet.topic_filters.size, Protocol::SubAck::ReasonCode::NotAuthorized)
+              send(Protocol::SubAck.new(codes, packet.packet_id))
+            else
+              close_socket
+            end
             return
           end
         end

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -12,8 +12,11 @@ module LavinMQ
     class ConnectionFactory < LavinMQ::ConnectionFactory
       Log = LavinMQ::Log.for "mqtt.connection_factory"
 
+      @server_capabilities : Protocol::ConnackProperties
+
       def initialize(@authenticator : Auth::Authenticator,
                      @brokers : Brokers, @config : Config)
+        @server_capabilities = build_server_capabilities
       end
 
       def start(socket : ::IO, connection_info : ConnectionInfo)
@@ -50,8 +53,29 @@ module LavinMQ
       end
 
       private def connack(io : Protocol::IO, session_present : Bool, return_code : Protocol::Connack::ReturnCode)
-        Protocol::Connack.new(session_present, return_code).to_io(io)
+        reason = Protocol::Connack::ReasonCode.from_v3_return_code(return_code)
+        # A v5 server must advertise which optional features it supports; an
+        # accepted v5 connection carries the capability set. On v3 the properties
+        # are ignored on the wire, so the v3 CONNACK is byte-for-byte unchanged.
+        properties = io.version.v5? && return_code.accepted? ? @server_capabilities : Protocol::ConnackProperties.new
+        Protocol::Connack.new(session_present, reason, properties).to_io(io)
         io.flush
+      end
+
+      # The fixed v5 capabilities LavinMQ advertises in CONNACK. They depend only
+      # on config (fixed after startup), so this is built once in initialize.
+      # Advertising a feature as unavailable is what makes deferring it spec-
+      # compliant; each deferred feature is then rejected in its own packet handler.
+      private def build_server_capabilities : Protocol::ConnackProperties
+        props = Protocol::ConnackProperties.new
+        props.maximum_qos = 1u8       # QoS 2 not implemented
+        props.retain_available = true # LavinMQ has a retain store
+        props.wildcard_subscription_available = true
+        props.topic_alias_maximum = 0u16                # topic aliases not implemented
+        props.subscription_identifier_available = false # subscription ids not implemented
+        props.shared_subscription_available = false     # shared subscriptions not implemented
+        props.maximum_packet_size = @config.mqtt_max_packet_size
+        props
       end
 
       def authenticate(io : Protocol::IO, packet)

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -31,6 +31,14 @@ module LavinMQ
           io = Protocol::IO::V3.new(socket, @config.mqtt_max_packet_size)
           packet, io = io.read_connect
           logger.trace { "recv #{packet.inspect}" }
+          # Enhanced authentication (the AUTH-packet flow) is not supported;
+          # reject before username/password auth so the reason is accurate. v5
+          # only - v3 has no properties. [MQTT-4.12]
+          if packet.properties.authentication_method
+            logger.warn { "Enhanced authentication requested but not supported" }
+            reject_connack(io, Protocol::Connack::ReasonCode::BadAuthenticationMethod)
+            return socket.close
+          end
           user, broker = authenticate(io, packet)
           # A client that sends an empty client id gets one assigned; a v5
           # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
@@ -55,6 +63,13 @@ module LavinMQ
           logger.warn { "Received invalid Connect packet: #{ex.inspect}" }
           socket.close
         end
+      end
+
+      # Send a v5 CONNACK carrying a reason code that has no v3 return-code
+      # equivalent (e.g. BadAuthenticationMethod 0x8C). v5-only by construction.
+      private def reject_connack(io : Protocol::IO, reason : Protocol::Connack::ReasonCode)
+        Protocol::Connack.new(false, reason).to_io(io)
+        io.flush
       end
 
       private def connack(io : Protocol::IO, session_present : Bool,

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -23,27 +23,26 @@ module LavinMQ
         metadata = ::Log::Metadata.build({address: connection_info.remote_address.to_s})
         logger = Logger.new(Log, metadata)
         begin
-          # CONNECT carries the protocol version on the wire, so bootstrap with a
-          # v3 IO and reframe to the negotiated version (v3.1 / v3.1.1 / v5) for
-          # every subsequent packet. Keeping the v3 boot IO in scope lets the
-          # rescue below still answer a parse-time Connect error with a CONNACK.
+          # CONNECT carries the protocol version on the wire; read_connect
+          # bootstraps with a v3 IO and hands back one reframed to the negotiated
+          # version (v3.1 / v3.1.1 / v5) for every subsequent packet. It only
+          # rebinds io on success, so the v3 boot IO survives a parse error and
+          # the rescue below can still answer with a CONNACK.
           io = Protocol::IO::V3.new(socket, @config.mqtt_max_packet_size)
-          if packet = io.read_packet.as?(Protocol::Connect)
-            io = io.reframe(packet.version)
-            logger.trace { "recv #{packet.inspect}" }
-            user, broker = authenticate(io, packet)
-            # A client that sends an empty client id gets one assigned; a v5
-            # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
-            assigned_client_id = nil
-            if packet.client_id.empty?
-              packet = with_assigned_client_id(packet, user.name)
-              assigned_client_id = packet.client_id
-            end
-            validate_client_id!(packet.client_id, user.name)
-            session_present = broker.session_present?(packet.client_id, packet.clean_session?)
-            connack io, session_present, Protocol::Connack::ReturnCode::Accepted, assigned_client_id
-            broker.run_client(io, connection_info, user, packet)
+          packet, io = io.read_connect
+          logger.trace { "recv #{packet.inspect}" }
+          user, broker = authenticate(io, packet)
+          # A client that sends an empty client id gets one assigned; a v5
+          # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
+          assigned_client_id = nil
+          if packet.client_id.empty?
+            assigned_client_id = generated_client_id(user.name)
+            packet = packet.copy_with(client_id: assigned_client_id)
           end
+          validate_client_id!(packet.client_id, user.name)
+          session_present = broker.session_present?(packet.client_id, packet.clean_session?)
+          connack io, session_present, Protocol::Connack::ReturnCode::Accepted, assigned_client_id
+          broker.run_client(io, connection_info, user, packet)
         rescue ex : Protocol::Error::Connect
           logger.warn { "Connect error #{ex.inspect}" }
           if io
@@ -121,24 +120,12 @@ module LavinMQ
         {user, broker}
       end
 
-      # Returns a copy of the CONNECT with a server-generated client id filled in
-      # (Connect is an immutable struct, so the id can't be set in place). Used
-      # when the client sends an empty client id.
-      def with_assigned_client_id(packet, username : String)
-        client_id = case @config.mqtt_client_id_validation
-                    in .none?     then Random::Secure.base64(32)
-                    in .username? then username
-                    end
-        # Preserve the negotiated version and the client's CONNECT properties;
-        # only the client id changes.
-        Protocol::Connect.new(client_id,
-          packet.clean_session?,
-          packet.keepalive,
-          packet.username,
-          packet.password,
-          packet.will,
-          packet.version,
-          packet.properties)
+      # A server-generated client id for a client that connected without one.
+      private def generated_client_id(username : String) : String
+        case @config.mqtt_client_id_validation
+        in .none?     then Random::Secure.base64(32)
+        in .username? then username
+        end
       end
 
       private def validate_client_id!(client_id : String, username : String) : Nil

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -20,8 +20,13 @@ module LavinMQ
         metadata = ::Log::Metadata.build({address: connection_info.remote_address.to_s})
         logger = Logger.new(Log, metadata)
         begin
-          io = Protocol::IO.new(socket, @config.mqtt_max_packet_size)
+          # CONNECT carries the protocol version on the wire, so bootstrap with a
+          # v3 IO and reframe to the negotiated version (v3.1 / v3.1.1 / v5) for
+          # every subsequent packet. Keeping the v3 boot IO in scope lets the
+          # rescue below still answer a parse-time Connect error with a CONNACK.
+          io = Protocol::IO::V3.new(socket, @config.mqtt_max_packet_size)
           if packet = io.read_packet.as?(Protocol::Connect)
+            io = io.reframe(packet.version)
             logger.trace { "recv #{packet.inspect}" }
             user, broker = authenticate(io, packet)
             packet = assign_client_id(packet, user.name) if packet.client_id.empty?

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -32,10 +32,16 @@ module LavinMQ
             io = io.reframe(packet.version)
             logger.trace { "recv #{packet.inspect}" }
             user, broker = authenticate(io, packet)
-            packet = assign_client_id(packet, user.name) if packet.client_id.empty?
+            # A client that sends an empty client id gets one assigned; a v5
+            # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
+            assigned_client_id = nil
+            if packet.client_id.empty?
+              packet = with_assigned_client_id(packet, user.name)
+              assigned_client_id = packet.client_id
+            end
             validate_client_id!(packet.client_id, user.name)
             session_present = broker.session_present?(packet.client_id, packet.clean_session?)
-            connack io, session_present, Protocol::Connack::ReturnCode::Accepted
+            connack io, session_present, Protocol::Connack::ReturnCode::Accepted, assigned_client_id
             broker.run_client(io, connection_info, user, packet)
           end
         rescue ex : Protocol::Error::Connect
@@ -52,12 +58,27 @@ module LavinMQ
         end
       end
 
-      private def connack(io : Protocol::IO, session_present : Bool, return_code : Protocol::Connack::ReturnCode)
+      private def connack(io : Protocol::IO, session_present : Bool,
+                          return_code : Protocol::Connack::ReturnCode,
+                          assigned_client_id : String? = nil)
         reason = Protocol::Connack::ReasonCode.from_v3_return_code(return_code)
         # A v5 server must advertise which optional features it supports; an
         # accepted v5 connection carries the capability set. On v3 the properties
         # are ignored on the wire, so the v3 CONNACK is byte-for-byte unchanged.
-        properties = io.version.v5? && return_code.accepted? ? @server_capabilities : Protocol::ConnackProperties.new
+        properties =
+          if io.version.v5? && return_code.accepted?
+            if assigned_client_id
+              # Per-connection, so build a fresh set rather than mutating the
+              # shared static one.
+              caps = build_server_capabilities
+              caps.assigned_client_identifier = assigned_client_id
+              caps
+            else
+              @server_capabilities
+            end
+          else
+            Protocol::ConnackProperties.new
+          end
         Protocol::Connack.new(session_present, reason, properties).to_io(io)
         io.flush
       end
@@ -100,18 +121,24 @@ module LavinMQ
         {user, broker}
       end
 
-      def assign_client_id(packet, username : String)
+      # Returns a copy of the CONNECT with a server-generated client id filled in
+      # (Connect is an immutable struct, so the id can't be set in place). Used
+      # when the client sends an empty client id.
+      def with_assigned_client_id(packet, username : String)
         client_id = case @config.mqtt_client_id_validation
                     in .none?     then Random::Secure.base64(32)
                     in .username? then username
                     end
+        # Preserve the negotiated version and the client's CONNECT properties;
+        # only the client id changes.
         Protocol::Connect.new(client_id,
           packet.clean_session?,
           packet.keepalive,
           packet.username,
           packet.password,
           packet.will,
-          packet.version)
+          packet.version,
+          packet.properties)
       end
 
       private def validate_client_id!(client_id : String, username : String) : Nil

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -88,7 +88,7 @@ module LavinMQ
       # compliant; each deferred feature is then rejected in its own packet handler.
       private def build_server_capabilities : Protocol::ConnackProperties
         props = Protocol::ConnackProperties.new
-        props.maximum_qos = 1u8       # QoS 2 not implemented
+        props.maximum_qos = MAX_QOS   # QoS 2 not implemented
         props.retain_available = true # LavinMQ has a retain store
         props.wildcard_subscription_available = true
         props.topic_alias_maximum = 0u16                # topic aliases not implemented

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -23,31 +23,30 @@ module LavinMQ
         metadata = ::Log::Metadata.build({address: connection_info.remote_address.to_s})
         logger = Logger.new(Log, metadata)
         begin
-          # CONNECT carries the protocol version on the wire, so bootstrap with a
-          # v3 IO and reframe to the negotiated version (v3.1 / v3.1.1 / v5) for
-          # every subsequent packet. Keeping the v3 boot IO in scope lets the
-          # rescue below still answer a parse-time Connect error with a CONNACK.
+          # CONNECT carries the protocol version on the wire; read_connect
+          # bootstraps with a v3 IO and hands back one reframed to the negotiated
+          # version (v3.1 / v3.1.1 / v5) for every subsequent packet. It only
+          # rebinds io on success, so the v3 boot IO survives a parse error and
+          # the rescue below can still answer with a CONNACK.
           io = Protocol::IO::V3.new(socket, @config.mqtt_max_packet_size)
-          if packet = io.read_packet.as?(Protocol::Connect)
-            io = io.reframe(packet.version)
-            logger.trace { "recv #{packet.inspect}" }
-            user, broker = authenticate(io, packet)
-            # A client that sends an empty client id gets one assigned; a v5
-            # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
-            assigned_client_id = nil
-            if packet.client_id.empty?
-              packet = with_assigned_client_id(packet, user.name)
-              assigned_client_id = packet.client_id
-            end
-            validate_client_id!(packet.client_id, user.name)
-            if broker.connection_limit_reached?(packet.client_id)
-              raise Protocol::Error::ServerUnavailable.new(
-                "too many connections to vhost \"#{broker.vhost.name}\"")
-            end
-            session_present = broker.session_present?(packet.client_id, packet.clean_session?)
-            connack io, session_present, Protocol::Connack::ReturnCode::Accepted, assigned_client_id
-            broker.run_client(io, connection_info, user, packet)
+          packet, io = io.read_connect
+          logger.trace { "recv #{packet.inspect}" }
+          user, broker = authenticate(io, packet)
+          # A client that sends an empty client id gets one assigned; a v5
+          # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
+          assigned_client_id = nil
+          if packet.client_id.empty?
+            assigned_client_id = generated_client_id(user.name)
+            packet = packet.copy_with(client_id: assigned_client_id)
           end
+          validate_client_id!(packet.client_id, user.name)
+          if broker.connection_limit_reached?(packet.client_id)
+            raise Protocol::Error::ServerUnavailable.new(
+              "too many connections to vhost \"#{broker.vhost.name}\"")
+          end
+          session_present = broker.session_present?(packet.client_id, packet.clean_session?)
+          connack io, session_present, Protocol::Connack::ReturnCode::Accepted, assigned_client_id
+          broker.run_client(io, connection_info, user, packet)
         rescue ex : Protocol::Error::Connect
           logger.warn { "Connect error #{ex.inspect}" }
           if io
@@ -125,24 +124,12 @@ module LavinMQ
         {user, broker}
       end
 
-      # Returns a copy of the CONNECT with a server-generated client id filled in
-      # (Connect is an immutable struct, so the id can't be set in place). Used
-      # when the client sends an empty client id.
-      def with_assigned_client_id(packet, username : String)
-        client_id = case @config.mqtt_client_id_validation
-                    in .none?     then Random::Secure.base64(32)
-                    in .username? then username
-                    end
-        # Preserve the negotiated version and the client's CONNECT properties;
-        # only the client id changes.
-        Protocol::Connect.new(client_id,
-          packet.clean_session?,
-          packet.keepalive,
-          packet.username,
-          packet.password,
-          packet.will,
-          packet.version,
-          packet.properties)
+      # A server-generated client id for a client that connected without one.
+      private def generated_client_id(username : String) : String
+        case @config.mqtt_client_id_validation
+        in .none?     then Random::Secure.base64(32)
+        in .username? then username
+        end
       end
 
       private def validate_client_id!(client_id : String, username : String) : Nil

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -31,6 +31,14 @@ module LavinMQ
           io = Protocol::IO::V3.new(socket, @config.mqtt_max_packet_size)
           packet, io = io.read_connect
           logger.trace { "recv #{packet.inspect}" }
+          # Enhanced authentication (the AUTH-packet flow) is not supported;
+          # reject before username/password auth so the reason is accurate. v5
+          # only - v3 has no properties. [MQTT-4.12]
+          if packet.properties.authentication_method
+            logger.warn { "Enhanced authentication requested but not supported" }
+            reject_connack(io, Protocol::Connack::ReasonCode::BadAuthenticationMethod)
+            return socket.close
+          end
           user, broker = authenticate(io, packet)
           # A client that sends an empty client id gets one assigned; a v5
           # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
@@ -59,6 +67,13 @@ module LavinMQ
           logger.warn { "Received invalid Connect packet: #{ex.inspect}" }
           socket.close
         end
+      end
+
+      # Send a v5 CONNACK carrying a reason code that has no v3 return-code
+      # equivalent (e.g. BadAuthenticationMethod 0x8C). v5-only by construction.
+      private def reject_connack(io : Protocol::IO, reason : Protocol::Connack::ReasonCode)
+        Protocol::Connack.new(false, reason).to_io(io)
+        io.flush
       end
 
       private def connack(io : Protocol::IO, session_present : Bool,

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -92,7 +92,7 @@ module LavinMQ
       # compliant; each deferred feature is then rejected in its own packet handler.
       private def build_server_capabilities : Protocol::ConnackProperties
         props = Protocol::ConnackProperties.new
-        props.maximum_qos = 1u8       # QoS 2 not implemented
+        props.maximum_qos = MAX_QOS   # QoS 2 not implemented
         props.retain_available = true # LavinMQ has a retain store
         props.wildcard_subscription_available = true
         props.topic_alias_maximum = 0u16                # topic aliases not implemented

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -39,6 +39,15 @@ module LavinMQ
             reject_connack(io, Protocol::Connack::ReasonCode::BadAuthenticationMethod)
             return socket.close
           end
+          # We advertise maximum_qos = MAX_QOS, and 3.1.2.6 wants a Will above
+          # it refused rather than quietly clamped. v5 only, and deliberately:
+          # v3 has no return code meaning "QoS not supported", so a v3 Will at
+          # QoS 2 stays accepted and is clamped at delivery, as it always was.
+          if packet.version.v5? && packet.will.try { |w| w.qos > MAX_QOS }
+            logger.warn { "Will QoS #{packet.will.try(&.qos)} exceeds maximum_qos #{MAX_QOS}" }
+            reject_connack(io, Protocol::Connack::ReasonCode::QoSNotSupported)
+            return socket.close
+          end
           user, broker = authenticate(io, packet)
           # A client that sends an empty client id gets one assigned; a v5
           # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -32,14 +32,20 @@ module LavinMQ
             io = io.reframe(packet.version)
             logger.trace { "recv #{packet.inspect}" }
             user, broker = authenticate(io, packet)
-            packet = assign_client_id(packet, user.name) if packet.client_id.empty?
+            # A client that sends an empty client id gets one assigned; a v5
+            # CONNACK must echo it back so the client learns its id [MQTT-3.2.2-16].
+            assigned_client_id = nil
+            if packet.client_id.empty?
+              packet = with_assigned_client_id(packet, user.name)
+              assigned_client_id = packet.client_id
+            end
             validate_client_id!(packet.client_id, user.name)
             if broker.connection_limit_reached?(packet.client_id)
               raise Protocol::Error::ServerUnavailable.new(
                 "too many connections to vhost \"#{broker.vhost.name}\"")
             end
             session_present = broker.session_present?(packet.client_id, packet.clean_session?)
-            connack io, session_present, Protocol::Connack::ReturnCode::Accepted
+            connack io, session_present, Protocol::Connack::ReturnCode::Accepted, assigned_client_id
             broker.run_client(io, connection_info, user, packet)
           end
         rescue ex : Protocol::Error::Connect
@@ -56,12 +62,27 @@ module LavinMQ
         end
       end
 
-      private def connack(io : Protocol::IO, session_present : Bool, return_code : Protocol::Connack::ReturnCode)
+      private def connack(io : Protocol::IO, session_present : Bool,
+                          return_code : Protocol::Connack::ReturnCode,
+                          assigned_client_id : String? = nil)
         reason = Protocol::Connack::ReasonCode.from_v3_return_code(return_code)
         # A v5 server must advertise which optional features it supports; an
         # accepted v5 connection carries the capability set. On v3 the properties
         # are ignored on the wire, so the v3 CONNACK is byte-for-byte unchanged.
-        properties = io.version.v5? && return_code.accepted? ? @server_capabilities : Protocol::ConnackProperties.new
+        properties =
+          if io.version.v5? && return_code.accepted?
+            if assigned_client_id
+              # Per-connection, so build a fresh set rather than mutating the
+              # shared static one.
+              caps = build_server_capabilities
+              caps.assigned_client_identifier = assigned_client_id
+              caps
+            else
+              @server_capabilities
+            end
+          else
+            Protocol::ConnackProperties.new
+          end
         Protocol::Connack.new(session_present, reason, properties).to_io(io)
         io.flush
       end
@@ -104,18 +125,24 @@ module LavinMQ
         {user, broker}
       end
 
-      def assign_client_id(packet, username : String)
+      # Returns a copy of the CONNECT with a server-generated client id filled in
+      # (Connect is an immutable struct, so the id can't be set in place). Used
+      # when the client sends an empty client id.
+      def with_assigned_client_id(packet, username : String)
         client_id = case @config.mqtt_client_id_validation
                     in .none?     then Random::Secure.base64(32)
                     in .username? then username
                     end
+        # Preserve the negotiated version and the client's CONNECT properties;
+        # only the client id changes.
         Protocol::Connect.new(client_id,
           packet.clean_session?,
           packet.keepalive,
           packet.username,
           packet.password,
           packet.will,
-          packet.version)
+          packet.version,
+          packet.properties)
       end
 
       private def validate_client_id!(client_id : String, username : String) : Nil

--- a/src/lavinmq/mqtt/connection_factory.cr
+++ b/src/lavinmq/mqtt/connection_factory.cr
@@ -12,8 +12,11 @@ module LavinMQ
     class ConnectionFactory < LavinMQ::ConnectionFactory
       Log = LavinMQ::Log.for "mqtt.connection_factory"
 
+      @server_capabilities : Protocol::ConnackProperties
+
       def initialize(@authenticator : Auth::Authenticator,
                      @brokers : Brokers, @config : Config)
+        @server_capabilities = build_server_capabilities
       end
 
       def start(socket : ::IO, connection_info : ConnectionInfo)
@@ -54,8 +57,29 @@ module LavinMQ
       end
 
       private def connack(io : Protocol::IO, session_present : Bool, return_code : Protocol::Connack::ReturnCode)
-        Protocol::Connack.new(session_present, return_code).to_io(io)
+        reason = Protocol::Connack::ReasonCode.from_v3_return_code(return_code)
+        # A v5 server must advertise which optional features it supports; an
+        # accepted v5 connection carries the capability set. On v3 the properties
+        # are ignored on the wire, so the v3 CONNACK is byte-for-byte unchanged.
+        properties = io.version.v5? && return_code.accepted? ? @server_capabilities : Protocol::ConnackProperties.new
+        Protocol::Connack.new(session_present, reason, properties).to_io(io)
         io.flush
+      end
+
+      # The fixed v5 capabilities LavinMQ advertises in CONNACK. They depend only
+      # on config (fixed after startup), so this is built once in initialize.
+      # Advertising a feature as unavailable is what makes deferring it spec-
+      # compliant; each deferred feature is then rejected in its own packet handler.
+      private def build_server_capabilities : Protocol::ConnackProperties
+        props = Protocol::ConnackProperties.new
+        props.maximum_qos = 1u8       # QoS 2 not implemented
+        props.retain_available = true # LavinMQ has a retain store
+        props.wildcard_subscription_available = true
+        props.topic_alias_maximum = 0u16                # topic aliases not implemented
+        props.subscription_identifier_available = false # subscription ids not implemented
+        props.shared_subscription_available = false     # shared subscriptions not implemented
+        props.maximum_packet_size = @config.mqtt_max_packet_size
+        props
       end
 
       def authenticate(io : Protocol::IO, packet)

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -3,5 +3,9 @@ module LavinMQ
     EXCHANGE      = "mqtt.default"
     QOS_HEADER    = "mqtt.qos"
     RETAIN_HEADER = "mqtt.retain"
+    # Highest QoS LavinMQ supports. QoS 2 is not implemented, so this is the
+    # value advertised in the v5 CONNACK, enforced on inbound v5 PUBLISH, and
+    # used to clamp delivery QoS.
+    MAX_QOS = 1u8
   end
 end

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -7,5 +7,9 @@ module LavinMQ
     # value advertised in the v5 CONNACK, enforced on inbound v5 PUBLISH, and
     # used to clamp delivery QoS.
     MAX_QOS = 1u8
+    # Queue argument carrying a session's Session Expiry Interval, in seconds.
+    # It lives in the arguments because that is the only part of the
+    # Queue::Declare frame definitions_store persists that can hold a UInt32.
+    SESSION_EXPIRY_ARG = "x-mqtt-session-expiry"
   end
 end

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -5,6 +5,10 @@ module LavinMQ
     EXCHANGE      = "mqtt.default"
     QOS_HEADER    = "mqtt.qos"
     RETAIN_HEADER = "mqtt.retain"
+    # Highest QoS LavinMQ supports. QoS 2 is not implemented, so this is the
+    # value advertised in the v5 CONNACK, enforced on inbound v5 PUBLISH, and
+    # used to clamp delivery QoS.
+    MAX_QOS = 1u8
 
     QOS0_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 0u8})
     QOS1_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 1u8})

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -1,10 +1,17 @@
 require "../amqp"
+require "./subscription_options"
 
 module LavinMQ
   module MQTT
     EXCHANGE      = "mqtt.default"
     QOS_HEADER    = "mqtt.qos"
     RETAIN_HEADER = "mqtt.retain"
+    # Binding arguments carrying the v5 subscription options that outlive the
+    # SUBSCRIBE. Left out of the table entirely when false, so a default
+    # subscription's arguments stay byte-identical to what LavinMQ has always
+    # written and older definitions files keep loading unchanged.
+    NO_LOCAL_HEADER            = "mqtt.no-local"
+    RETAIN_AS_PUBLISHED_HEADER = "mqtt.retain-as-published"
     # Highest QoS LavinMQ supports. QoS 2 is not implemented, so this is the
     # value advertised in the v5 CONNACK, enforced on inbound v5 PUBLISH, and
     # used to clamp delivery QoS.
@@ -14,27 +21,62 @@ module LavinMQ
     # Queue::Declare frame definitions_store persists that can hold a UInt32.
     SESSION_EXPIRY_ARG = "x-mqtt-session-expiry"
 
+    # Two constants because MAX_QOS is 1; raising it means adding one per QoS
+    # level. Treat as read-only - they are shared by every default subscription.
     QOS0_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 0u8})
     QOS1_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 1u8})
+    # Stamped on every message replayed from the retain store at subscribe time,
+    # which always carries RETAIN=1 [MQTT-3.3.1-8]. Shared and never mutated, so
+    # a SUBSCRIBE allocates no table - and none at all when Retain Handling
+    # suppresses the replay.
+    RETAINED_HEADERS = AMQP::Table.new({RETAIN_HEADER => true})
 
-    # The binding arguments that carry the given QoS, as one of the two shared,
-    # treat-as-read-only constants above, so no table is allocated per subscription.
-    # QoS 2 isn't supported and is granted as QoS 1, hence anything above 0 maps to
-    # QOS1_ARGUMENTS.
-    def self.qos_arguments(qos : UInt8) : AMQP::Table
-      qos.zero? ? QOS0_ARGUMENTS : QOS1_ARGUMENTS
+    # The highest QoS we can actually deliver for a requested one, and the single
+    # place that rule lives. Accepts anything: the packet hands us a `UInt8`, the
+    # message store a `UInt8?`, and a binding table any `Int` at all, since
+    # bindings made over the HTTP API or imported from a definitions file never
+    # pass through the MQTT parser. QoS 2 is granted as QoS 1 [MQTT-3.9.3-1]; a
+    # missing or negative value as QoS 0.
+    def self.granted_qos(qos : Int?) : UInt8
+      return 0u8 unless qos
+      qos.clamp(0, MAX_QOS).to_u8
     end
 
-    # The QoS carried in binding arguments, the inverse of `qos_arguments`.
+    # A session's queue name. The one place the prefix is spelled.
+    def self.session_name(client_id : String) : String
+      "mqtt.#{client_id}"
+    end
+
+    # The binding arguments carrying a subscription's options.
     #
-    # Any integer type is accepted: bindings made over the HTTP API or imported
-    # from a definitions file don't go through the MQTT protocol parser, so the
-    # header isn't necessarily a `UInt8`. The value is granted as the closest
-    # supported QoS, never higher than what we can deliver: QoS 2 as QoS 1
-    # [MQTT-3.9.3-1], a missing, negative or non-integer value as QoS 0.
-    def self.qos(arguments : AMQP::Table?) : UInt8
-      qos = arguments.try { |args| args[QOS_HEADER]?.as?(Int) } || 0
-      qos.clamp(0, 1).to_u8
+    # Returns one of the two shared constants when neither option is set, which
+    # is the overwhelmingly common case, so an ordinary subscription allocates
+    # nothing. Only a subscription that actually uses an option builds a table.
+    def self.subscription_arguments(options : SubscriptionOptions) : AMQP::Table
+      qos = options.qos
+      unless options.no_local? || options.retain_as_published?
+        return qos.zero? ? QOS0_ARGUMENTS : QOS1_ARGUMENTS
+      end
+      arguments = AMQP::Table.new({QOS_HEADER => qos})
+      arguments[NO_LOCAL_HEADER] = true if options.no_local?
+      arguments[RETAIN_AS_PUBLISHED_HEADER] = true if options.retain_as_published?
+      arguments
+    end
+
+    # The options carried in binding arguments, the inverse of
+    # `subscription_arguments`.
+    #
+    # Hostile-input safe, and it has to be: `Exchange#bind` runs this during
+    # `load!`, so a raise here is a boot failure. Any integer type is accepted
+    # for the QoS and clamped; a boolean key that is not exactly `true` - a
+    # string, an int, absent - reads as false. Unlike `Session.expiry_from`
+    # nothing is lost by degrading quietly, so it does not warn.
+    def self.subscription_options(arguments : AMQP::Table?) : SubscriptionOptions
+      return SubscriptionOptions.new unless arguments
+      SubscriptionOptions.new(
+        granted_qos(arguments[QOS_HEADER]?.as?(Int)),
+        arguments[NO_LOCAL_HEADER]? == true,
+        arguments[RETAIN_AS_PUBLISHED_HEADER]? == true)
     end
   end
 end

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -9,6 +9,10 @@ module LavinMQ
     # value advertised in the v5 CONNACK, enforced on inbound v5 PUBLISH, and
     # used to clamp delivery QoS.
     MAX_QOS = 1u8
+    # Queue argument carrying a session's Session Expiry Interval, in seconds.
+    # It lives in the arguments because that is the only part of the
+    # Queue::Declare frame definitions_store persists that can hold a UInt32.
+    SESSION_EXPIRY_ARG = "x-mqtt-session-expiry"
 
     QOS0_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 0u8})
     QOS1_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 1u8})

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -31,14 +31,18 @@ module LavinMQ
         bodysize = packet.payload.bytesize.to_u64
         body = ::IO::Memory.new(packet.payload, writable: false)
 
+        # `Publish#topic` decodes @topic into a fresh String on every call, so
+        # hold it once: this is the publish hot path.
+        topic = packet.topic
+
         if packet.retain?
-          @retain_store.retain(packet.topic, body, bodysize)
+          @retain_store.retain(topic, body, bodysize)
           body.rewind
         end
 
-        msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
+        msg = Message.new(timestamp, EXCHANGE, topic, properties, bodysize, body)
         count = 0u32
-        @tree.each_entry(packet.topic) do |queue, qos, _filter|
+        @tree.each_entry(topic) do |queue, qos, _filter|
           # The minimum of the publish and subscription QoS [MQTT-3.8.4-8];
           # the subscription's alone would upgrade a fire-and-forget publish.
           msg.properties.delivery_mode = Math.min(packet.qos, qos)

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -39,7 +39,9 @@ module LavinMQ
         msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
         count = 0u32
         @tree.each_entry(packet.topic) do |queue, qos, _filter|
-          msg.properties.delivery_mode = qos
+          # The minimum of the publish and subscription QoS [MQTT-3.8.4-8];
+          # the subscription's alone would upgrade a fire-and-forget publish.
+          msg.properties.delivery_mode = Math.min(packet.qos, qos)
           if queue.publish(msg)
             count += 1
             msg.body_io.rewind

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -1,5 +1,6 @@
 require "../amqp/exchange"
 require "./consts"
+require "./publish_headers"
 require "../destination"
 require "./subscription_tree"
 require "./session"
@@ -21,7 +22,9 @@ module LavinMQ
 
       def publish(packet : Protocol::Publish) : UInt32
         @publish_in_count.add(1, :relaxed)
-        properties = AMQP::Properties.new(headers: AMQP::Table.new)
+        headers = AMQP::Table.new
+        PublishHeaders.store(packet.properties, headers)
+        properties = AMQP::Properties.new(headers: headers)
         properties.delivery_mode = packet.qos
 
         timestamp = RoughTime.unix_ms

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -31,9 +31,13 @@ module LavinMQ
         bodysize = packet.payload.bytesize.to_u64
         body = ::IO::Memory.new(packet.payload, writable: false)
 
-        msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
+        # `Publish#topic` decodes @topic into a fresh String on every call, so
+        # hold it once: this is the publish hot path.
+        topic = packet.topic
+
+        msg = Message.new(timestamp, EXCHANGE, topic, properties, bodysize, body)
         count = 0u32
-        @tree.each_entry(packet.topic) do |queue, qos, _filter|
+        @tree.each_entry(topic) do |queue, qos, _filter|
           # The minimum of the publish and subscription QoS [MQTT-3.8.4-8];
           # the subscription's alone would upgrade a fire-and-forget publish.
           msg.properties.delivery_mode = Math.min(packet.qos, qos)

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -20,9 +20,16 @@ module LavinMQ
         super(vhost, name, false, false, true)
       end
 
-      def publish(packet : Protocol::Publish) : UInt32
+      # `publisher` is the publishing client's session name, needed to resolve
+      # the No Local subscription option [MQTT-3.8.3-3].
+      def publish(packet : Protocol::Publish, publisher : String) : UInt32
         @publish_in_count.add(1, :relaxed)
         headers = AMQP::Table.new
+        # Reserve the slot before the properties, and always as a Bool, so the
+        # per-subscription overwrite below stays on Table's in-place path and
+        # scans one key rather than up to six v5 property fields.
+        retained = packet.retain?
+        headers[RETAIN_HEADER] = false if retained
         PublishHeaders.store(packet.properties, headers)
         properties = AMQP::Properties.new(headers: headers)
         properties.delivery_mode = packet.qos
@@ -38,9 +45,17 @@ module LavinMQ
         msg = Message.new(timestamp, EXCHANGE, topic, properties, bodysize, body)
         count = 0u32
         @tree.each_entry(topic) do |queue, options, _filter|
+          # No Local [MQTT-3.8.3-3]. Bit first: the name compare is then paid
+          # for only by a subscription that asked for it.
+          next if options.no_local? && queue.name == publisher
           # The minimum of the publish and subscription QoS [MQTT-3.8.4-8];
           # the subscription's alone would upgrade a fire-and-forget publish.
           msg.properties.delivery_mode = Math.min(packet.qos, options.qos)
+          # Retain As Published. Written for every matched entry, or a `true`
+          # leaks into every later subscriber in this walk. Safe to vary per
+          # destination only because MessageStore#push serializes the
+          # properties synchronously, as delivery_mode above already assumes.
+          headers[RETAIN_HEADER] = options.retain_as_published? if retained
           if queue.publish(msg)
             count += 1
             msg.body_io.rewind

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -37,10 +37,10 @@ module LavinMQ
 
         msg = Message.new(timestamp, EXCHANGE, topic, properties, bodysize, body)
         count = 0u32
-        @tree.each_entry(topic) do |queue, qos, _filter|
+        @tree.each_entry(topic) do |queue, options, _filter|
           # The minimum of the publish and subscription QoS [MQTT-3.8.4-8];
           # the subscription's alone would upgrade a fire-and-forget publish.
-          msg.properties.delivery_mode = Math.min(packet.qos, qos)
+          msg.properties.delivery_mode = Math.min(packet.qos, options.qos)
           if queue.publish(msg)
             count += 1
             msg.body_io.rewind
@@ -53,8 +53,8 @@ module LavinMQ
 
       def bindings_details : Array(SubscriptionDetails)
         result = Array(SubscriptionDetails).new
-        @tree.each_entry do |session, qos, filter|
-          result << SubscriptionDetails.new(name, vhost.name, SubscriptionKey.new(filter, qos), session)
+        @tree.each_entry do |session, options, filter|
+          result << SubscriptionDetails.new(name, vhost.name, SubscriptionKey.new(filter, options), session)
         end
         result
       end
@@ -68,20 +68,20 @@ module LavinMQ
       end
 
       def bind(destination : MQTT::Session, routing_key : String, arguments = nil) : Bool
-        qos = MQTT.qos(arguments)
-        @tree.subscribe(routing_key, destination, qos)
+        options = MQTT.subscription_options(arguments)
+        @tree.subscribe(routing_key, destination, options)
 
-        binding_key = SubscriptionKey.new(routing_key, qos)
+        binding_key = SubscriptionKey.new(routing_key, options)
         data = SubscriptionDetails.new(name, vhost.name, binding_key, destination)
         notify_observers(ExchangeEvent::Bind, data)
         true
       end
 
       def unbind(destination : MQTT::Session, routing_key, arguments = nil) : Bool
-        qos = MQTT.qos(arguments)
+        options = MQTT.subscription_options(arguments)
         @tree.unsubscribe(routing_key, destination)
 
-        binding_key = SubscriptionKey.new(routing_key, qos)
+        binding_key = SubscriptionKey.new(routing_key, options)
         data = SubscriptionDetails.new(name, vhost.name, binding_key, destination)
         notify_observers(ExchangeEvent::Unbind, data)
 

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -34,7 +34,9 @@ module LavinMQ
         msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
         count = 0u32
         @tree.each_entry(packet.topic) do |queue, qos, _filter|
-          msg.properties.delivery_mode = qos
+          # The minimum of the publish and subscription QoS [MQTT-3.8.4-8];
+          # the subscription's alone would upgrade a fire-and-forget publish.
+          msg.properties.delivery_mode = Math.min(packet.qos, qos)
           if queue.publish(msg)
             count += 1
             msg.body_io.rewind

--- a/src/lavinmq/mqtt/publish_headers.cr
+++ b/src/lavinmq/mqtt/publish_headers.cr
@@ -1,0 +1,78 @@
+require "../amqp"
+require "./protocol"
+
+module LavinMQ
+  module MQTT
+    # Round-trips v5 PUBLISH properties through AMQP message headers, so a v5
+    # publisher's properties survive store-and-forward to a v5 subscriber.
+    #
+    # Header-only mapping (no AMQP-native slots like content_type/reply_to - that
+    # cross-protocol mapping is a separate concern). `topic_alias` and
+    # `subscription_identifiers` are intentionally not carried (rejected on
+    # ingress / not supported). Retained messages don't carry properties yet -
+    # the retain store keeps only the body (follow-up).
+    module PublishHeaders
+      PAYLOAD_FORMAT_INDICATOR = "mqtt.payload_format_indicator"
+      MESSAGE_EXPIRY_INTERVAL  = "mqtt.message_expiry_interval"
+      RESPONSE_TOPIC           = "mqtt.response_topic"
+      CORRELATION_DATA         = "mqtt.correlation_data"
+      CONTENT_TYPE             = "mqtt.content_type"
+      USER_PROPERTIES          = "mqtt.user_properties"
+
+      # Stash the present (non-nil) v5 properties into `headers`. A v3 or
+      # property-less publish adds nothing.
+      def self.store(props : Protocol::PublishProperties, headers : AMQP::Table) : Nil
+        if v = props.payload_format_indicator
+          headers[PAYLOAD_FORMAT_INDICATOR] = v
+        end
+        if v = props.message_expiry_interval
+          headers[MESSAGE_EXPIRY_INTERVAL] = v
+        end
+        if v = props.response_topic
+          headers[RESPONSE_TOPIC] = v
+        end
+        if v = props.correlation_data
+          headers[CORRELATION_DATA] = v
+        end
+        if v = props.content_type
+          headers[CONTENT_TYPE] = v
+        end
+        return if props.user_properties.empty?
+        # An array of {key,value} tables preserves order and duplicate keys
+        # [MQTT-3.3.2-18], which a flat Table/Hash would lose.
+        headers[USER_PROPERTIES] = props.user_properties.map do |(key, value)|
+          pair = AMQP::Table.new
+          pair["key"] = key
+          pair["value"] = value
+          pair
+        end
+      end
+
+      # Rebuild v5 properties from `headers`; returns empty properties when none
+      # were stashed.
+      def self.restore(headers : AMQP::Table?) : Protocol::PublishProperties
+        props = Protocol::PublishProperties.new
+        return props unless headers
+        props.payload_format_indicator = headers[PAYLOAD_FORMAT_INDICATOR]?.as?(Bool)
+        headers[MESSAGE_EXPIRY_INTERVAL]?.as?(Int).try { |i| props.message_expiry_interval = i.to_u32 }
+        props.response_topic = headers[RESPONSE_TOPIC]?.as?(String)
+        props.correlation_data = headers[CORRELATION_DATA]?.as?(Bytes)
+        props.content_type = headers[CONTENT_TYPE]?.as?(String)
+        entries = headers[USER_PROPERTIES]?
+        props.user_properties = restore_user_properties(entries) if entries.is_a?(Array)
+        props
+      end
+
+      private def self.restore_user_properties(entries : Array) : Array({String, String})
+        result = Array({String, String}).new(entries.size)
+        entries.each do |entry|
+          pair = entry.as?(AMQP::Table) || next
+          key = pair["key"]?.as?(String)
+          value = pair["value"]?.as?(String)
+          result << {key, value} if key && value
+        end
+        result
+      end
+    end
+  end
+end

--- a/src/lavinmq/mqtt/publish_headers.cr
+++ b/src/lavinmq/mqtt/publish_headers.cr
@@ -50,17 +50,40 @@ module LavinMQ
 
       # Rebuild v5 properties from `headers`; returns empty properties when none
       # were stashed.
+      #
+      # `headers` is not necessarily something `store` wrote: an AMQP client can
+      # bind `mqtt.<client-id>` to `amq.topic` and publish arbitrary values. Every
+      # field must therefore degrade to nil rather than raise - a raise here lands
+      # in `Session#get_packet`, which requeues and re-raises, so the message
+      # poisons the queue on every redelivery.
       def self.restore(headers : AMQP::Table?) : Protocol::PublishProperties
         props = Protocol::PublishProperties.new
         return props unless headers
         props.payload_format_indicator = headers[PAYLOAD_FORMAT_INDICATOR]?.as?(Bool)
-        headers[MESSAGE_EXPIRY_INTERVAL]?.as?(Int).try { |i| props.message_expiry_interval = i.to_u32 }
-        props.response_topic = headers[RESPONSE_TOPIC]?.as?(String)
+        props.message_expiry_interval = fetch_u32?(headers, MESSAGE_EXPIRY_INTERVAL)
+        props.response_topic = fetch_topic?(headers, RESPONSE_TOPIC)
         props.correlation_data = headers[CORRELATION_DATA]?.as?(Bytes)
         props.content_type = headers[CONTENT_TYPE]?.as?(String)
         entries = headers[USER_PROPERTIES]?
         props.user_properties = restore_user_properties(entries) if entries.is_a?(Array)
         props
+      end
+
+      # Every four-byte-int property goes through here, so a value outside
+      # UInt32 drops the property instead of raising `OverflowError`. `Int` has
+      # no `to_u32?`, hence the explicit bounds check.
+      private def self.fetch_u32?(headers : AMQP::Table, key : String) : UInt32?
+        i = headers[key]?.as?(Int) || return
+        return unless i >= 0 && i <= UInt32::MAX
+        i.to_u32
+      end
+
+      # A Response Topic must be a topic name, not a filter [MQTT-3.3.2-14], and
+      # nothing validated it on the way in via an AMQP header.
+      private def self.fetch_topic?(headers : AMQP::Table, key : String) : String?
+        topic = headers[key]?.as?(String) || return
+        return if topic.includes?('#') || topic.includes?('+')
+        topic
       end
 
       private def self.restore_user_properties(entries : Array) : Array({String, String})

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -168,9 +168,14 @@ module LavinMQ
         @vhost.bind_queue(@name, EXCHANGE, tf, arguments)
       end
 
-      def unsubscribe(tf)
+      # Returns whether a matching subscription existed, so the v5 UNSUBACK can
+      # report Success vs NoSubscriptionExisted per topic filter [MQTT-3.11.3].
+      def unsubscribe(tf) : Bool
         if binding = find_binding(tf)
           unbind(tf, binding.binding_key.arguments)
+          true
+        else
+          false
         end
       end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -24,6 +24,13 @@ module LavinMQ
       ARGUMENTS      = AMQP::Table.new({"x-queue-type" => "mqtt"})
       EFFECTIVE_ARGS = {"x-queue-type"}
 
+      # Per-instance, not the ARGUMENTS constant: definitions_store persists a
+      # session as a Queue::Declare frame carrying this table, so it is the only
+      # place session state can survive a restart. Never mutated, so sharing the
+      # constant as the default is safe - but it MUST keep x-queue-type, or
+      # QueueFactory rebuilds the session as a plain AMQP queue on the next boot.
+      @arguments : AMQP::Table
+
       getter name : String
       getter vhost : VHost
       getter? auto_delete
@@ -42,7 +49,8 @@ module LavinMQ
       protected def initialize(@vhost : VHost,
                                @name : String,
                                @auto_delete = false,
-                               arguments : ::AMQ::Protocol::Table = AMQP::Table.new)
+                               arguments : ::AMQ::Protocol::Table = ARGUMENTS)
+        @arguments = arguments
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
 
@@ -76,7 +84,7 @@ module LavinMQ
       end
 
       def arguments : AMQP::Table
-        ARGUMENTS
+        @arguments
       end
 
       def close : Bool

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -206,13 +206,12 @@ module LavinMQ
           if no_ack
             begin
               packet = build_packet(env, nil)
-              yield packet, sp.bytesize
-              if env.redelivered
-                @redeliver_count.add(1, :relaxed)
-              else
-                @deliver_no_ack_count.add(1, :relaxed)
-                @deliver_get_count.add(1, :relaxed)
+              if exceeds_max_packet_size?(packet)
+                delete_message(sp)
+                next
               end
+              yield packet, sp.bytesize
+              record_delivery(env.redelivered, no_ack)
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
               raise ex
@@ -226,15 +225,16 @@ module LavinMQ
                 return false
               end
               packet = build_packet(env, id)
+              if exceeds_max_packet_size?(packet)
+                # Discard without sending and complete the delivery: do not track
+                # it in @unacked, so it is not redelivered [MQTT-3.1.2-25].
+                delete_message(sp)
+                next
+              end
               @unacked_count.add(1, :relaxed)
               @unacked_bytesize.add(sp.bytesize, :relaxed)
               yield packet, sp.bytesize
-              if env.redelivered
-                @redeliver_count.add(1, :relaxed)
-              else
-                @deliver_count.add(1, :relaxed)
-                @deliver_get_count.add(1, :relaxed)
-              end
+              record_delivery(env.redelivered, no_ack)
               @unacked[id] = sp
               @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
             rescue ex # requeue failed delivery
@@ -251,6 +251,24 @@ module LavinMQ
         @log.error(ex) { "Queue closed due to error" }
         close
         raise ClosedError.new(cause: ex)
+      end
+
+      private def record_delivery(redelivered : Bool, no_ack : Bool) : Nil
+        if redelivered
+          @redeliver_count.add(1, :relaxed)
+        else
+          (no_ack ? @deliver_no_ack_count : @deliver_count).add(1, :relaxed)
+          @deliver_get_count.add(1, :relaxed)
+        end
+      end
+
+      # A v5 client's Maximum Packet Size caps the packets we may send it
+      # [MQTT-3.1.2-24]. Only v5 clients set it, so size against v5 framing.
+      private def exceeds_max_packet_size?(packet : Protocol::Publish) : Bool
+        max = @client.try(&.max_packet_size) || return false
+        return false unless packet.bytesize(Protocol::Version::V5) > max
+        @log.debug { "Dropping PUBLISH exceeding client Maximum Packet Size (#{max} bytes)" }
+        true
       end
 
       def build_packet(env, packet_id) : Protocol::Publish

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -1,5 +1,6 @@
 require "digest/sha1"
 require "./protocol"
+require "./publish_headers"
 require "../mqtt"
 require "../amqp/queue/queue"
 require "../error"
@@ -258,13 +259,15 @@ module LavinMQ
         qos = msg.properties.delivery_mode || 0u8
         qos = MAX_QOS if qos > MAX_QOS
         dup = qos.zero? ? false : env.redelivered
+        properties = PublishHeaders.restore(msg.properties.headers)
         Protocol::Publish.new(
           packet_id: packet_id,
           payload: msg.body,
           dup: dup,
           qos: qos,
           retain: retained,
-          topic: msg.routing_key
+          topic: msg.routing_key,
+          properties: properties
         )
       end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -256,7 +256,7 @@ module LavinMQ
         msg = env.message
         retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
         qos = msg.properties.delivery_mode || 0u8
-        qos = 1u8 if qos > 1
+        qos = MAX_QOS if qos > MAX_QOS
         dup = qos.zero? ? false : env.redelivered
         Protocol::Publish.new(
           packet_id: packet_id,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -288,7 +288,13 @@ module LavinMQ
         qos = msg.properties.delivery_mode || 0u8
         qos = MAX_QOS if qos > MAX_QOS
         dup = qos.zero? ? false : env.redelivered
-        properties = PublishHeaders.restore(msg.properties.headers)
+        # IO::V3#write_properties discards these, so a v3 subscriber should not
+        # pay six Table#fetch linear scans per delivery to build them.
+        properties = if @client.try(&.version.v5?)
+                       PublishHeaders.restore(msg.properties.headers)
+                     else
+                       Protocol::PublishProperties.new
+                     end
         Protocol::Publish.new(
           packet_id: packet_id,
           payload: msg.body,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -156,9 +156,12 @@ module LavinMQ
         delivered_bytes = 0_i32
         loop do
           break if closed?
-          next @msg_store.empty.when_false.receive? if @msg_store.empty?
+          # Client before store: an offline session has to park on @has_client,
+          # both so the expiry clock runs and so it does not wake on a publish it
+          # cannot deliver.
           client = @client
-          next @has_client.when_true.receive? if client.nil?
+          next wait_for_client if client.nil?
+          next wait_for_messages if @msg_store.empty?
           next @has_capacity.when_true.receive? unless @has_capacity.value
           get_packet do |pub_packet, bytesize|
             client.send(pub_packet)
@@ -173,6 +176,46 @@ module LavinMQ
           @client.try &.close("Server force closed client")
           self.client = nil
         end
+      end
+
+      # Parks until there is something to deliver. The detach arm matters: on its
+      # own, a park on @msg_store.empty never wakes when the client leaves, so the
+      # loop would never reach the top again to start the expiry clock.
+      private def wait_for_messages : Nil
+        select
+        when @msg_store.empty.when_false.receive?
+        when @has_client.when_false.receive?
+        end
+      end
+
+      # Parks until a client attaches, or until the session expires. This is the
+      # only place the expiry clock runs - exactly the window in which the session
+      # has no connection [MQTT-3.1.2.11.2]. Reattaching cancels the timer, and
+      # the next disconnect enters a fresh select, so the interval is measured
+      # from each disconnect rather than accumulated.
+      private def wait_for_client : Nil
+        ttl = @session_expiry_interval
+        # Unreachable in practice - Broker#remove_client deletes a 0-interval
+        # session - but expiring is the right answer if it is ever reached.
+        return expire if ttl.zero?
+        if ttl == UInt32::MAX
+          @has_client.when_true.receive?
+          return
+        end
+        select
+        when @has_client.when_true.receive?
+        when timeout ttl.seconds
+          expire
+        end
+      end
+
+      # Runs on the session's own fiber. `delete` closes @has_client and the
+      # message store, so deliver_loop's `break if closed?` exits on the next
+      # pass; the re-entrant q.delete from @vhost.delete_queue is a no-op via
+      # @deleted.
+      private def expire : Nil
+        @log.info { "Session expired after #{@session_expiry_interval}s offline" }
+        delete
       end
 
       def client : MQTT::Client?

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -33,7 +33,11 @@ module LavinMQ
 
       getter name : String
       getter vhost : VHost
-      getter? auto_delete
+
+      # Seconds the session outlives its connection [MQTT-3.1.2.11.2]. 0 means it
+      # ends when the connection closes, UInt32::MAX means it never expires.
+      # Single source for durable?/auto_delete? so the three cannot drift.
+      getter session_expiry_interval : UInt32
 
       @max_length : Int64? = nil
       @max_length_bytes : Int64? = nil
@@ -48,9 +52,12 @@ module LavinMQ
 
       protected def initialize(@vhost : VHost,
                                @name : String,
-                               @auto_delete = false,
+                               auto_delete = false,
                                arguments : ::AMQ::Protocol::Table = ARGUMENTS)
         @arguments = arguments
+        # Must precede any durable? use below: it decides the data dir, the
+        # replicator and the message store's durability.
+        @session_expiry_interval = self.class.expiry_from(arguments, auto_delete)
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
 
@@ -87,6 +94,22 @@ module LavinMQ
         @arguments
       end
 
+      # The argument wins when present. Read as a plain Int and bounds-checked
+      # rather than cast: it can come from an AMQP client declaring the queue by
+      # hand, in any int type.
+      #
+      # Without it, fall back to what the declare flag meant before Session
+      # Expiry Interval existed - auto_delete was clean_session, so a durable
+      # session meant "keep forever". That covers both a definitions file written
+      # by an older LavinMQ and a caller declaring a session directly.
+      protected def self.expiry_from(arguments : ::AMQ::Protocol::Table,
+                                     auto_delete : Bool) : UInt32
+        if i = arguments[SESSION_EXPIRY_ARG]?.as?(Int)
+          return i.to_u32 if i >= 0 && i <= UInt32::MAX
+        end
+        auto_delete ? 0u32 : UInt32::MAX
+      end
+
       def close : Bool
         return false if @closed.swap(true)
         @has_capacity.close
@@ -108,8 +131,25 @@ module LavinMQ
         true
       end
 
-      def clean_session?
-        @auto_delete
+      def auto_delete? : Bool
+        @session_expiry_interval.zero?
+      end
+
+      # A reconnecting client may name a different interval, and so may its
+      # DISCONNECT [MQTT-3.14.2.2.2]. Kept in @arguments too so it persists.
+      #
+      # Only ever narrows to 0 (a resumed session always had a non-zero interval,
+      # and [MQTT-3.14.2] forbids 0 -> non-zero on DISCONNECT), and a 0 interval
+      # is followed by deletion. That matters because durable? is baked into the
+      # message store's data dir and durability at construction and cannot be
+      # re-derived here.
+      def session_expiry_interval=(interval : UInt32) : Nil
+        return if interval == @session_expiry_interval
+        @session_expiry_interval = interval
+        # clone, never mutate: @arguments may be the shared ARGUMENTS constant.
+        args = @arguments.clone
+        args[SESSION_EXPIRY_ARG] = interval
+        @arguments = args
       end
 
       private def deliver_loop
@@ -143,7 +183,7 @@ module LavinMQ
         return if closed?
         @last_get_time = RoughTime.instant
 
-        unless clean_session?
+        if durable?
           @msg_store_lock.synchronize do
             @unacked.values.each do |sp|
               @msg_store.requeue(sp)
@@ -163,7 +203,7 @@ module LavinMQ
       end
 
       def durable?
-        !clean_session?
+        !@session_expiry_interval.zero?
       end
 
       def subscribe(tf, qos)
@@ -423,7 +463,7 @@ module LavinMQ
       end
 
       def match?(durable, exclusive, auto_delete, arguments) : Bool
-        durable? == durable && @auto_delete == auto_delete
+        durable? == durable && auto_delete? == auto_delete
       end
 
       def unacked_messages
@@ -444,7 +484,7 @@ module LavinMQ
           name:                         @name,
           durable:                      durable?,
           exclusive:                    false,
-          auto_delete:                  @auto_delete,
+          auto_delete:                  auto_delete?,
           arguments:                    NamedTuple.new, # "empty" AMQP::Table
           consumers:                    consumer_count,
           vhost:                        @vhost.name,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -36,8 +36,13 @@ module LavinMQ
 
       # Seconds the session outlives its connection [MQTT-3.1.2.11.2]. 0 means it
       # ends when the connection closes, UInt32::MAX means it never expires.
-      # Single source for durable?/auto_delete? so the three cannot drift.
+      # Single source for auto_delete? and the expiry clock.
       getter session_expiry_interval : UInt32
+
+      # Derived from the interval once, at construction: it selects the data dir,
+      # the replicator and the message store's durability, none of which can be
+      # re-derived once that store exists.
+      @durable : Bool
 
       @max_length : Int64? = nil
       @max_length_bytes : Int64? = nil
@@ -55,9 +60,8 @@ module LavinMQ
                                auto_delete = false,
                                arguments : ::AMQ::Protocol::Table = ARGUMENTS)
         @arguments = arguments
-        # Must precede any durable? use below: it decides the data dir, the
-        # replicator and the message store's durability.
-        @session_expiry_interval = self.class.expiry_from(arguments, auto_delete)
+        @session_expiry_interval = self.class.expiry_from(@name, arguments, auto_delete)
+        @durable = !@session_expiry_interval.zero?
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
 
@@ -94,18 +98,23 @@ module LavinMQ
         @arguments
       end
 
-      # The argument wins when present. Read as a plain Int and bounds-checked
-      # rather than cast: it can come from an AMQP client declaring the queue by
-      # hand, in any int type.
+      # The argument wins when usable. Bounds-checked rather than cast, and warned
+      # about rather than swallowed, because an AMQP client can declare mqtt.<id>
+      # by hand with any int type in there - or something that is not an int.
       #
-      # Without it, fall back to what the declare flag meant before Session
-      # Expiry Interval existed - auto_delete was clean_session, so a durable
-      # session meant "keep forever". That covers both a definitions file written
-      # by an older LavinMQ and a caller declaring a session directly.
-      protected def self.expiry_from(arguments : ::AMQ::Protocol::Table,
+      # Without a usable one, fall back to what the declare flag meant before
+      # Session Expiry Interval existed - auto_delete was clean_session, so a
+      # durable session meant "keep forever". That covers both a definitions file
+      # written by an older LavinMQ and a caller declaring a session directly.
+      protected def self.expiry_from(name : String,
+                                     arguments : ::AMQ::Protocol::Table,
                                      auto_delete : Bool) : UInt32
-        if i = arguments[SESSION_EXPIRY_ARG]?.as?(Int)
-          return i.to_u32 if i >= 0 && i <= UInt32::MAX
+        v = arguments[SESSION_EXPIRY_ARG]?
+        if v.is_a?(Int)
+          return v.to_u32 if v >= 0 && v <= UInt32::MAX
+          Log.warn { "#{name}: ignoring out-of-range #{SESSION_EXPIRY_ARG}=#{v}" }
+        elsif !v.nil?
+          Log.warn { "#{name}: ignoring non-integer #{SESSION_EXPIRY_ARG}=#{v.inspect}" }
         end
         auto_delete ? 0u32 : UInt32::MAX
       end
@@ -136,13 +145,13 @@ module LavinMQ
       end
 
       # A reconnecting client may name a different interval, and so may its
-      # DISCONNECT [MQTT-3.14.2.2.2]. Kept in @arguments too so it persists.
+      # DISCONNECT [MQTT-3.14.2.2.2]. @arguments carries it, but the definitions
+      # log has no update frame for an existing queue, so it only reaches disk at
+      # the next compaction.
       #
-      # Only ever narrows to 0 (a resumed session always had a non-zero interval,
-      # and [MQTT-3.14.2] forbids 0 -> non-zero on DISCONNECT), and a 0 interval
-      # is followed by deletion. That matters because durable? is baked into the
-      # message store's data dir and durability at construction and cannot be
-      # re-derived here.
+      # auto_delete? and the expiry clock follow this; durable? deliberately does
+      # not, so narrowing to 0 still writes a persisted deletion frame rather than
+      # leaving the original declare to replay.
       def session_expiry_interval=(interval : UInt32) : Nil
         return if interval == @session_expiry_interval
         @session_expiry_interval = interval
@@ -245,8 +254,8 @@ module LavinMQ
         @log.debug { "client set to '#{client.try &.name}'" }
       end
 
-      def durable?
-        !@session_expiry_interval.zero?
+      def durable? : Bool
+        @durable
       end
 
       def subscribe(tf, qos)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -238,14 +238,20 @@ module LavinMQ
               end
               @unacked_count.add(1, :relaxed)
               @unacked_bytesize.add(sp.bytesize, :relaxed)
-              yield packet, sp.bytesize
-              record_delivery(env.redelivered, no_ack)
-              @unacked[id] = sp
-              @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
+              begin
+                yield packet, sp.bytesize
+                record_delivery(env.redelivered, no_ack)
+                @unacked[id] = sp
+                @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
+              rescue ex # roll back only what this block added
+                # Scoped tightly on purpose: build_packet above can raise, and
+                # subtracting a count that was never added goes negative.
+                @unacked_count.sub(1, :relaxed)
+                @unacked_bytesize.sub(sp.bytesize, :relaxed)
+                raise ex
+              end
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
-              @unacked_count.sub(1, :relaxed)
-              @unacked_bytesize.sub(sp.bytesize, :relaxed)
               raise ex
             end
           end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -21,8 +21,11 @@ module LavinMQ
       include AMQP::QueueStats
       Log = ::LavinMQ::Log.for "mqtt.session"
 
-      ARGUMENTS      = AMQP::Table.new({"x-queue-type" => "mqtt"})
-      EFFECTIVE_ARGS = {"x-queue-type"}
+      ARGUMENTS = AMQP::Table.new({"x-queue-type" => "mqtt"})
+      # The arguments a session actually acts on, reported as `effective_arguments`
+      # over the HTTP API. Both are honoured whether declared by a client or read
+      # back from the definitions file.
+      EFFECTIVE_ARGS = {"x-queue-type", SESSION_EXPIRY_ARG}
 
       # Per-instance, not the ARGUMENTS constant: definitions_store persists a
       # session as a Queue::Declare frame carrying this table, so it is the only
@@ -33,7 +36,11 @@ module LavinMQ
 
       getter name : String
       getter vhost : VHost
-      getter? auto_delete
+
+      # Seconds the session outlives its connection [MQTT-3.1.2.11.2]. 0 means it
+      # ends when the connection closes, UInt32::MAX means it never expires.
+      # Single source for durable?/auto_delete? so the three cannot drift.
+      getter session_expiry_interval : UInt32
 
       @max_length : Int64? = nil
       @max_length_bytes : Int64? = nil
@@ -48,9 +55,12 @@ module LavinMQ
 
       protected def initialize(@vhost : VHost,
                                @name : String,
-                               @auto_delete = false,
+                               auto_delete = false,
                                arguments : ::AMQ::Protocol::Table = ARGUMENTS)
         @arguments = arguments
+        # Must precede any durable? use below: it decides the data dir, the
+        # replicator and the message store's durability.
+        @session_expiry_interval = self.class.expiry_from(arguments, auto_delete)
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
 
@@ -87,6 +97,22 @@ module LavinMQ
         @arguments
       end
 
+      # The argument wins when present. Read as a plain Int and bounds-checked
+      # rather than cast: it can come from an AMQP client declaring the queue by
+      # hand, in any int type.
+      #
+      # Without it, fall back to what the declare flag meant before Session
+      # Expiry Interval existed - auto_delete was clean_session, so a durable
+      # session meant "keep forever". That covers both a definitions file written
+      # by an older LavinMQ and a caller declaring a session directly.
+      protected def self.expiry_from(arguments : ::AMQ::Protocol::Table,
+                                     auto_delete : Bool) : UInt32
+        if i = arguments[SESSION_EXPIRY_ARG]?.as?(Int)
+          return i.to_u32 if i >= 0 && i <= UInt32::MAX
+        end
+        auto_delete ? 0u32 : UInt32::MAX
+      end
+
       def close : Bool
         return false if @closed.swap(true)
         @has_capacity.close
@@ -108,8 +134,25 @@ module LavinMQ
         true
       end
 
-      def clean_session?
-        @auto_delete
+      def auto_delete? : Bool
+        @session_expiry_interval.zero?
+      end
+
+      # A reconnecting client may name a different interval, and so may its
+      # DISCONNECT [MQTT-3.14.2.2.2]. Kept in @arguments too so it persists.
+      #
+      # Only ever narrows to 0 (a resumed session always had a non-zero interval,
+      # and [MQTT-3.14.2] forbids 0 -> non-zero on DISCONNECT), and a 0 interval
+      # is followed by deletion. That matters because durable? is baked into the
+      # message store's data dir and durability at construction and cannot be
+      # re-derived here.
+      def session_expiry_interval=(interval : UInt32) : Nil
+        return if interval == @session_expiry_interval
+        @session_expiry_interval = interval
+        # clone, never mutate: @arguments may be the shared ARGUMENTS constant.
+        args = @arguments.clone
+        args[SESSION_EXPIRY_ARG] = interval
+        @arguments = args
       end
 
       private def deliver_loop
@@ -143,7 +186,7 @@ module LavinMQ
         return if closed?
         @last_get_time = RoughTime.instant
 
-        unless clean_session?
+        if durable?
           @msg_store_lock.synchronize do
             @unacked.values.each do |sp|
               @msg_store.requeue(sp)
@@ -163,7 +206,7 @@ module LavinMQ
       end
 
       def durable?
-        !clean_session?
+        !@session_expiry_interval.zero?
       end
 
       def subscribe(tf, qos)
@@ -422,7 +465,7 @@ module LavinMQ
       end
 
       def match?(durable, exclusive, auto_delete, arguments) : Bool
-        durable? == durable && @auto_delete == auto_delete
+        durable? == durable && auto_delete? == auto_delete
       end
 
       def unacked_messages
@@ -443,7 +486,7 @@ module LavinMQ
           name:                         @name,
           durable:                      durable?,
           exclusive:                    false,
-          auto_delete:                  @auto_delete,
+          auto_delete:                  auto_delete?,
           arguments:                    NamedTuple.new, # "empty" AMQP::Table
           consumers:                    consumer_count,
           vhost:                        @vhost.name,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -287,7 +287,13 @@ module LavinMQ
         qos = msg.properties.delivery_mode || 0u8
         qos = MAX_QOS if qos > MAX_QOS
         dup = qos.zero? ? false : env.redelivered
-        properties = PublishHeaders.restore(msg.properties.headers)
+        # IO::V3#write_properties discards these, so a v3 subscriber should not
+        # pay six Table#fetch linear scans per delivery to build them.
+        properties = if @client.try(&.version.v5?)
+                       PublishHeaders.restore(msg.properties.headers)
+                     else
+                       Protocol::PublishProperties.new
+                     end
         Protocol::Publish.new(
           packet_id: packet_id,
           payload: msg.body,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -255,7 +255,7 @@ module LavinMQ
         msg = env.message
         retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
         qos = msg.properties.delivery_mode || 0u8
-        qos = 1u8 if qos > 1
+        qos = MAX_QOS if qos > MAX_QOS
         dup = qos.zero? ? false : env.redelivered
         Protocol::Publish.new(
           packet_id: packet_id,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -205,13 +205,12 @@ module LavinMQ
           if no_ack
             begin
               packet = build_packet(env, nil)
-              yield packet, sp.bytesize
-              if env.redelivered
-                @redeliver_count.add(1, :relaxed)
-              else
-                @deliver_no_ack_count.add(1, :relaxed)
-                @deliver_get_count.add(1, :relaxed)
+              if exceeds_max_packet_size?(packet)
+                delete_message(sp)
+                next
               end
+              yield packet, sp.bytesize
+              record_delivery(env.redelivered, no_ack)
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
               raise ex
@@ -225,15 +224,16 @@ module LavinMQ
                 return false
               end
               packet = build_packet(env, id)
+              if exceeds_max_packet_size?(packet)
+                # Discard without sending and complete the delivery: do not track
+                # it in @unacked, so it is not redelivered [MQTT-3.1.2-25].
+                delete_message(sp)
+                next
+              end
               @unacked_count.add(1, :relaxed)
               @unacked_bytesize.add(sp.bytesize, :relaxed)
               yield packet, sp.bytesize
-              if env.redelivered
-                @redeliver_count.add(1, :relaxed)
-              else
-                @deliver_count.add(1, :relaxed)
-                @deliver_get_count.add(1, :relaxed)
-              end
+              record_delivery(env.redelivered, no_ack)
               @unacked[id] = sp
               @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
             rescue ex # requeue failed delivery
@@ -250,6 +250,24 @@ module LavinMQ
         @log.error(ex) { "Queue closed due to error" }
         close
         raise ClosedError.new(cause: ex)
+      end
+
+      private def record_delivery(redelivered : Bool, no_ack : Bool) : Nil
+        if redelivered
+          @redeliver_count.add(1, :relaxed)
+        else
+          (no_ack ? @deliver_no_ack_count : @deliver_count).add(1, :relaxed)
+          @deliver_get_count.add(1, :relaxed)
+        end
+      end
+
+      # A v5 client's Maximum Packet Size caps the packets we may send it
+      # [MQTT-3.1.2-24]. Only v5 clients set it, so size against v5 framing.
+      private def exceeds_max_packet_size?(packet : Protocol::Publish) : Bool
+        max = @client.try(&.max_packet_size) || return false
+        return false unless packet.bytesize(Protocol::Version::V5) > max
+        @log.debug { "Dropping PUBLISH exceeding client Maximum Packet Size (#{max} bytes)" }
+        true
       end
 
       def build_packet(env, packet_id) : Protocol::Publish

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -237,14 +237,20 @@ module LavinMQ
               end
               @unacked_count.add(1, :relaxed)
               @unacked_bytesize.add(sp.bytesize, :relaxed)
-              yield packet, sp.bytesize
-              record_delivery(env.redelivered, no_ack)
-              @unacked[id] = sp
-              @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
+              begin
+                yield packet, sp.bytesize
+                record_delivery(env.redelivered, no_ack)
+                @unacked[id] = sp
+                @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
+              rescue ex # roll back only what this block added
+                # Scoped tightly on purpose: build_packet above can raise, and
+                # subtracting a count that was never added goes negative.
+                @unacked_count.sub(1, :relaxed)
+                @unacked_bytesize.sub(sp.bytesize, :relaxed)
+                raise ex
+              end
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
-              @unacked_count.sub(1, :relaxed)
-              @unacked_bytesize.sub(sp.bytesize, :relaxed)
               raise ex
             end
           end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -39,8 +39,13 @@ module LavinMQ
 
       # Seconds the session outlives its connection [MQTT-3.1.2.11.2]. 0 means it
       # ends when the connection closes, UInt32::MAX means it never expires.
-      # Single source for durable?/auto_delete? so the three cannot drift.
+      # Single source for auto_delete? and the expiry clock.
       getter session_expiry_interval : UInt32
+
+      # Derived from the interval once, at construction: it selects the data dir,
+      # the replicator and the message store's durability, none of which can be
+      # re-derived once that store exists.
+      @durable : Bool
 
       @max_length : Int64? = nil
       @max_length_bytes : Int64? = nil
@@ -58,9 +63,8 @@ module LavinMQ
                                auto_delete = false,
                                arguments : ::AMQ::Protocol::Table = ARGUMENTS)
         @arguments = arguments
-        # Must precede any durable? use below: it decides the data dir, the
-        # replicator and the message store's durability.
-        @session_expiry_interval = self.class.expiry_from(arguments, auto_delete)
+        @session_expiry_interval = self.class.expiry_from(@name, arguments, auto_delete)
+        @durable = !@session_expiry_interval.zero?
         @count = 0u16
         @unacked = Hash(UInt16, SegmentPosition).new
 
@@ -97,18 +101,23 @@ module LavinMQ
         @arguments
       end
 
-      # The argument wins when present. Read as a plain Int and bounds-checked
-      # rather than cast: it can come from an AMQP client declaring the queue by
-      # hand, in any int type.
+      # The argument wins when usable. Bounds-checked rather than cast, and warned
+      # about rather than swallowed, because an AMQP client can declare mqtt.<id>
+      # by hand with any int type in there - or something that is not an int.
       #
-      # Without it, fall back to what the declare flag meant before Session
-      # Expiry Interval existed - auto_delete was clean_session, so a durable
-      # session meant "keep forever". That covers both a definitions file written
-      # by an older LavinMQ and a caller declaring a session directly.
-      protected def self.expiry_from(arguments : ::AMQ::Protocol::Table,
+      # Without a usable one, fall back to what the declare flag meant before
+      # Session Expiry Interval existed - auto_delete was clean_session, so a
+      # durable session meant "keep forever". That covers both a definitions file
+      # written by an older LavinMQ and a caller declaring a session directly.
+      protected def self.expiry_from(name : String,
+                                     arguments : ::AMQ::Protocol::Table,
                                      auto_delete : Bool) : UInt32
-        if i = arguments[SESSION_EXPIRY_ARG]?.as?(Int)
-          return i.to_u32 if i >= 0 && i <= UInt32::MAX
+        v = arguments[SESSION_EXPIRY_ARG]?
+        if v.is_a?(Int)
+          return v.to_u32 if v >= 0 && v <= UInt32::MAX
+          Log.warn { "#{name}: ignoring out-of-range #{SESSION_EXPIRY_ARG}=#{v}" }
+        elsif !v.nil?
+          Log.warn { "#{name}: ignoring non-integer #{SESSION_EXPIRY_ARG}=#{v.inspect}" }
         end
         auto_delete ? 0u32 : UInt32::MAX
       end
@@ -139,13 +148,13 @@ module LavinMQ
       end
 
       # A reconnecting client may name a different interval, and so may its
-      # DISCONNECT [MQTT-3.14.2.2.2]. Kept in @arguments too so it persists.
+      # DISCONNECT [MQTT-3.14.2.2.2]. @arguments carries it, but the definitions
+      # log has no update frame for an existing queue, so it only reaches disk at
+      # the next compaction.
       #
-      # Only ever narrows to 0 (a resumed session always had a non-zero interval,
-      # and [MQTT-3.14.2] forbids 0 -> non-zero on DISCONNECT), and a 0 interval
-      # is followed by deletion. That matters because durable? is baked into the
-      # message store's data dir and durability at construction and cannot be
-      # re-derived here.
+      # auto_delete? and the expiry clock follow this; durable? deliberately does
+      # not, so narrowing to 0 still writes a persisted deletion frame rather than
+      # leaving the original declare to replay.
       def session_expiry_interval=(interval : UInt32) : Nil
         return if interval == @session_expiry_interval
         @session_expiry_interval = interval
@@ -248,8 +257,8 @@ module LavinMQ
         @log.debug { "client set to '#{client.try &.name}'" }
       end
 
-      def durable?
-        !@session_expiry_interval.zero?
+      def durable? : Bool
+        @durable
       end
 
       def subscribe(tf, qos)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -159,9 +159,12 @@ module LavinMQ
         delivered_bytes = 0_i32
         loop do
           break if closed?
-          next @msg_store.empty.when_false.receive? if @msg_store.empty?
+          # Client before store: an offline session has to park on @has_client,
+          # both so the expiry clock runs and so it does not wake on a publish it
+          # cannot deliver.
           client = @client
-          next @has_client.when_true.receive? if client.nil?
+          next wait_for_client if client.nil?
+          next wait_for_messages if @msg_store.empty?
           next @has_capacity.when_true.receive? unless @has_capacity.value
           get_packet do |pub_packet, bytesize|
             client.send(pub_packet)
@@ -176,6 +179,46 @@ module LavinMQ
           @client.try &.close("Server force closed client")
           self.client = nil
         end
+      end
+
+      # Parks until there is something to deliver. The detach arm matters: on its
+      # own, a park on @msg_store.empty never wakes when the client leaves, so the
+      # loop would never reach the top again to start the expiry clock.
+      private def wait_for_messages : Nil
+        select
+        when @msg_store.empty.when_false.receive?
+        when @has_client.when_false.receive?
+        end
+      end
+
+      # Parks until a client attaches, or until the session expires. This is the
+      # only place the expiry clock runs - exactly the window in which the session
+      # has no connection [MQTT-3.1.2.11.2]. Reattaching cancels the timer, and
+      # the next disconnect enters a fresh select, so the interval is measured
+      # from each disconnect rather than accumulated.
+      private def wait_for_client : Nil
+        ttl = @session_expiry_interval
+        # Unreachable in practice - Broker#remove_client deletes a 0-interval
+        # session - but expiring is the right answer if it is ever reached.
+        return expire if ttl.zero?
+        if ttl == UInt32::MAX
+          @has_client.when_true.receive?
+          return
+        end
+        select
+        when @has_client.when_true.receive?
+        when timeout ttl.seconds
+          expire
+        end
+      end
+
+      # Runs on the session's own fiber. `delete` closes @has_client and the
+      # message store, so deliver_loop's `break if closed?` exits on the next
+      # pass; the re-entrant q.delete from @vhost.delete_queue is a no-op via
+      # @deleted.
+      private def expire : Nil
+        @log.info { "Session expired after #{@session_expiry_interval}s offline" }
+        delete
       end
 
       def client : MQTT::Client?

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -1,5 +1,6 @@
 require "digest/sha1"
 require "./protocol"
+require "./publish_headers"
 require "../mqtt"
 require "../amqp/queue/queue"
 require "../error"
@@ -257,13 +258,15 @@ module LavinMQ
         qos = msg.properties.delivery_mode || 0u8
         qos = MAX_QOS if qos > MAX_QOS
         dup = qos.zero? ? false : env.redelivered
+        properties = PublishHeaders.restore(msg.properties.headers)
         Protocol::Publish.new(
           packet_id: packet_id,
           payload: msg.body,
           dup: dup,
           qos: qos,
           retain: retained,
-          topic: msg.routing_key
+          topic: msg.routing_key,
+          properties: properties
         )
       end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -167,9 +167,14 @@ module LavinMQ
         @vhost.bind_queue(@name, EXCHANGE, tf, arguments)
       end
 
-      def unsubscribe(tf)
+      # Returns whether a matching subscription existed, so the v5 UNSUBACK can
+      # report Success vs NoSubscriptionExisted per topic filter [MQTT-3.11.3].
+      def unsubscribe(tf) : Bool
         if binding = find_binding(tf)
           unbind(tf, binding.binding_key.arguments)
+          true
+        else
+          false
         end
       end
 

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -261,13 +261,21 @@ module LavinMQ
         @durable
       end
 
-      def subscribe(tf, qos)
-        arguments = MQTT.qos_arguments(qos)
-        if binding = find_binding(tf)
-          return if binding.binding_key.arguments == arguments
-          unbind(tf, binding.binding_key.arguments)
+      # Returns whether this filter had no subscription before, so Retain
+      # Handling 1 replays the retain store only for a genuinely new
+      # subscription. Existence is by topic filter alone: [MQTT-3.8.4-3]
+      # replaces a subscription whose filter is identical, so a re-subscribe
+      # that changes the QoS or the options is a replacement, not a new one.
+      def subscribe(tf, options : SubscriptionOptions) : Bool
+        existing = find_binding(tf)
+        if existing
+          # Compare the options, not the rendered tables: two tables per
+          # re-subscribe is pure waste, and this does not lean on Table#==.
+          return false if existing.binding_key.options == options
+          unbind(tf, existing.binding_key.arguments)
         end
-        @vhost.bind_queue(@name, EXCHANGE, tf, arguments)
+        @vhost.bind_queue(@name, EXCHANGE, tf, MQTT.subscription_arguments(options))
+        existing.nil?
       end
 
       # Returns whether a matching subscription existed, so the v5 UNSUBACK can
@@ -296,8 +304,18 @@ module LavinMQ
         @vhost.queue_bindings(self)
       end
 
-      private def find_binding(rk)
-        bindings.find { |b| b.binding_key.routing_key == rk }
+      # The type check is load-bearing: `queue_bindings` prepends a synthetic
+      # default-exchange binding whose routing key is the queue's own name, so
+      # matching on routing key alone makes a subscription to the literal filter
+      # `mqtt.<own client id>` find that instead of its own binding. Only
+      # `MQTT::Exchange` produces `SubscriptionDetails`, and there is one of
+      # those, so this is exact - and it narrows the union enough for `options`.
+      private def find_binding(rk) : SubscriptionDetails?
+        bindings.each do |b|
+          next unless b.is_a?(SubscriptionDetails)
+          return b if b.binding_key.routing_key == rk
+        end
+        nil
       end
 
       private def unbind(rk, arguments)
@@ -386,9 +404,8 @@ module LavinMQ
 
       def build_packet(env, packet_id) : Protocol::Publish
         msg = env.message
-        retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
-        qos = msg.properties.delivery_mode || 0u8
-        qos = MAX_QOS if qos > MAX_QOS
+        retained = msg.properties.try &.headers.try &.[RETAIN_HEADER]? == true
+        qos = MQTT.granted_qos(msg.properties.delivery_mode)
         dup = qos.zero? ? false : env.redelivered
         # IO::V3#write_properties discards these, so a v3 subscriber should not
         # pay six Table#fetch linear scans per delivery to build them.

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -17,7 +17,14 @@ module LavinMQ
 
       def declare(client : Client)
         self[client.client_id]? || begin
-          @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, AMQP::Table.new({"x-queue-type": "mqtt"}))
+          # The interval is the single input: it decides durability, auto-delete
+          # and - carried in the arguments - survives a restart.
+          interval = client.session_expiry_interval
+          arguments = AMQP::Table.new({
+            "x-queue-type"     => "mqtt",
+            SESSION_EXPIRY_ARG => interval,
+          })
+          @vhost.declare_queue("mqtt.#{client.client_id}", !interval.zero?, interval.zero?, arguments)
           self[client.client_id].client = client
           self[client.client_id]
         end

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -8,11 +8,11 @@ module LavinMQ
       end
 
       def []?(client_id : String) : Session?
-        @vhost.session?("mqtt.#{client_id}")
+        @vhost.session?(MQTT.session_name(client_id))
       end
 
       def [](client_id : String) : Session
-        @vhost.session("mqtt.#{client_id}")
+        @vhost.session(MQTT.session_name(client_id))
       end
 
       # Returns nil if creating the session would exceed the vhost's max-queues
@@ -28,7 +28,7 @@ module LavinMQ
             "x-queue-type"     => "mqtt",
             SESSION_EXPIRY_ARG => interval,
           })
-          @vhost.declare_queue("mqtt.#{client.client_id}", !interval.zero?, interval.zero?, arguments)
+          @vhost.declare_queue(MQTT.session_name(client.client_id), !interval.zero?, interval.zero?, arguments)
           self[client.client_id].client = client
           self[client.client_id]
         end

--- a/src/lavinmq/mqtt/sessions.cr
+++ b/src/lavinmq/mqtt/sessions.cr
@@ -21,7 +21,14 @@ module LavinMQ
       def declare(client : Client) : Session?
         self[client.client_id]? || begin
           return if @vhost.queue_limit_reached?
-          @vhost.declare_queue("mqtt.#{client.client_id}", !client.@clean_session, client.@clean_session, AMQP::Table.new({"x-queue-type": "mqtt"}))
+          # The interval is the single input: it decides durability, auto-delete
+          # and - carried in the arguments - survives a restart.
+          interval = client.session_expiry_interval
+          arguments = AMQP::Table.new({
+            "x-queue-type"     => "mqtt",
+            SESSION_EXPIRY_ARG => interval,
+          })
+          @vhost.declare_queue("mqtt.#{client.client_id}", !interval.zero?, interval.zero?, arguments)
           self[client.client_id].client = client
           self[client.client_id]
         end

--- a/src/lavinmq/mqtt/subscription_key.cr
+++ b/src/lavinmq/mqtt/subscription_key.cr
@@ -1,5 +1,6 @@
 require "../amqp"
 require "./consts"
+require "./subscription_options"
 
 module LavinMQ
   module MQTT
@@ -11,15 +12,30 @@ module LavinMQ
     # MQTT decoupled from the AMQP binding key type.
     #
     # The subscription topic filter is carried in `topic_filter` (also exposed as
-    # `routing_key` for interface parity); the QoS is carried in `qos`. `arguments`
-    # exposes the QoS as the `AMQP::Table` the rest of the system expects, see
-    # `MQTT.qos_arguments`. It is nilable only for parity with
-    # `AMQP::BindingKey#arguments`; it never is.
+    # `routing_key` for interface parity); the QoS and the v5 subscription options
+    # are carried in `options`. `arguments` renders those as the `AMQP::Table` the
+    # rest of the system expects, see `MQTT.subscription_arguments`. It is nilable
+    # only for parity with `AMQP::BindingKey#arguments`; it never is.
+    #
+    # `arguments` is on the persistence path, not just the HTTP API: `compact!`
+    # re-derives every binding from `bindings_details` rather than replaying the
+    # original frames, so anything this method cannot reconstruct is dropped at
+    # the first definitions compaction.
     struct SubscriptionKey
       getter topic_filter : String
-      getter qos : UInt8
+      getter options : SubscriptionOptions
 
-      def initialize(@topic_filter : String, @qos : UInt8 = 0u8)
+      def initialize(@topic_filter : String, @options : SubscriptionOptions = SubscriptionOptions.new)
+      end
+
+      # The QoS alone is how most callers name a subscription, so take it
+      # directly rather than making every one of them wrap it.
+      def initialize(topic_filter : String, qos : UInt8)
+        initialize(topic_filter, SubscriptionOptions.new(qos))
+      end
+
+      def qos : UInt8
+        @options.qos
       end
 
       # Kept for parity with `LavinMQ::AMQP::BindingKey#routing_key` (duck typing).
@@ -28,12 +44,20 @@ module LavinMQ
       end
 
       def arguments : AMQP::Table?
-        MQTT.qos_arguments(@qos)
+        MQTT.subscription_arguments(@options)
       end
 
+      # Deliberately the filter and QoS only, not the full option set: this is
+      # the subscription's identity in the HTTP API, and widening it would change
+      # every existing binding's URL. Two keys differing only by an option
+      # therefore share a properties_key while being distinct values - which
+      # cannot arise through MQTT, since a session has one binding per filter.
+      #
+      # Note the QoS here is whatever the key was built with, un-clamped, while
+      # `arguments` clamps to `MAX_QOS`. That split is intentional and spec'd.
       def properties_key
         return "~" if topic_filter.empty?
-        "#{topic_filter}~#{@qos}"
+        "#{topic_filter}~#{qos}"
       end
     end
   end

--- a/src/lavinmq/mqtt/subscription_options.cr
+++ b/src/lavinmq/mqtt/subscription_options.cr
@@ -1,0 +1,26 @@
+module LavinMQ
+  module MQTT
+    # What the delivery path needs to know about a subscription: the granted QoS
+    # plus the two v5 subscription options that outlive the SUBSCRIBE.
+    #
+    # Retain Handling is deliberately not a field. It only decides whether the
+    # retain store is replayed during the SUBSCRIBE itself, is never consulted at
+    # delivery, and so is never carried in the tree or the binding arguments.
+    #
+    # A `record` rather than a bare struct on purpose: `Hash::Entry#clone` calls
+    # `value.clone`, and the structural `==` is what `Session#subscribe` compares
+    # to decide whether a re-subscribe actually changed anything.
+    record SubscriptionOptions,
+      qos : UInt8 = 0u8,
+      no_local : Bool = false,
+      retain_as_published : Bool = false do
+      def no_local?
+        @no_local
+      end
+
+      def retain_as_published?
+        @retain_as_published
+      end
+    end
+  end
+end

--- a/src/lavinmq/mqtt/subscription_tree.cr
+++ b/src/lavinmq/mqtt/subscription_tree.cr
@@ -1,4 +1,5 @@
 require "./session"
+require "./subscription_options"
 require "./bytes_token_iterator"
 
 module LavinMQ
@@ -8,15 +9,15 @@ module LavinMQ
       HASH = "#".to_slice
       PLUS = "+".to_slice
 
-      @wildcard_rest = Hash(T, UInt8).new
+      @wildcard_rest = Hash(T, SubscriptionOptions).new
       @wildcard_rest_filter : String?
       @plus : SubscriptionTree(T)?
-      @leafs = Hash(T, UInt8).new
+      @leafs = Hash(T, SubscriptionOptions).new
       @leaf_filter : String?
       # Non wildcards may be an unnecessary "optimization". We store all subscriptions without
       # wildcard in the first level. No need to make a tree out of them.
-      @non_wildcards = Hash(String, Hash(T, UInt8)).new do |h, k|
-        h[k] = Hash(T, UInt8).new.compare_by_identity
+      @non_wildcards = Hash(String, Hash(T, SubscriptionOptions)).new do |h, k|
+        h[k] = Hash(T, SubscriptionOptions).new.compare_by_identity
       end
       # Keyed by owned Bytes copies of each level. Bytes hash and compare by
       # content, so matching can look up with zero-allocation views into the
@@ -28,33 +29,39 @@ module LavinMQ
         @leafs.compare_by_identity
       end
 
+      # Convenience for the common case of a subscription with no v5 options,
+      # which is every v3 subscription and most v5 ones.
       def subscribe(filter : String, session : T, qos : UInt8)
-        if filter.index('#').nil? && filter.index('+').nil?
-          @non_wildcards[filter][session] = qos
-          return
-        end
-        subscribe(BytesTokenIterator.new(filter.to_slice), session, qos)
+        subscribe(filter, session, SubscriptionOptions.new(qos))
       end
 
-      protected def subscribe(filter : BytesTokenIterator, session : T, qos : UInt8)
+      def subscribe(filter : String, session : T, options : SubscriptionOptions)
+        if filter.index('#').nil? && filter.index('+').nil?
+          @non_wildcards[filter][session] = options
+          return
+        end
+        subscribe(BytesTokenIterator.new(filter.to_slice), session, options)
+      end
+
+      protected def subscribe(filter : BytesTokenIterator, session : T, options : SubscriptionOptions)
         unless current = filter.next
           @leaf_filter = filter.to_s
-          @leafs[session] = qos
+          @leafs[session] = options
           return
         end
         if current == HASH
-          @wildcard_rest[session] = qos
+          @wildcard_rest[session] = options
           @wildcard_rest_filter = filter.to_s
           return
         end
         if current == PLUS
           plus = (@plus ||= SubscriptionTree(T).new)
-          plus.subscribe filter, session, qos
+          plus.subscribe filter, session, options
           return
         end
         # dup the token to own it as a persistent hash key (subscribe is cold)
         sublevel = @sublevels[current]? || (@sublevels[current.dup] = SubscriptionTree(T).new)
-        sublevel.subscribe filter, session, qos
+        sublevel.subscribe filter, session, options
         return
       end
 
@@ -125,24 +132,24 @@ module LavinMQ
         count
       end
 
-      def each_entry(topic : String, &block : (T, UInt8, String) -> _)
+      def each_entry(topic : String, &block : (T, SubscriptionOptions, String) -> _)
         if subs = @non_wildcards[topic]?
-          subs.each { |s, q| yield s, q, topic }
+          subs.each { |s, o| yield s, o, topic }
         end
         # Nothing to walk when there are no wildcard subscriptions.
         return if @wildcard_rest.empty? && @plus.nil? && @sublevels.empty?
         each_entry(BytesTokenIterator.new(topic.to_slice), &block)
       end
 
-      protected def each_entry(topic : BytesTokenIterator, &block : (T, UInt8, String) -> _)
+      protected def each_entry(topic : BytesTokenIterator, &block : (T, SubscriptionOptions, String) -> _)
         unless current = topic.next
           if f = @leaf_filter
-            @leafs.each { |s, q| yield s, q, f }
+            @leafs.each { |s, o| yield s, o, f }
           end
           return
         end
         if f = @wildcard_rest_filter
-          @wildcard_rest.each { |s, q| yield s, q, f }
+          @wildcard_rest.each { |s, o| yield s, o, f }
         end
         @plus.try &.each_entry topic, &block
         if sublevel = @sublevels[current]?
@@ -150,15 +157,15 @@ module LavinMQ
         end
       end
 
-      def each_entry(&block : (T, UInt8, String) -> _)
+      def each_entry(&block : (T, SubscriptionOptions, String) -> _)
         @non_wildcards.each do |filter, entries|
-          entries.each { |s, q| yield s, q, filter }
+          entries.each { |s, o| yield s, o, filter }
         end
         if f = @leaf_filter
-          @leafs.each { |s, q| yield s, q, f }
+          @leafs.each { |s, o| yield s, o, f }
         end
         if f = @wildcard_rest_filter
-          @wildcard_rest.each { |s, q| yield s, q, f }
+          @wildcard_rest.each { |s, o| yield s, o, f }
         end
         @plus.try &.each_entry &block
         @sublevels.each_value do |sublevel|

--- a/src/lavinmqperf/mqtt/throughput.cr
+++ b/src/lavinmqperf/mqtt/throughput.cr
@@ -98,7 +98,9 @@ module LavinMQPerf
         password = @uri.password || "guest"
 
         socket = connect_socket(host, port, tls)
-        io = LavinMQ::MQTT::Protocol::IO.new(socket)
+        # The version is fixed by the IO's type, and this tool always speaks
+        # 3.1.1 (the CONNECT below carries no v5 properties).
+        io = LavinMQ::MQTT::Protocol::IO::V3.new(socket)
 
         client_id = "#{role}-#{id}"
         connect_packet = LavinMQ::MQTT::Protocol::Connect.new(


### PR DESCRIPTION
Adds MQTT 5.0 support alongside the existing 3.1 / 3.1.1, on the same listener.

A v5 client can connect, subscribe, publish and receive with properties intact,
gets an accurate reason code on every ack, gets a session whose lifetime it
controls, and gets a spec-correct rejection for every feature we do not
implement.

**Read `MQTT5.md` first.** It is committed in this PR and is the design and
status doc: section 2 is the correctness anchor, section 5 the remaining work,
section 8 the sequencing to ship.

The one thing to know before reviewing: MQTT 5.0 lets a server omit optional
features only if it advertises their absence in CONNACK *and* rejects clients
that use them anyway. Advertising alone is not compliance, and enforcing alone is
not compliance. That is what makes the deferrals here legal rather than broken,
so every deferred feature (QoS 2, topic aliases, shared subscriptions,
subscription identifiers, enhanced auth) has both an advertised capability and a
spec-cited rejection with a test. Section 2 has the matrix.

## Blocked on

84codes/mqtt-protocol.cr#9. `shard.yml` pins `branch: feat/mqtt5`, which cannot
ship, so that PR needs its version bump and tag first.

## Up for grabs

Independent of each other and of the shard work. `MQTT5.md` section 5 has the
detail and the files.

- **B, subscription options.** The shard already parses No Local, Retain As
  Published and Retain Handling; `Broker#subscribe` reads only `tf.qos`. Pure
  LavinMQ behaviour, no shard work, well bounded.
- **E, will properties and will delay.** `Client#publish_will` builds a PUBLISH
  with no properties at all, so every v5 Will Property is silently dropped.
- **F, properties on retained messages.** The retain store keeps only the body,
  so a retained v5 message reaches a later subscriber stripped. Needs a
  store-format change, so the most invasive of the three.

## Behaviour changes for existing v3.1.1 users

Both deliberate, both need release notes, both in `MQTT5.md` section 6.

- Delivery QoS is now the minimum of the publish and subscription QoS, not the
  subscription's alone ([MQTT-3.8.4-6]). This is a real bug fix, LavinMQ used to
  wait for a PUBACK on a fire-and-forget message and store it for an offline
  subscriber, but it is visible: a QoS 0 publish to a QoS 1 subscription is no
  longer upgraded. Fourteen existing specs had encoded the old behaviour.
- A v5 client sending Clean Start 0 with no Session Expiry Interval now gets a
  session that ends with its connection, where it used to get one that persisted
  forever. v3.1.1 is unaffected.

## Test plan

- [x] `make test TAGS=~etcd` - 2125 examples, 0 failures, 9 pending (pre-existing
      and unrelated to MQTT)
- [x] `make test SPEC=spec/mqtt` - 280 examples, 0 failures
- [x] `make lint` - 403 inspected, 0 failures
- [x] `crystal tool format --check` clean
- [ ] etcd-tagged specs - skipped locally, no etcd running
- [ ] Re-run the interop harness in `MQTT5-INTEROP.md`. The last run was
      2026-08-19 and predates the delivery-QoS fix, the unexpected-packet
      handling, the review fixes and session expiry, so its delivery-QoS and
      DISCONNECT `0x82` rows are expectations to confirm rather than results.
