### PR TITLE
Aggregate return_unroutable to vhost stats

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -54,6 +54,7 @@ Aggregate broker, queue, runtime, and clustering metrics.
 | `global_messages_redelivered_total` | counter | Total messages redelivered to consumers |
 | `global_messages_acknowledged_total` | counter | Total messages acknowledged by consumers |
 | `global_messages_confirmed_total` | counter | Total messages confirmed to publishers |
+| `global_messages_unroutable_returned_total` | counter | Total unroutable messages returned to publishers |
 
 #### Runtime and clustering
 

--- a/spec/api/http_api_spec.cr
+++ b/spec/api/http_api_spec.cr
@@ -58,6 +58,20 @@ describe LavinMQ::HTTP::Server do
       end
     end
 
+    it "should count returned unroutable messages in message_stats" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          returned = Channel(Nil).new
+          ch.on_return { |_msg| returned.send nil }
+          ch.basic_publish("m1", "amq.direct", "none", mandatory: true)
+          returned.receive
+        end
+        response = http.get("/api/overview")
+        count = JSON.parse(response.body).dig("message_stats", "return_unroutable")
+        count.should eq 1
+      end
+    end
+
     it "should return sum of all published messages" do
       with_http_server do |http, s|
         response = http.get("/api/overview")

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -96,6 +96,22 @@ describe LavinMQ::HTTP::PrometheusController do
       end
     end
 
+    it "should count returned unroutable messages" do
+      with_metrics_server do |http, s|
+        with_channel(s) do |ch|
+          returned = Channel(Nil).new
+          ch.on_return { |_msg| returned.send nil }
+          ch.basic_publish("m1", "amq.direct", "none", mandatory: true)
+          returned.receive
+        end
+        raw = http.get("/metrics").body
+        parsed_metrics = PrometheusSpecHelper.parse_prometheus(raw)
+        metric = parsed_metrics.find { |m| m[:key] == "lavinmq_global_messages_unroutable_returned_total" }
+        metric.should_not be_nil
+        metric.try(&.[:value].should eq 1)
+      end
+    end
+
     it "should support specifying prefix" do
       with_metrics_server do |http, _|
         prefix = "testing"

--- a/spec/api/vhosts_spec.cr
+++ b/spec/api/vhosts_spec.cr
@@ -61,6 +61,21 @@ describe LavinMQ::HTTP::VHostsController do
         response.status_code.should eq 403
       end
     end
+
+    it "should count returned unroutable messages in message_stats" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          returned = Channel(Nil).new
+          ch.on_return { |_msg| returned.send nil }
+          ch.basic_publish("m1", "amq.direct", "none", mandatory: true)
+          returned.receive
+        end
+        response = http.get("/api/vhosts/%2f")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.dig("message_stats", "return_unroutable").should eq 1
+      end
+    end
   end
 
   describe "PUT /api/vhosts/vhost" do

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -381,6 +381,7 @@ module LavinMQ
 
       private def basic_return(msg : Message, mandatory : Bool, immediate : Bool)
         @return_unroutable_count.add(1, :relaxed)
+        @client.vhost.event_tick(EventType::ClientReturnUnroutable)
         if immediate
           retrn = AMQP::Frame::Basic::Return.new(@id, 313_u16, "NO_CONSUMERS", msg.exchange_name, msg.routing_key)
           deliver(retrn, msg)

--- a/src/lavinmq/event_type.cr
+++ b/src/lavinmq/event_type.cr
@@ -15,6 +15,7 @@ module LavinMQ
     ClientPublishConfirm
     ClientRedeliver
     ClientReject
+    ClientReturnUnroutable
     ConsumerAdded
     ConsumerRemoved
   end

--- a/src/lavinmq/http/controller/main.cr
+++ b/src/lavinmq/http/controller/main.cr
@@ -7,7 +7,7 @@ module LavinMQ
     class MainController < Controller
       include StatsHelpers
 
-      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject"}
+      OVERVIEW_STATS = {"ack", "deliver", "get", "deliver_get", "publish", "confirm", "redeliver", "reject", "return_unroutable"}
       EXCHANGE_TYPES = {
         {name: "direct", human: "Direct"},
         {name: "fanout", human: "Fanout"},

--- a/src/lavinmq/http/controller/prometheus.cr
+++ b/src/lavinmq/http/controller/prometheus.cr
@@ -350,6 +350,11 @@ module LavinMQ
                              message_stats.sum { |ms| ms[:confirm] },
                       type: "counter",
                       help: "Total number of messages confirmed to publishers"})
+        writer.write({name:  "global_messages_unroutable_returned_total",
+                      value: @server.deleted_vhosts_messages_unroutable_returned_total +
+                             message_stats.sum { |ms| ms[:return_unroutable] },
+                      type: "counter",
+                      help: "Total number of unroutable messages returned to publishers"})
       end
 
       private def overview_queue_metrics(vhosts, writer)

--- a/src/lavinmq/http/controller/vhosts.cr
+++ b/src/lavinmq/http/controller/vhosts.cr
@@ -61,6 +61,7 @@ module LavinMQ
               @server.deleted_vhosts_messages_redelivered_total += message_stats[:redeliver]
               @server.deleted_vhosts_messages_acknowledged_total += message_stats[:ack]
               @server.deleted_vhosts_messages_confirmed_total += message_stats[:confirm]
+              @server.deleted_vhosts_messages_unroutable_returned_total += message_stats[:return_unroutable]
               context.response.status_code = 204
             else
               context.response.status_code = 404

--- a/src/lavinmq/server.cr
+++ b/src/lavinmq/server.cr
@@ -304,6 +304,7 @@ module LavinMQ
     property deleted_vhosts_messages_redelivered_total = 0_u64
     property deleted_vhosts_messages_acknowledged_total = 0_u64
     property deleted_vhosts_messages_confirmed_total = 0_u64
+    property deleted_vhosts_messages_unroutable_returned_total = 0_u64
 
     private def control_flow!
       if disk_full?

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -29,7 +29,7 @@ module LavinMQ
 
     rate_stats({"channel_closed", "channel_created", "connection_closed", "connection_created",
                 "queue_declared", "queue_deleted", "ack", "deliver", "deliver_no_ack", "deliver_get", "get", "get_no_ack", "publish", "confirm",
-                "redeliver", "reject", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
+                "redeliver", "reject", "return_unroutable", "consumer_added", "consumer_removed", "recv_oct", "send_oct"})
 
     getter name, data_dir, operator_policies, policies, parameters, shovels, dir, users, replicator
     getter closed = BoolChannel.new(true)
@@ -319,7 +319,7 @@ module LavinMQ
 
     def message_details
       ready = unacked = 0_u64
-      ack = confirm = deliver = deliver_no_ack = get = get_no_ack = publish = redeliver = return_unroutable = deliver_get = 0_u64
+      ack = confirm = deliver = deliver_no_ack = get = get_no_ack = publish = redeliver = deliver_get = 0_u64
       each_queue do |q|
         ready += q.message_count
         unacked += q.unacked_count
@@ -332,7 +332,6 @@ module LavinMQ
         get_no_ack += q.get_no_ack_count
         publish += q.publish_count
         redeliver += q.redeliver_count
-        return_unroutable += q.return_unroutable_count
       end
       each_session do |s|
         ready += s.message_count
@@ -362,7 +361,7 @@ module LavinMQ
           deliver_get:       deliver_get,
           publish:           publish,
           redeliver:         redeliver,
-          return_unroutable: return_unroutable,
+          return_unroutable: return_unroutable_count,
         },
       }
     end
@@ -602,19 +601,20 @@ module LavinMQ
 
     def event_tick(event_type)
       case event_type
-      in EventType::ChannelClosed        then @channel_closed_count.add(1, :relaxed)
-      in EventType::ChannelCreated       then @channel_created_count.add(1, :relaxed)
-      in EventType::ConnectionClosed     then @connection_closed_count.add(1, :relaxed)
-      in EventType::ConnectionCreated    then @connection_created_count.add(1, :relaxed)
-      in EventType::QueueDeclared        then @queue_declared_count.add(1, :relaxed)
-      in EventType::QueueDeleted         then @queue_deleted_count.add(1, :relaxed)
-      in EventType::ClientAck            then @ack_count.add(1, :relaxed)
-      in EventType::ClientPublish        then @publish_count.add(1, :relaxed)
-      in EventType::ClientPublishConfirm then @confirm_count.add(1, :relaxed)
-      in EventType::ClientRedeliver      then @redeliver_count.add(1, :relaxed)
-      in EventType::ClientReject         then @reject_count.add(1, :relaxed)
-      in EventType::ConsumerAdded        then @consumer_added_count.add(1, :relaxed)
-      in EventType::ConsumerRemoved      then @consumer_removed_count.add(1, :relaxed)
+      in EventType::ChannelClosed          then @channel_closed_count.add(1, :relaxed)
+      in EventType::ChannelCreated         then @channel_created_count.add(1, :relaxed)
+      in EventType::ConnectionClosed       then @connection_closed_count.add(1, :relaxed)
+      in EventType::ConnectionCreated      then @connection_created_count.add(1, :relaxed)
+      in EventType::QueueDeclared          then @queue_declared_count.add(1, :relaxed)
+      in EventType::QueueDeleted           then @queue_deleted_count.add(1, :relaxed)
+      in EventType::ClientAck              then @ack_count.add(1, :relaxed)
+      in EventType::ClientPublish          then @publish_count.add(1, :relaxed)
+      in EventType::ClientPublishConfirm   then @confirm_count.add(1, :relaxed)
+      in EventType::ClientRedeliver        then @redeliver_count.add(1, :relaxed)
+      in EventType::ClientReject           then @reject_count.add(1, :relaxed)
+      in EventType::ConsumerAdded          then @consumer_added_count.add(1, :relaxed)
+      in EventType::ConsumerRemoved        then @consumer_removed_count.add(1, :relaxed)
+      in EventType::ClientReturnUnroutable then @return_unroutable_count.add(1, :relaxed)
       in EventType::ClientGet
         @get_count.add(1, :relaxed)
         @deliver_get_count.add(1, :relaxed)

--- a/static/docs/schemas/main.yaml
+++ b/static/docs/schemas/main.yaml
@@ -53,6 +53,10 @@ overview:
           type: integer
         reject_details:
           "$ref": "#/stats_details"
+        return_unroutable:
+          type: integer
+        return_unroutable_details:
+          "$ref": "#/stats_details"
     node:
       type: string
       description: Node hostname.


### PR DESCRIPTION
`return_unroutable` was only counted per channel and never aggregated to the vhost, so per-vhost `message_stats`, `/api/overview` and the global Prometheus metrics always reported 0. The vhost aggregation summed `return_unroutable_count` from queues, which never increments since an unroutable message never reaches a queue.

This adds `EventType::ClientReturnUnroutable` and ticks it from `Channel#basic_return` (covers both the normal and tx publish paths), adds a `return_unroutable` counter to the vhost rate stats and uses it in `message_details` instead of the dead per-queue sum. The stat is included in `/api/overview` with rate and log, and `/metrics` gains `lavinmq_global_messages_unroutable_returned_total` with deleted vhost accumulation so the counter stays monotonic. The overview OpenAPI schema is updated accordingly.

Verified end to end by publishing a mandatory message to an exchange that routes nowhere: all three surfaces now report the return, and without the change they stay at 0.

Fixes #2140