### PR TITLE
Add `tls_prefer_server_ciphers` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Negative `x-stream-offset` values to consume the last N stream messages [#1941](https://github.com/cloudamqp/lavinmq/pull/1941)
 - Tab navigation on queue detail pages in the management UI [#2006](https://github.com/cloudamqp/lavinmq/pull/2006)
 - `client_id_validation` MQTT config option to require the client ID to match the authenticated username [#2038](https://github.com/cloudamqp/lavinmq/pull/2038)
+- `tls_prefer_server_ciphers` config option that makes the server's cipher order decide the negotiated cipher
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `tls_cert` | `--cert` | `LAVINMQ_TLS_CERT_PATH` | String | (empty) | TLS certificate path (including chain) |
 | `tls_key` | `--key` | `LAVINMQ_TLS_KEY_PATH` | String | (empty) | TLS private key path |
 | `tls_ciphers` | `--ciphers` | `LAVINMQ_TLS_CIPHERS` | String | (empty) | Allowed TLS ciphers |
+| `tls_prefer_server_ciphers` | `--tls-prefer-server-ciphers` | `LAVINMQ_TLS_PREFER_SERVER_CIPHERS` | Bool | `false` | Pick the cipher by the server's order in `tls_ciphers` instead of the client's preference |
 | `tls_min_version` | `--tls-min-version` | `LAVINMQ_TLS_MIN_VERSION` | String | (empty) | Minimum TLS version. When empty, the TLS library default (1.2) is used. |
 | `tls_keylog_file` | — | — | String | (empty) | TLS key log file (for debugging) |
 | `tls_ktls` | `--tls-ktls` | — | Bool | `false` | Enable kernel TLS offloading |
@@ -152,6 +153,7 @@ Per-hostname TLS configuration. Create a section for each hostname.
 | `tls_key` | Private key file. If empty, the cert file is expected to contain both. |
 | `tls_min_version` | Minimum TLS version |
 | `tls_ciphers` | Allowed cipher list |
+| `tls_prefer_server_ciphers` | Pick the cipher by the server's order instead of the client's preference |
 | `tls_verify_peer` | Require client certificate (mTLS) |
 | `tls_ca_cert` | CA bundle for verifying client certs (mTLS) |
 | `tls_keylog_file` | TLS key log file for debugging |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `tls_cert` | `--cert` | `LAVINMQ_TLS_CERT_PATH` | String | (empty) | TLS certificate path (including chain) |
 | `tls_key` | `--key` | `LAVINMQ_TLS_KEY_PATH` | String | (empty) | TLS private key path |
 | `tls_ciphers` | `--ciphers` | `LAVINMQ_TLS_CIPHERS` | String | (empty) | Allowed TLS ciphers |
-| `tls_prefer_server_ciphers` | `--tls-prefer-server-ciphers` | `LAVINMQ_TLS_PREFER_SERVER_CIPHERS` | Bool | `false` | Pick the cipher by the server's order in `tls_ciphers` instead of the client's preference |
+| `tls_prefer_server_ciphers` | `--tls-prefer-server-ciphers` | `LAVINMQ_TLS_PREFER_SERVER_CIPHERS` | Bool | `false` | Use the server's cipher order instead of the client's preference |
 | `tls_min_version` | `--tls-min-version` | `LAVINMQ_TLS_MIN_VERSION` | String | (empty) | Minimum TLS version. When empty, the TLS library default (1.2) is used. |
 | `tls_keylog_file` | — | — | String | (empty) | TLS key log file (for debugging) |
 | `tls_ktls` | `--tls-ktls` | — | Bool | `false` | Enable kernel TLS offloading |
@@ -153,7 +153,7 @@ Per-hostname TLS configuration. Create a section for each hostname.
 | `tls_key` | Private key file. If empty, the cert file is expected to contain both. |
 | `tls_min_version` | Minimum TLS version |
 | `tls_ciphers` | Allowed cipher list |
-| `tls_prefer_server_ciphers` | Pick the cipher by the server's order instead of the client's preference |
+| `tls_prefer_server_ciphers` | Use the server's cipher order instead of the client's preference |
 | `tls_verify_peer` | Require client certificate (mTLS) |
 | `tls_ca_cert` | CA bundle for verifying client certs (mTLS) |
 | `tls_keylog_file` | TLS key log file for debugging |

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -17,7 +17,7 @@ tls_key = /etc/lavinmq/key.pem
 | `tls_cert` | `[main]` | (empty) | Certificate file (including chain) |
 | `tls_key` | `[main]` | (empty) | Private key file. If empty, the cert file is expected to contain both. |
 | `tls_ciphers` | `[main]` | (empty) | Allowed cipher list, in OpenSSL cipher list format |
-| `tls_prefer_server_ciphers` | `[main]` | `false` | Pick the cipher by the server's order in `tls_ciphers` instead of the client's preference |
+| `tls_prefer_server_ciphers` | `[main]` | `false` | Use the server's cipher order instead of the client's preference |
 | `tls_min_version` | `[main]` | (empty) | Minimum TLS version. Empty falls back to the TLS library default (1.2). |
 | `tls_ktls` | `[main]` | `false` | Enable kernel TLS offloading |
 | `tls_keylog_file` | `[main]` | (empty) | Key log file for debugging |
@@ -82,7 +82,7 @@ The following keys accept a prefix: `tls_cert`, `tls_key`, `tls_min_version`, `t
 
 ## Cipher order
 
-By default the client decides which cipher is used: the server walks the client's preference list and picks the first cipher it also supports, so the order of `tls_ciphers` only decides which ciphers are allowed, not which one wins. Setting `tls_prefer_server_ciphers = true` (OpenSSL's `SSL_OP_CIPHER_SERVER_PREFERENCE`) flips that around, so the first entry in `tls_ciphers` that the client supports is the one negotiated.
+By default the client decides which cipher is used: the server walks the client's preference list and picks the first cipher it also supports, so the order of `tls_ciphers` only decides which ciphers are allowed, not which one wins. Setting `tls_prefer_server_ciphers = true` (OpenSSL's `SSL_OP_CIPHER_SERVER_PREFERENCE`) flips that around, so the highest-ranked cipher on the server that the client also supports is the one negotiated.
 
 ```ini
 [main]

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -17,6 +17,7 @@ tls_key = /etc/lavinmq/key.pem
 | `tls_cert` | `[main]` | (empty) | Certificate file (including chain) |
 | `tls_key` | `[main]` | (empty) | Private key file. If empty, the cert file is expected to contain both. |
 | `tls_ciphers` | `[main]` | (empty) | Allowed cipher list, in OpenSSL cipher list format |
+| `tls_prefer_server_ciphers` | `[main]` | `false` | Pick the cipher by the server's order in `tls_ciphers` instead of the client's preference |
 | `tls_min_version` | `[main]` | (empty) | Minimum TLS version. Empty falls back to the TLS library default (1.2). |
 | `tls_ktls` | `[main]` | `false` | Enable kernel TLS offloading |
 | `tls_keylog_file` | `[main]` | (empty) | Key log file for debugging |
@@ -77,7 +78,19 @@ amqp_tls_ca_cert = /etc/lavinmq/clients-ca.pem
 mqtt_tls_keylog_file = /var/log/lavinmq/mqtt-keys.log
 ```
 
-The following keys accept a prefix: `tls_cert`, `tls_key`, `tls_min_version`, `tls_ciphers`, `tls_verify_peer`, `tls_ca_cert`, `tls_keylog_file`.
+The following keys accept a prefix: `tls_cert`, `tls_key`, `tls_min_version`, `tls_ciphers`, `tls_prefer_server_ciphers`, `tls_verify_peer`, `tls_ca_cert`, `tls_keylog_file`.
+
+## Cipher order
+
+By default the client decides which cipher is used: the server walks the client's preference list and picks the first cipher it also supports, so the order of `tls_ciphers` only decides which ciphers are allowed, not which one wins. Setting `tls_prefer_server_ciphers = true` (OpenSSL's `SSL_OP_CIPHER_SERVER_PREFERENCE`) flips that around, so the first entry in `tls_ciphers` that the client supports is the one negotiated.
+
+```ini
+[main]
+tls_ciphers = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305
+tls_prefer_server_ciphers = true
+```
+
+The setting can also be given per SNI host and per protocol, like the other TLS settings, and it is applied on reload.
 
 ## Reloading certificates
 

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -127,6 +127,7 @@ describe LavinMQ::Config do
           data_dir_lock = false
           tls_cert = /etc/lavinmq/cert.pem
           tls_ciphers = ECDHE-RSA-AES256-GCM-SHA384
+          tls_prefer_server_ciphers = true
           tls_key = /etc/lavinmq/key.pem
           tls_min_version = 1.3
           tls_keylog_file = /tmp/keylog.txt
@@ -212,6 +213,7 @@ describe LavinMQ::Config do
     config.data_dir_lock?.should be_false
     config.tls_cert_path.should eq "/etc/lavinmq/cert.pem"
     config.tls_ciphers.should eq "ECDHE-RSA-AES256-GCM-SHA384"
+    config.tls_prefer_server_ciphers?.should be_true
     config.tls_key_path.should eq "/etc/lavinmq/key.pem"
     config.tls_min_version.should eq "1.3"
     config.tls_keylog_file.should eq "/tmp/keylog.txt"
@@ -289,6 +291,7 @@ describe LavinMQ::Config do
       "--https-port=15675",
       "--cert=/etc/ssl/cert.pem",
       "--ciphers=ECDHE-RSA-AES256-GCM-SHA384",
+      "--tls-prefer-server-ciphers=true",
       "--key=/etc/ssl/key.pem",
       "--tls-min-version=1.3",
       "--metrics-http-bind=0.0.0.0",
@@ -329,6 +332,7 @@ describe LavinMQ::Config do
     config.https_port.should eq 15675
     config.tls_cert_path.should eq "/etc/ssl/cert.pem"
     config.tls_ciphers.should eq "ECDHE-RSA-AES256-GCM-SHA384"
+    config.tls_prefer_server_ciphers?.should be_true
     config.tls_key_path.should eq "/etc/ssl/key.pem"
     config.tls_min_version.should eq "1.3"
     config.metrics_http_bind.should eq "0.0.0.0"
@@ -370,6 +374,7 @@ describe LavinMQ::Config do
     ENV["LAVINMQ_HTTPS_PORT"] = "15676"
     ENV["LAVINMQ_TLS_CERT_PATH"] = "/etc/certs/env-cert.pem"
     ENV["LAVINMQ_TLS_CIPHERS"] = "ENV-CIPHER-SUITE"
+    ENV["LAVINMQ_TLS_PREFER_SERVER_CIPHERS"] = "true"
     ENV["LAVINMQ_TLS_KEY_PATH"] = "/etc/certs/env-key.pem"
     ENV["LAVINMQ_TLS_MIN_VERSION"] = "1.2"
     ENV["LAVINMQ_DEFAULT_CONSUMER_PREFETCH"] = "2000"
@@ -395,6 +400,7 @@ describe LavinMQ::Config do
     config.https_port.should eq 15676
     config.tls_cert_path.should eq "/etc/certs/env-cert.pem"
     config.tls_ciphers.should eq "ENV-CIPHER-SUITE"
+    config.tls_prefer_server_ciphers?.should be_true
     config.tls_key_path.should eq "/etc/certs/env-key.pem"
     config.tls_min_version.should eq "1.2"
     config.default_consumer_prefetch.should eq 2000
@@ -417,6 +423,7 @@ describe LavinMQ::Config do
     ENV.delete("LAVINMQ_HTTPS_PORT")
     ENV.delete("LAVINMQ_TLS_CERT_PATH")
     ENV.delete("LAVINMQ_TLS_CIPHERS")
+    ENV.delete("LAVINMQ_TLS_PREFER_SERVER_CIPHERS")
     ENV.delete("LAVINMQ_TLS_KEY_PATH")
     ENV.delete("LAVINMQ_TLS_MIN_VERSION")
     ENV.delete("LAVINMQ_DEFAULT_CONSUMER_PREFETCH")
@@ -872,6 +879,27 @@ describe LavinMQ::Launcher do
           INI
         launcher.reload!
         served_cn(amqp_ctx, "foobar.localhost").should eq "foobar.localhost"
+      end
+    end
+
+    it "applies and clears tls_prefer_server_ciphers on reload" do
+      with_launcher(<<-INI) do |launcher, _config, config_file|
+        [main]
+        tls_cert = spec/resources/server_certificate.pem
+        tls_key = spec/resources/server_key.pem
+        tls_prefer_server_ciphers = true
+        INI
+        amqp_ctx = launcher.@amqp_tls_context.not_nil!
+        amqp_ctx.options.includes?(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should be_true
+
+        File.write(config_file.path, <<-INI)
+          [main]
+          tls_cert = spec/resources/server_certificate.pem
+          tls_key = spec/resources/server_key.pem
+          tls_prefer_server_ciphers = false
+          INI
+        launcher.reload!
+        amqp_ctx.options.includes?(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should be_false
       end
     end
 

--- a/spec/sni_spec.cr
+++ b/spec/sni_spec.cr
@@ -52,6 +52,27 @@ describe LavinMQ::SNIHost do
     # HTTP should NOT have peer verification
     http_ctx.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
   end
+
+  it "does not prefer server ciphers by default" do
+    host = LavinMQ::SNIHost.new("example.com")
+    host.tls_cert = "spec/resources/server_certificate.pem"
+    host.tls_key = "spec/resources/server_key.pem"
+
+    host.amqp_tls_context.options.includes?(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should be_false
+  end
+
+  it "creates TLS contexts that prefer the server cipher order" do
+    host = LavinMQ::SNIHost.new("example.com")
+    host.tls_cert = "spec/resources/server_certificate.pem"
+    host.tls_key = "spec/resources/server_key.pem"
+    host.tls_prefer_server_ciphers = true
+    # MQTT opts out of the default
+    host.mqtt_tls_prefer_server_ciphers = false
+
+    host.amqp_tls_context.options.includes?(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should be_true
+    host.http_tls_context.options.includes?(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should be_true
+    host.mqtt_tls_context.options.includes?(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should be_false
+  end
 end
 
 describe LavinMQ::SNIManager do

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -211,37 +211,41 @@ module LavinMQ
       settings.each do |config, v|
         case config
         # Default TLS settings
-        when "tls_cert"        then host.tls_cert = v
-        when "tls_key"         then host.tls_key = v
-        when "tls_min_version" then host.tls_min_version = v
-        when "tls_ciphers"     then host.tls_ciphers = v
-        when "tls_verify_peer" then host.tls_verify_peer = true?(v)
-        when "tls_ca_cert"     then host.tls_ca_cert = v
-        when "tls_keylog_file" then host.tls_keylog_file = v
+        when "tls_cert"                  then host.tls_cert = v
+        when "tls_key"                   then host.tls_key = v
+        when "tls_min_version"           then host.tls_min_version = v
+        when "tls_ciphers"               then host.tls_ciphers = v
+        when "tls_prefer_server_ciphers" then host.tls_prefer_server_ciphers = true?(v)
+        when "tls_verify_peer"           then host.tls_verify_peer = true?(v)
+        when "tls_ca_cert"               then host.tls_ca_cert = v
+        when "tls_keylog_file"           then host.tls_keylog_file = v
           # AMQP-specific overrides
-        when "amqp_tls_cert"        then host.amqp_tls_cert = v
-        when "amqp_tls_key"         then host.amqp_tls_key = v
-        when "amqp_tls_min_version" then host.amqp_tls_min_version = v
-        when "amqp_tls_ciphers"     then host.amqp_tls_ciphers = v
-        when "amqp_tls_verify_peer" then host.amqp_tls_verify_peer = true?(v)
-        when "amqp_tls_ca_cert"     then host.amqp_tls_ca_cert = v
-        when "amqp_tls_keylog_file" then host.amqp_tls_keylog_file = v
+        when "amqp_tls_cert"                  then host.amqp_tls_cert = v
+        when "amqp_tls_key"                   then host.amqp_tls_key = v
+        when "amqp_tls_min_version"           then host.amqp_tls_min_version = v
+        when "amqp_tls_ciphers"               then host.amqp_tls_ciphers = v
+        when "amqp_tls_prefer_server_ciphers" then host.amqp_tls_prefer_server_ciphers = true?(v)
+        when "amqp_tls_verify_peer"           then host.amqp_tls_verify_peer = true?(v)
+        when "amqp_tls_ca_cert"               then host.amqp_tls_ca_cert = v
+        when "amqp_tls_keylog_file"           then host.amqp_tls_keylog_file = v
           # MQTT-specific overrides
-        when "mqtt_tls_cert"        then host.mqtt_tls_cert = v
-        when "mqtt_tls_key"         then host.mqtt_tls_key = v
-        when "mqtt_tls_min_version" then host.mqtt_tls_min_version = v
-        when "mqtt_tls_ciphers"     then host.mqtt_tls_ciphers = v
-        when "mqtt_tls_verify_peer" then host.mqtt_tls_verify_peer = true?(v)
-        when "mqtt_tls_ca_cert"     then host.mqtt_tls_ca_cert = v
-        when "mqtt_tls_keylog_file" then host.mqtt_tls_keylog_file = v
+        when "mqtt_tls_cert"                  then host.mqtt_tls_cert = v
+        when "mqtt_tls_key"                   then host.mqtt_tls_key = v
+        when "mqtt_tls_min_version"           then host.mqtt_tls_min_version = v
+        when "mqtt_tls_ciphers"               then host.mqtt_tls_ciphers = v
+        when "mqtt_tls_prefer_server_ciphers" then host.mqtt_tls_prefer_server_ciphers = true?(v)
+        when "mqtt_tls_verify_peer"           then host.mqtt_tls_verify_peer = true?(v)
+        when "mqtt_tls_ca_cert"               then host.mqtt_tls_ca_cert = v
+        when "mqtt_tls_keylog_file"           then host.mqtt_tls_keylog_file = v
           # HTTP-specific overrides
-        when "http_tls_cert"        then host.http_tls_cert = v
-        when "http_tls_key"         then host.http_tls_key = v
-        when "http_tls_min_version" then host.http_tls_min_version = v
-        when "http_tls_ciphers"     then host.http_tls_ciphers = v
-        when "http_tls_verify_peer" then host.http_tls_verify_peer = true?(v)
-        when "http_tls_ca_cert"     then host.http_tls_ca_cert = v
-        when "http_tls_keylog_file" then host.http_tls_keylog_file = v
+        when "http_tls_cert"                  then host.http_tls_cert = v
+        when "http_tls_key"                   then host.http_tls_key = v
+        when "http_tls_min_version"           then host.http_tls_min_version = v
+        when "http_tls_ciphers"               then host.http_tls_ciphers = v
+        when "http_tls_prefer_server_ciphers" then host.http_tls_prefer_server_ciphers = true?(v)
+        when "http_tls_verify_peer"           then host.http_tls_verify_peer = true?(v)
+        when "http_tls_ca_cert"               then host.http_tls_ca_cert = v
+        when "http_tls_keylog_file"           then host.http_tls_keylog_file = v
         else
           @io.puts "WARNING: Unrecognized configuration 'sni:#{hostname}/#{config}'"
         end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -214,6 +214,11 @@ module LavinMQ
       @[EnvOpt("LAVINMQ_TLS_CIPHERS")]
       property tls_ciphers = ""
 
+      @[CliOpt("", "--tls-prefer-server-ciphers=BOOL", "Let the server's cipher order decide which cipher is used (default: false)", section: "tls")]
+      @[IniOpt(section: "main")]
+      @[EnvOpt("LAVINMQ_TLS_PREFER_SERVER_CIPHERS")]
+      property? tls_prefer_server_ciphers = false
+
       @[CliOpt("", "--key FILE", "Private key for the TLS certificate", section: "tls")]
       @[IniOpt(ini_name: tls_key, section: "main")]
       @[EnvOpt("LAVINMQ_TLS_KEY_PATH")]

--- a/src/lavinmq/launcher.cr
+++ b/src/lavinmq/launcher.cr
@@ -323,6 +323,11 @@ module LavinMQ
       ctx.certificate_chain = @config.tls_cert_path
       ctx.private_key = @config.tls_key_path.empty? ? @config.tls_cert_path : @config.tls_key_path
       ctx.ciphers = @config.tls_ciphers unless @config.tls_ciphers.empty?
+      if @config.tls_prefer_server_ciphers?
+        ctx.add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
+      else
+        ctx.remove_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
+      end
       if @config.tls_ktls?
         {% if OpenSSL::SSL::Options.has_constant?(:ENABLE_KTLS) %}
           ctx.add_options(OpenSSL::SSL::Options::ENABLE_KTLS)

--- a/src/lavinmq/sni_config.cr
+++ b/src/lavinmq/sni_config.cr
@@ -12,6 +12,7 @@ module LavinMQ
     property tls_key : String = ""
     property tls_min_version : String = ""
     property tls_ciphers : String = ""
+    property? tls_prefer_server_ciphers : Bool = false
     property? tls_verify_peer : Bool = false
     property tls_ca_cert : String = ""
     property tls_keylog_file : String = ""
@@ -21,6 +22,7 @@ module LavinMQ
     property amqp_tls_key : String? = nil
     property amqp_tls_min_version : String? = nil
     property amqp_tls_ciphers : String? = nil
+    property amqp_tls_prefer_server_ciphers : Bool? = nil
     property amqp_tls_verify_peer : Bool? = nil
     property amqp_tls_ca_cert : String? = nil
     property amqp_tls_keylog_file : String? = nil
@@ -30,6 +32,7 @@ module LavinMQ
     property mqtt_tls_key : String? = nil
     property mqtt_tls_min_version : String? = nil
     property mqtt_tls_ciphers : String? = nil
+    property mqtt_tls_prefer_server_ciphers : Bool? = nil
     property mqtt_tls_verify_peer : Bool? = nil
     property mqtt_tls_ca_cert : String? = nil
     property mqtt_tls_keylog_file : String? = nil
@@ -39,6 +42,7 @@ module LavinMQ
     property http_tls_key : String? = nil
     property http_tls_min_version : String? = nil
     property http_tls_ciphers : String? = nil
+    property http_tls_prefer_server_ciphers : Bool? = nil
     property http_tls_verify_peer : Bool? = nil
     property http_tls_ca_cert : String? = nil
     property http_tls_keylog_file : String? = nil
@@ -57,6 +61,7 @@ module LavinMQ
         @amqp_tls_key || @tls_key,
         @amqp_tls_min_version || @tls_min_version,
         @amqp_tls_ciphers || @tls_ciphers,
+        {@amqp_tls_prefer_server_ciphers, @tls_prefer_server_ciphers}.find(&.is_a?(Bool)),
         {@amqp_tls_verify_peer, @tls_verify_peer}.find &.is_a?(Bool),
         @amqp_tls_ca_cert || @tls_ca_cert,
         @amqp_tls_keylog_file || @tls_keylog_file
@@ -70,6 +75,7 @@ module LavinMQ
         @mqtt_tls_key || @tls_key,
         @mqtt_tls_min_version || @tls_min_version,
         @mqtt_tls_ciphers || @tls_ciphers,
+        {@mqtt_tls_prefer_server_ciphers, @tls_prefer_server_ciphers}.find(&.is_a?(Bool)),
         {@mqtt_tls_verify_peer, @tls_verify_peer}.find &.is_a?(Bool),
         @mqtt_tls_ca_cert || @tls_ca_cert,
         @mqtt_tls_keylog_file || @tls_keylog_file
@@ -83,13 +89,15 @@ module LavinMQ
         @http_tls_key || @tls_key,
         @http_tls_min_version || @tls_min_version,
         @http_tls_ciphers || @tls_ciphers,
+        {@http_tls_prefer_server_ciphers, @tls_prefer_server_ciphers}.find(&.is_a?(Bool)),
         {@http_tls_verify_peer, @tls_verify_peer}.find &.is_a?(Bool),
         @http_tls_ca_cert || @tls_ca_cert,
         @http_tls_keylog_file || @tls_keylog_file
       )
     end
 
-    private def create_tls_context(cert_path, key_path, min_version, ciphers, verify_peer, ca_cert, keylog_file) : OpenSSL::SSL::Context::Server
+    # ameba:disable Metrics/CyclomaticComplexity
+    private def create_tls_context(cert_path, key_path, min_version, ciphers, prefer_server_ciphers, verify_peer, ca_cert, keylog_file) : OpenSSL::SSL::Context::Server
       context = OpenSSL::SSL::Context::Server.new
       context.add_options(OpenSSL::SSL::Options.new(0x40000000)) # disable client initiated renegotiation
 
@@ -117,6 +125,9 @@ module LavinMQ
 
       # Set ciphers
       context.ciphers = ciphers unless ciphers.empty?
+
+      # Let the server's cipher order win over the client's
+      context.add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE) if prefer_server_ciphers
 
       # Set client certificate verification (mTLS)
       if verify_peer


### PR DESCRIPTION
### WHAT is this pull request doing?

Lets the server's cipher order in tls_ciphers decide which cipher is negotiated instead of the client's preference, by setting OpenSSL's `SSL_OP_CIPHER_SERVER_PREFERENCE`.

The usual reason to want this is compliance: several hardening baselines and TLS scanners check that the server, not the client, controls cipher selection. It also helps when a weak cipher has to stay enabled for one legacy client but every other client should still land on a strong one, which filtering with tls_ciphers alone cannot express.

Off by default, since a cipher list that only contains strong suites makes the order largely irrelevant, and overriding the client can pick a cipher that is slower on its hardware. Settable in `[main]`, per SNI host, and per protocol within an SNI section, and applied on config reload.

### HOW can this pull request be tested?

Specs. Tested manually locally.