### PR TITLE
Allow HTTP shovel destinations without queue or exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP shovels could no longer be created through the API, config validation demanded a destination queue or exchange that an HTTP destination has no use for [#2215](https://github.com/cloudamqp/lavinmq/pull/2215)
 - Management UI OAuth2 login now works with identity providers that require a specific scope (e.g. Entra ID), via the new `mgmt_scopes` config option [#2127](https://github.com/cloudamqp/lavinmq/pull/2127)
 - Accept JWKS keys that omit the `alg` parameter when fetching keys for OAuth/OIDC [#2124](https://github.com/cloudamqp/lavinmq/pull/2124)
 - Document that OAuth/OIDC JWTs must include a `kid` header matching a JWKS key [#2107](https://github.com/cloudamqp/lavinmq/pull/2107)

--- a/spec/api/shovels_spec.cr
+++ b/spec/api/shovels_spec.cr
@@ -148,4 +148,20 @@ describe LavinMQ::HTTP::ShovelsController do
       end
     end
   end
+
+  describe "PUT api/parameters/shovel/:vhost/:name" do
+    it "should create a shovel with an HTTP destination" do
+      with_http_server do |http, s|
+        body = {
+          value: {
+            "src-uri":   s.amqp_server.url,
+            "src-queue": "events",
+            "dest-uri":  "https://example.com/webhook",
+          },
+        }
+        response = http.put("/api/parameters/shovel/%2F/webhook-shovel", body: body.to_json)
+        response.status_code.should eq 201
+      end
+    end
+  end
 end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -943,5 +943,64 @@ describe LavinMQ::Shovel do
         end
       end
     end
+
+    it "accepts an HTTP destination without a dest queue or exchange" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user3", "pass")
+        s.users.add_permission("shovel_user3", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  "https://example.com/webhook",
+          "src-queue": "q1",
+        }.to_json)
+        LavinMQ::Shovel::Store.validate_config!(config, user)
+      end
+    end
+
+    it "raises when only some destinations are HTTP and none names a queue or exchange" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user5", "pass")
+        s.users.add_permission("shovel_user5", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  ["https://example.com/webhook", "amqp:///"],
+          "src-queue": "q1",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError, "Shovel destination requires queue and/or exchange") do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
+
+    # Only http and https build an HTTPDestination, so nothing else may skip the check
+    it "raises for an unknown scheme that merely starts with http" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user6", "pass")
+        s.users.add_permission("shovel_user6", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  "httpx://example.com/webhook",
+          "src-queue": "q1",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError, "Shovel destination requires queue and/or exchange") do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
+
+    it "raises when an AMQP destination has no queue or exchange" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user4", "pass")
+        s.users.add_permission("shovel_user4", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  "amqp:///",
+          "src-queue": "q1",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError, "Shovel destination requires queue and/or exchange") do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
   end
 end

--- a/src/lavinmq/shovel/store.cr
+++ b/src/lavinmq/shovel/store.cr
@@ -58,8 +58,11 @@ module LavinMQ
           dst = "" # default exchange
         end
 
+        # HTTP destinations POST the body to the endpoint, there is no exchange or queue to name
+        http_dest = !dest_uris.empty? && dest_uris.all?(&.scheme.in?("http", "https"))
+
         raise ConfigError.new("Shovel source requires a queue or an exchange") if src_q.nil? && src_x.nil?
-        raise ConfigError.new("Shovel destination requires queue and/or exchange") if dst.nil?
+        raise ConfigError.new("Shovel destination requires queue and/or exchange") if dst.nil? && !http_dest
 
         return unless user
 


### PR DESCRIPTION
Fixes #2220.

## Background

HTTP shovels cannot be created through the API. #1670 added a check that a shovel destination names either a queue or an exchange. An HTTP destination names neither: it POSTs the message body to the endpoint, so there is nothing the caller can add to make the request succeed. The CLI and the management UI go through the same endpoint, so webhook shovels have been unconfigurable everywhere since that release.

#2218 is the precursor to this PR. It adds the specs and is red on main. This PR is the fix and turns them green, so the diff here is 5 lines of `store.cr` and a changelog entry.

Found while finishing #1423, which adds request signing for HTTP shovels and is unreachable until this is fixed.

## Summary

The check now applies only when every destination URI is AMQP. It matches on the exact `http` and `https` schemes, the same way `Store#destination` decides which destination class to build, so validation cannot accept a config that construction then rejects.

A config that mixes an HTTP and an AMQP destination is still rejected, since the AMQP destination does need somewhere to publish.

## Test plan

No new specs, #2218 has them. Both of its failing specs pass with this change:

- `PUT /api/parameters/shovel/...` with an HTTP `dest-uri` returns 201
- `validate_config!` accepts an HTTP destination with no dest queue or exchange

Its three passing specs stay passing: an AMQP destination still needs a queue or an exchange, a mixed HTTP/AMQP destination list is still rejected, and `httpx://` is not treated as an HTTP destination.

`make test`, `make lint` clean.

## Review order

1. #2218, specs, red
2. This PR, the fix, green
3. #1423, Standard Webhooks signing for HTTP shovels
