### PR TITLE
Add specs for shovels with an HTTP destination (red)

### DIFF
--- a/spec/api/shovels_spec.cr
+++ b/spec/api/shovels_spec.cr
@@ -148,4 +148,20 @@ describe LavinMQ::HTTP::ShovelsController do
       end
     end
   end
+
+  describe "PUT api/parameters/shovel/:vhost/:name" do
+    it "should create a shovel with an HTTP destination" do
+      with_http_server do |http, s|
+        body = {
+          value: {
+            "src-uri":   s.amqp_server.url,
+            "src-queue": "events",
+            "dest-uri":  "https://example.com/webhook",
+          },
+        }
+        response = http.put("/api/parameters/shovel/%2F/webhook-shovel", body: body.to_json)
+        response.status_code.should eq 201
+      end
+    end
+  end
 end

--- a/spec/shovel_spec.cr
+++ b/spec/shovel_spec.cr
@@ -943,5 +943,64 @@ describe LavinMQ::Shovel do
         end
       end
     end
+
+    it "accepts an HTTP destination without a dest queue or exchange" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user3", "pass")
+        s.users.add_permission("shovel_user3", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  "https://example.com/webhook",
+          "src-queue": "q1",
+        }.to_json)
+        LavinMQ::Shovel::Store.validate_config!(config, user)
+      end
+    end
+
+    it "raises when only some destinations are HTTP and none names a queue or exchange" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user5", "pass")
+        s.users.add_permission("shovel_user5", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  ["https://example.com/webhook", "amqp:///"],
+          "src-queue": "q1",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError, "Shovel destination requires queue and/or exchange") do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
+
+    # Only http and https build an HTTPDestination, so nothing else may skip the check
+    it "raises for an unknown scheme that merely starts with http" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user6", "pass")
+        s.users.add_permission("shovel_user6", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  "httpx://example.com/webhook",
+          "src-queue": "q1",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError, "Shovel destination requires queue and/or exchange") do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
+
+    it "raises when an AMQP destination has no queue or exchange" do
+      with_amqp_server do |s|
+        user = s.users.create("shovel_user4", "pass")
+        s.users.add_permission("shovel_user4", "/", /.*/, /.*/, /.*/)
+        config = JSON.parse({
+          "src-uri":   "amqp:///",
+          "dest-uri":  "amqp:///",
+          "src-queue": "q1",
+        }.to_json)
+        expect_raises(LavinMQ::Shovel::ConfigError, "Shovel destination requires queue and/or exchange") do
+          LavinMQ::Shovel::Store.validate_config!(config, user)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Specs for #2220.

## Background

HTTP shovels cannot be created through the API. #1670 added a check that a shovel destination names either a queue or an exchange. An HTTP destination names neither: it POSTs the message body to the endpoint, so there is nothing the caller can add to make the request succeed.

```
$ curl -u guest:guest -X PUT http://localhost:15672/api/parameters/shovel/%2F/webhook \
    -d '{"value":{"src-uri":"amqp:///","src-queue":"events","dest-uri":"https://example.com/webhook"}}'
{"error":"bad_request","reason":"Shovel destination requires queue and/or exchange"}
```

The CLI and the management UI go through the same endpoint, so webhook shovels have been unconfigurable everywhere since that release. The UI happens to still work, but only by accident: it submits the hidden AMQP destination field as an empty string, and `""` is not `nil`, so the check passes.

Found while finishing #1423, which adds request signing for HTTP shovels and is unreachable until this is fixed.

## Summary

**This PR is specs only, and CI is red on purpose.** It puts the failure on the record before the fix lands, so the fix has something to turn green rather than a claim in a commit message. #2215 is the fix and turns these green; it contains no specs of its own.

Two specs fail on main:

| Spec | On main |
|------|---------|
| `PUT /api/parameters/shovel/...` with an HTTP `dest-uri` returns 201 | 400 |
| `validate_config!` accepts an HTTP destination with no dest queue or exchange | raises `ConfigError` |

Three pass on main and pin down what must keep working after the fix:

- an AMQP destination still has to name a queue or an exchange
- a destination list that mixes HTTP and AMQP is still rejected
- a scheme that merely starts with `http`, such as `httpx://`, is not treated as an HTTP destination

## Review order

1. This PR, specs, red
2. #2215, the fix, green
3. #1423, Standard Webhooks signing for HTTP shovels
