### PR TITLE
Add collapsible AI investigation section to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,24 +10,22 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**Describe your setup**
-Please describe the environment you are using by including the build info. Please also include any relevant information about the client software or amqp libraries that you may be using. 
+<details>
+<summary>Investigation details</summary>
 
-To retrieve the build info: `bin/lavinmq --build-info`
+**Setup**
+Build info from `bin/lavinmq --build-info`, and client libraries.
 
 **How to reproduce**
-Please provide steps to reproduce the behavior.
+Steps to reproduce the behavior.
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What you expected to happen.
 
-<details>
-<summary>AI investigation</summary>
+**Logs**
+Relevant log output.
 
-<!--
-Paste detailed AI findings here: root cause analysis, call chains,
-evidence, and alternatives that were considered.
-Delete this section if there is no AI investigation.
--->
+**AI investigation**
+Root cause analysis, call chains, evidence.
 
 </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,3 +20,14 @@ Please provide steps to reproduce the behavior.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
+
+<details>
+<summary>AI investigation</summary>
+
+<!--
+Paste detailed AI findings here: root cause analysis, call chains,
+evidence, and alternatives that were considered.
+Delete this section if there is no AI investigation.
+-->
+
+</details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise human readable description of what the bug is.
 
 <details>
 <summary>Investigation details</summary>

--- a/.github/ISSUE_TEMPLATE/docs-improvement.md
+++ b/.github/ISSUE_TEMPLATE/docs-improvement.md
@@ -10,3 +10,14 @@ assignees: ''
 **Describe your issue**
 
 Please write a line or two about the changes you'd like to suggest. Maybe something is unclear and you'd like clarification, something is described incorrectly, or a feature may be missing documentation. Tell us about that here...
+
+<details>
+<summary>AI investigation</summary>
+
+<!--
+Paste detailed AI findings here: root cause analysis, call chains,
+evidence, and alternatives that were considered.
+Delete this section if there is no AI investigation.
+-->
+
+</details>

--- a/.github/ISSUE_TEMPLATE/docs-improvement.md
+++ b/.github/ISSUE_TEMPLATE/docs-improvement.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **Describe your issue**
 
-Please write a line or two about the changes you'd like to suggest. Maybe something is unclear and you'd like clarification, something is described incorrectly, or a feature may be missing documentation. Tell us about that here...
+Please write a human readable line or two about the changes you'd like to suggest. Maybe something is unclear and you'd like clarification, something is described incorrectly, or a feature may be missing documentation. Tell us about that here...
 
 <details>
 <summary>AI investigation</summary>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,3 +15,14 @@ A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
+
+<details>
+<summary>AI investigation</summary>
+
+<!--
+Paste detailed AI findings here: root cause analysis, call chains,
+evidence, and alternatives that were considered.
+Delete this section if there is no AI investigation.
+-->
+
+</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise human readable description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,11 +13,11 @@ A clear and concise human readable description of what the problem is. Ex. I'm a
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
 <details>
 <summary>AI investigation</summary>
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
 
 <!--
 Paste detailed AI findings here: root cause analysis, call chains,

--- a/.github/ISSUE_TEMPLATE/uiux_improvements.md
+++ b/.github/ISSUE_TEMPLATE/uiux_improvements.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Summary**  
-Provide a brief description of the issue or improvement.
+Provide a brief human readable description of the issue or improvement.
 
 **Current Behavior**  
 Describe how the feature or UI element currently works.

--- a/.github/ISSUE_TEMPLATE/uiux_improvements.md
+++ b/.github/ISSUE_TEMPLATE/uiux_improvements.md
@@ -24,3 +24,14 @@ Suggest how to resolve the issue or implement the improvement.
 
 **Screenshots/Mockups**  
 Add visuals to clarify the issue or illustrate your suggestion.
+
+<details>
+<summary>AI investigation</summary>
+
+<!--
+Paste detailed AI findings here: root cause analysis, call chains,
+evidence, and alternatives that were considered.
+Delete this section if there is no AI investigation.
+-->
+
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
-### WHAT is this pull request doing?
-Please fill me in.
+### What does this pull request do?
 
-### HOW can this pull request be tested?
-Specs? Manual steps? Please fill me in.
+<!-- Write a short, technical description in flowing text. -->
+
+### How can it be tested?
+
+<!-- Specs, or manual steps. -->


### PR DESCRIPTION
The bug report template now has one short human readable section, Describe the bug, at the top. The setup, repro steps, expected behavior, logs and AI findings move into one collapsed details block, so the issue list and the issue view stay easy to read.

The other three issue templates keep their human readable sections unchanged and get a collapsed AI investigation block at the bottom for detailed AI findings such as root cause analysis, call chains and evidence. An HTML comment in that block tells the author to delete it when unused, since GitHub hides the comment but still renders an empty details row.

The PR template stays fully human written. The two questions become headings with comment prompts, so authors can write flowing prose without placeholder text ending up in the description.