### PR TITLE
Default permission group instead of a mode switch, keep permission_check_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab navigation on queue detail pages in the management UI [#2006](https://github.com/cloudamqp/lavinmq/pull/2006)
 - `client_id_validation` MQTT config option to require the client ID to match the authenticated username [#2038](https://github.com/cloudamqp/lavinmq/pull/2038)
 - `tls_prefer_server_ciphers` config option that makes the server's cipher order decide the negotiated cipher
-- MQTT topic permissions: per-user, per-topic-filter authorization managed via `/api/mqtt/permission-groups` [#2126](https://github.com/cloudamqp/lavinmq/pull/2126)
-
-### Removed
-
-- The `permission_check_enabled` MQTT config option; topic permissions replace the coarse per-exchange ACL checks. The option is ignored with a startup warning if still configured [#2126](https://github.com/cloudamqp/lavinmq/pull/2126)
+- MQTT topic permissions: per-user, per-topic-filter authorization managed via `/api/mqtt/permission-groups`. Every vhost gets a `default` group that allows all topics, delete it to lock the vhost down [#2126](https://github.com/cloudamqp/lavinmq/pull/2126)
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `max_inflight_messages` | — | — | UInt16 | `65535` | Max unacknowledged messages per session |
 | `max_packet_size` | — | — | UInt32 | `268435455` | Max MQTT packet size (bytes) |
 | `default_vhost` | — | — | String | `/` | Default vhost for MQTT connections |
+| `permission_check_enabled` | — | — | Bool | `false` | Apply the user's AMQP permissions to the MQTT exchange and session queue |
 | `client_id_validation` | — | — | String | `none` | Validate client_id against the username: `none` or `username` |
 
 ## [mgmt] Section

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -98,11 +98,13 @@ Internally, MQTT is implemented on top of LavinMQ's AMQP infrastructure:
 
 Topic permissions restrict which topics a user's MQTT clients can publish to and receive from. They are defined as permission groups on a vhost.
 
-- With no groups on a vhost, any authenticated client can publish and subscribe to any topic
-- When the first group is created, the vhost becomes default deny: a client can only publish to or receive on topics granted by a matching rule
+- A client can only publish to or receive on topics granted by a matching rule
+- Every vhost starts with a group named `default`. Its member is `*` and its single rule `#` grants read and write, so any authenticated client can publish and subscribe to any topic
+- To lock a vhost down, delete the `default` group or narrow its rule. Groups added next to an intact `default` group grant nothing new, because the `default` group already grants everything
+- A vhost with no groups denies every topic
 - There is no administrator bypass
-- Deleting the last group restores unrestricted topic access
 - A user still needs a permission entry on the vhost to connect
+- The `permission_check_enabled` option under `[mqtt]` adds the AMQP permission check in front of the topic check, see [Upgrading](#upgrading)
 
 ### Groups
 
@@ -188,11 +190,12 @@ curl -u admin:pw -X PUT localhost:15672/api/mqtt/permission-groups/%2f/devices/r
   -d '{"pattern": "chat/{client_id}/#", "read": true, "write": true}'
 ```
 
-Groups are stored per vhost in `mqtt_permissions.json` and are included in definitions export and import under the `mqtt_permissions` key.
+Groups are stored per vhost in `mqtt_permissions.json` and are included in definitions export and import under the `mqtt_permissions` key. On a vhost where nobody has changed the groups yet, an import with groups for that vhost replaces the automatic `default` group, so an import of a locked-down export gives a locked-down vhost. On a vhost with changes, an import adds groups and replaces groups by name, and deletes none.
 
 ### Upgrading
 
-- The `permission_check_enabled` option under `[mqtt]` is removed. It applied the AMQP permission model to the MQTT exchange. Topic permissions replace it. A config that still sets the option gets a warning at startup and the option is ignored
+- The `default` group is created in memory when a vhost has no `mqtt_permissions.json`, so an upgraded server keeps every topic open until an operator locks a vhost down. `mqtt_permissions.json` is written at the first change over the HTTP API or from a definitions import
+- The `permission_check_enabled` option under `[mqtt]` is unchanged. When it is set, a publish needs write permission on the `mqtt.default` exchange, and a subscribe needs read permission on that exchange and write permission on the `mqtt.<client_id>` session queue. A client that fails this check is disconnected. The topic check runs after it
 - A persistent session that existed before the upgrade has no stored username until its device reconnects once. Until then it is checked against `"*"` rules only
 
 ## Authentication

--- a/spec/api/definitions_spec.cr
+++ b/spec/api/definitions_spec.cr
@@ -1,6 +1,18 @@
 require "../spec_helper"
 require "../../src/lavinmq/definitions"
 
+private def import_defs(s, defs)
+  tmpfile = File.tempname("lavinmq-defs", ".json")
+  File.write(tmpfile, defs.to_json)
+  LavinMQ::GlobalDefinitions.import_from_file(tmpfile, s)
+ensure
+  File.delete?(tmpfile) if tmpfile
+end
+
+private def ctx(username)
+  LavinMQ::MQTT::PermissionService::Context.new(username, "dev")
+end
+
 describe LavinMQ::GlobalDefinitions do
   describe ".import_from_file" do
     it "does not overwrite existing users" do
@@ -390,7 +402,53 @@ describe LavinMQ::HTTP::Server do
         response.status_code.should eq 200
         service = s.vhosts["iot"].mqtt_permission_service
         service["devices"]?.should_not be_nil
-        service.in_use?.should be_true
+      end
+    end
+
+    describe "mqtt_permissions on a vhost nobody has configured" do
+      it "applies a narrowed default group from the file over the automatic one" do
+        defs = {"mqtt_permissions" => [
+          {"name" => "default", "vhost" => "/", "members" => ["*"],
+           "rules" => [{"identifier" => "public", "pattern" => "public/#", "read" => true, "write" => true}]},
+        ]}
+        with_amqp_server do |s|
+          import_defs(s, defs)
+          service = s.vhosts["/"].mqtt_permission_service
+          service.can_write?(ctx("guest"), "public/x").should be_true
+          service.can_write?(ctx("guest"), "private/x").should be_false
+        end
+      end
+
+      it "replaces the automatic default group with the groups from the file" do
+        defs = {"mqtt_permissions" => [
+          {"name" => "sensors", "vhost" => "/", "members" => ["alice"],
+           "rules" => [{"identifier" => "s", "pattern" => "sensors/#", "read" => true, "write" => true}]},
+        ]}
+        with_amqp_server do |s|
+          import_defs(s, defs)
+          service = s.vhosts["/"].mqtt_permission_service
+          service["default"]?.should be_nil
+          service.can_write?(ctx("alice"), "sensors/1").should be_true
+          service.can_write?(ctx("guest"), "sensors/1").should be_false
+        end
+      end
+
+      it "keeps the groups of a configured vhost and adds only new names" do
+        defs = {"mqtt_permissions" => [
+          {"name" => "sensors", "vhost" => "/", "members" => ["alice"],
+           "rules" => [{"identifier" => "s", "pattern" => "sensors/#", "read" => true, "write" => true}]},
+          {"name" => "default", "vhost" => "/", "members" => ["*"],
+           "rules" => [{"identifier" => "none", "pattern" => "nothing", "read" => false, "write" => false}]},
+        ]}
+        with_amqp_server do |s|
+          service = s.vhosts["/"].mqtt_permission_service
+          service.put(LavinMQ::MQTT::PermissionGroup.new("mine", "/", ["bob"],
+            [LavinMQ::MQTT::PermissionGroup::Rule.new("m", "mine/#", read: true, write: true)]))
+          import_defs(s, defs)
+          service["mine"]?.should_not be_nil
+          service["sensors"]?.should_not be_nil
+          service.can_write?(ctx("guest"), "anything").should be_true
+        end
       end
     end
 
@@ -625,8 +683,7 @@ describe LavinMQ::HTTP::Server do
         # A valid group followed by one with an invalid topic filter pattern.
         # Groups are parsed and validated up front, so a malformed later entry
         # makes the whole import a clean no-op: the earlier group is neither
-        # applied in memory (so in_use? does not flip and put every MQTT
-        # client into default-deny) nor written to disk.
+        # applied in memory nor written to disk.
         body = <<-JSON
           { "mqtt_permissions": [
             {
@@ -644,7 +701,6 @@ describe LavinMQ::HTTP::Server do
         response = http.post("/api/definitions", body: body)
         response.status_code.should_not eq 200
         s.vhosts["/"].mqtt_permission_service["regression_group_ok"]?.should be_nil
-        s.vhosts["/"].mqtt_permission_service.in_use?.should be_false
         groups_file = File.join(s.vhosts["/"].data_dir, "mqtt_permissions.json")
         File.read(groups_file).should_not contain("regression_group_ok") if File.exists?(groups_file)
       end

--- a/spec/api/permission_groups_spec.cr
+++ b/spec/api/permission_groups_spec.cr
@@ -50,8 +50,8 @@ describe LavinMQ::HTTP::PermissionGroupsController do
 
         paged = JSON.parse(http.get("/api/mqtt/permission-groups/%2f?page=1&page_size=1").body)
         paged["items"].as_a.size.should eq 1
-        paged["total_count"].as_i.should eq 2
-        paged["page_count"].as_i.should eq 2
+        paged["total_count"].as_i.should eq 3
+        paged["page_count"].as_i.should eq 3
 
         filtered = JSON.parse(http.get("/api/mqtt/permission-groups/%2f?name=chat").body).as_a
         filtered.size.should eq 1
@@ -71,7 +71,7 @@ describe LavinMQ::HTTP::PermissionGroupsController do
         ].each do |name|
           http.put("/api/mqtt/permission-groups/%2f/#{name}").status_code.should eq 400
         end
-        JSON.parse(http.get("/api/mqtt/permission-groups/%2f").body).as_a.should be_empty
+        JSON.parse(http.get("/api/mqtt/permission-groups/%2f").body).as_a.map(&.["name"]).should eq ["default"]
       end
     end
 

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -153,6 +153,7 @@ describe LavinMQ::Config do
           port = 1884
           tls_port = 8884
           unix_path = /tmp/mqtt.sock
+          permission_check_enabled = true
           max_packet_size = 536870910
           max_inflight_messages = 100
           default_vhost = /mqtt
@@ -238,6 +239,7 @@ describe LavinMQ::Config do
     config.mqtt_port.should eq 1884
     config.mqtts_port.should eq 8884
     config.mqtt_unix_path.should eq "/tmp/mqtt.sock"
+    config.mqtt_permission_check_enabled?.should be_true
     config.mqtt_max_packet_size.should eq 536870910
     config.max_inflight_messages.should eq 100
     config.default_mqtt_vhost.should eq "/mqtt"

--- a/spec/definitions_generator_spec.cr
+++ b/spec/definitions_generator_spec.cr
@@ -34,7 +34,27 @@ describe LavinMQCtl::DefinitionsGenerator do
     end
   end
 
-  it "emits an empty mqtt_permissions array when no vhost has groups" do
+  it "emits the automatic default group for a vhost without mqtt_permissions.json" do
+    with_data_dir do |data_dir|
+      File.write(File.join(data_dir, "vhosts.json"), %([{"name": "/", "dir": "vh1"}]))
+      vhost_dir = File.join(data_dir, "vh1")
+      Dir.mkdir_p vhost_dir
+      File.open(File.join(vhost_dir, "definitions.amqp"), "w") { |f| f.write_bytes(1i32) }
+
+      io = IO::Memory.new
+      LavinMQCtl::DefinitionsGenerator.new(data_dir).generate(io)
+      body = JSON.parse(io.to_s)
+
+      groups = body["mqtt_permissions"].as_a
+      groups.size.should eq 1
+      groups[0]["name"].as_s.should eq "default"
+      groups[0]["vhost"].as_s.should eq "/"
+      groups[0]["members"].as_a.map(&.as_s).should eq ["*"]
+      groups[0]["rules"][0]["pattern"].as_s.should eq "#"
+    end
+  end
+
+  it "emits an empty mqtt_permissions array when there is no vhost" do
     with_data_dir do |data_dir|
       io = IO::Memory.new
       LavinMQCtl::DefinitionsGenerator.new(data_dir).generate(io)

--- a/spec/mqtt/integrations/topic_permissions_http_update_spec.cr
+++ b/spec/mqtt/integrations/topic_permissions_http_update_spec.cr
@@ -17,6 +17,7 @@ module MqttSpecs
       with_server do |server|
         http = MqttSpecs.serve_http(server)
 
+        http.delete("/api/mqtt/permission-groups/%2f/default").status_code.should eq 204
         http.put("/api/mqtt/permission-groups/%2f/g").status_code.should eq 201
         http.put("/api/mqtt/permission-groups/%2f/g/members/*").status_code.should eq 201
         rule = {pattern: "chat/#", read: true, write: true}.to_json
@@ -50,6 +51,7 @@ module MqttSpecs
       with_server do |server|
         http = MqttSpecs.serve_http(server)
 
+        http.delete("/api/mqtt/permission-groups/%2f/default").status_code.should eq 204
         http.put("/api/mqtt/permission-groups/%2f/g").status_code.should eq 201
         http.put("/api/mqtt/permission-groups/%2f/g/members/*").status_code.should eq 201
         rule = {pattern: "chat/#", read: true, write: true}.to_json
@@ -88,6 +90,7 @@ module MqttSpecs
       with_server do |server|
         http = MqttSpecs.serve_http(server)
 
+        http.delete("/api/mqtt/permission-groups/%2f/default").status_code.should eq 204
         http.put("/api/mqtt/permission-groups/%2f/g").status_code.should eq 201
         http.put("/api/mqtt/permission-groups/%2f/g/members/*").status_code.should eq 201
         rule = {pattern: "chat/#", read: true, write: true}.to_json

--- a/spec/mqtt/integrations/topic_permissions_live_update_spec.cr
+++ b/spec/mqtt/integrations/topic_permissions_live_update_spec.cr
@@ -9,6 +9,7 @@ module MqttSpecs
       with_server do |server|
         server.users.create("alice", "alice")
         server.users.add_permission("alice", "/", /.*/, /.*/, /.*/)
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(LavinMQ::MQTT::PermissionGroup.new(
           "g", "/", ["*"],
           [LavinMQ::MQTT::PermissionGroup::Rule.new("chat--", "chat/#", read: true, write: true)]))
@@ -42,6 +43,7 @@ module MqttSpecs
       with_server do |server|
         server.users.create("alice", "alice")
         server.users.add_permission("alice", "/", /.*/, /.*/, /.*/)
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(LavinMQ::MQTT::PermissionGroup.new(
           "g", "/", ["*"],
           [LavinMQ::MQTT::PermissionGroup::Rule.new("chat--", "chat/#", read: true, write: true)]))

--- a/spec/mqtt/integrations/topic_permissions_publish_spec.cr
+++ b/spec/mqtt/integrations/topic_permissions_publish_spec.cr
@@ -5,7 +5,7 @@ module MqttSpecs
   extend MqttMatchers
 
   describe "MQTT topic permissions: publish" do
-    it "does not restrict publish or subscribe when no permission groups exist" do
+    it "does not restrict publish or subscribe while the default group exists" do
       with_server do |server|
         server.users.create("alice", "alice")
         server.users.add_permission("alice", "/", /.*/, /.*/, /.*/)
@@ -43,6 +43,7 @@ module MqttSpecs
             LavinMQ::MQTT::PermissionGroup::Rule.new("chat--", "chat/#", read: true, write: false),
           ]
         )
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(group)
 
         with_client_io(server) do |sub_io|
@@ -96,6 +97,7 @@ module MqttSpecs
             LavinMQ::MQTT::PermissionGroup::Rule.new("chat--", "chat/#", read: true, write: false),
           ]
         )
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(group)
 
         with_client_io(server) do |sub_io|

--- a/spec/mqtt/integrations/topic_permissions_read_spec.cr
+++ b/spec/mqtt/integrations/topic_permissions_read_spec.cr
@@ -10,6 +10,7 @@ module MqttSpecs
         server.users.create("bob", "bob")
         server.users.add_permission("bob", "/", /.*/, /.*/, /.*/)
         service = server.vhosts["/"].mqtt_permission_service
+        service.delete("default")
         service.put(LavinMQ::MQTT::PermissionGroup.new("writer", "/", ["guest"],
           [LavinMQ::MQTT::PermissionGroup::Rule.new("all", "#", read: true, write: true)]))
         service.put(LavinMQ::MQTT::PermissionGroup.new("bob-read", "/", ["bob"],
@@ -46,6 +47,7 @@ module MqttSpecs
             LavinMQ::MQTT::PermissionGroup::Rule.new("chat-alice--", "chat/alice/#", read: true, write: false),
           ]
         )
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(group)
 
         writer_group = LavinMQ::MQTT::PermissionGroup.new(
@@ -99,6 +101,7 @@ module MqttSpecs
             LavinMQ::MQTT::PermissionGroup::Rule.new("chat-alice--", "chat/alice/#", read: true, write: false),
           ]
         )
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(group)
 
         # guest (the seeders) may write everything so they can seed retained messages

--- a/spec/mqtt/integrations/topic_permissions_session_user_spec.cr
+++ b/spec/mqtt/integrations/topic_permissions_session_user_spec.cr
@@ -12,6 +12,7 @@ module MqttSpecs
         server.users.create("bob", "bob")
         server.users.add_permission("bob", "/", /.*/, /.*/, /.*/)
         service = server.vhosts["/"].mqtt_permission_service
+        service.delete("default")
         service.put(LavinMQ::MQTT::PermissionGroup.new("alice-read", "/", ["alice"],
           [LavinMQ::MQTT::PermissionGroup::Rule.new("chat", "chat/#", read: true)]))
         service.put(LavinMQ::MQTT::PermissionGroup.new("guest-write", "/", ["guest"],
@@ -52,6 +53,7 @@ module MqttSpecs
         server.users.create("alice", "alice")
         server.users.add_permission("alice", "/", /.*/, /.*/, /.*/)
         service = server.vhosts["/"].mqtt_permission_service
+        service.delete("default")
         service.put(LavinMQ::MQTT::PermissionGroup.new("alice-read", "/", ["alice"],
           [LavinMQ::MQTT::PermissionGroup::Rule.new("chat", "chat/#", read: true)]))
         service.put(LavinMQ::MQTT::PermissionGroup.new("guest-write", "/", ["guest"],
@@ -93,6 +95,7 @@ module MqttSpecs
           server.users.create("alice", "alice")
           server.users.add_permission("alice", "/", /.*/, /.*/, /.*/)
           service = server.vhosts["/"].mqtt_permission_service
+          service.delete("default")
           service.put(LavinMQ::MQTT::PermissionGroup.new("alice-read", "/", ["alice"],
             [LavinMQ::MQTT::PermissionGroup::Rule.new("chat", "chat/#", read: true)]))
           service.put(LavinMQ::MQTT::PermissionGroup.new("public", "/", ["*"],

--- a/spec/mqtt/integrations/topic_permissions_subscribe_spec.cr
+++ b/spec/mqtt/integrations/topic_permissions_subscribe_spec.cr
@@ -12,6 +12,7 @@ module MqttSpecs
         server.users.create("pub", "pub")
         server.users.add_permission("pub", "/", /.*/, /.*/, /.*/)
         # alice may read only her own subtree.
+        server.vhosts["/"].mqtt_permission_service.delete("default")
         server.vhosts["/"].mqtt_permission_service.put(LavinMQ::MQTT::PermissionGroup.new(
           "alice-read", "/", ["alice"],
           [LavinMQ::MQTT::PermissionGroup::Rule.new("chat-alice--", "chat/alice/#", read: true, write: false)]))

--- a/spec/mqtt/permission_service_spec.cr
+++ b/spec/mqtt/permission_service_spec.cr
@@ -14,21 +14,89 @@ private def ctx(username, client_id = "dev")
   LavinMQ::MQTT::PermissionService::Context.new(username, client_id)
 end
 
-private def with_service(&)
+private def with_data_dir(&)
   data_dir = File.tempname
   Dir.mkdir_p data_dir
   begin
-    yield LavinMQ::MQTT::PermissionService.new(data_dir, nil)
+    yield data_dir
   ensure
     FileUtils.rm_rf data_dir
   end
 end
 
+private def lock_down(service)
+  service.delete(LavinMQ::MQTT::PermissionService::DEFAULT_GROUP)
+  service
+end
+
+# A fresh vhost is open through its default group. Most examples test what a
+# rule grants, so they start from a locked-down service.
+private def with_service(&)
+  with_data_dir do |data_dir|
+    yield lock_down(LavinMQ::MQTT::PermissionService.new("/", data_dir, nil))
+  end
+end
+
 describe LavinMQ::MQTT::PermissionService do
-  it "allows everything with no groups" do
-    with_service do |service|
-      service.in_use?.should be_false
+  it "seeds a default group that allows every user every topic" do
+    with_data_dir do |data_dir|
+      service = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      default = service[LavinMQ::MQTT::PermissionService::DEFAULT_GROUP]?.should_not be_nil
+      default.members.should eq ["*"]
       service.can_write?(ctx("c1"), "a/b").should be_true
+      service.can_read?(ctx(nil), "a/b").should be_true
+    end
+  end
+
+  it "keeps the default group's grant next to a narrower group" do
+    with_data_dir do |data_dir|
+      service = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      service.put(group("g", ["c1"], [rule("a/#", read: true)]))
+      service.can_write?(ctx("c2"), "b/c").should be_true
+    end
+  end
+
+  it "is untouched until the first change, and never after a load from disk" do
+    with_data_dir do |data_dir|
+      service = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      service.untouched?.should be_true
+      service.put(group("g", ["c1"], [rule("a/#", read: true)]))
+      service.untouched?.should be_false
+      LavinMQ::MQTT::PermissionService.new("/", data_dir, nil).untouched?.should be_false
+    end
+    with_data_dir do |data_dir|
+      service = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      service.delete("nonexistent")
+      service.untouched?.should be_true
+      service.delete(LavinMQ::MQTT::PermissionService::DEFAULT_GROUP)
+      service.untouched?.should be_false
+    end
+  end
+
+  it "denies everything once the default group is deleted" do
+    with_service do |service|
+      service.can_write?(ctx("c1"), "a/b").should be_false
+      service.can_read?(ctx("c1"), "a/b").should be_false
+    end
+  end
+
+  it "keeps the automatic default group in memory only" do
+    with_data_dir do |data_dir|
+      LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      File.exists?(File.join(data_dir, "mqtt_permissions.json")).should be_false
+      # The next start creates it again, so an unchanged vhost stays open.
+      again = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      again.untouched?.should be_true
+      again.can_write?(ctx("c1"), "a/b").should be_true
+    end
+  end
+
+  it "does not create the default group again after it was deleted" do
+    with_data_dir do |data_dir|
+      lock_down(LavinMQ::MQTT::PermissionService.new("/", data_dir, nil))
+      reloaded = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
+      reloaded.size.should eq 0
+      reloaded.can_write?(ctx("c1"), "a/b").should be_false
     end
   end
 
@@ -37,7 +105,7 @@ describe LavinMQ::MQTT::PermissionService do
       expect_raises(ArgumentError, /Invalid MQTT topic filter/) do
         service.put(group("g", ["*"], [rule("a/#/b", write: true)]))
       end
-      service.in_use?.should be_false
+      service.can_write?(ctx("c1"), "a/b").should be_false
     end
   end
 
@@ -101,10 +169,9 @@ describe LavinMQ::MQTT::PermissionService do
   it "reflects a delete on the next check" do
     with_service do |service|
       service.put(group("g", ["c1"], [rule("a/#", read: true)]))
-      service.can_read?(ctx("c2"), "a/b").should be_false
+      service.can_read?(ctx("c1"), "a/b").should be_true
       service.delete("g")
-      service.can_read?(ctx("c2"), "a/b").should be_true
-      service.in_use?.should be_false
+      service.can_read?(ctx("c1"), "a/b").should be_false
     end
   end
 
@@ -120,17 +187,13 @@ describe LavinMQ::MQTT::PermissionService do
   end
 
   it "survives a reload from disk" do
-    data_dir = File.tempname
-    Dir.mkdir_p data_dir
-    begin
-      first = LavinMQ::MQTT::PermissionService.new(data_dir, nil)
+    with_data_dir do |data_dir|
+      first = lock_down(LavinMQ::MQTT::PermissionService.new("/", data_dir, nil))
       first.put(group("g", ["c1"], [rule("a/#", write: true)]))
 
-      second = LavinMQ::MQTT::PermissionService.new(data_dir, nil)
-      second.in_use?.should be_true
+      second = LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
       second.can_write?(ctx("c1"), "a/b").should be_true
-    ensure
-      FileUtils.rm_rf data_dir
+      second.can_write?(ctx("c2"), "a/b").should be_false
     end
   end
 
@@ -151,7 +214,7 @@ describe LavinMQ::MQTT::PermissionService do
       begin
         File.write File.join(data_dir, "mqtt_permissions.json"), json
         expect_raises(ArgumentError, message) do
-          LavinMQ::MQTT::PermissionService.new(data_dir, nil)
+          LavinMQ::MQTT::PermissionService.new("/", data_dir, nil)
         end
       ensure
         FileUtils.rm_rf data_dir
@@ -159,27 +222,19 @@ describe LavinMQ::MQTT::PermissionService do
     end
   end
 
-  it "leaves in_use? false for a group with rules but no members" do
+  it "grants nothing for a group with rules but no members" do
     with_service do |service|
       service.put(group("g", Array(String).new, [rule("a/#", read: true)]))
-      service.in_use?.should be_false
-      service.can_read?(ctx("c1"), "a/b").should be_true
+      service.can_read?(ctx("c1"), "a/b").should be_false
     end
   end
 
-  it "leaves in_use? false for a group with an empty rules array" do
+  it "grants nothing for a group with an empty rules array" do
     with_service do |service|
-      service.put(group("g", ["*"], [] of LavinMQ::MQTT::PermissionGroup::Rule))
-      service.in_use?.should be_false
-    end
-  end
-
-  it "flips in_use? true when an empty-rules group gains a valid rule" do
-    with_service do |service|
-      service.put(group("g", ["*"], [] of LavinMQ::MQTT::PermissionGroup::Rule))
-      service.in_use?.should be_false
+      service.put(group("g", ["*"], Array(LavinMQ::MQTT::PermissionGroup::Rule).new))
+      service.can_read?(ctx("c1"), "a/b").should be_false
       service.put(group("g", ["*"], [rule("a/#", read: true)]))
-      service.in_use?.should be_true
+      service.can_read?(ctx("c1"), "a/b").should be_true
     end
   end
 

--- a/spec/mqtt/permissions_spec.cr
+++ b/spec/mqtt/permissions_spec.cr
@@ -1,0 +1,118 @@
+require "./spec_helper"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+  describe LavinMQ::MQTT do
+    describe "permissions" do
+      before_each do
+        LavinMQ::Config.instance.mqtt_permission_check_enabled = true
+      end
+
+      after_each do
+        LavinMQ::Config.instance.mqtt_permission_check_enabled = false
+      end
+
+      it "should block publish when user has no write permissions" do
+        with_server do |server|
+          server.users.create("no_write", "pass")
+          server.users.add_permission("no_write", "/", /.*/, /.*/, /^$/) # config: .*, read: .*, write: ^$
+
+          with_client_io(server) do |io|
+            connect(io, username: "no_write", password: "pass".to_slice)
+            publish(io, false, topic: "test/topic", payload: "hello".to_slice)
+            # Connection should be closed due to permission denial
+            io.should be_closed
+          end
+        end
+      end
+
+      it "should block subscribe when user has no read permissions" do
+        with_server do |server|
+          server.users.create("no_read", "pass")
+          server.users.add_permission("no_read", "/", /.*/, /^$/, /^$/) # config: .*, read: ^$, write: ^$
+
+          with_client_io(server) do |io|
+            connect(io, username: "no_read", password: "pass".to_slice)
+            topic_filter = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+            subscribe(io, false, topic_filters: [topic_filter])
+            # Connection should be closed due to permission denial
+            io.should be_closed
+          end
+        end
+      end
+
+      it "should block subscribe when user has write-only permissions" do
+        with_server do |server|
+          server.users.create("write_only", "pass")
+          server.users.add_permission("write_only", "/", /.*/, /^$/, /.*/) # config: .*, read: ^$, write: .*
+
+          with_client_io(server) do |io|
+            connect(io, username: "write_only", password: "pass".to_slice)
+            topic_filter = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+            subscribe(io, false, topic_filters: [topic_filter])
+            io.should be_closed
+          end
+        end
+      end
+
+      it "should block subscribe when user has read-only permissions" do
+        with_server do |server|
+          server.users.create("read_only", "pass")
+          server.users.add_permission("read_only", "/", /.*/, /.*/, /^$/) # config: .*, read: .*, write: ^$
+
+          with_client_io(server) do |io|
+            connect(io, username: "read_only", password: "pass".to_slice)
+            topic_filter = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+            subscribe(io, false, topic_filters: [topic_filter])
+            io.should be_closed
+          end
+        end
+      end
+
+      it "should allow operations when user has full permissions" do
+        with_server do |server|
+          server.users.create("full_user", "pass")
+          server.users.add_permission("full_user", "/", /.*/, /.*/, /.*/) # full permissions
+
+          with_client_io(server) do |io|
+            connect(io, username: "full_user", password: "pass".to_slice)
+
+            # Both operations should succeed
+            publish(io, topic: "test/topic", payload: "hello".to_slice)
+            topic_filter = MQTT::Protocol::Subscribe::TopicFilter.new("test/topic", 0u8)
+            subscribe(io, topic_filters: [topic_filter])
+
+            # Connection should still be alive
+            io.should_not be_closed
+          end
+        end
+      end
+
+      it "should block will messages when user lacks write permissions" do
+        with_server do |server|
+          server.users.create("no_write", "pass")
+          server.users.add_permission("no_write", "/", /.*/, /.*/, /^$/) # config: .*, read: .*, write: ^$
+
+          with_client_io(server) do |subscriber_io|
+            connect(subscriber_io, username: "guest", password: "guest".to_slice)
+            initial_publish_count = server.mqtt_server.broker("/").@exchange.@publish_in_count.get
+
+            # Create a client with no write permissions and a will message
+            will_socket = nil
+            with_client_io(server) do |will_client_io|
+              will = MQTT::Protocol::Will.new(topic: "will/topic", payload: "dead".to_slice, qos: 0u8, retain: false)
+              connect(will_client_io, username: "no_write", password: "pass".to_slice, will: will)
+              will_socket = will_client_io.@io.as(TCPSocket)
+              will_socket.close
+            end
+
+            sleep 0.1.seconds
+            final_publish_count = server.mqtt_server.broker("/").@exchange.@publish_in_count.get
+            final_publish_count.should eq(initial_publish_count)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lavinmq/config/options.cr
+++ b/src/lavinmq/config/options.cr
@@ -244,6 +244,9 @@ module LavinMQ
       @[CliOpt("", "--metrics-http-port=PORT", "HTTP port that prometheus will listen to (default: 15692)")]
       property metrics_http_port = 15692
 
+      @[IniOpt(ini_name: permission_check_enabled, section: "mqtt")]
+      property? mqtt_permission_check_enabled : Bool = false
+
       @[IniOpt(ini_name: client_id_validation, section: "mqtt", transform: ->MQTT::ClientIdValidation.parse(String))]
       property mqtt_client_id_validation : MQTT::ClientIdValidation = MQTT::ClientIdValidation::None
 

--- a/src/lavinmq/definitions.cr
+++ b/src/lavinmq/definitions.cr
@@ -159,15 +159,20 @@ module LavinMQ
         parsed = Array({VHost, MQTT::PermissionGroup}).new
         groups.as_a.each do |g|
           next unless v = fetch_vhost?(g)
+          service = v.mqtt_permission_service
           name = g["name"].as_s
-          next if skip_existing && v.mqtt_permission_service[name]?
+          next if skip_existing && !service.untouched? && service[name]?
           members = (m = g["members"]?) ? Array(String).from_json(m.to_json) : Array(String).new
           rules = (r = g["rules"]?) ? Array(MQTT::PermissionGroup::Rule).from_json(r.to_json) : Array(MQTT::PermissionGroup::Rule).new
           parsed << {v, MQTT::PermissionGroup.new(name, v.name, members, rules).validate!}
         end
         touched = Set(VHost).new
         parsed.each do |v, group|
-          v.mqtt_permission_service.put(group, save: false)
+          service = v.mqtt_permission_service
+          # The definitions JSON decides the groups of a vhost nobody has configured
+          # yet, so the automatic allow-all default group must not stay next to them.
+          service.delete(MQTT::PermissionService::DEFAULT_GROUP, save: false) if service.untouched?
+          service.put(group, save: false)
           touched << v
         end
         touched.each(&.mqtt_permission_service.save!)

--- a/src/lavinmq/definitions_generator.cr
+++ b/src/lavinmq/definitions_generator.cr
@@ -2,6 +2,7 @@ require "./version"
 require "../stdlib/slice"
 require "json"
 require "amq-protocol"
+require "./mqtt/permission_group"
 
 class LavinMQCtl
   class DefinitionsGenerator
@@ -55,7 +56,7 @@ class LavinMQCtl
             json.field("mqtt_permissions") do
               json.array do
                 each_vhost do |vhost, vhost_dir|
-                  mqtt_permissions(vhost_dir).each do |g|
+                  mqtt_permissions(vhost, vhost_dir).each do |g|
                     g.as_h.merge!({"vhost" => JSON::Any.new(vhost)}).to_json(json)
                   end
                 end
@@ -180,12 +181,14 @@ class LavinMQCtl
       File.open("users.json") { |f| JSON.parse f }.as_a
     end
 
-    private def mqtt_permissions(vhost_dir)
+    # A vhost without mqtt_permissions.json has the automatic default group in
+    # memory while the server runs, so the export shows the same group.
+    private def mqtt_permissions(vhost, vhost_dir)
       File.open(File.join(vhost_dir, "mqtt_permissions.json")) do |f|
         JSON.parse(f).as_a
       end
     rescue File::NotFoundError
-      Array(JSON::Any).new
+      [JSON.parse(LavinMQ::MQTT::PermissionGroup.default(vhost).to_json)]
     end
 
     private def vhosts

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -184,7 +184,12 @@ module LavinMQ
       end
 
       def recieve_publish(packet : Protocol::Publish)
-        # A denial acks and drops, it never closes the connection.
+        if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
+          Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
+          close_socket
+          return
+        end
+        # A topic denial acks and drops, it never closes the connection.
         unless @broker.permission_service.can_write?(@permission_context, packet.topic)
           Log.debug { "Publish refused: no topic permission rule allows user '#{@user.name}' (client '#{@client_id}') to write topic '#{packet.topic}'" }
           if packet.qos > 0 && (packet_id = packet.packet_id)
@@ -206,8 +211,16 @@ module LavinMQ
       end
 
       def recieve_subscribe(packet : Protocol::Subscribe)
+        if Config.instance.mqtt_permission_check_enabled?
+          unless user.can_read?(@broker.vhost.name, EXCHANGE) && user.can_write?(@broker.vhost.name, "mqtt.#{client_id}")
+            Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
+            close_socket
+            return
+          end
+        end
         # Topic permissions are enforced at delivery, not at SUBSCRIBE, so a client
-        # may subscribe to a filter it cannot read. Mosquitto behaves the same way.
+        # may subscribe to a filter it cannot read. Mosquitto also filters at
+        # delivery, but it additionally refuses the filter in the SUBACK.
         qos = @broker.subscribe(self, packet.topic_filters)
         send(Protocol::SubAck.new(qos, packet.packet_id))
       end
@@ -254,6 +267,10 @@ module LavinMQ
 
       private def publish_will
         if will = @will
+          if Config.instance.mqtt_permission_check_enabled? && !user.can_write?(@broker.vhost.name, EXCHANGE)
+            Log.debug { "Access refused: user '#{user.name}' does not have permissions" }
+            return
+          end
           unless @broker.permission_service.can_write?(@permission_context, will.topic)
             Log.debug { "Will publish refused: no topic permission rule allows user '#{@user.name}' (client '#{@client_id}') to write topic '#{will.topic}'" }
             return

--- a/src/lavinmq/mqtt/permission_group.cr
+++ b/src/lavinmq/mqtt/permission_group.cr
@@ -10,6 +10,7 @@ module LavinMQ
       IDENTIFIER_PATTERN = /\A[A-Za-z0-9-]+\z/
       # Group names travel in URL paths; the charset keeps them unambiguous there.
       NAME_PATTERN = /\A[A-Za-z0-9_-]{1,255}\z/
+      DEFAULT_NAME = "default"
 
       struct Rule
         include JSON::Serializable
@@ -31,6 +32,13 @@ module LavinMQ
                      @vhost : String,
                      @members = Array(String).new,
                      @rules = Array(Rule).new)
+      end
+
+      # The group every vhost gets until somebody configures it: every user may
+      # read and write every topic.
+      def self.default(vhost : String) : self
+        rule = Rule.new("allow-all", "#", read: true, write: true)
+        new(DEFAULT_NAME, vhost, ["*"], [rule])
       end
 
       def validate! : self

--- a/src/lavinmq/mqtt/permission_service.cr
+++ b/src/lavinmq/mqtt/permission_service.cr
@@ -6,8 +6,14 @@ module LavinMQ
   module MQTT
     # Every change rebuilds the compiled state and publishes it with one
     # reference assignment, so readers never see stale or partial state.
+    #
+    # A topic is allowed only when a rule grants it. A vhost is still open by
+    # default: the DEFAULT_GROUP grants every user every topic, and the
+    # operator locks the vhost down by deleting or narrowing that group.
     class PermissionService
       Log = LavinMQ::Log.for "mqtt.permission_service"
+
+      DEFAULT_GROUP = PermissionGroup::DEFAULT_NAME
 
       record CompiledRule,
         chain : TopicRuleSegment,
@@ -21,21 +27,18 @@ module LavinMQ
         username : String?,
         client_id : String
 
-      class Compiled
-        getter by_member : Hash(String, Array(CompiledRule))
-        getter global_rules : Array(CompiledRule)
-        getter? empty : Bool
-
-        def initialize(@by_member : Hash(String, Array(CompiledRule)),
-                       @global_rules : Array(CompiledRule))
-          @empty = @by_member.empty? && @global_rules.empty?
-        end
-      end
+      record Compiled,
+        by_member : Hash(String, Array(CompiledRule)),
+        global_rules : Array(CompiledRule)
 
       @save_lock = Mutex.new
       @compiled : Compiled
+      # True while the only group is the default group this service created
+      # itself. A definitions import may then replace it, because nobody has
+      # made a change that the import must not undo.
+      getter? untouched = false
 
-      def initialize(@data_dir : String, @replicator : Clustering::Replicator?)
+      def initialize(@vhost : String, @data_dir : String, @replicator : Clustering::Replicator?)
         @groups = Hash(String, PermissionGroup).new
         @compiled = Compiled.new(Hash(String, Array(CompiledRule)).new, Array(CompiledRule).new)
         load!
@@ -57,12 +60,9 @@ module LavinMQ
         @groups.each_value { |group| yield group }
       end
 
-      def in_use? : Bool
-        !@compiled.empty?
-      end
-
       def put(group : PermissionGroup, save = true) : PermissionGroup
         group.validate!
+        @untouched = false
         @groups[group.name] = group
         rebuild
         save! if save
@@ -71,6 +71,7 @@ module LavinMQ
 
       def delete(name : String, save = true) : PermissionGroup?
         if group = @groups.delete(name)
+          @untouched = false
           rebuild
           save! if save
           group
@@ -78,12 +79,10 @@ module LavinMQ
       end
 
       def can_write?(context : Context, topic : String) : Bool
-        return true unless in_use?
         matches?(context, topic, write: true)
       end
 
       def can_read?(context : Context, topic : String) : Bool
-        return true unless in_use?
         matches?(context, topic, write: false)
       end
 
@@ -124,8 +123,7 @@ module LavinMQ
             end
             compiled_rules << CompiledRule.new(chain, rule.read?, rule.write?)
           end
-          # A group with no valid rule grants nothing; skip it so its members
-          # don't get empty entries that would flip every client to default-deny.
+          # A group with no valid rule grants nothing, so its members need no entry.
           next if compiled_rules.empty?
           if group.members.includes?("*")
             global_rules.concat(compiled_rules)
@@ -147,7 +145,7 @@ module LavinMQ
       # can only fail on the change being made.
       private def load!
         path = File.join(@data_dir, "mqtt_permissions.json")
-        return unless File.exists? path
+        return create_default_group unless File.exists? path
         File.open(path) do |f|
           Array(PermissionGroup).from_json(f) do |group|
             @groups[group.name] = group.validate!
@@ -158,6 +156,15 @@ module LavinMQ
       rescue ex
         Log.error(exception: ex) { "Failed to load permission groups" }
         raise ex
+      end
+
+      # Created only when mqtt_permissions.json is missing, and kept in memory
+      # only: the first real change writes mqtt_permissions.json, and from then
+      # on the groups on disk decide. A deleted default group stays deleted
+      # across restarts, because the delete leaves an empty list on disk.
+      private def create_default_group
+        put(PermissionGroup.default(@vhost), save: false)
+        @untouched = true
       end
 
       def save!

--- a/src/lavinmq/vhost.cr
+++ b/src/lavinmq/vhost.cr
@@ -224,7 +224,7 @@ module LavinMQ
       @operator_policies = ParameterStore(OperatorPolicy).new(@data_dir, "operator_policies.json", @replicator, vhost: @name)
       @policies = ParameterStore(Policy).new(@data_dir, "policies.json", @replicator, vhost: @name)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @replicator, vhost: @name)
-      @mqtt_permission_service = MQTT::PermissionService.new(@data_dir, @replicator)
+      @mqtt_permission_service = MQTT::PermissionService.new(@name, @data_dir, @replicator)
       @shovels = Shovel::Store.new(self)
       @upstreams = Federation::UpstreamStore.new(self)
       @definitions = DefinitionsStore.new(self, @data_dir, @replicator, @log)


### PR DESCRIPTION
Stacked on #2126, merges into `topic-permissions`.

Replaces the mode switch in `PermissionService` with a default group. Today a vhost allows every topic while no rule exists and flips to default deny when the first group is created, so an operator who adds a group for one team locks out every other client at once. Now a topic is allowed only when a rule grants it, and a vhost without `mqtt_permissions.json` gets a group named `default` in memory, member `*` and rule `#` for read and write. A new or upgraded vhost is open as before. The operator locks it down by deleting or narrowing `default` over the API. The group is not written to disk, the first put or delete writes `mqtt_permissions.json`, and from then on the groups on disk decide. `in_use?` and the empty flag on `Compiled` are gone.

A definitions import must not keep the automatic group next to the groups it brings. The service tracks with `untouched?` that its only group is the one it created itself, and while that holds the import deletes the automatic group before it puts the imported groups and skips nothing. After the first change by anyone the startup import behaves as for policies: it adds new names and never touches an existing one. This makes a `default` group in the `load_definitions` JSON apply on a fresh server, and an export of a locked down vhost stays locked down when imported into a fresh server.

The `permission_check_enabled` option and the AMQP checks it enables are restored in front of the topic checks, so a hosted customer with the option set sees no change at the upgrade. A client that fails the AMQP check is disconnected as before, a client that fails a topic check is acked and dropped.

`lavinmqctl definitions export` emits the same `default` group for a vhost without `mqtt_permissions.json`, so the offline export and `GET /api/definitions` agree.

The allow all rule check costs about 1 ns with no allocation, so there is no fast path flag for it.
