### PR TITLE
fix(mqtt): resend unacked publishes with their original packet ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The management UI version is advertised via the `LavinMQ-Version` response header instead of being injected at build time [#2123](https://github.com/cloudamqp/lavinmq/pull/2123)
 - CC and BCC headers are removed from dead-lettered messages when `x-dead-letter-routing-key` is set, instead of being preserved, matching RabbitMQ [#1993](https://github.com/cloudamqp/lavinmq/pull/1993)
 - A connection with a PROXY protocol header never counts as loopback for `default_user_only_loopback`, including through a cluster follower. The default user can only connect directly on the broker host [#2224](https://github.com/cloudamqp/lavinmq/pull/2224)
+- `max_inflight_messages` must be at least `1`; `0` is now rejected at startup and on config reload instead of leaving every MQTT session accepting publishes it can never deliver [#2233](https://github.com/cloudamqp/lavinmq/pull/2233)
 
 ### Fixed
 
 - Per-vhost `message_stats` no longer over-counts published messages by the fan-out factor; cumulative message counters are read from the vhost's own counters instead of summing per-queue [#2092](https://github.com/cloudamqp/lavinmq/issues/2092)
 - Prometheus and HTTP API counters (`global_messages_*`, churn `*_total`, `/api/overview`, `/api/nodes`) no longer decrease when a queue or vhost is deleted, which previously made `rate()`/`increase()` fabricate spikes [#2093](https://github.com/cloudamqp/lavinmq/issues/2093)
 - MQTT sessions now respect the vhost `max-queues` limit; a SUBSCRIBE that would create a session beyond the cap is answered with failure return codes instead of exceeding the limit
+- Unacknowledged MQTT QoS 1 publishes are resent under the packet IDs the client already holds, with `dup` set, instead of being assigned new ones [MQTT-4.4.0-1]. The IDs are remembered in-process, so a session resumed after a broker restart is still redelivered under fresh IDs [#2233](https://github.com/cloudamqp/lavinmq/pull/2233)
 
 ## [2.9.1] - 2026-07-01
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `port` | `--mqtt-port` | — | Int | `1883` | MQTT port |
 | `tls_port` | `--mqtts-port` | — | Int | `8883` | MQTTS port |
 | `unix_path` | `--mqtt-unix-path` | — | String | (empty) | MQTT Unix socket path |
-| `max_inflight_messages` | — | — | UInt16 | `65535` | Max unacknowledged messages per session |
+| `max_inflight_messages` | — | — | UInt16 | `65535` | Max unacknowledged messages per session, must be at least `1` |
 | `max_packet_size` | — | — | UInt32 | `268435455` | Max MQTT packet size (bytes) |
 | `default_vhost` | — | — | String | `/` | Default vhost for MQTT connections |
 | `permission_check_enabled` | — | — | Bool | `false` | Enable MQTT permission checks |

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -38,8 +38,10 @@ When a client connects with `clean_session=false`:
 
 - The session persists across disconnections
 - Subscriptions are preserved
-- Unacknowledged QoS 1 messages are requeued and redelivered on reconnect
+- Unacknowledged QoS 1 messages are requeued and redelivered on reconnect, under the packet IDs the client already holds and with the `dup` flag set
 - The session queue is durable
+
+The reuse of packet IDs on redelivery is remembered in-process only, so after a broker restart the session's outstanding messages are redelivered under fresh packet IDs. If a `max-length` policy or a purge discards a message the session still owes, its packet ID is forgotten along with it; the messages that remain keep theirs.
 
 ### Session Takeover
 
@@ -53,7 +55,7 @@ Sessions count towards the vhost's `max-queues` [limit](vhosts.md#vhost-limits),
 
 - QoS 0 messages are not enqueued if no consumer (client) is currently connected to the session
 - QoS 1 messages are stored in the session queue and tracked with packet IDs
-- Unacknowledged messages are requeued when a persistent session client disconnects or a new client takes over. For clean sessions, unacknowledged messages are discarded.
+- Unacknowledged messages are requeued when a persistent session client disconnects or a new client takes over, and keep their packet IDs for the redelivery. For clean sessions, unacknowledged messages are discarded.
 
 ## Connection Limits
 
@@ -97,7 +99,7 @@ Internally, MQTT is implemented on top of LavinMQ's AMQP infrastructure:
 | `port` | `[mqtt]` | `1883` | MQTT listen port |
 | `tls_port` | `[mqtt]` | `8883` | MQTT over TLS port |
 | `unix_path` | `[mqtt]` | (empty) | Unix socket path |
-| `max_inflight_messages` | `[mqtt]` | `65535` | Max unacknowledged messages per session |
+| `max_inflight_messages` | `[mqtt]` | `65535` | Max unacknowledged messages per session, must be at least `1` |
 | `max_packet_size` | `[mqtt]` | `268435455` | Max MQTT packet size in bytes |
 | `default_vhost` | `[mqtt]` | `/` | Default vhost for MQTT connections |
 | `permission_check_enabled` | `[mqtt]` | `false` | Enable ACL checks on MQTT publish/subscribe |

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -634,6 +634,21 @@ describe LavinMQ::Config do
     end
   end
 
+  describe "max_inflight_messages" do
+    it "rejects zero" do
+      config_file = File.tempfile do |file|
+        file.print <<-CONFIG
+          [mqtt]
+          max_inflight_messages = 0
+          CONFIG
+      end
+      config = LavinMQ::Config.new
+      expect_raises(LavinMQ::Config::Error, /max_inflight_messages/) do
+        config.parse(["-c", config_file.path])
+      end
+    end
+  end
+
   describe "reload" do
     it "keeps the running config when the new config has an invalid value" do
       config_file = File.tempfile("lavinmq-config", ".ini")

--- a/spec/mqtt/integrations/message_qos_spec.cr
+++ b/spec/mqtt/integrations/message_qos_spec.cr
@@ -318,6 +318,46 @@ module MqttSpecs
       ensure
         LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
       end
+
+      it "never exceeds a limit that was lowered while messages were in flight" do
+        LavinMQ::Config.instance.max_inflight_messages = 3u16
+        with_server do |server|
+          with_client_io(server) do |io|
+            connect(io, client_id: "subscriber")
+            subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+            with_client_io(server) do |pub_io|
+              connect(pub_io, client_id: "publisher")
+              5.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8) }
+              disconnect(pub_io)
+            end
+
+            first = read_publish(io)
+            second = read_publish(io)
+            third = read_publish(io)
+            read_packet(io).should be_nil
+
+            LavinMQ::Config.instance.max_inflight_messages = 1u16
+
+            # Acking frees a slot, but two are still in flight against a limit of
+            # one, so nothing may be sent.
+            puback(io, first.packet_id)
+            read_packet(io).should be_nil
+
+            # Draining the rest brings the window back under the limit and
+            # resumes delivery; a gate left closed on a stale reading would stall
+            # here, with no ack left to re-open it.
+            puback(io, second.packet_id)
+            read_packet(io).should be_nil
+            puback(io, third.packet_id)
+            read_publish(io) # the fourth message, at last
+
+            disconnect(io)
+          end
+        end
+      ensure
+        LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
+      end
     end
 
     it "should not enqueue messages with QoS 0 if no client is connected to the session" do

--- a/spec/mqtt/integrations/session_resume_spec.cr
+++ b/spec/mqtt/integrations/session_resume_spec.cr
@@ -1,0 +1,397 @@
+require "../spec_helper.cr"
+
+module SessionResumeHelpers
+  include MqttHelpers
+
+  # Publishes each payload to `topic` over a throwaway connection, so the client
+  # under test is only ever the subscriber.
+  def publish_from(server, topic : String, payloads : Enumerable(String), qos = 1u8)
+    with_client_io(server) do |io|
+      connect(io, client_id: "publisher")
+      payloads.each { |payload| publish(io, topic: topic, payload: payload.to_slice, qos: qos) }
+      disconnect(io)
+    end
+  end
+
+  def read_publishes(io, count : Int) : Array(MQTT::Protocol::Publish)
+    Array(MQTT::Protocol::Publish).new(count) { read_publish(io) }
+  end
+
+  # Subscribes `client_id` at QoS 1, takes delivery of every payload without
+  # acking any, then disconnects - leaving the session offline still owing them.
+  # Returns the PUBLISH packets as they were delivered.
+  def deliver_unacked(server, payloads : Enumerable(String),
+                      topic = "a/b", client_id = "resumer") : Array(MQTT::Protocol::Publish)
+    with_client_io(server) do |io|
+      connect(io, client_id: client_id)
+      subscribe(io, topic_filters: mk_topic_filters({topic, 1u8}))
+      publish_from(server, topic, payloads)
+      delivered = read_publishes(io, payloads.size)
+      disconnect(io)
+      delivered
+    end
+  end
+end
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+  extend SessionResumeHelpers
+
+  describe "session resume" do
+    it "resends an unacked qos1 publish with its original packet id [MQTT-4.4.0-1]" do
+      with_server do |server|
+        sent = deliver_unacked(server, ["1"]).first
+        sent.dup?.should be_false
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publish(io)
+          resent.packet_id.should eq sent.packet_id
+          resent.dup?.should be_true
+          resent.qos.should eq 1u8
+          String.new(resent.payload).should eq "1"
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "resends unacked publishes in their original order [MQTT-4.6.0-6]" do
+      with_server do |server|
+        sent = deliver_unacked(server, ["0", "1", "2"])
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publishes(io, 3)
+          resent.each &.dup?.should be_true
+          resent.map(&.packet_id).should eq sent.map(&.packet_id)
+          resent.map { |p| String.new(p.payload) }.should eq ["0", "1", "2"]
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "resends the owed window before delivering anything new" do
+      with_server do |server|
+        sent = deliver_unacked(server, ["old"]).first
+        # Must be offline first: published to a session that has not detached
+        # yet, "new" would go to the dying connection and join the window.
+        wait_for { server.vhosts["/"].session("mqtt.resumer").client.nil? }
+        publish_from(server, "a/b", ["new"])
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publish(io)
+          resent.packet_id.should eq sent.packet_id
+          resent.dup?.should be_true
+          String.new(resent.payload).should eq "old"
+
+          fresh = read_publish(io)
+          fresh.dup?.should be_false
+          String.new(fresh.payload).should eq "new"
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "resends only the publishes left unacked" do
+      with_server do |server|
+        second = nil
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+          publish_from(server, "a/b", ["0", "1"])
+
+          first, second = read_publishes(io, 2)
+          puback(io, first.packet_id)
+          pingpong(io) # the PUBACK lands before the session detaches
+          disconnect(io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publish(io)
+          resent.packet_id.should eq second.try &.packet_id
+          String.new(resent.payload).should eq "1"
+          read_packet(io).should be_nil
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "resends nothing once the resent publish is acked" do
+      with_server do |server|
+        deliver_unacked(server, ["1"])
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          puback(io, read_publish(io).packet_id)
+          pingpong(io)
+          disconnect(io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          read_packet(io).should be_nil
+          disconnect(io)
+        end
+      end
+    end
+
+    it "keeps the original ids across a second reconnect" do
+      with_server do |server|
+        sent = deliver_unacked(server, ["0", "1"])
+
+        # Take delivery of the resend but ack none of it, so the window is
+        # remembered, delivered and remembered again.
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          read_publishes(io, 2)
+          disconnect(io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publishes(io, 2)
+          resent.each &.dup?.should be_true
+          resent.map(&.packet_id).should eq sent.map(&.packet_id)
+          resent.map { |p| String.new(p.payload) }.should eq ["0", "1"]
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "drops a clean session on disconnect, leaving nothing to resend [MQTT-3.1.2-6]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "cleaner", clean_session: true)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+          publish_from(server, "a/b", ["1"])
+
+          read_publish(io) # read, never acked: a message is in flight
+          server.vhosts["/"].session("mqtt.cleaner").unacked_count.should eq 1
+          disconnect(io)
+        end
+
+        # The session goes with the connection, in-flight window and all.
+        wait_for { !server.vhosts["/"].session_exists?("mqtt.cleaner") }
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "cleaner", clean_session: true)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+          read_packet(io).should be_nil
+          disconnect(io)
+        end
+      end
+    end
+
+    it "keeps owing the window while the session is offline" do
+      with_server do |server|
+        deliver_unacked(server, ["1"])
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+
+        # Requeued on detach, so still ready and still counted - only the packet
+        # id is held aside for the resend.
+        session.message_count.should eq 1
+        session.unacked_count.should eq 0
+        session.redeliver_count.should eq 0
+        session.in_use?.should be_true
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          read_publish(io)
+          # Counted after the yielding send, so the client can have the packet
+          # before the session has counted it.
+          wait_for { session.redeliver_count == 1 }
+          disconnect(io)
+        end
+      end
+    end
+
+    # The two paths that can drop a message the session still owes, taking the
+    # remembered packet id with it.
+    it "forgets an owed id when the session is purged" do
+      with_server do |server|
+        deliver_unacked(server, ["1"])
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+
+        session.purge.should eq 1
+        session.@msg_store.@packet_ids.should be_empty
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          read_packet(io).should be_nil
+          disconnect(io)
+        end
+      end
+    end
+
+    it "forgets an owed id when a max-length policy drops its message" do
+      with_server do |server|
+        deliver_unacked(server, ["1"])
+
+        vhost = server.vhosts["/"]
+        session = vhost.session("mqtt.resumer")
+        wait_for { session.client.nil? }
+        session.message_count.should eq 1
+
+        defs = {"max-length" => JSON::Any.new(0_i64)} of String => JSON::Any
+        vhost.add_policy("ml", "^mqtt\\.", "queues", defs, 10_i8, apply: false)
+        vhost.apply_policies
+
+        session.message_count.should eq 0
+        session.@msg_store.@packet_ids.should be_empty
+      end
+    end
+
+    it "does not resend under packet id 0 [MQTT-2.3.1-5]" do
+      with_server do |server|
+        deliver_unacked(server, ["1"])
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+
+        # `next_id` hands out 0 once the sequence wraps, so a real session can put
+        # one in here. Reissued from memory, the client rejects the illegal id and
+        # gets it again on every reconnect.
+        sp = session.@msg_store.@packet_ids.keys.first
+        session.@msg_store.@packet_ids[sp] = 0u16
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publish(io)
+          resent.packet_id.should_not eq 0u16
+          String.new(resent.payload).should eq "1"
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "keeps the ids of the messages a partial purge left behind" do
+      with_server do |server|
+        sent = deliver_unacked(server, ["0", "1", "2"])
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+        # A purge takes the requeued messages first, in delivery order, so "0"
+        # goes and the two the client still holds ids for stay.
+        session.purge(1).should eq 1
+        session.@msg_store.@packet_ids.size.should eq 2
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publishes(io, 2)
+          resent.map(&.packet_id).should eq sent[1..].map(&.packet_id)
+          resent.map { |p| String.new(p.payload) }.should eq ["1", "2"]
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "forgets the ids of every owed message a purge deletes" do
+      with_server do |server|
+        deliver_unacked(server, ["0", "1", "2"])
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+        publish_from(server, "a/b", ["3", "4"])
+        wait_for { session.message_count == 5 }
+
+        # The three owed messages are requeued, and a purge takes those first, so
+        # this deletes every message an id is remembered for and leaves the two
+        # that were published while the session was offline.
+        session.purge(3).should eq 3
+        session.message_count.should eq 2
+        session.@msg_store.@packet_ids.should be_empty
+      end
+    end
+
+    # Two remembered sps mapped to one id, which the store cannot produce on its
+    # own - `@requeued` is sp-sorted and drains before any new message.
+    it "passes over a remembered id that is already in flight" do
+      with_server do |server|
+        sent = deliver_unacked(server, ["0", "1"])
+        first_id = sent.first.packet_id.not_nil!
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+
+        # Point the second message at the first one's id. Resends go out in sp
+        # order, so the first delivery books that id and the second one arrives
+        # to find it taken.
+        second_sp = session.@msg_store.@packet_ids.keys.last
+        session.@msg_store.@packet_ids[second_sp] = first_id
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publishes(io, 2)
+          resent.map { |p| String.new(p.payload) }.should eq ["0", "1"]
+          resent.first.packet_id.should eq first_id
+          # Both still booked, under different ids. `wait_for` because
+          # `@unacked[id] = sp` is written after the yielding send.
+          resent.last.packet_id.should_not eq first_id
+          wait_for { session.@unacked.size == 2 }
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "counts the resent window against the inflight limit" do
+      LavinMQ::Config.instance.max_inflight_messages = 3u16
+      with_server do |server|
+        sent = [] of UInt16?
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+          publish_from(server, "a/b", ["0", "1", "2", "3"])
+
+          sent = read_publishes(io, 3).map &.packet_id
+          read_packet(io).should be_nil
+          disconnect(io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer")
+
+          resent = read_publishes(io, 3)
+          resent.each &.dup?.should be_true
+          resent.map(&.packet_id).should eq sent
+          # The window is still full, so the fourth message stays in the store.
+          read_packet(io).should be_nil
+
+          # Acking one frees a slot, and the fourth is delivered with a fresh id.
+          puback(io, resent.first.packet_id)
+          fourth = read_publish(io)
+          String.new(fourth.payload).should eq "3"
+          sent.should_not contain fourth.packet_id
+
+          disconnect(io)
+        end
+      end
+    ensure
+      LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
+    end
+  end
+end

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -141,4 +141,21 @@ module MqttHelpers
   rescue IO::TimeoutError
     nil
   end
+
+  # Reads the next packet as a PUBLISH, asserting it carries a packet id when the
+  # QoS needs one and none at QoS 0 [MQTT-2.3.1-5]. Use this instead of casting
+  # `read_packet` when comparing packet ids: `packet_id` is nilable, so a pair of
+  # nils would otherwise satisfy an equality assertion.
+  def read_publish(io) : MQTT::Protocol::Publish
+    # `should be_a` rather than `as`: on a read timeout `read_packet` returns nil,
+    # and a cast would report "cast from Nil" instead of naming the PUBLISH that
+    # never arrived.
+    pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
+    if pub.qos.positive?
+      pub.packet_id.should_not be_nil
+    else
+      pub.packet_id.should be_nil
+    end
+    pub
+  end
 end

--- a/src/lavinmq/config.cr
+++ b/src/lavinmq/config.cr
@@ -87,6 +87,11 @@ module LavinMQ
       unless @stats_interval.positive?
         raise Error.new("stats_interval must be positive (got #{@stats_interval})")
       end
+      # 0 is not "unlimited": the capacity gate would never open, so every MQTT
+      # session would accept publishes and deliver none of them.
+      unless @max_inflight_messages.positive?
+        raise Error.new("max_inflight_messages must be positive (got #{@max_inflight_messages})")
+      end
     end
 
     private def parse_config_from_cli(argv)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -9,6 +9,7 @@ require "../policy"
 require "../queue_stats"
 require "../vhost"
 require "./consts"
+require "./session_message_store"
 
 module LavinMQ
   module MQTT
@@ -30,7 +31,7 @@ module LavinMQ
       @max_length : Int64? = nil
       @max_length_bytes : Int64? = nil
       @msg_store_lock = Mutex.new(:reentrant)
-      @msg_store : MessageStore
+      @msg_store : SessionMessageStore
       @metadata : ::Log::Metadata
       @closed = Atomic(Bool).new(false)
       @deleted = false
@@ -52,7 +53,7 @@ module LavinMQ
         )
         Dir.mkdir_p(data_dir) unless Dir.exists?(data_dir)
         replicator = durable? ? @vhost.@replicator : nil
-        @msg_store = MessageStore.new(data_dir, replicator, durable?, metadata: @metadata)
+        @msg_store = SessionMessageStore.new(data_dir, replicator, durable?, metadata: @metadata)
 
         @log = Logger.new(Log, @metadata)
         spawn deliver_loop, name: "Session#deliver_loop"
@@ -126,6 +127,27 @@ module LavinMQ
         end
       end
 
+      # A resend keeps the packet id the client already knows [MQTT-4.4.0-1],
+      # unless that id is still in flight - reissuing it would overwrite the
+      # `@unacked` entry holding it - or is `0`, which may not go on the wire
+      # [MQTT-2.3.1-5]. Both fall back to a fresh id.
+      private def delivery_id(sp : SegmentPosition) : UInt16?
+        if id = @msg_store.packet_id?(sp)
+          return id unless id.zero? || @unacked.has_key?(id)
+        end
+        next_id
+      end
+
+      # `@has_capacity` mirrors "the in-flight window has room". Recomputed from
+      # `@unacked` rather than written as a literal, since it is updated from both
+      # the deliver_loop and the client's fiber and a stale `false` parks the
+      # deliver_loop with no ack left to reopen the gate. `swap` rather than `set`
+      # because this runs per delivery and per ack, and `set` takes both channel
+      # locks even when the value is unchanged.
+      private def refresh_capacity : Nil
+        @has_capacity.swap(@unacked.size < Config.instance.max_inflight_messages)
+      end
+
       def client : MQTT::Client?
         @client
       end
@@ -134,9 +156,13 @@ module LavinMQ
         return if closed?
         @last_get_time = RoughTime.instant
 
+        # A clean session carries nothing between connections [MQTT-3.1.2-6]. A
+        # persistent one requeues what it owes and remembers the packet ids, to
+        # resend under the ids the client already knows [MQTT-4.4.0-1].
         unless clean_session?
           @msg_store_lock.synchronize do
-            @unacked.values.each do |sp|
+            @unacked.each do |packet_id, sp|
+              @msg_store.remember_packet_id(sp, packet_id)
               @msg_store.requeue(sp)
             end
           end
@@ -145,7 +171,7 @@ module LavinMQ
         @unacked.clear
         @unacked_count.set(0, :release)
         @unacked_bytesize.set(0, :release)
-        @has_capacity.set(true)
+        refresh_capacity
 
         @client = client
         @has_client.set(!client.nil?)
@@ -218,9 +244,14 @@ module LavinMQ
             delete_message(sp)
           else
             begin
-              id = next_id
+              id = delivery_id(sp)
               unless id
                 @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+                # Without this the deliver_loop spins: the store is non-empty and
+                # capacity still reads true. Recomputed rather than closed
+                # outright, since an ack can free a slot while the requeue above
+                # waits on a contended @msg_store_lock.
+                refresh_capacity
                 return false
               end
               packet = build_packet(env, id)
@@ -234,7 +265,8 @@ module LavinMQ
                 @deliver_get_count.add(1, :relaxed)
               end
               @unacked[id] = sp
-              @has_capacity.set(false) if @unacked.size >= Config.instance.max_inflight_messages
+              @msg_store.forget_packet_id(sp)
+              refresh_capacity
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
               @unacked_count.sub(1, :relaxed)
@@ -299,7 +331,7 @@ module LavinMQ
           rescue ex
             raise ::IO::Error.new("Could not acknowledge packet with id '#{id}'", ex)
           ensure
-            @has_capacity.set(true)
+            refresh_capacity
           end
         else
           raise ::IO::Error.new("No message inflight for id '#{id}'")

--- a/src/lavinmq/mqtt/session_message_store.cr
+++ b/src/lavinmq/mqtt/session_message_store.cr
@@ -1,0 +1,29 @@
+require "../message_store"
+
+module LavinMQ
+  module MQTT
+    # A session's message store, which also holds the packet ids of the messages
+    # the session owes a resuming client. The ids live here so that a message
+    # leaving the store takes its id with it, whichever path removed it.
+    class SessionMessageStore < LavinMQ::MessageStore
+      @packet_ids = Hash(SegmentPosition, UInt16).new
+
+      def remember_packet_id(sp : SegmentPosition, packet_id : UInt16) : Nil
+        @packet_ids[sp] = packet_id
+      end
+
+      def packet_id?(sp : SegmentPosition) : UInt16?
+        @packet_ids[sp]? unless @packet_ids.empty?
+      end
+
+      def forget_packet_id(sp : SegmentPosition) : Nil
+        @packet_ids.delete(sp) unless @packet_ids.empty?
+      end
+
+      def delete(sp) : Nil
+        super
+        forget_packet_id(sp)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A resuming persistent session redelivered its unacknowledged QoS 1 messages under freshly allocated packet ids, so a client had no way to match them to the ids it still held `[MQTT-4.4.0-1]`. A subscriber dedupes on the id it was given, so after any mid-flight reconnect it could not tell a redelivery from a new message.

The ids now live next to the messages they belong to, in a new `MQTT::SessionMessageStore`: `client=` remembers the id of every message it requeues, `delivery_id` reuses it, and an override of `MessageStore#delete` drops an id whenever its message leaves the store. That one hook covers `purge`, `drop_overflow` and the ack path, so an id cannot outlive the message it names. Resends go out in segment-position order, which is the order they were first delivered in (`[MQTT-4.6.0-5]`, `[MQTT-4.6.0-6]`), with DUP set. Clean sessions still drop the window `[MQTT-3.1.2-6]`.

A remembered id is refused rather than reissued when it is already in flight, since reissuing it would overwrite the `@unacked` entry holding it and lose that message, or when it is `0`, which may not go on the wire `[MQTT-2.3.1-5]`. Both fall back to a fresh id.

`@has_capacity` is recomputed from `@unacked` instead of being set unconditionally when a client attaches, so a gate closed on a stale reading reopens. That also makes `max_inflight_messages = 0` close the gate before any client connects, with no ack able to reopen it, so `Config#validate!` now rejects it: **a config file with `max_inflight_messages = 0` will no longer boot.**

Precursor for QoS 2, whose PUBREL step is meaningless unless packet ids survive a reconnect.

### Scope of the guarantee

The remembered ids are process-local, so `[MQTT-4.4.0-1]` holds for in-process resumes:

- after a broker restart the unacked messages still survive, but come back under fresh ids with DUP unset
- a `max-length` policy or a `DELETE .../contents` purge reaches the owed window first, since `client=` requeues exactly what the session owes and `shift?` drains requeued messages ahead of ready ones. Those messages are dropped, ids and all.
- when a remembered id is refused, the resends behind it can also get fresh ids, because `next_id` only avoids ids that are in `@unacked`

### Test plan

- [x] `make test` - 2203 examples, 0 failures, 10 pending (all pre-existing)
- [x] `make lint` - 403 inspected, 0 failures
- [x] `crystal tool format` clean
- [x] Every new spec verified to have teeth by reverting the fix it covers: dropping the `MessageStore#delete` override fails the four id-lifecycle specs, reducing `delivery_id` to `next_id` fails the six behavioural resume specs, and removing the `Config#validate!` guard fails `max_inflight_messages rejects zero`
- [x] All `[MQTT-x.x.x-x]` citations checked against the OASIS 3.1.1 text
- [ ] Exercised against a real client (mosquitto, paho)
- [ ] Paho interop suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
