### PR TITLE
API endpoint and UI to close a specific channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Negative `x-stream-offset` values to consume the last N stream messages [#1941](https://github.com/cloudamqp/lavinmq/pull/1941)
 - Tab navigation on queue detail pages in the management UI [#2006](https://github.com/cloudamqp/lavinmq/pull/2006)
 - `client_id_validation` MQTT config option to require the client ID to match the authenticated username [#2038](https://github.com/cloudamqp/lavinmq/pull/2038)
+- Be able to close a specific channel [#2144](https://github.com/cloudamqp/lavinmq/issues/2144)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `client_id_validation` MQTT config option to require the client ID to match the authenticated username [#2038](https://github.com/cloudamqp/lavinmq/pull/2038)
 - `tls_prefer_server_ciphers` config option that makes the server's cipher order decide the negotiated cipher
 - The vhost `max-connections` limit is now enforced for MQTT connections [#2222](https://github.com/cloudamqp/lavinmq/pull/2222)
+- Be able to close a specific channel [#2144](https://github.com/cloudamqp/lavinmq/issues/2144)
 
 ### Changed
 

--- a/spec/api/channels_spec.cr
+++ b/spec/api/channels_spec.cr
@@ -163,4 +163,90 @@ describe LavinMQ::HTTP::ChannelsController do
       end
     end
   end
+
+  describe "DELETE /api/channels/:channel" do
+    it "should close the channel and tell the client why" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          close_code = 0_u16
+          close_text = ""
+          ch.on_close do |code, text|
+            close_code = code
+            close_text = text
+          end
+
+          hdrs = ::HTTP::Headers{"X-Reason" => "Misbehaving client"}
+          response = http.delete("/api/channels/#{channel_name(http)}", headers: hdrs)
+          response.status_code.should eq 204
+
+          wait_for { close_code != 0 }
+          close_code.should eq 406
+          close_text.should contain "Misbehaving client"
+          wait_for { JSON.parse(http.get("/api/channels").body).as_a.empty? }
+        end
+      end
+    end
+
+    it "should requeue the channel's unacked messages" do
+      with_http_server do |http, s|
+        with_channel(s) do |ch|
+          q = ch.queue("close_channel_requeue")
+          q.publish_confirm "msg"
+          q.get(no_ack: false).should_not be_nil
+          queue = s.vhosts["/"].queue("close_channel_requeue")
+          queue.message_count.should eq 0
+
+          response = http.delete("/api/channels/#{channel_name(http)}")
+          response.status_code.should eq 204
+
+          wait_for { queue.message_count == 1 }
+        end
+      end
+    end
+
+    it "should remove the channel without waiting for close-ok" do
+      with_http_server do |http, s|
+        with_raw_amqp_connection(s) do |io, stream|
+          io.write_bytes AMQ::Protocol::Frame::Channel::Open.new(1_u16), IO::ByteFormat::NetworkEndian
+          io.flush
+          stream.next_frame.as(AMQ::Protocol::Frame::Channel::OpenOk)
+
+          name = channel_name(http)
+          connection = s.connections.first
+          connection.channel_count.should eq 1
+
+          http.delete("/api/channels/#{name}").status_code.should eq 204
+          connection.channel_count.should eq 0
+          JSON.parse(http.get("/api/channels").body).as_a.empty?.should be_true
+
+          stream.next_frame.should be_a(AMQ::Protocol::Frame::Channel::Close)
+        end
+      end
+    end
+
+    it "should return 404 if the channel does not exist" do
+      with_http_server do |http, _|
+        response = http.delete("/api/channels/no-such-channel")
+        response.status_code.should eq 404
+      end
+    end
+
+    it "should refuse to close another user's channel" do
+      with_http_server do |http, s|
+        s.users.create("bob", "pw", [LavinMQ::Tag::Management])
+        s.users.add_permission("bob", "/", /.*/, /.*/, /.*/)
+        with_channel(s) do
+          hdrs = ::HTTP::Headers{"Authorization" => "Basic Ym9iOnB3"} # bob:pw
+          response = http.delete("/api/channels/#{channel_name(http)}", headers: hdrs)
+          response.status_code.should eq 403
+        end
+      end
+    end
+  end
+end
+
+# The name of the first open channel, encoded for use in a request path
+private def channel_name(http) : String
+  body = JSON.parse(http.get("/api/channels").body)
+  URI.encode_path(body[0]["name"].as_s)
 end

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -57,32 +57,6 @@ class AMQP::Client::UnsafeClient < AMQP::Client
   end
 end
 
-def with_raw_amqp_connection(s, &)
-  io = TCPSocket.new("localhost", amqp_port(s))
-  io.read_timeout = 5.seconds
-
-  io.write AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
-  io.flush
-  stream = AMQ::Protocol::Stream.new(io)
-  stream.next_frame.as(AMQ::Protocol::Frame::Connection::Start)
-  response = "\u0000guest\u0000guest"
-  io.write_bytes(AMQ::Protocol::Frame::Connection::StartOk.new(
-    AMQ::Protocol::Table.new, "PLAIN", response, ""),
-    IO::ByteFormat::NetworkEndian)
-  io.flush
-  tune = stream.next_frame.as(AMQ::Protocol::Frame::Connection::Tune)
-  io.write_bytes AMQ::Protocol::Frame::Connection::TuneOk.new(
-    channel_max: tune.channel_max, frame_max: tune.frame_max, heartbeat: 0_u16),
-    IO::ByteFormat::NetworkEndian
-  io.write_bytes AMQ::Protocol::Frame::Connection::Open.new("/"), IO::ByteFormat::NetworkEndian
-  io.flush
-  stream.next_frame.as(AMQ::Protocol::Frame::Connection::OpenOk)
-
-  yield io, stream
-ensure
-  io.try &.close
-end
-
 describe LavinMQ::Server do
   describe "channel close" do
     it "does not close the connection for frames on a channel waiting for close-ok" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -154,6 +154,32 @@ def amqp_port(s)
   s.amqp_server.@listeners.select(TCPServer).first.local_address.port
 end
 
+def with_raw_amqp_connection(s, &)
+  io = TCPSocket.new("localhost", amqp_port(s))
+  io.read_timeout = 5.seconds
+
+  io.write AMQ::Protocol::PROTOCOL_START_0_9_1.to_slice
+  io.flush
+  stream = AMQ::Protocol::Stream.new(io)
+  stream.next_frame.as(AMQ::Protocol::Frame::Connection::Start)
+  response = "\u0000guest\u0000guest"
+  io.write_bytes(AMQ::Protocol::Frame::Connection::StartOk.new(
+    AMQ::Protocol::Table.new, "PLAIN", response, ""),
+    IO::ByteFormat::NetworkEndian)
+  io.flush
+  tune = stream.next_frame.as(AMQ::Protocol::Frame::Connection::Tune)
+  io.write_bytes AMQ::Protocol::Frame::Connection::TuneOk.new(
+    channel_max: tune.channel_max, frame_max: tune.frame_max, heartbeat: 0_u16),
+    IO::ByteFormat::NetworkEndian
+  io.write_bytes AMQ::Protocol::Frame::Connection::Open.new("/"), IO::ByteFormat::NetworkEndian
+  io.flush
+  stream.next_frame.as(AMQ::Protocol::Frame::Connection::OpenOk)
+
+  yield io, stream
+ensure
+  io.try &.close
+end
+
 # Poll interval for the wait_for/should_eventually loops below. We sleep
 # (rather than busy-spinning with Fiber.yield) so the polling fiber blocks on
 # an event-loop timer instead of re-enqueueing itself every round. A tight

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -17,7 +17,7 @@ module LavinMQ
       include Stats
       include SortableJSON
 
-      getter id, name
+      getter id, name, client
       property? running = true
       getter? flow = true
       @consumers = Array(AMQP::Consumer).new
@@ -738,6 +738,16 @@ module LavinMQ
         @next_msg_body_file.try &.close
         @log.debug { "Closed" }
         true
+      end
+
+      # Closes the channel from the server side, e.g. from the management API.
+      # The client is told why with a Channel::Close frame, but the channel is
+      # torn down right away so that a client that never replies with
+      # Channel::CloseOk can't keep it alive.
+      def close(reason : String) : Nil
+        code = ChannelReplyCode::PRECONDITION_FAILED
+        send AMQP::Frame::Channel::Close.new(@id, code.value, "#{code} - #{reason}", 0_u16, 0_u16)
+        @client.close_channel(self)
       end
 
       protected def next_delivery_tag(queue : Queue, sp, no_ack, consumer) : UInt64

--- a/src/lavinmq/amqp/channel.cr
+++ b/src/lavinmq/amqp/channel.cr
@@ -17,7 +17,7 @@ module LavinMQ
       include Stats
       include SortableJSON
 
-      getter id, name
+      getter id, name, client
       property? running = true
       getter? flow = true
       @consumers = Array(AMQP::Consumer).new
@@ -739,6 +739,16 @@ module LavinMQ
         @next_msg_body_file.try &.close
         @log.debug { "Closed" }
         true
+      end
+
+      # Closes the channel from the server side, e.g. from the management API.
+      # The client is told why with a Channel::Close frame, but the channel is
+      # torn down right away so that a client that never replies with
+      # Channel::CloseOk can't keep it alive.
+      def close(reason : String) : Nil
+        code = ChannelReplyCode::PRECONDITION_FAILED
+        send AMQP::Frame::Channel::Close.new(@id, code.value, "#{code} - #{reason}", 0_u16, 0_u16)
+        @client.close_channel(self)
       end
 
       protected def next_delivery_tag(queue : Queue, sp, no_ack, consumer) : UInt64

--- a/src/lavinmq/amqp/client.cr
+++ b/src/lavinmq/amqp/client.cr
@@ -437,8 +437,10 @@ module LavinMQ
         channel
       end
 
-      private def close_channel(channel : Client::Channel?) : Nil
-        if channel.try &.close
+      protected def close_channel(channel : Client::Channel?) : Nil
+        return unless channel
+        @channels.delete(channel.id)
+        if channel.close
           @vhost.event_tick(EventType::ChannelClosed)
         end
       end
@@ -452,10 +454,10 @@ module LavinMQ
         when AMQP::Frame::Channel::Open
           open_channel(frame)
         when AMQP::Frame::Channel::Close
-          close_channel(@channels.delete(frame.channel))
+          close_channel(@channels[frame.channel]?)
           send AMQP::Frame::Channel::CloseOk.new(frame.channel), true
         when AMQP::Frame::Channel::CloseOk
-          close_channel(@channels.delete(frame.channel))
+          close_channel(@channels[frame.channel]?)
         when AMQP::Frame::Channel::Flow
           with_channel frame, &.flow(frame.active)
         when AMQP::Frame::Channel::FlowOk
@@ -529,7 +531,7 @@ module LavinMQ
       private def cleanup
         @running = false
         i = 0u32
-        @channels.each_value do |ch|
+        @channels.values.each do |ch|
           close_channel(ch)
           Fiber.yield if (i &+= 1) % 512 == 0
         end

--- a/src/lavinmq/http/controller/channels.cr
+++ b/src/lavinmq/http/controller/channels.cr
@@ -26,6 +26,15 @@ module LavinMQ
           end
         end
 
+        delete "/api/channels/:name" do |context, params|
+          with_channel(context, params) do |channel|
+            access_refused(context) unless can_access_connection?(channel.client, user(context))
+            reason = context.request.headers["X-Reason"]? || "Closed via management plugin"
+            channel.close(reason)
+            context.response.status_code = 204
+          end
+        end
+
         put "/api/channels/:name" do |context, params|
           with_channel(context, params) do |channel|
             body = parse_body(context)

--- a/src/lavinmq/http/controller/connections.cr
+++ b/src/lavinmq/http/controller/connections.cr
@@ -4,6 +4,10 @@ require "../controller"
 module LavinMQ
   module HTTP
     module ConnectionsHelper
+      private def can_access_connection?(c : Client, user : Auth::BaseUser) : Bool
+        c.user == user || user.tags.any? { |t| t.administrator? || t.monitoring? }
+      end
+
       private def connections(user : Auth::BaseUser)
         if user.tags.any? { |t| t.administrator? || t.monitoring? }
           @server.connections
@@ -78,10 +82,6 @@ module LavinMQ
         access_refused(context) unless can_access_connection?(connection, user)
         yield connection
         context
-      end
-
-      private def can_access_connection?(c : Client, user : Auth::BaseUser) : Bool
-        c.user == user || user.tags.any? { |t| t.administrator? || t.monitoring? }
       end
     end
   end

--- a/static/docs/paths/channels.yaml
+++ b/static/docs/paths/channels.yaml
@@ -91,6 +91,29 @@
           application/json:
             schema:
               "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+  delete:
+    tags:
+    - channels
+    description: Close a specific channel. Consumers on the channel are cancelled
+      and its unacknowledged messages are requeued. The client is notified with a
+      channel close frame, but is free to open a new channel.
+    summary: Close channel
+    operationId: DeleteChannel
+    responses:
+      '204':
+        description: The channel was closed successfully.
+      4XX:
+        description: Client Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
+      5XX:
+        description: Server Error
+        content:
+          application/json:
+            schema:
+              "$ref": "../openapi.yaml#/components/schemas/ErrorResponse"
   put:
     tags:
     - channels

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -122,3 +122,12 @@ function updateChannel () {
 }
 updateChannel()
 setInterval(updateChannel, 5000)
+
+document.querySelector('#closeChannel').addEventListener('submit', function (evt) {
+  evt.preventDefault()
+  const headers = new window.Headers({
+    'X-Reason': document.querySelector('[name=reason]').value
+  })
+  HTTP.request('DELETE', channelUrl, { headers })
+    .then(() => { window.location = 'channels' })
+})

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -119,3 +119,12 @@ function updateChannel () {
 }
 updateChannel()
 setInterval(updateChannel, 5000)
+
+document.querySelector('#closeChannel').addEventListener('submit', function (evt) {
+  evt.preventDefault()
+  const headers = new window.Headers({
+    'X-Reason': document.querySelector('[name=reason]').value
+  })
+  HTTP.request('DELETE', channelUrl, { headers })
+    .then(() => { window.location = 'channels' })
+})

--- a/static/js/channels.js
+++ b/static/js/channels.js
@@ -22,6 +22,7 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.user)
+    Table.renderCell(tr, 7, Helpers.closeChannelForm(item.name), 'right')
   }
   if (item.confirm) {
     const confirmSpan = document.createElement('span')

--- a/static/js/channels.js
+++ b/static/js/channels.js
@@ -1,6 +1,21 @@
 import * as Table from './table.js'
 import * as Helpers from './helpers.js'
 import * as HTTP from './http.js'
+import * as DOM from './dom.js'
+
+// A one button form that closes the named channel, for use in a table cell
+function closeChannelForm (name) {
+  const form = document.createElement('form')
+  form.appendChild(DOM.button.delete({ text: 'Close', type: 'submit' }))
+  form.addEventListener('submit', function (evt) {
+    evt.preventDefault()
+    if (!window.confirm(`Are you sure you want to close channel ${name}?`)) return false
+    const headers = new window.Headers({ 'X-Reason': 'Closed via Web management' })
+    HTTP.request('DELETE', HTTP.url`api/channels/${name}`, { headers })
+      .then(() => { DOM.toast(`Channel ${name} closed`) })
+  })
+  return form
+}
 
 const vhost = window.sessionStorage.getItem('vhost')
 let url = 'api/channels'
@@ -22,6 +37,7 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.user)
+    Table.renderCell(tr, 7, closeChannelForm(item.name), 'right')
   }
   if (item.confirm) {
     const confirmSpan = document.createElement('span')

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -89,6 +89,7 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.username)
+    Table.renderCell(tr, 7, Helpers.closeChannelForm(item.name), 'right')
   }
   let mode = ''
   mode += item.confirm ? ' C' : ''

--- a/static/js/connection.js
+++ b/static/js/connection.js
@@ -13,6 +13,20 @@ const connection = new URLSearchParams(window.location.hash.substring(1)).get('n
 document.title = `Connection ${connection} | LavinMQ`
 document.querySelector('#pagename-label').textContent = connection
 
+// A one button form that closes the named channel, for use in a table cell
+function closeChannelForm (name) {
+  const form = document.createElement('form')
+  form.appendChild(DOM.button.delete({ text: 'Close', type: 'submit' }))
+  form.addEventListener('submit', function (evt) {
+    evt.preventDefault()
+    if (!window.confirm(`Are you sure you want to close channel ${name}?`)) return false
+    const headers = new window.Headers({ 'X-Reason': 'Closed via Web management' })
+    HTTP.request('DELETE', HTTP.url`api/channels/${name}`, { headers })
+      .then(() => { DOM.toast(`Channel ${name} closed`) })
+  })
+  return form
+}
+
 const connectionUrl = `api/connections/${connection}`
 function updateConnection (all) {
   HTTP.request('GET', connectionUrl).then(item => {
@@ -89,6 +103,7 @@ Table.renderTable('table', tableOptions, function (tr, item, all) {
     Table.renderCell(tr, 0, channelLink)
     Table.renderCell(tr, 1, item.vhost)
     Table.renderCell(tr, 2, item.username)
+    Table.renderCell(tr, 7, closeChannelForm(item.name), 'right')
   }
   let mode = ''
   mode += item.confirm ? ' C' : ''

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -1,4 +1,5 @@
 import * as HTTP from './http.js'
+import * as DOM from './dom.js'
 
 function formatNumber (num) {
   if (typeof num.toLocaleString === 'function') {
@@ -239,8 +240,23 @@ const stateClasses = new class {
     this.#persist()
   }
 }()
+// A one button form that closes the named channel, for use in a table cell
+function closeChannelForm (name) {
+  const form = document.createElement('form')
+  form.appendChild(DOM.button.delete({ text: 'Close', type: 'submit' }))
+  form.addEventListener('submit', function (evt) {
+    evt.preventDefault()
+    if (!window.confirm(`Are you sure you want to close channel ${name}?`)) return false
+    const headers = new window.Headers({ 'X-Reason': 'Closed via Web management' })
+    HTTP.request('DELETE', HTTP.url`api/channels/${name}`, { headers })
+      .then(() => { DOM.toast(`Channel ${name} closed`) })
+  })
+  return form
+}
+
 export {
   addVhostOptions,
+  closeChannelForm,
   formatNumber,
   nFormatter,
   duration,

--- a/views/channel.shtml
+++ b/views/channel.shtml
@@ -76,6 +76,14 @@
           </table>
         </div>
       </section>
+      <form method="delete" id="closeChannel" class="form card">
+        <h3>Close channel</h3>
+        <label>
+          <span>Reason</span>
+          <input type="text" name="reason" value="Closed via Web management">
+        </label>
+        <button type="submit" class="btn btn-outlined"><span>Close</span><img src="img/icon-cross.svg" /></button>
+      </form>
     </main>
     <!--#include file="partials/footer.shtml" -->
   </body>

--- a/views/channels.shtml
+++ b/views/channels.shtml
@@ -30,6 +30,7 @@
                 <th data-sort-key="consumer_count">Consumers<span></span></th>
                 <th data-sort-key="prefetch_count">Prefetch limit<span></span></th>
                 <th data-sort-key="messages_unacknowledged">Messages Unacknowledged<span></span></th>
+                <th></th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/views/connection.shtml
+++ b/views/connection.shtml
@@ -92,6 +92,7 @@
                 <th data-sort-key="consumer_count">Consumers<span></span></th>
                 <th data-sort-key="prefetch_count">Prefetch limit<span></span></th>
                 <th data-sort-key="messages_unacknowledged">Messages Unacknowledged<span></span></th>
+                <th></th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
### WHAT is this pull request doing?

Adds API endpoint and UI parts to allow closing a specific channel 

Fixes #2144 

### HOW can this pull request be tested?

Specs and manual testing

Open a connection and a channel, close the channel from the UI or via http API directly and observe in the client that the channel was closed with a reason 