### PR TITLE
Changes to tooltips to work better on different screen sizes

### DIFF
--- a/static/js/nodes.js
+++ b/static/js/nodes.js
@@ -62,12 +62,15 @@ const renderGCStats = (gc) => {
     const th = document.createElement('th')
     const tooltip = document.createElement('a')
     tooltip.className = 'prop-tooltip'
+    const anchorName = '--tt-' + field.key
+    tooltip.style.setProperty('anchor-name', anchorName)
     tooltip.append(document.createTextNode(field.heading))
     const icon = document.createElement('span')
     icon.className = 'tooltip-icon'
     icon.textContent = '?'
     const text = document.createElement('span')
     text.className = 'prop-tooltiptext'
+    text.style.setProperty('position-anchor', anchorName)
     text.textContent = field.info
     tooltip.append(icon, text)
     th.append(tooltip)

--- a/static/js/shovels.js
+++ b/static/js/shovels.js
@@ -11,9 +11,12 @@ function renderState (item) {
   if (item.error) {
     const state = document.createElement('a')
     state.classList.add('arg-tooltip')
+    const anchorName = '--tt-' + `${item.vhost}-${item.name}`.replace(/[^a-zA-Z0-9_-]/g, '-')
+    state.style.setProperty('anchor-name', anchorName)
     state.appendChild(document.createTextNode(item.state))
     const tooltip = document.createElement('span')
     tooltip.classList.add('tooltiptext')
+    tooltip.style.setProperty('position-anchor', anchorName)
     tooltip.textContent = item.error
     state.appendChild(tooltip)
     return state

--- a/static/main.css
+++ b/static/main.css
@@ -2043,7 +2043,12 @@ fieldset.inline {
 
 .arg-tooltip,
 .prop-tooltip {
-  position: relative;
+  /* Must NOT be `position: relative` (or any other positioned value): an anchor
+     element can't also be its positioned element's containing block, so this
+     stays a normal-flow box and the tooltip's containing block bubbles up to
+     the nearest positioned ancestor (e.g. a modal dialog), which is what lets
+     the tooltip escape any intermediate overflow/scroll clipping. */
+  position: static;
   display: inline-block;
 }
 
@@ -2052,21 +2057,20 @@ fieldset.inline {
   visibility: hidden;
   background-color: var(--color-tooltip-bg);
   color: var(--color-text-inverse);
-  padding: 10px 10px;
-  border-radius: 6px;
-  width: max-content;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
   max-width: 400px;
   min-width: 150px;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
   position: absolute;
+  position-area: top;
+  position-try-fallbacks: flip-block;
+  justify-self: anchor-center;
+  margin-bottom: 8px;
   z-index: 10000;
   white-space: normal;
-}
-
-.prop-tooltip .prop-tooltiptext {
-  margin-bottom: 5px;
 }
 
 .arg-tooltip:hover .tooltiptext,

--- a/static/main.css
+++ b/static/main.css
@@ -2043,12 +2043,7 @@ fieldset.inline {
 
 .arg-tooltip,
 .prop-tooltip {
-  /* Must NOT be `position: relative` (or any other positioned value): an anchor
-     element can't also be its positioned element's containing block, so this
-     stays a normal-flow box and the tooltip's containing block bubbles up to
-     the nearest positioned ancestor (e.g. a modal dialog), which is what lets
-     the tooltip escape any intermediate overflow/scroll clipping. */
-  position: static;
+  position: relative;
   display: inline-block;
 }
 
@@ -2065,10 +2060,10 @@ fieldset.inline {
   max-width: 400px;
   min-width: 150px;
   position: absolute;
-  position-area: top;
-  position-try-fallbacks: flip-block;
-  justify-self: anchor-center;
-  margin-bottom: 8px;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 4px;
   z-index: 10000;
   white-space: normal;
 }
@@ -2078,6 +2073,33 @@ fieldset.inline {
   transition-delay: 0.3s;
   visibility: visible;
   pointer-events: none;
+}
+
+/* CSS Anchor Positioning progressive enhancement (Baseline newly-available as of
+   Jan 2026 — Chrome 125+, Safari 26+, recent Firefox; older browsers still get the
+   plain bottom/left/transform fallback above). Gated behind @supports because an
+   anchor can't also be its positioned element's containing block, so on a
+   supporting browser we drop `position: relative` from the anchor and let the
+   tooltip's containing block bubble up to the nearest positioned ancestor (e.g. a
+   modal dialog) — that's what lets it escape overflow/scroll clipping and flip
+   above/below automatically. Every `.arg-tooltip`/`.prop-tooltip` instance also
+   needs its own unique `anchor-name` (and matching `position-anchor` on its nested
+   tooltip span), set inline per element. */
+@supports (anchor-name: --tooltip-anchor-support-check) {
+  .arg-tooltip,
+  .prop-tooltip {
+    position: static;
+  }
+
+  .arg-tooltip .tooltiptext,
+  .prop-tooltip .prop-tooltiptext {
+    position-area: top;
+    position-try-fallbacks: flip-block;
+    justify-self: anchor-center;
+    bottom: auto;
+    left: auto;
+    transform: none;
+  }
 }
 
 pre.arguments>div {

--- a/views/exchange.shtml
+++ b/views/exchange.shtml
@@ -99,39 +99,39 @@
         <span>Properties</span>
         <textarea name="properties" placeholder='{ "key": value }'></textarea>
         <div id="dataTags" class="label">
-          <a class="arg-tooltip" data-tag="content_type" data-value="&quot;application/json&quot;">Content Type
-            <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
+          <a class="arg-tooltip" data-tag="content_type" data-value="&quot;application/json&quot;" style="anchor-name: --tt-content_type">Content Type
+            <span class="tooltiptext" style="position-anchor: --tt-content_type">Type of the content used by application. Default set to 'application/json'</span>
           </a> |
-          <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
-            <span class="tooltiptext">Encoding of the content used by application.</span>
+          <a class="arg-tooltip" data-tag="content_encoding" style="anchor-name: --tt-content_encoding">Content Encoding
+            <span class="tooltiptext" style="position-anchor: --tt-content_encoding">Encoding of the content used by application.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="expiration" data-value="0">Message TTL
-            <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+          <a class="arg-tooltip" data-tag="expiration" data-value="0" style="anchor-name: --tt-expiration">Message TTL
+            <span class="tooltiptext" style="position-anchor: --tt-expiration">How long a message published to a queue can live before it is discarded
               (milliseconds).</span>
           </a> |
-          <a class="arg-tooltip" data-tag="priority" data-value="0">Priority
-            <span class="tooltiptext">Priority of the message in the queue.</span>
+          <a class="arg-tooltip" data-tag="priority" data-value="0" style="anchor-name: --tt-priority">Priority
+            <span class="tooltiptext" style="position-anchor: --tt-priority">Priority of the message in the queue.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="message_id">Message ID
-            <span class="tooltiptext">Message identifier of the message used by application.</span>
+          <a class="arg-tooltip" data-tag="message_id" style="anchor-name: --tt-message_id">Message ID
+            <span class="tooltiptext" style="position-anchor: --tt-message_id">Message identifier of the message used by application.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="timestamp" data-value="0">Timestamp
-            <span class="tooltiptext">Timestamp of the message used by application.</span>
+          <a class="arg-tooltip" data-tag="timestamp" data-value="0" style="anchor-name: --tt-timestamp">Timestamp
+            <span class="tooltiptext" style="position-anchor: --tt-timestamp">Timestamp of the message used by application.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="type">Type
-            <span class="tooltiptext">Type of the message used by application.</span>
+          <a class="arg-tooltip" data-tag="type" style="anchor-name: --tt-type">Type
+            <span class="tooltiptext" style="position-anchor: --tt-type">Type of the message used by application.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="user_id">User ID
-            <span class="tooltiptext">User identifier when impersonating another user.</span>
+          <a class="arg-tooltip" data-tag="user_id" style="anchor-name: --tt-user_id">User ID
+            <span class="tooltiptext" style="position-anchor: --tt-user_id">User identifier when impersonating another user.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="app_id">App ID
-            <span class="tooltiptext">Application identifier.</span>
+          <a class="arg-tooltip" data-tag="app_id" style="anchor-name: --tt-app_id">App ID
+            <span class="tooltiptext" style="position-anchor: --tt-app_id">Application identifier.</span>
           </a> |
-          <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
-            <span class="tooltiptext">Correlation identifier for RPC</span>
+          <a class="arg-tooltip" data-tag="correlation_id" style="anchor-name: --tt-correlation_id">Correlation ID
+            <span class="tooltiptext" style="position-anchor: --tt-correlation_id">Correlation identifier for RPC</span>
           </a> |
-          <a class="arg-tooltip" data-tag="reply_to">Reply To
-            <span class="tooltiptext">Reply to queue for RPC</span>
+          <a class="arg-tooltip" data-tag="reply_to" style="anchor-name: --tt-reply_to">Reply To
+            <span class="tooltiptext" style="position-anchor: --tt-reply_to">Reply to queue for RPC</span>
           </a>
         </div>
       </label>

--- a/views/exchanges.shtml
+++ b/views/exchanges.shtml
@@ -52,8 +52,8 @@
         </label>
         <label>
           <span>
-            <a class="prop-tooltip" data-tag="alternate-exchange">Durable<span class="tooltip-icon">?</span>
-              <span class="prop-tooltiptext">"Durable" exchanges persist even when the server restarts,
+            <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-durable">Durable<span class="tooltip-icon">?</span>
+              <span class="prop-tooltiptext" style="position-anchor: --tt-durable">"Durable" exchanges persist even when the server restarts,
                 ensuring their availability and preventing data loss.</span>
             </a>
           </span>
@@ -61,8 +61,8 @@
         </label>
         <label>
           <span>
-          <a class="prop-tooltip" data-tag="alternate-exchange">Auto-delete<span class="tooltip-icon">?</span>
-          <span class="prop-tooltiptext">"Auto-delete" exchanges are automatically removed when they
+          <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-auto-delete">Auto-delete<span class="tooltip-icon">?</span>
+          <span class="prop-tooltiptext" style="position-anchor: --tt-auto-delete">"Auto-delete" exchanges are automatically removed when they
           are no longer in use, freeing up system resources.</span>
           </a>
           </span>
@@ -70,8 +70,8 @@
         </label>
         <label>
           <span>
-          <a class="prop-tooltip" data-tag="alternate-exchange">Internal<span class="tooltip-icon">?</span>
-          <span class="prop-tooltiptext"> "Internal" exchanges are specifically designed for internal
+          <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-internal">Internal<span class="tooltip-icon">?</span>
+          <span class="prop-tooltiptext" style="position-anchor: --tt-internal"> "Internal" exchanges are specifically designed for internal
           use within the messaging system and are not intended for direct interaction with external components.</span>
           </a>
           </span>
@@ -79,8 +79,8 @@
         </label>
         <label>
           <span>
-          <a class="prop-tooltip" data-tag="alternate-exchange">Delayed<span class="tooltip-icon">?</span>
-          <span class="prop-tooltiptext">"Delayed" exchanges introduce a delay before delivering
+          <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-delayed">Delayed<span class="tooltip-icon">?</span>
+          <span class="prop-tooltiptext" style="position-anchor: --tt-delayed">"Delayed" exchanges introduce a delay before delivering
           messages, allowing for delayed processing or scheduling of tasks.</span>
           </a>
           </span>
@@ -90,23 +90,23 @@
           <span>Arguments</span>
           <textarea name="arguments" placeholder='{ "key": value }'></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="x-alternate-exchange">Alternate Exchange
-              <span class="tooltiptext">If messages to this exchange cannot otherwise be routed, send them to the alternate exchange named here.</span>
+            <a class="arg-tooltip" data-tag="x-alternate-exchange" style="anchor-name: --tt-x-alternate-exchange">Alternate Exchange
+              <span class="tooltiptext" style="position-anchor: --tt-x-alternate-exchange">If messages to this exchange cannot otherwise be routed, send them to the alternate exchange named here.</span>
             </a>
-            <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true">Message deduplication
-              <span class="tooltiptext">Enable deduplication for this exchange</span>
+            <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true" style="anchor-name: --tt-x-message-deduplication">Message deduplication
+              <span class="tooltiptext" style="position-anchor: --tt-x-message-deduplication">Enable deduplication for this exchange</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-cache-size" data-value="100">Deduplication cache size
-              <span class="tooltiptext">Deduplication cache size, in number of entries</span>
+            <a class="arg-tooltip" data-tag="x-cache-size" data-value="100" style="anchor-name: --tt-x-cache-size">Deduplication cache size
+              <span class="tooltiptext" style="position-anchor: --tt-x-cache-size">Deduplication cache size, in number of entries</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000">Deduplication cache ttl
-              <span class="tooltiptext">How long an entry lives in the deduplication cache, in milliseconds</span>
+            <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000" style="anchor-name: --tt-x-cache-ttl">Deduplication cache ttl
+              <span class="tooltiptext" style="position-anchor: --tt-x-cache-ttl">How long an entry lives in the deduplication cache, in milliseconds</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-deduplication-header">Deduplication header
-              <span class="tooltiptext">Which header to check for deduplication, defaults to x-deduplication-header</span>
+            <a class="arg-tooltip" data-tag="x-deduplication-header" style="anchor-name: --tt-x-deduplication-header">Deduplication header
+              <span class="tooltiptext" style="position-anchor: --tt-x-deduplication-header">Which header to check for deduplication, defaults to x-deduplication-header</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-algorithm">Hash Algorithm
-              <span class="tooltiptext">Which algorithm to use for the Consistent Hash Exchange (ring or jump)</span>
+            <a class="arg-tooltip" data-tag="x-algorithm" style="anchor-name: --tt-x-algorithm">Hash Algorithm
+              <span class="tooltiptext" style="position-anchor: --tt-x-algorithm">Which algorithm to use for the Consistent Hash Exchange (ring or jump)</span>
             </a>
           </div>
         </label>

--- a/views/nodes.shtml
+++ b/views/nodes.shtml
@@ -28,16 +28,16 @@
           </tr>
           <tr>
             <th>
-              <a class="prop-tooltip" data-tag="alternate-exchange">Memory usage<span class="tooltip-icon">?</span>
-              <span class="prop-tooltiptext">The amount of memory LavinMQ uses relative to the available system space</span>
+              <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-memory-usage">Memory usage<span class="tooltip-icon">?</span>
+              <span class="prop-tooltiptext" style="position-anchor: --tt-memory-usage">The amount of memory LavinMQ uses relative to the available system space</span>
               </a>
             </th>
             <td id="tr-memory"></td>
           </tr>
           <tr>
             <th>
-              <a class="prop-tooltip" data-tag="alternate-exchange">Disk usage<span class="tooltip-icon">?</span>
-              <span class="prop-tooltiptext">The amount of disk memory the system uses relative to the available system space</span>
+              <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-disk-usage">Disk usage<span class="tooltip-icon">?</span>
+              <span class="prop-tooltiptext" style="position-anchor: --tt-disk-usage">The amount of disk memory the system uses relative to the available system space</span>
               </a>
             </th>
             <td id="tr-disk"></td>

--- a/views/operator-policies.shtml
+++ b/views/operator-policies.shtml
@@ -65,27 +65,27 @@
           <span>Definition</span>
           <textarea name="definition" placeholder='{ "key": value }'></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="max-length" data-value="0">Max length
-              <span class="tooltiptext">How many (ready) messages a queue can contain before it starts dropping them.
+            <a class="arg-tooltip" data-tag="max-length" data-value="0" style="anchor-name: --tt-max-length">Max length
+              <span class="tooltiptext" style="position-anchor: --tt-max-length">How many (ready) messages a queue can contain before it starts dropping them.
                 Dropping strategy decided by overflow arg.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="max-length-bytes" data-value="0">Max length bytes
-              <span class="tooltiptext">The max length of a queue in bytes.</span>
+            <a class="arg-tooltip" data-tag="max-length-bytes" data-value="0" style="anchor-name: --tt-max-length-bytes">Max length bytes
+              <span class="tooltiptext" style="position-anchor: --tt-max-length-bytes">The max length of a queue in bytes.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="message-ttl" data-value="0">Message TTL
-              <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+            <a class="arg-tooltip" data-tag="message-ttl" data-value="0" style="anchor-name: --tt-message-ttl">Message TTL
+              <span class="tooltiptext" style="position-anchor: --tt-message-ttl">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="expires" data-value="0">Auto expire
-              <span class="tooltiptext">How long a queue can be unused for before it is automatically deleted
+            <a class="arg-tooltip" data-tag="expires" data-value="0" style="anchor-name: --tt-expires">Auto expire
+              <span class="tooltiptext" style="position-anchor: --tt-expires">How long a queue can be unused for before it is automatically deleted
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="delivery-limit" data-value="0">Delivery limit
-              <span class="tooltiptext">The number of times a message can be redelivered before dropped or
+            <a class="arg-tooltip" data-tag="delivery-limit" data-value="0" style="anchor-name: --tt-delivery-limit">Delivery limit
+              <span class="tooltiptext" style="position-anchor: --tt-delivery-limit">The number of times a message can be redelivered before dropped or
                 dead-lettered</span>
             </a> |
-            <a class="arg-tooltip" data-tag="max-age" data-value="1M">Max age
-              <span class="tooltiptext">Stream queue segments will be deleted when all messages in the segmented is older than this.
+            <a class="arg-tooltip" data-tag="max-age" data-value="1M" style="anchor-name: --tt-max-age">Max age
+              <span class="tooltiptext" style="position-anchor: --tt-max-age">Stream queue segments will be deleted when all messages in the segmented is older than this.
                 Valid units are Y(ear), M(onth), D(ays), h(ours), m(inutes), s(seconds).
                 Segments are only deleted when new messages are published to the stream queue.</span>
             </a>

--- a/views/policies.shtml
+++ b/views/policies.shtml
@@ -65,48 +65,48 @@
           <span>Definition</span>
           <textarea name="definition" placeholder='{ "key": value }'></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="max-length" data-value="0">Max length
-              <span class="tooltiptext">How many (ready) messages a queue can contain before it starts dropping them.
+            <a class="arg-tooltip" data-tag="max-length" data-value="0" style="anchor-name: --tt-max-length">Max length
+              <span class="tooltiptext" style="position-anchor: --tt-max-length">How many (ready) messages a queue can contain before it starts dropping them.
                 Dropping strategy decided by overflow arg.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="max-length-bytes" data-value="0">Max length bytes
-              <span class="tooltiptext">The max length of a queue in bytes.</span>
+            <a class="arg-tooltip" data-tag="max-length-bytes" data-value="0" style="anchor-name: --tt-max-length-bytes">Max length bytes
+              <span class="tooltiptext" style="position-anchor: --tt-max-length-bytes">The max length of a queue in bytes.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="message-ttl" data-value="0">Message TTL
-              <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+            <a class="arg-tooltip" data-tag="message-ttl" data-value="0" style="anchor-name: --tt-message-ttl">Message TTL
+              <span class="tooltiptext" style="position-anchor: --tt-message-ttl">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="overflow">Overflow behaviour
-              <span class="tooltiptext">This determines what happens to messages when the maximum length of a queue is
+            <a class="arg-tooltip" data-tag="overflow" style="anchor-name: --tt-overflow">Overflow behaviour
+              <span class="tooltiptext" style="position-anchor: --tt-overflow">This determines what happens to messages when the maximum length of a queue is
                 reached. Valid value are: drop-head (default) or reject-publish.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="expires" data-value="0">Auto expire
-              <span class="tooltiptext">How long a queue can be unused for before it is automatically deleted
+            <a class="arg-tooltip" data-tag="expires" data-value="0" style="anchor-name: --tt-expires">Auto expire
+              <span class="tooltiptext" style="position-anchor: --tt-expires">How long a queue can be unused for before it is automatically deleted
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="dead-letter-exchange">Dead letter exchange
-              <span class="tooltiptext">Optional name of an exchange to which messages will be republished if they are
+            <a class="arg-tooltip" data-tag="dead-letter-exchange" style="anchor-name: --tt-dead-letter-exchange">Dead letter exchange
+              <span class="tooltiptext" style="position-anchor: --tt-dead-letter-exchange">Optional name of an exchange to which messages will be republished if they are
                 rejected or expire.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="dead-letter-routing-key">Dead letter routing key
-              <span class="tooltiptext">Optional replacement routing key to use when a message is dead-lettered. If not
+            <a class="arg-tooltip" data-tag="dead-letter-routing-key" style="anchor-name: --tt-dead-letter-routing-key">Dead letter routing key
+              <span class="tooltiptext" style="position-anchor: --tt-dead-letter-routing-key">Optional replacement routing key to use when a message is dead-lettered. If not
                 set, the message's original routing key will be used.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="federation-upstream">Federation upstream
-              <span class="tooltiptext">Chooses a specific upstream set to use for federation. Incompatible with
+            <a class="arg-tooltip" data-tag="federation-upstream" style="anchor-name: --tt-federation-upstream">Federation upstream
+              <span class="tooltiptext" style="position-anchor: --tt-federation-upstream">Chooses a specific upstream set to use for federation. Incompatible with
                 federation-upstream-set.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="federation-upstream-set">Federation upstream set
-              <span class="tooltiptext">Chooses the name of a set of upstreams to use with federation, or "all" to use
+            <a class="arg-tooltip" data-tag="federation-upstream-set" style="anchor-name: --tt-federation-upstream-set">Federation upstream set
+              <span class="tooltiptext" style="position-anchor: --tt-federation-upstream-set">Chooses the name of a set of upstreams to use with federation, or "all" to use
                 all
                 upstreams. Incompatible with federation-upstream.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="delivery-limit" data-value="0">Delivery limit
-              <span class="tooltiptext">The number of times a message can be redelivered before dropped or
+            <a class="arg-tooltip" data-tag="delivery-limit" data-value="0" style="anchor-name: --tt-delivery-limit">Delivery limit
+              <span class="tooltiptext" style="position-anchor: --tt-delivery-limit">The number of times a message can be redelivered before dropped or
                 dead-lettered</span>
             </a> |
-            <a class="arg-tooltip" data-tag="max-age" data-value="1M">Max age
-              <span class="tooltiptext">Stream queue segments will be deleted when all messages in the segmented is older than this.
+            <a class="arg-tooltip" data-tag="max-age" data-value="1M" style="anchor-name: --tt-max-age">Max age
+              <span class="tooltiptext" style="position-anchor: --tt-max-age">Stream queue segments will be deleted when all messages in the segmented is older than this.
                 Valid units are Y(ear), M(onth), D(ays), h(ours), m(inutes), s(seconds).
                 Segments are only deleted when new messages are published to the stream queue.</span>
             </a>

--- a/views/queue.shtml
+++ b/views/queue.shtml
@@ -211,39 +211,39 @@
             <span>Properties</span>
             <textarea name="properties" placeholder='{ "key": value }'></textarea>
             <div id="dataTags" class="label">
-              <a class="arg-tooltip" data-tag="content_type" data-value="&quot;application/json&quot;">Content Type
-                <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
+              <a class="arg-tooltip" data-tag="content_type" data-value="&quot;application/json&quot;" style="anchor-name: --tt-content_type">Content Type
+                <span class="tooltiptext" style="position-anchor: --tt-content_type">Type of the content used by application. Default set to 'application/json'</span>
               </a> |
-              <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
-                <span class="tooltiptext">Encoding of the content used by application.</span>
+              <a class="arg-tooltip" data-tag="content_encoding" style="anchor-name: --tt-content_encoding">Content Encoding
+                <span class="tooltiptext" style="position-anchor: --tt-content_encoding">Encoding of the content used by application.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="expiration" data-value="0">Message TTL
-                <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+              <a class="arg-tooltip" data-tag="expiration" data-value="0" style="anchor-name: --tt-expiration">Message TTL
+                <span class="tooltiptext" style="position-anchor: --tt-expiration">How long a message published to a queue can live before it is discarded
                   (milliseconds).</span>
               </a> |
-              <a class="arg-tooltip" data-tag="priority" data-value="1">Priority
-                <span class="tooltiptext">Priority of the message in the queue.</span>
+              <a class="arg-tooltip" data-tag="priority" data-value="1" style="anchor-name: --tt-priority">Priority
+                <span class="tooltiptext" style="position-anchor: --tt-priority">Priority of the message in the queue.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="message_id">Message ID
-                <span class="tooltiptext">Message identifier of the message used by application.</span>
+              <a class="arg-tooltip" data-tag="message_id" style="anchor-name: --tt-message_id">Message ID
+                <span class="tooltiptext" style="position-anchor: --tt-message_id">Message identifier of the message used by application.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="timestamp">Timestamp
-                <span class="tooltiptext">Timestamp of the message used by application.</span>
+              <a class="arg-tooltip" data-tag="timestamp" style="anchor-name: --tt-timestamp">Timestamp
+                <span class="tooltiptext" style="position-anchor: --tt-timestamp">Timestamp of the message used by application.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="type">Type
-                <span class="tooltiptext">Type of the message used by application.</span>
+              <a class="arg-tooltip" data-tag="type" style="anchor-name: --tt-type">Type
+                <span class="tooltiptext" style="position-anchor: --tt-type">Type of the message used by application.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="user_id">User ID
-                <span class="tooltiptext">User identifier when impersonate another user.</span>
+              <a class="arg-tooltip" data-tag="user_id" style="anchor-name: --tt-user_id">User ID
+                <span class="tooltiptext" style="position-anchor: --tt-user_id">User identifier when impersonate another user.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="app_id">App ID
-                <span class="tooltiptext">Application identifier.</span>
+              <a class="arg-tooltip" data-tag="app_id" style="anchor-name: --tt-app_id">App ID
+                <span class="tooltiptext" style="position-anchor: --tt-app_id">Application identifier.</span>
               </a> |
-              <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
-                <span class="tooltiptext">Correlation identifier for RPC</span>
+              <a class="arg-tooltip" data-tag="correlation_id" style="anchor-name: --tt-correlation_id">Correlation ID
+                <span class="tooltiptext" style="position-anchor: --tt-correlation_id">Correlation identifier for RPC</span>
               </a> |
-              <a class="arg-tooltip" data-tag="reply_to">Reply To
-                <span class="tooltiptext">Reply to queue for RPC</span>
+              <a class="arg-tooltip" data-tag="reply_to" style="anchor-name: --tt-reply_to">Reply To
+                <span class="tooltiptext" style="position-anchor: --tt-reply_to">Reply to queue for RPC</span>
               </a>
             </div>
           </label>

--- a/views/queues.shtml
+++ b/views/queues.shtml
@@ -63,8 +63,8 @@
         </label>
         <label>
           <span>
-          <a class="prop-tooltip" data-tag="alternate-exchange">Durable<span class="tooltip-icon">?</span>
-          <span class="prop-tooltiptext">"Durable" queues persist even when the server restarts,
+          <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-durable">Durable<span class="tooltip-icon">?</span>
+          <span class="prop-tooltiptext" style="position-anchor: --tt-durable">"Durable" queues persist even when the server restarts,
           ensuring their availability and preventing data loss.</span>
           </a>
           </span>
@@ -72,8 +72,8 @@
         </label>
         <label>
           <span>
-          <a class="prop-tooltip" data-tag="alternate-exchange">Auto-delete<span class="tooltip-icon">?</span>
-          <span class="prop-tooltiptext">"Auto-delete" queues are automatically removed when the
+          <a class="prop-tooltip" data-tag="alternate-exchange" style="anchor-name: --tt-auto-delete">Auto-delete<span class="tooltip-icon">?</span>
+          <span class="prop-tooltiptext" style="position-anchor: --tt-auto-delete">"Auto-delete" queues are automatically removed when the
           last consumer disconnects, freeing up system resources.</span>
           </a>
           </span>
@@ -83,56 +83,56 @@
           <span>Arguments</span>
           <textarea name="arguments" placeholder='{ "key": value }'></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="x-expires" data-value="0">Auto Expire
-              <span class="tooltiptext">How long a queue can be unused for before it is automatically deleted
+            <a class="arg-tooltip" data-tag="x-expires" data-value="0" style="anchor-name: --tt-x-expires">Auto Expire
+              <span class="tooltiptext" style="position-anchor: --tt-x-expires">How long a queue can be unused for before it is automatically deleted
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-max-length" data-value="0">Max Length
-              <span class="tooltiptext">How many (ready) messages a queue can contain before it starts to drop them from
+            <a class="arg-tooltip" data-tag="x-max-length" data-value="0" style="anchor-name: --tt-x-max-length">Max Length
+              <span class="tooltiptext" style="position-anchor: --tt-x-max-length">How many (ready) messages a queue can contain before it starts to drop them from
                 its head.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-message-ttl" data-value="0">Message TTL
-              <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+            <a class="arg-tooltip" data-tag="x-message-ttl" data-value="0" style="anchor-name: --tt-x-message-ttl">Message TTL
+              <span class="tooltiptext" style="position-anchor: --tt-x-message-ttl">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-delivery-limit" data-value="0">Delivery limit
-              <span class="tooltiptext">The number of times a message can be redelivered before dropped or
+            <a class="arg-tooltip" data-tag="x-delivery-limit" data-value="0" style="anchor-name: --tt-x-delivery-limit">Delivery limit
+              <span class="tooltiptext" style="position-anchor: --tt-x-delivery-limit">The number of times a message can be redelivered before dropped or
                 dead-lettered</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-overflow">Overflow behaviour
-              <span class="tooltiptext">Determines what happens to messages when the maximum length of a queue is
+            <a class="arg-tooltip" data-tag="x-overflow" style="anchor-name: --tt-x-overflow">Overflow behaviour
+              <span class="tooltiptext" style="position-anchor: --tt-x-overflow">Determines what happens to messages when the maximum length of a queue is
                 reached. Valid value are drop-head (default) and reject-publish.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-dead-letter-exchange">Dead letter exchange
-              <span class="tooltiptext">Optional name of an exchange to which messages will be republished if they are
+            <a class="arg-tooltip" data-tag="x-dead-letter-exchange" style="anchor-name: --tt-x-dead-letter-exchange">Dead letter exchange
+              <span class="tooltiptext" style="position-anchor: --tt-x-dead-letter-exchange">Optional name of an exchange to which messages will be republished if they are
                 rejected or expire.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-dead-letter-routing-key">Dead letter routing key
-              <span class="tooltiptext">Optional replacement routing key to use when a message is dead-lettered. If not
+            <a class="arg-tooltip" data-tag="x-dead-letter-routing-key" style="anchor-name: --tt-x-dead-letter-routing-key">Dead letter routing key
+              <span class="tooltiptext" style="position-anchor: --tt-x-dead-letter-routing-key">Optional replacement routing key to use when a message is dead-lettered. If not
                 set, the message's original routing key will be used.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-max-priority" data-value="0">Max Priority
-              <span class="tooltiptext">Make the queue a priority queue, with a fixed level of different priorities (max 255)</span>
+            <a class="arg-tooltip" data-tag="x-max-priority" data-value="0" style="anchor-name: --tt-x-max-priority">Max Priority
+              <span class="tooltiptext" style="position-anchor: --tt-x-max-priority">Make the queue a priority queue, with a fixed level of different priorities (max 255)</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-queue-type" data-value="stream">Stream Queue
-              <span class="tooltiptext">Make the queue a stream queue. It has to be durable and can't be auto-delete</span>
+            <a class="arg-tooltip" data-tag="x-queue-type" data-value="stream" style="anchor-name: --tt-x-queue-type">Stream Queue
+              <span class="tooltiptext" style="position-anchor: --tt-x-queue-type">Make the queue a stream queue. It has to be durable and can't be auto-delete</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-max-age" data-value="1M">Max age
-              <span class="tooltiptext">Stream queue segments will be deleted when all messages in the segmented is older than this.
+            <a class="arg-tooltip" data-tag="x-max-age" data-value="1M" style="anchor-name: --tt-x-max-age">Max age
+              <span class="tooltiptext" style="position-anchor: --tt-x-max-age">Stream queue segments will be deleted when all messages in the segmented is older than this.
                 Valid units are Y(ear), M(onth), D(ays), h(ours), m(inutes), s(seconds).
                 Segments are only deleted when new messages are published to the stream queue.</span>
             </a> |
-             <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true">Message deduplication
-              <span class="tooltiptext">Enable deduplication for this exchange</span>
+             <a class="arg-tooltip" data-tag="x-message-deduplication" data-value="true" style="anchor-name: --tt-x-message-deduplication">Message deduplication
+              <span class="tooltiptext" style="position-anchor: --tt-x-message-deduplication">Enable deduplication for this exchange</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-cache-size" data-value="100">Deduplication cache size
-              <span class="tooltiptext">Deduplication cache size, in number of entries</span>
+            <a class="arg-tooltip" data-tag="x-cache-size" data-value="100" style="anchor-name: --tt-x-cache-size">Deduplication cache size
+              <span class="tooltiptext" style="position-anchor: --tt-x-cache-size">Deduplication cache size, in number of entries</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000">Deduplication cache ttl
-              <span class="tooltiptext">How long an entry lives in the deduplication cache, in milliseconds</span>
+            <a class="arg-tooltip" data-tag="x-cache-ttl" data-value="1000" style="anchor-name: --tt-x-cache-ttl">Deduplication cache ttl
+              <span class="tooltiptext" style="position-anchor: --tt-x-cache-ttl">How long an entry lives in the deduplication cache, in milliseconds</span>
             </a> |
-            <a class="arg-tooltip" data-tag="x-deduplication-header">Deduplication header
-              <span class="tooltiptext">Which header to check for deduplication, defaults to x-deduplication-header</span>
+            <a class="arg-tooltip" data-tag="x-deduplication-header" style="anchor-name: --tt-x-deduplication-header">Deduplication header
+              <span class="tooltiptext" style="position-anchor: --tt-x-deduplication-header">Which header to check for deduplication, defaults to x-deduplication-header</span>
             </a>
           </div>
         </label>

--- a/views/stream.shtml
+++ b/views/stream.shtml
@@ -145,39 +145,39 @@
           <span>Properties</span>
           <textarea name="properties" placeholder='{ "key": value }'></textarea>
           <div id="dataTags" class="label">
-            <a class="arg-tooltip" data-tag="content_type" data-value="&quot;application/json&quot;">Content Type
-              <span class="tooltiptext">Type of the content used by application. Default set to 'application/json'</span>
+            <a class="arg-tooltip" data-tag="content_type" data-value="&quot;application/json&quot;" style="anchor-name: --tt-content_type">Content Type
+              <span class="tooltiptext" style="position-anchor: --tt-content_type">Type of the content used by application. Default set to 'application/json'</span>
             </a> |
-            <a class="arg-tooltip" data-tag="content_encoding">Content Encoding
-              <span class="tooltiptext">Encoding of the content used by application.</span>
+            <a class="arg-tooltip" data-tag="content_encoding" style="anchor-name: --tt-content_encoding">Content Encoding
+              <span class="tooltiptext" style="position-anchor: --tt-content_encoding">Encoding of the content used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="expiration" data-value="0">Message TTL
-              <span class="tooltiptext">How long a message published to a queue can live before it is discarded
+            <a class="arg-tooltip" data-tag="expiration" data-value="0" style="anchor-name: --tt-expiration">Message TTL
+              <span class="tooltiptext" style="position-anchor: --tt-expiration">How long a message published to a queue can live before it is discarded
                 (milliseconds).</span>
             </a> |
-            <a class="arg-tooltip" data-tag="priority" data-value="1">Priority
-              <span class="tooltiptext">Priority of the message in the queue.</span>
+            <a class="arg-tooltip" data-tag="priority" data-value="1" style="anchor-name: --tt-priority">Priority
+              <span class="tooltiptext" style="position-anchor: --tt-priority">Priority of the message in the queue.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="message_id">Message ID
-              <span class="tooltiptext">Message identifier of the message used by application.</span>
+            <a class="arg-tooltip" data-tag="message_id" style="anchor-name: --tt-message_id">Message ID
+              <span class="tooltiptext" style="position-anchor: --tt-message_id">Message identifier of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="timestamp">Timestamp
-              <span class="tooltiptext">Timestamp of the message used by application.</span>
+            <a class="arg-tooltip" data-tag="timestamp" style="anchor-name: --tt-timestamp">Timestamp
+              <span class="tooltiptext" style="position-anchor: --tt-timestamp">Timestamp of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="type">Type
-              <span class="tooltiptext">Type of the message used by application.</span>
+            <a class="arg-tooltip" data-tag="type" style="anchor-name: --tt-type">Type
+              <span class="tooltiptext" style="position-anchor: --tt-type">Type of the message used by application.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="user_id">User ID
-              <span class="tooltiptext">User identifier when impersonate another user.</span>
+            <a class="arg-tooltip" data-tag="user_id" style="anchor-name: --tt-user_id">User ID
+              <span class="tooltiptext" style="position-anchor: --tt-user_id">User identifier when impersonate another user.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="app_id">App ID
-              <span class="tooltiptext">Application identifier.</span>
+            <a class="arg-tooltip" data-tag="app_id" style="anchor-name: --tt-app_id">App ID
+              <span class="tooltiptext" style="position-anchor: --tt-app_id">Application identifier.</span>
             </a> |
-            <a class="arg-tooltip" data-tag="correlation_id">Correlation ID
-              <span class="tooltiptext">Correlation identifier for RPC</span>
+            <a class="arg-tooltip" data-tag="correlation_id" style="anchor-name: --tt-correlation_id">Correlation ID
+              <span class="tooltiptext" style="position-anchor: --tt-correlation_id">Correlation identifier for RPC</span>
             </a> |
-            <a class="arg-tooltip" data-tag="reply_to">Reply To
-              <span class="tooltiptext">Reply to queue for RPC</span>
+            <a class="arg-tooltip" data-tag="reply_to" style="anchor-name: --tt-reply_to">Reply To
+              <span class="tooltiptext" style="position-anchor: --tt-reply_to">Reply to queue for RPC</span>
             </a>
           </div>
         </label>


### PR DESCRIPTION
### What does this pull request do?

 Replace the tooltip positioning implementation with native CSS Anchor Positioning to fix tooltips getting clipped or badly placed when their trigger is near an edge of the
  viewport or a scrollable/overflow container.

### How can it be tested?

Tooltips (.arg-tooltip/.prop-tooltip) were positioned with a fixed bottom: 100%; left: 50%; transform: translateX(-50%), computed relative to the trigger's own containing block. That has no awareness of viewport bounds, so a tooltip near the bottom or edge of a container (a scrollable table, a form near the bottom of the page, etc.) simply got clipped or ran off-screen, with no way to reposition itself.

CSS Anchor Positioning (anchor-name, position-anchor, position-area, position-try-fallbacks) lets a tooltip be positioned relative to its trigger while its actual containing block is a different, unclipped ancestor (e.g. the viewport), and lets the browser automatically flip the tooltip to the other side when there isn't room — all without JavaScript. This is now Baseline-supported across Chrome, Firefox, and Safari.

 What changed

- .arg-tooltip/.prop-tooltip triggers no longer establish their own containing block (position: static instead of relative) — the anchor can't also be the positioned element's containing block, so this lets it bubble up to a real (non-clipping) ancestor.
- Tooltip text spans use position-area: top, position-try-fallbacks: flip-block, and justify-self: anchor-center to center above the trigger and flip below automatically when clipped.
- Every tooltip trigger/text pair gets a unique anchor-name/position-anchor so each tooltip anchors to its own trigger.
- Applied consistently across all pages using this pattern: queues, exchanges, exchange, policies, operator-policies, queue, stream, plus the dynamically-rendered tooltips in nodes.js (GC stats) and shovels.js (per-row shovel errors).

No behavior change from a user's perspective (still hover-triggered, same markup/classes, no JS added), and no visual change in the common case — only the edge-of-viewport clipping behavior is fixed.

Test by clicking around on tooltips and change window size.
