### PR TITLE
Add state filter to queue list endpoints

### DIFF
--- a/docs/queues.md
+++ b/docs/queues.md
@@ -94,6 +94,8 @@ A queue can be in one of the following states:
 
 Pause and resume are available via the management API (`PUT /api/queues/:vhost/:name/pause` and `/resume`). A closed queue can be restarted with `PUT /api/queues/:vhost/:name/restart`.
 
+The queue list endpoints (`GET /api/queues` and `GET /api/queues/:vhost`) accept a `state` query parameter to only return queues in the given state(s), comma separated, e.g. `?state=closed` or `?state=paused,closed`.
+
 ## Reserved Queue Name Prefixes
 
 Queue names starting with `amq.` or `mqtt.` are reserved for server-internal use. Client queue declarations using these prefixes will be rejected, except for `amq.direct.reply-to.*` queues used for direct reply-to consumers.

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -18,6 +18,41 @@ describe LavinMQ::HTTP::QueuesController do
         body.as_a.each { |v| keys.each { |k| v.as_h.keys.should contain(k) } }
       end
     end
+
+    it "should only return queues in the given state" do
+      with_http_server do |http, s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("q_running", false, false)
+        vhost.declare_queue("q_paused", false, false)
+        vhost.queue("q_paused").pause!
+        response = http.get("/api/queues?state=paused")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.map(&.["name"]).should eq ["q_paused"]
+      end
+    end
+
+    it "should filter on multiple states" do
+      with_http_server do |http, s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("q_running", false, false)
+        vhost.declare_queue("q_paused", false, false)
+        vhost.queue("q_paused").pause!
+        vhost.declare_queue("q_closed", true, false)
+        vhost.queue("q_closed").close
+        response = http.get("/api/queues?state=paused,closed")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.map(&.["name"].as_s).sort!.should eq ["q_closed", "q_paused"]
+      end
+    end
+
+    it "should return 400 for an invalid state" do
+      with_http_server do |http, _|
+        response = http.get("/api/queues?state=foo")
+        response.status_code.should eq 400
+      end
+    end
   end
   describe "GET /api/queues/vhost" do
     it "should return all queues for a vhost" do
@@ -27,6 +62,19 @@ describe LavinMQ::HTTP::QueuesController do
         response.status_code.should eq 200
         body = JSON.parse(response.body)
         body.as_a.empty?.should be_false
+      end
+    end
+
+    it "should only return queues in the given state" do
+      with_http_server do |http, s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("q_running", false, false)
+        vhost.declare_queue("q_closed", true, false)
+        vhost.queue("q_closed").close
+        response = http.get("/api/queues/%2f?state=closed")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body.as_a.map(&.["name"]).should eq ["q_closed"]
       end
     end
   end

--- a/spec/api/queues_spec.cr
+++ b/spec/api/queues_spec.cr
@@ -53,6 +53,21 @@ describe LavinMQ::HTTP::QueuesController do
         response.status_code.should eq 400
       end
     end
+
+    it "should keep total_count unfiltered when filtering on state" do
+      with_http_server do |http, s|
+        vhost = s.vhosts["/"]
+        vhost.declare_queue("q_running", false, false)
+        vhost.declare_queue("q_paused", false, false)
+        vhost.queue("q_paused").pause!
+        response = http.get("/api/queues?page=1&state=paused")
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        body["total_count"].should eq 2
+        body["filtered_count"].should eq 1
+        body["items"].as_a.map(&.["name"]).should eq ["q_paused"]
+      end
+    end
   end
   describe "GET /api/queues/vhost" do
     it "should return all queues for a vhost" do
@@ -65,7 +80,7 @@ describe LavinMQ::HTTP::QueuesController do
       end
     end
 
-    it "should only return queues in the given state" do
+    it "should only return queues in the given state for a vhost" do
       with_http_server do |http, s|
         vhost = s.vhosts["/"]
         vhost.declare_queue("q_running", false, false)

--- a/src/lavinmq/amqp/queue/queue.cr
+++ b/src/lavinmq/amqp/queue/queue.cr
@@ -508,6 +508,10 @@ module LavinMQ::AMQP
       consumers_size.to_u32
     end
 
+    def state_match?(states : Array(QueueState)) : Bool
+      states.includes?(@state)
+    end
+
     def pause!
       return unless @state.running?
       @state = QueueState::Paused

--- a/src/lavinmq/http/controller.cr
+++ b/src/lavinmq/http/controller.cr
@@ -22,9 +22,11 @@ module LavinMQ
         params = context.request.query_params
         page_size = extract_page_size(context)
         search_term = extract_search_term(params)
+        states = extract_state_filter(context)
         total_count = items.size
         all_items = items.compact_map do |i|
           next unless i.search_match?(search_term) if search_term
+          next unless i.state_match?(states) if states
           i.details_tuple
         rescue ex
           Log.warn(exception: ex) { "Could not list all items" }
@@ -140,6 +142,13 @@ module LavinMQ
           else
             term
           end
+        end
+      end
+
+      private def extract_state_filter(context) : Array(QueueState)?
+        return unless param = context.request.query_params["state"]?
+        param.split(',').map do |s|
+          QueueState.parse?(s) || bad_request(context, "Invalid queue state '#{s}'")
         end
       end
 

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -31,15 +31,13 @@ module LavinMQ
         get "/api/queues" do |context, _|
           vhosts = vhosts(user(context))
           itr = vhosts.flat_map(&.queues) + vhosts.flat_map(&.sessions)
-          itr = filter_by_state(context, itr)
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            queues = filter_by_state(context, vhost.queues + vhost.sessions)
-            page(context, queues)
+            page(context, vhost.queues + vhost.sessions)
           end
         end
 
@@ -287,14 +285,6 @@ module LavinMQ
             bad_request(context, e.message)
           end
         end
-      end
-
-      private def filter_by_state(context, queues)
-        return queues unless param = context.request.query_params["state"]?
-        states = param.split(',').map do |s|
-          QueueState.parse?(s) || bad_request(context, "Invalid queue state '#{s}'")
-        end
-        queues.select { |q| states.includes?(q.state) }
       end
 
       private def encode_body(message, truncate, encoding, io) : String

--- a/src/lavinmq/http/controller/queues.cr
+++ b/src/lavinmq/http/controller/queues.cr
@@ -31,13 +31,15 @@ module LavinMQ
         get "/api/queues" do |context, _|
           vhosts = vhosts(user(context))
           itr = vhosts.flat_map(&.queues) + vhosts.flat_map(&.sessions)
+          itr = filter_by_state(context, itr)
           page(context, itr)
         end
 
         get "/api/queues/:vhost" do |context, params|
           with_vhost(context, params) do |vhost|
             refuse_unless_management(context, user(context), vhost)
-            page(context, vhost.queues + vhost.sessions)
+            queues = filter_by_state(context, vhost.queues + vhost.sessions)
+            page(context, queues)
           end
         end
 
@@ -285,6 +287,14 @@ module LavinMQ
             bad_request(context, e.message)
           end
         end
+      end
+
+      private def filter_by_state(context, queues)
+        return queues unless param = context.request.query_params["state"]?
+        states = param.split(',').map do |s|
+          QueueState.parse?(s) || bad_request(context, "Invalid queue state '#{s}'")
+        end
+        queues.select { |q| states.includes?(q.state) }
       end
 
       private def encode_body(message, truncate, encoding, io) : String

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -365,6 +365,10 @@ module LavinMQ
         closed? ? QueueState::Closed : QueueState::Running
       end
 
+      def state_match?(states : Array(QueueState)) : Bool
+        states.includes?(state)
+      end
+
       def purge(max_count : Int = UInt32::MAX) : UInt32
         count = @msg_store_lock.synchronize { @msg_store.purge(max_count) }
         @log.info { "Purged #{count} messages" }

--- a/src/lavinmq/sortable_json.cr
+++ b/src/lavinmq/sortable_json.cr
@@ -17,5 +17,9 @@ module LavinMQ
     def search_match?(value : Regex)
       value === search_value
     end
+
+    def state_match?(_states : Array(QueueState)) : Bool
+      true
+    end
   end
 end

--- a/static/docs/paths/queues.yaml
+++ b/static/docs/paths/queues.yaml
@@ -6,6 +6,14 @@
     description: List all queues in the server.
     summary: List all queues
     operationId: GetQueues
+    parameters:
+    - in: query
+      name: state
+      required: false
+      schema:
+        type: string
+      description: Only return queues in the given state(s), comma separated. Valid
+        states are running, paused, flow, closed and deleted.
     responses:
       '200':
         description: OK
@@ -39,6 +47,14 @@
     description: List all queues for specific vhost.
     summary: List queues for vhost
     operationId: GetQueuesVhost
+    parameters:
+    - in: query
+      name: state
+      required: false
+      schema:
+        type: string
+      description: Only return queues in the given state(s), comma separated. Valid
+        states are running, paused, flow, closed and deleted.
     responses:
       '200':
         description: OK


### PR DESCRIPTION
### What does this pull request do?

Adds a `state` query parameter to `GET /api/queues` and `GET /api/queues/:vhost` to filter queues by state, e.g. `?state=closed` or `?state=paused,closed`. An invalid state returns 400. This makes it possible to monitor closed queues without paging through all queues. 

Should probably add state to some prometheus metric as well, but starting with this. 

More info in https://github.com/84codes/ssh-monitor/issues/313

### How can it be tested?

make test or create some queues, get them into different states and then request queues with specific states. 