### PR TITLE
Handle rejected vhost limits request on page load

### DIFF
--- a/spec/frontend/vhost.spec.js
+++ b/spec/frontend/vhost.spec.js
@@ -120,6 +120,35 @@ test.describe("vhost", _ => {
     expect(errors).toEqual([])
   })
 
+  test('failed limits load on page load does not raise a page error', async ({ page }) => {
+    const errors = []
+    let limitsRequests = 0
+    page.on('pageerror', err => errors.push(err.message))
+    page.on('dialog', dialog => dialog.dismiss())
+    await page.route(url => url.pathname === `/api/vhosts/${vhostName}`, async route => {
+      await route.fulfill({ json: { messages_ready: 0, messages_unacknowledged: 0, messages: 0 } })
+    })
+    await page.route(url => url.pathname === `/api/vhosts/${vhostName}/permissions`, async route => {
+      await route.fulfill({ json: permissionsResponse })
+    })
+    await page.route(url => url.pathname === '/api/users', async route => {
+      await route.fulfill({ json: usersResponse })
+    })
+    await page.route(url => url.pathname === `/api/vhost-limits/${vhostName}`, async route => {
+      limitsRequests += 1
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'access_refused', reason: 'No permission' })
+      })
+    })
+
+    await page.goto(`/vhost#name=${vhostName}`)
+    await expect.poll(() => limitsRequests).toBe(1)
+    await expect(page.locator('#permissions tbody tr')).toHaveCount(permissionsResponse.length)
+    expect(errors).toEqual([])
+  })
+
   test('delete button works', async ({ page }) => {
     await page.goto(`/vhost#name=${vhostName}`)
 

--- a/static/js/vhost.js
+++ b/static/js/vhost.js
@@ -23,9 +23,7 @@ async function fetchLimits () {
   document.getElementById('max-queues').textContent = maxQueues.toLocaleString()
   document.forms.setLimits['max-queues'].value = maxQueues
 }
-try {
-  fetchLimits()
-} catch {}
+fetchLimits().catch(() => {})
 
 const permissionsUrl = HTTP.url`api/vhosts/${vhost}/permissions`
 const tableOptions = { url: permissionsUrl, keyColumns: ['user'], countId: 'permissions-count' }


### PR DESCRIPTION
Follow-up to #2214, I merged it but then I saw that we had a small fix left. 

The page load call to `fetchLimits` in `static/js/vhost.js` was wrapped in try/catch, but `fetchLimits` is async so a failed `GET api/vhost-limits` rejected the returned promise instead of throwing, and the rejection was unhandled. This replaces the try/catch with `.catch` on the promise, matching the other call sites in #2214. Adds a spec that returns `403` for the limits request on page load and asserts no page error.