### PR TITLE
feat(mqtt): QoS 2 (exactly once) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tls_prefer_server_ciphers` config option that makes the server's cipher order decide the negotiated cipher
 - The vhost `max-connections` limit is now enforced for MQTT connections [#2222](https://github.com/cloudamqp/lavinmq/pull/2222)
 - Be able to close a specific channel [#2144](https://github.com/cloudamqp/lavinmq/issues/2144)
+- MQTT QoS 2 (exactly once): the full PUBLISH/PUBREC/PUBREL/PUBCOMP handshake in both directions, and QoS 2 subscriptions are granted rather than downgraded. An unfinished exchange is resumed on reconnect, re-sending the PUBREL under its original packet ID. The state is in memory, so it does not survive a broker restart
 
 ### Changed
 
@@ -25,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CC and BCC headers are removed from dead-lettered messages when `x-dead-letter-routing-key` is set, instead of being preserved, matching RabbitMQ [#1993](https://github.com/cloudamqp/lavinmq/pull/1993)
 - A connection with a PROXY protocol header never counts as loopback for `default_user_only_loopback`, including through a cluster follower. The default user can only connect directly on the broker host [#2224](https://github.com/cloudamqp/lavinmq/pull/2224)
 - `max_inflight_messages` must be at least `1`; `0` is now rejected at startup and on config reload instead of leaving every MQTT session accepting publishes it can never deliver [#2233](https://github.com/cloudamqp/lavinmq/pull/2233)
+- An MQTT message is now delivered at the lower of the QoS it was published with and the QoS of the subscription, instead of always the subscription's. A QoS 0 publish to a QoS 1 or QoS 2 subscriber is no longer acknowledged and is no longer stored while that session is offline
+- `max_inflight_messages` bounds outstanding MQTT packet IDs rather than outstanding messages. A QoS 2 delivery holds its ID across both round trips, so it occupies a slot until PUBCOMP
+- MQTT definitions files may now carry `mqtt.qos = 2` in a binding's arguments. An older broker reading one clamps it back to QoS 1
 
 ### Fixed
 
@@ -32,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prometheus and HTTP API counters (`global_messages_*`, churn `*_total`, `/api/overview`, `/api/nodes`) no longer decrease when a queue or vhost is deleted, which previously made `rate()`/`increase()` fabricate spikes [#2093](https://github.com/cloudamqp/lavinmq/issues/2093)
 - MQTT sessions now respect the vhost `max-queues` limit; a SUBSCRIBE that would create a session beyond the cap is answered with failure return codes instead of exceeding the limit
 - Unacknowledged MQTT QoS 1 publishes are resent under the packet IDs the client already holds, with `dup` set, instead of being assigned new ones [MQTT-4.4.0-1]. The IDs are remembered in-process, so a session resumed after a broker restart is still redelivered under fresh IDs [#2233](https://github.com/cloudamqp/lavinmq/pull/2233)
+- An MQTT in-flight packet ID is recorded before the PUBLISH is written rather than after, so an acknowledgement that arrives while the write is still parked is no longer mistaken for one referring to nothing, which reported a lost connection and published the client's will
 
 ## [2.9.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tls_prefer_server_ciphers` config option that makes the server's cipher order decide the negotiated cipher
 - The vhost `max-connections` limit is now enforced for MQTT connections [#2222](https://github.com/cloudamqp/lavinmq/pull/2222)
 - Be able to close a specific channel [#2144](https://github.com/cloudamqp/lavinmq/issues/2144)
-- MQTT QoS 2 (exactly once): the full PUBLISH/PUBREC/PUBREL/PUBCOMP handshake in both directions, and QoS 2 subscriptions are granted rather than downgraded. An unfinished exchange is resumed on reconnect, re-sending the PUBREL under its original packet ID. The state is in memory, so it does not survive a broker restart
+- MQTT QoS 2 (exactly once): the full PUBLISH/PUBREC/PUBREL/PUBCOMP handshake in both directions, and QoS 2 subscriptions are granted rather than downgraded. An unfinished exchange is resumed on reconnect, re-sending the PUBREL under its original packet ID. The state is in memory, so it survives neither a broker restart nor a failover; persisting it is planned as follow-up work
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ Not every setting takes effect on reload. The log level and TLS certificates are
 | `port` | `--mqtt-port` | — | Int | `1883` | MQTT port |
 | `tls_port` | `--mqtts-port` | — | Int | `8883` | MQTTS port |
 | `unix_path` | `--mqtt-unix-path` | — | String | (empty) | MQTT Unix socket path |
-| `max_inflight_messages` | — | — | UInt16 | `65535` | Max unacknowledged messages per session, must be at least `1` |
+| `max_inflight_messages` | — | — | UInt16 | `65535` | Max outstanding packet IDs per session, must be at least `1`. A QoS 2 delivery holds its ID until PUBCOMP |
 | `max_packet_size` | — | — | UInt32 | `268435455` | Max MQTT packet size (bytes) |
 | `default_vhost` | — | — | String | `/` | Default vhost for MQTT connections |
 | `permission_check_enabled` | — | — | Bool | `false` | Enable MQTT permission checks |

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -18,11 +18,23 @@ Unix domain sockets are also supported via `unix_path` in the `[mqtt]` section. 
 |-----|-----------|----------|
 | 0 (at most once) | Yes | Fire and forget. Messages are not persisted for the session. |
 | 1 (at least once) | Yes | Messages are acknowledged with PUBACK. |
-| 2 (exactly once) | Downgraded to QoS 1 | LavinMQ does not implement the full QoS 2 handshake. |
+| 2 (exactly once) | Yes | Four-step handshake: PUBLISH, PUBREC, PUBREL, PUBCOMP. |
+
+A message is delivered at the lower of the QoS it was published with and the QoS of the subscription that matched it. Publishing at QoS 2 to a QoS 0 subscriber delivers at QoS 0, and publishing at QoS 0 to a QoS 2 subscriber delivers at QoS 0 as well.
+
+### QoS 2 exactly-once
+
+Exactly-once rests on remembering packet IDs, not messages.
+
+When a client publishes at QoS 2, LavinMQ records the packet ID, routes the message, and answers PUBREC. A re-sent PUBLISH carrying an ID that is still recorded is answered with another PUBREC and is not routed a second time, which is what makes the delivery exactly-once. The client's PUBREL releases the ID and is answered with PUBCOMP. A PUBREL for an ID LavinMQ is not holding is answered with PUBCOMP as well, so a client whose PUBCOMP was lost can always complete the exchange.
+
+When LavinMQ delivers at QoS 2, the packet ID stays outstanding across both round trips. The message itself is released at PUBREC, since the subscriber owns it from that point and it must never be sent again; the ID alone is held until PUBCOMP. `max_inflight_messages` therefore bounds outstanding *packet IDs* rather than outstanding messages, and a QoS 2 subscriber reaches that bound at a lower message rate than a QoS 1 one.
+
+The QoS 2 state on both sides is held in memory and does not survive a broker restart. See [Limitations](#limitations).
 
 ## Sessions
 
-Each MQTT session is implemented as an internal AMQP queue named `mqtt.<client_id>`. The queue holds the session's pending QoS 1 messages and tracks subscriptions as bindings. This is an implementation detail of how LavinMQ stores session state — MQTT clients never see the queue directly, but it explains why session names share the `mqtt.` prefix and why durability and lifetime follow the AMQP queue model.
+Each MQTT session is implemented as an internal AMQP queue named `mqtt.<client_id>`. The queue holds the session's pending QoS 1 and QoS 2 messages and tracks subscriptions as bindings. This is an implementation detail of how LavinMQ stores session state — MQTT clients never see the queue directly, but it explains why session names share the `mqtt.` prefix and why durability and lifetime follow the AMQP queue model.
 
 ### Clean Sessions
 
@@ -38,10 +50,11 @@ When a client connects with `clean_session=false`:
 
 - The session persists across disconnections
 - Subscriptions are preserved
-- Unacknowledged QoS 1 messages are requeued and redelivered on reconnect, under the packet IDs the client already holds and with the `dup` flag set
+- Unacknowledged QoS 1 and QoS 2 messages are requeued and redelivered on reconnect, under the packet IDs the client already holds and with the `dup` flag set
+- QoS 2 deliveries that reached PUBREC but not PUBCOMP have no message left to resend, so their PUBREL is re-sent instead, under the original packet ID [MQTT-4.4.0-1]
 - The session queue is durable
 
-The reuse of packet IDs on redelivery is remembered in-process only, so after a broker restart the session's outstanding messages are redelivered under fresh packet IDs. If a `max-length` policy or a purge discards a message the session still owes, its packet ID is forgotten along with it; the messages that remain keep theirs.
+The reuse of packet IDs on redelivery is remembered in-process only, so after a broker restart the session's outstanding messages are redelivered under fresh packet IDs, and an unfinished QoS 2 exchange is forgotten entirely. If a `max-length` policy or a purge discards a message the session still owes, its packet ID is forgotten along with it; the messages that remain keep theirs.
 
 ### Session Takeover
 
@@ -54,7 +67,7 @@ Sessions count towards the vhost's `max-queues` [limit](vhosts.md#vhost-limits),
 ### Message Delivery
 
 - QoS 0 messages are not enqueued if no consumer (client) is currently connected to the session
-- QoS 1 messages are stored in the session queue and tracked with packet IDs
+- QoS 1 and QoS 2 messages are stored in the session queue and tracked with packet IDs
 - Unacknowledged messages are requeued when a persistent session client disconnects or a new client takes over, and keep their packet IDs for the redelivery. For clean sessions, unacknowledged messages are discarded.
 
 ## Connection Limits
@@ -99,7 +112,7 @@ Internally, MQTT is implemented on top of LavinMQ's AMQP infrastructure:
 | `port` | `[mqtt]` | `1883` | MQTT listen port |
 | `tls_port` | `[mqtt]` | `8883` | MQTT over TLS port |
 | `unix_path` | `[mqtt]` | (empty) | Unix socket path |
-| `max_inflight_messages` | `[mqtt]` | `65535` | Max unacknowledged messages per session, must be at least `1` |
+| `max_inflight_messages` | `[mqtt]` | `65535` | Max outstanding packet IDs per session, must be at least `1`. A QoS 2 delivery holds its ID until PUBCOMP |
 | `max_packet_size` | `[mqtt]` | `268435455` | Max MQTT packet size in bytes |
 | `default_vhost` | `[mqtt]` | `/` | Default vhost for MQTT connections |
 | `permission_check_enabled` | `[mqtt]` | `false` | Enable ACL checks on MQTT publish/subscribe |
@@ -133,7 +146,9 @@ Note that connecting with a client_id already in use takes over that session, so
 ## Limitations
 
 - Only MQTT 3.1.0 and 3.1.1 are supported. MQTT 5 features (session expiry interval, shared subscriptions, topic aliases, message expiry, user properties, response topics) are not available.
-- QoS 2 is downgraded to QoS 1 — the full four-step QoS 2 handshake (PUBREC/PUBREL/PUBCOMP) is not implemented.
+- QoS 2 state is held in memory and is lost on a broker restart, in both directions. A client that re-sends a QoS 2 PUBLISH afterwards has it routed a second time, so that message degrades to at-least-once; a client that re-sends a PUBREL is answered with PUBCOMP and completes normally.
+- A subscriber that answers PUBREC but never PUBCOMP holds its packet ID indefinitely. Enough of them fill the session's in-flight window and delivery to that session stops until the client completes the exchanges or the session is deleted. Nothing times these out, and MQTT 3.1.1 mandates no timeout.
+- Retained messages are delivered at the subscription's QoS, ignoring the QoS they were published with, because the retain store keeps only the topic and the payload. A message retained from a QoS 0 publish runs a full handshake when replayed to a QoS 2 subscriber.
 - Federation and shovels operate at the AMQP layer. There is no MQTT-level bridging between brokers.
 - AMQP and MQTT components cannot be cross-connected. Exchange-to-exchange bindings between the MQTT exchange and AMQP exchanges are not supported, so an AMQP publisher cannot reach MQTT subscribers (or vice versa) within the same broker.
 - MQTT topics are mapped to AMQP routing keys, so AMQP routing key constraints apply (length and encoding).

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -30,7 +30,13 @@ When a client publishes at QoS 2, LavinMQ records the packet ID, routes the mess
 
 When LavinMQ delivers at QoS 2, the packet ID stays outstanding across both round trips. The message itself is released at PUBREC, since the subscriber owns it from that point and it must never be sent again; the ID alone is held until PUBCOMP. `max_inflight_messages` therefore bounds outstanding *packet IDs* rather than outstanding messages, and a QoS 2 subscriber reaches that bound at a lower message rate than a QoS 1 one.
 
-The QoS 2 state on both sides is held in memory and does not survive a broker restart. See [Limitations](#limitations).
+The QoS 2 state on both sides is held in memory. It is not persisted and not replicated, so it survives neither a broker restart nor a failover to another node. Persisting it is planned; see [Limitations](#limitations) for what the gap costs today.
+
+### Acknowledging with the wrong packet type
+
+A QoS 2 delivery is settled by PUBREC [MQTT-4.3.3-2] and a QoS 1 delivery by PUBACK. Acknowledging one with the other, or sending PUBCOMP before PUBREC, is a protocol violation, so the connection is closed [MQTT-4.8.0-1] and the client's Will is published, which [MQTT-3.1.2-8] requires for any close that does not follow a DISCONNECT. A client that cannot complete the QoS 2 handshake should subscribe at QoS 1 rather than QoS 2.
+
+A PUBREC, PUBCOMP or PUBREL for a packet ID the session never issued is treated differently: it is logged and ignored. Neither the outbound in-flight window nor the set of unreleased inbound IDs survives a broker restart, and [MQTT-4.4.0-1] has a resuming client re-send its PUBLISH and PUBREL packets, so such a client legitimately arrives with IDs the broker has no record of. That is a limitation of the broker rather than an error by the client. PUBACK is not covered by this: nothing in the protocol re-sends one, so an unknown ID there closes the connection like any other protocol violation.
 
 ## Sessions
 
@@ -146,8 +152,8 @@ Note that connecting with a client_id already in use takes over that session, so
 ## Limitations
 
 - Only MQTT 3.1.0 and 3.1.1 are supported. MQTT 5 features (session expiry interval, shared subscriptions, topic aliases, message expiry, user properties, response topics) are not available.
-- QoS 2 state is held in memory and is lost on a broker restart, in both directions. A client that re-sends a QoS 2 PUBLISH afterwards has it routed a second time, so that message degrades to at-least-once; a client that re-sends a PUBREL is answered with PUBCOMP and completes normally.
-- A subscriber that answers PUBREC but never PUBCOMP holds its packet ID indefinitely. Enough of them fill the session's in-flight window and delivery to that session stops until the client completes the exchanges or the session is deleted. Nothing times these out, and MQTT 3.1.1 mandates no timeout.
+- QoS 2 state is held in memory, and is neither written to disk nor replicated to followers, so it is lost on a broker restart and on a failover. Persisting it is planned as follow-up work. Outbound state, a delivery awaiting PUBREC or PUBCOMP, survives a reconnect but not a broker restart; a delivery already past PUBREC is gone with it, and since MQTT 3.1.1 §4.4 has a client re-send only PUBLISH and PUBREL, never PUBREC, that subscriber's packet ID stays outstanding for the life of the session. Inbound state, the packet IDs of QoS 2 publishes awaiting PUBREL, survives a reconnect only for a client that has a session, which means one that has subscribed at least once; for a publish-only client it is discarded on every disconnect. Whenever that state is gone, a re-sent PUBLISH is routed a second time and that message degrades to at-least-once. A re-sent PUBREL is always answered with PUBCOMP and completes normally.
+- A subscriber that answers PUBREC and never PUBCOMP holds its packet ID indefinitely. Enough of them fill the session's in-flight window and delivery to that session stops until the client completes the exchanges or the session is deleted. Nothing times these out, and MQTT 3.1.1 mandates no timeout.
 - Retained messages are delivered at the subscription's QoS, ignoring the QoS they were published with, because the retain store keeps only the topic and the payload. A message retained from a QoS 0 publish runs a full handshake when replayed to a QoS 2 subscriber.
 - Federation and shovels operate at the AMQP layer. There is no MQTT-level bridging between brokers.
 - AMQP and MQTT components cannot be cross-connected. Exchange-to-exchange bindings between the MQTT exchange and AMQP exchanges are not supported, so an AMQP publisher cannot reach MQTT subscribers (or vice versa) within the same broker.

--- a/shard.lock
+++ b/shard.lock
@@ -18,7 +18,7 @@ shards:
 
   mqtt-protocol:
     git: https://github.com/84codes/mqtt-protocol.cr.git
-    version: 0.3.1
+    version: 0.3.1+git.commit.935a1bcb341a4794c5f25c3507a3329350e0dc4a
 
   systemd:
     git: https://github.com/84codes/systemd.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -35,6 +35,9 @@ dependencies:
     github: 84codes/lz4.cr
   mqtt-protocol:
     github: 84codes/mqtt-protocol.cr
+    # Pinned to the PUBCOMP reserved-flag fix on fix/pubcomp-reserved-flags.
+    # Replace with a version constraint once that is released.
+    commit: 935a1bcb341a4794c5f25c3507a3329350e0dc4a
 
 development_dependencies:
   ameba:

--- a/spec/mqtt/consts_spec.cr
+++ b/spec/mqtt/consts_spec.cr
@@ -10,13 +10,14 @@ describe LavinMQ::MQTT do
       LavinMQ::MQTT.qos_arguments(1u8).should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
     end
 
-    it "returns the QoS 1 constant for QoS 2, which is granted as QoS 1" do
-      LavinMQ::MQTT.qos_arguments(2u8).should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+    it "returns the QoS 2 constant for QoS 2" do
+      LavinMQ::MQTT.qos_arguments(2u8).should be(LavinMQ::MQTT::QOS2_ARGUMENTS)
     end
 
     it "carries the QoS under the QoS header" do
       LavinMQ::MQTT.qos_arguments(0u8)[LavinMQ::MQTT::QOS_HEADER].should eq 0u8
       LavinMQ::MQTT.qos_arguments(1u8)[LavinMQ::MQTT::QOS_HEADER].should eq 1u8
+      LavinMQ::MQTT.qos_arguments(2u8)[LavinMQ::MQTT::QOS_HEADER].should eq 2u8
     end
   end
 
@@ -24,17 +25,22 @@ describe LavinMQ::MQTT do
     it "reads the QoS back from the arguments of qos_arguments" do
       LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(0u8)).should eq 0u8
       LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(1u8)).should eq 1u8
-      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(2u8)).should eq 1u8
+      LavinMQ::MQTT.qos(LavinMQ::MQTT.qos_arguments(2u8)).should eq 2u8
     end
 
-    it "grants QoS 2 as QoS 1" do
+    it "grants QoS 2 as QoS 2" do
       arguments = LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2u8})
-      LavinMQ::MQTT.qos(arguments).should eq 1u8
+      LavinMQ::MQTT.qos(arguments).should eq 2u8
+    end
+
+    it "caps a value above 2 at QoS 2" do
+      arguments = LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 3})
+      LavinMQ::MQTT.qos(arguments).should eq 2u8
     end
 
     it "accepts any integer type, not just UInt8" do
       LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 1})).should eq 1u8
-      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2i64})).should eq 1u8
+      LavinMQ::MQTT.qos(LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2i64})).should eq 2u8
     end
 
     it "is QoS 0 without arguments" do

--- a/spec/mqtt/exchange_spec.cr
+++ b/spec/mqtt/exchange_spec.cr
@@ -22,7 +22,7 @@ module MqttSpecs
       end
     end
 
-    it "grants a QoS 2 subscription bound from outside the MQTT protocol as QoS 1" do
+    it "grants a QoS 2 subscription bound from outside the MQTT protocol as QoS 2" do
       with_server do |server|
         vhost = server.vhosts["/"]
         exchange = vhost.mqtt_exchange
@@ -35,8 +35,8 @@ module MqttSpecs
           LavinMQ::AMQP::Table.new({LavinMQ::MQTT::QOS_HEADER => 2}))
 
         binding = exchange.bindings_details.first
-        binding.binding_key.qos.should eq 1u8
-        binding.arguments.should eq LavinMQ::MQTT::QOS1_ARGUMENTS
+        binding.binding_key.qos.should eq 2u8
+        binding.arguments.should eq LavinMQ::MQTT::QOS2_ARGUMENTS
 
         # bind and unbind must read the QoS the same way, or the unbind wouldn't
         # match the binding it's meant to remove

--- a/spec/mqtt/integrations/message_qos_spec.cr
+++ b/spec/mqtt/integrations/message_qos_spec.cr
@@ -19,11 +19,12 @@ module MqttSpecs
       end
     end
 
-    it "qos is set according to subscription qos [LavinMQ non-normative]" do
+    it "delivers at the lower of the publish and the subscription qos [MQTT-3.3.5-1]" do
       with_server do |server|
         with_client_io(server) do |io|
           connect(io)
-          # Subscribe with qos=0 means downgrade messages to qos=0
+          # A qos 0 subscription pins every delivery to qos 0, whatever it was
+          # published at.
           topic_filters = mk_topic_filters({"a/b", 0u8})
           subscribe(io, topic_filters: topic_filters)
 
@@ -46,6 +47,30 @@ module MqttSpecs
       end
     end
 
+    it "does not raise a qos 0 publish to the subscription's qos [MQTT-3.3.5-1]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+          with_client_io(server) do |publisher_io|
+            connect(publisher_io, client_id: "publisher")
+            publish(publisher_io, topic: "a/b", qos: 0u8)
+            disconnect(publisher_io)
+          end
+
+          # `read_publish` is what gives this teeth: it asserts the packet id is
+          # absent at qos 0 and present above it, so an upgrade to qos 1 fails
+          # here rather than silently delivering an acknowledgeable message the
+          # publisher never asked to have acknowledged.
+          pub = read_publish(io)
+          pub.qos.should eq 0u8
+
+          disconnect(io)
+        end
+      end
+    end
+
     it "qos1 messages are stored for offline sessions [MQTT-3.1.2-5]" do
       with_server do |server|
         with_client_io(server) do |io|
@@ -59,7 +84,7 @@ module MqttSpecs
           connect(publisher_io, client_id: "publisher")
           100.times do
             # qos doesnt matter here
-            publish(publisher_io, topic: "a/b", qos: 0u8)
+            publish(publisher_io, topic: "a/b", qos: 1u8)
           end
           disconnect(publisher_io)
         end
@@ -87,8 +112,8 @@ module MqttSpecs
 
           with_client_io(server) do |publisher_io|
             connect(publisher_io, client_id: "publisher")
-            publish(publisher_io, topic: "a/b", payload: "1".to_slice, qos: 0u8)
-            publish(publisher_io, topic: "a/b", payload: "2".to_slice, qos: 0u8)
+            publish(publisher_io, topic: "a/b", payload: "1".to_slice, qos: 1u8)
+            publish(publisher_io, topic: "a/b", payload: "2".to_slice, qos: 1u8)
             pingpong(publisher_io)
             disconnect(publisher_io)
           end
@@ -128,7 +153,7 @@ module MqttSpecs
           with_client_io(server) do |publisher_io|
             connect(publisher_io, client_id: "publisher")
             10.times do |i|
-              publish(publisher_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8)
+              publish(publisher_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8)
             end
             pingpong(publisher_io)
             disconnect(publisher_io)
@@ -179,7 +204,7 @@ module MqttSpecs
 
           with_client_io(server) do |publisher_io|
             connect(publisher_io, client_id: "publisher")
-            publish(publisher_io, topic: "a/b", qos: 0u8)
+            publish(publisher_io, topic: "a/b", qos: 1u8)
             disconnect(publisher_io)
           end
 
@@ -213,7 +238,7 @@ module MqttSpecs
               data = Bytes.new(sizeof(UInt16))
               IO::ByteFormat::SystemEndian.encode(i, data)
               # qos doesnt matter here
-              publish(publisher_io, topic: "a/b", payload: data, qos: 0u8)
+              publish(publisher_io, topic: "a/b", payload: data, qos: 1u8)
             end
             disconnect(publisher_io)
           end
@@ -278,7 +303,7 @@ module MqttSpecs
 
             with_client_io(server) do |pub_io|
               connect(pub_io, client_id: "publisher")
-              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8) }
+              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8) }
               disconnect(pub_io)
             end
 
@@ -301,7 +326,7 @@ module MqttSpecs
 
             with_client_io(server) do |pub_io|
               connect(pub_io, client_id: "publisher")
-              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 0u8) }
+              4.times { |i| publish(pub_io, topic: "a/b", payload: "#{i}".to_slice, qos: 1u8) }
               disconnect(pub_io)
             end
 

--- a/spec/mqtt/integrations/qos2_spec.cr
+++ b/spec/mqtt/integrations/qos2_spec.cr
@@ -4,6 +4,39 @@ module MqttSpecs
   extend MqttHelpers
   extend MqttMatchers
 
+  # Subscribes `io` at QoS 2, has a throwaway connection publish one message
+  # through the full receiver-side handshake, and returns the PUBLISH `io` was
+  # delivered - not yet acknowledged, so the session still owes it.
+  #
+  # Module level rather than beside a `describe`: a `def self.` inside a
+  # `describe` block raises "can't declare def dynamically".
+  def self.deliver_qos2(server, io, payload = "1", topic = "a/b")
+    subscribe(io, topic_filters: mk_topic_filters({topic, 2u8}))
+    with_client_io(server) do |pub_io|
+      connect(pub_io, client_id: "publisher")
+      publish(pub_io, topic: topic, payload: payload.to_slice, qos: 2u8, packet_id: 1u16)
+      pubrel(pub_io, 1u16)
+      read_packet(pub_io).should be_a(MQTT::Protocol::PubComp)
+      disconnect(pub_io)
+    end
+    read_publish(io)
+  end
+
+  # Publishes two QoS 2 messages through the full receiver-side handshake from a
+  # throwaway connection, so the client under test is only ever the subscriber.
+  def self.publish_two_qos2(server, topic)
+    with_client_io(server) do |pub_io|
+      connect(pub_io, client_id: "publisher")
+      2.times do |i|
+        id = (i + 1).to_u16
+        publish(pub_io, topic: topic, payload: i.to_s.to_slice, qos: 2u8, packet_id: id)
+        pubrel(pub_io, id)
+        read_packet(pub_io).should be_a(MQTT::Protocol::PubComp)
+      end
+      disconnect(pub_io)
+    end
+  end
+
   describe "qos2 as receiver" do
     it "completes the QoS 2 handshake for an inbound publish [MQTT-4.3.3-1]" do
       with_server do |server|
@@ -148,6 +181,233 @@ module MqttSpecs
           String.new(read_publish(sub_io).payload).should eq "1"
 
           disconnect(sub_io)
+        end
+      end
+    end
+  end
+
+  describe "qos2 as sender" do
+    it "completes the QoS 2 handshake for an outbound publish" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          pub = deliver_qos2(server, io)
+          pub.qos.should eq 2u8
+          id = pub.packet_id.not_nil!
+
+          pubrec(io, id)
+          rel = read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          rel.packet_id.should eq id
+
+          pubcomp(io, id)
+          io.should be_drained
+
+          session = server.vhosts["/"].session("mqtt.subscriber")
+          wait_for { session.@unacked.empty? }
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "deletes the message at PUBREC, not at PUBCOMP" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          pub = deliver_qos2(server, io)
+          id = pub.packet_id.not_nil!
+          session = server.vhosts["/"].session("mqtt.subscriber")
+
+          pubrec(io, id)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+
+          # The message is gone and counted as acknowledged, but the id is still
+          # booked - that is the whole of the second phase.
+          wait_for { session.ack_count == 1 }
+          session.message_count.should eq 0
+          session.unacked_count.should eq 0
+          session.@unacked.size.should eq 1
+
+          pubcomp(io, id)
+          disconnect(io)
+        end
+      end
+    end
+
+    it "holds the packet id against the inflight limit until PUBCOMP" do
+      LavinMQ::Config.instance.max_inflight_messages = 1u16
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 2u8}))
+
+          with_client_io(server) do |pub_io|
+            connect(pub_io, client_id: "publisher")
+            2.times do |i|
+              publish(pub_io, topic: "a/b", payload: i.to_s.to_slice, qos: 2u8,
+                packet_id: (i + 1).to_u16)
+              pubrel(pub_io, (i + 1).to_u16)
+              read_packet(pub_io).should be_a(MQTT::Protocol::PubComp)
+            end
+            disconnect(pub_io)
+          end
+
+          first = read_publish(io)
+          String.new(first.payload).should eq "0"
+          id = first.packet_id.not_nil!
+
+          pubrec(io, id)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          # The window is still full: the id is owed even though the message is
+          # gone, so the second message must not be delivered yet.
+          read_packet(io).should be_nil
+
+          pubcomp(io, id)
+          String.new(read_publish(io).payload).should eq "1"
+
+          disconnect(io)
+        end
+      end
+    ensure
+      LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
+    end
+  end
+
+  describe "qos2 across a reconnect" do
+    it "re-sends PUBREL with the original packet id on a persistent reconnect [MQTT-4.4.0-1]" do
+      with_server do |server|
+        owed = 0u16
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          pub = deliver_qos2(server, io)
+          owed = pub.packet_id.not_nil!
+          pubrec(io, owed)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          # Gone without a PUBCOMP, so the exchange is still open.
+          disconnect(io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          rel = read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          rel.packet_id.should eq owed
+          # The message went at PUBREC, so a PUBLISH must not follow.
+          read_packet(io).should be_nil
+
+          pubcomp(io, owed)
+          disconnect(io)
+        end
+      end
+    end
+
+    it "keeps owing a PUBREL while the session is offline" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          pub = deliver_qos2(server, io)
+          pubrec(io, pub.packet_id.not_nil!)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          disconnect(io)
+        end
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+
+        # Still booked against the window, but holding no message: the message
+        # was deleted at PUBREC and only the id is owed.
+        session.@unacked.size.should eq 1
+        session.@unacked.values.first.sp.should be_nil
+        session.unacked_count.should eq 0
+        session.message_count.should eq 0
+      end
+    end
+
+    it "owes no PUBREL to a clean session [MQTT-3.1.2-6]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "cleaner", clean_session: true)
+          pub = deliver_qos2(server, io)
+          pubrec(io, pub.packet_id.not_nil!)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          disconnect(io)
+        end
+
+        wait_for { !server.vhosts["/"].session_exists?("mqtt.cleaner") }
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "cleaner", clean_session: true)
+          io.should be_drained
+          disconnect(io)
+        end
+      end
+    end
+
+    it "re-sends the PUBREL before the replayed publishes" do
+      # Weakly toothed on purpose, and kept as documentation of the intended
+      # order: the misordering it guards against (opening the capacity gate
+      # before the PUBRELs go out) only shows when `client.send` yields on a
+      # full socket buffer, which a spec cannot force.
+      with_server do |server|
+        owed = 0u16
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 2u8}))
+          publish_two_qos2(server, "a/b")
+
+          first = read_publish(io)
+          owed = first.packet_id.not_nil!
+          read_publish(io) # the second, left unacknowledged entirely
+          pubrec(io, owed)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          disconnect(io)
+        end
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          rel = read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          rel.packet_id.should eq owed
+          resent = read_publish(io)
+          String.new(resent.payload).should eq "1"
+          resent.dup?.should be_true
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "does not redeliver under a packet id awaiting PUBCOMP" do
+      with_server do |server|
+        owed = 0u16
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 2u8}))
+          publish_two_qos2(server, "a/b")
+
+          first = read_publish(io)
+          owed = first.packet_id.not_nil!
+          read_publish(io)
+          pubrec(io, owed)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          disconnect(io)
+        end
+
+        session = server.vhosts["/"].session("mqtt.resumer")
+        wait_for { session.client.nil? }
+
+        # Point the requeued second message at the id the PUBREL still owes, the
+        # way `next_id` could once its counter wraps. Reissuing it would put one
+        # id on both a PUBREL and a PUBLISH.
+        sp = session.@msg_store.@packet_ids.keys.first
+        session.@msg_store.@packet_ids[sp] = owed
+
+        with_client_io(server) do |io|
+          connect(io, client_id: "resumer", clean_session: false)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          resent = read_publish(io)
+          String.new(resent.payload).should eq "1"
+          resent.packet_id.should_not eq owed
+
+          disconnect(io)
         end
       end
     end

--- a/spec/mqtt/integrations/qos2_spec.cr
+++ b/spec/mqtt/integrations/qos2_spec.cr
@@ -271,6 +271,51 @@ module MqttSpecs
     ensure
       LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
     end
+
+    it "encodes PUBCOMP with the reserved flags at 0 [MQTT-3.7.1]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "publisher")
+          publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
+          pubrel(io, 7u16)
+
+          # Read the PUBCOMP as bytes rather than a packet: only PUBREL,
+          # SUBSCRIBE and UNSUBSCRIBE carry 0b0010 in the low nibble, and a
+          # client seeing reserved bits set must drop the connection
+          # [MQTT-2.2.2-2].
+          io.read_byte.should eq 0x70u8
+          io.read_byte.should eq 2u8
+          io.read_int.should eq 7u16
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "accepts a conformant PUBCOMP" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          pub = deliver_qos2(server, io)
+          id = pub.packet_id.not_nil!
+
+          pubrec(io, id)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+
+          # Hand-built rather than via `pubcomp`, so this asserts on the bytes a
+          # real client sends rather than on whatever the shard happens to
+          # encode. A broker that rejects 0x70 answers a protocol error here,
+          # which publishes the will and closes the socket.
+          io.write_bytes_raw(Bytes[0x70u8, 0x02u8, (id >> 8).to_u8, (id & 0xff).to_u8])
+          io.should be_drained
+
+          session = server.vhosts["/"].session("mqtt.subscriber")
+          wait_for { session.@unacked.empty? }
+
+          disconnect(io)
+        end
+      end
+    end
   end
 
   describe "qos2 across a reconnect" do

--- a/spec/mqtt/integrations/qos2_spec.cr
+++ b/spec/mqtt/integrations/qos2_spec.cr
@@ -4,12 +4,9 @@ module MqttSpecs
   extend MqttHelpers
   extend MqttMatchers
 
-  # Subscribes `io` at QoS 2, has a throwaway connection publish one message
-  # through the full receiver-side handshake, and returns the PUBLISH `io` was
-  # delivered - not yet acknowledged, so the session still owes it.
-  #
-  # Module level rather than beside a `describe`: a `def self.` inside a
-  # `describe` block raises "can't declare def dynamically".
+  # Returns the PUBLISH `io` was delivered, unacknowledged, so the session still
+  # owes it. Module level because a `def self.` inside a `describe` raises
+  # "can't declare def dynamically".
   def self.deliver_qos2(server, io, payload = "1", topic = "a/b")
     subscribe(io, topic_filters: mk_topic_filters({topic, 2u8}))
     with_client_io(server) do |pub_io|
@@ -70,8 +67,7 @@ module MqttSpecs
 
           with_client_io(server) do |io|
             connect(io, client_id: "publisher")
-            # The same packet id twice, never released by a PUBREL. Both are
-            # answered with PUBREC, only the first is delivered onward.
+            # Same id twice, never released: both get a PUBREC, one is routed.
             publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
             publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16, dup: true)
             disconnect(io)
@@ -124,14 +120,44 @@ module MqttSpecs
       end
     end
 
+    it "lets a publisher pipeline more QoS 2 publishes than the outbound window" do
+      # `max_inflight_messages` is the server's outbound window and says nothing
+      # about how many ids a publisher may hold.
+      LavinMQ::Config.instance.max_inflight_messages = 1u16
+      with_server do |server|
+        with_client_io(server) do |sub_io|
+          connect(sub_io, client_id: "subscriber")
+          subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher")
+            # Three unreleased ids at once, three times the window.
+            3.times do |i|
+              publish(io, topic: "a/b", payload: i.to_s.to_slice, qos: 2u8,
+                packet_id: (i + 1).to_u16, expect_response: false)
+            end
+            3.times { read_packet(io).should be_a(MQTT::Protocol::PubRec) }
+            3.times { |i| pubrel(io, (i + 1).to_u16) }
+            3.times { read_packet(io).should be_a(MQTT::Protocol::PubComp) }
+            disconnect(io)
+          end
+
+          3.times { |i| String.new(read_publish(sub_io).payload).should eq i.to_s }
+
+          disconnect(sub_io)
+        end
+      end
+    ensure
+      LavinMQ::Config.instance.max_inflight_messages = UInt16::MAX
+    end
+
     it "keeps inbound QoS 2 state across a persistent reconnect [MQTT-4.4.0-1]" do
       with_server do |server|
         with_client_io(server) do |sub_io|
           connect(sub_io, client_id: "subscriber")
           subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
 
-          # A persistent session that subscribes, so it survives the disconnect
-          # below and can still be resumed.
+          # Subscribes, so the session survives the disconnect below.
           with_client_io(server) do |io|
             connect(io, client_id: "publisher", clean_session: false)
             subscribe(io, topic_filters: mk_topic_filters({"unused", 0u8}))
@@ -167,8 +193,8 @@ module MqttSpecs
             publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
           end
 
-          # A clean CONNECT discards the held id, so the re-send is a new message
-          # and is delivered a second time. The mirror of the spec above.
+          # A clean CONNECT discards the held id, so the re-send is routed
+          # again. The mirror of the spec above.
           with_client_io(server) do |io|
             connect(io, client_id: "publisher", clean_session: true)
             publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16, dup: true)
@@ -279,10 +305,9 @@ module MqttSpecs
           publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
           pubrel(io, 7u16)
 
-          # Read the PUBCOMP as bytes rather than a packet: only PUBREL,
-          # SUBSCRIBE and UNSUBSCRIBE carry 0b0010 in the low nibble, and a
-          # client seeing reserved bits set must drop the connection
-          # [MQTT-2.2.2-2].
+          # Read as bytes, not as a packet: only PUBREL, SUBSCRIBE and
+          # UNSUBSCRIBE carry 0b0010. [MQTT-2.2.2-2] requires a receiver to
+          # close on bad reserved bits, though mosquitto does not enforce it.
           io.read_byte.should eq 0x70u8
           io.read_byte.should eq 2u8
           io.read_int.should eq 7u16
@@ -302,15 +327,102 @@ module MqttSpecs
           pubrec(io, id)
           read_packet(io).should be_a(MQTT::Protocol::PubRel)
 
-          # Hand-built rather than via `pubcomp`, so this asserts on the bytes a
-          # real client sends rather than on whatever the shard happens to
-          # encode. A broker that rejects 0x70 answers a protocol error here,
-          # which publishes the will and closes the socket.
+          # Hand-built, not via `pubcomp`: this must assert on the bytes a real
+          # client sends, not on whatever the shard encodes.
           io.write_bytes_raw(Bytes[0x70u8, 0x02u8, (id >> 8).to_u8, (id & 0xff).to_u8])
           io.should be_drained
 
           session = server.vhosts["/"].session("mqtt.subscriber")
           wait_for { session.@unacked.empty? }
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "closes a subscriber that acknowledges a QoS 2 delivery with PUBACK [MQTT-4.8.0-1]" do
+      # A QoS 2 delivery is settled by PUBREC [MQTT-4.3.3-2], so a PUBACK for one
+      # is a protocol violation, and a violation must close the connection.
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          pub = deliver_qos2(server, io)
+
+          puback(io, pub.packet_id.not_nil!)
+          io.should be_closed
+        end
+      end
+    end
+
+    it "publishes the will when it closes on a mismatched acknowledgement [MQTT-3.1.2-8]" do
+      # 3.1.2.5 lists "the Server closes the Network Connection because of a
+      # protocol error" among the situations in which the Will is published, so
+      # closing here is not a reason to withhold it.
+      with_server do |server|
+        with_client_io(server) do |watcher|
+          connect(watcher, client_id: "will-watcher")
+          subscribe(watcher, topic_filters: mk_topic_filters({"w/t", 0u8}))
+
+          with_client_io(server) do |io|
+            will = MQTT::Protocol::Will.new(
+              topic: "w/t", payload: "dead".to_slice, qos: 0u8, retain: false)
+            connect(io, client_id: "subscriber", will: will)
+            pub = deliver_qos2(server, io)
+            puback(io, pub.packet_id.not_nil!)
+            io.should be_closed
+          end
+
+          read_publish(watcher).payload.should eq "dead".to_slice
+
+          disconnect(watcher)
+        end
+      end
+    end
+
+    it "closes a subscriber that answers a QoS 1 delivery with PUBREC [MQTT-4.8.0-1]" do
+      # The mirror of the PUBACK case: a QoS 1 delivery is settled by PUBACK.
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1u8}))
+
+          with_client_io(server) do |pub_io|
+            connect(pub_io, client_id: "publisher")
+            publish(pub_io, topic: "a/b", payload: "1".to_slice, qos: 1u8, packet_id: 1u16)
+            disconnect(pub_io)
+          end
+
+          pubrec(io, read_publish(io).packet_id.not_nil!)
+          io.should be_closed
+        end
+      end
+    end
+
+    it "closes a subscriber that sends PUBCOMP before PUBREC [MQTT-4.8.0-1]" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          pub = deliver_qos2(server, io)
+
+          # The id is booked, but still owes a PUBREC first.
+          pubcomp(io, pub.packet_id.not_nil!)
+          io.should be_closed
+        end
+      end
+    end
+
+    it "does not close on an acknowledgement for an id it never issued" do
+      # The window does not survive a broker restart, so a resuming client
+      # legitimately arrives with ids we have never seen. Unlike the wrong-type
+      # case above, that is our limitation rather than the client's error.
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "subscriber")
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 2u8}))
+
+          pubrec(io, 4242u16)
+          pubcomp(io, 4243u16)
+          io.should be_drained
 
           disconnect(io)
         end

--- a/spec/mqtt/integrations/qos2_spec.cr
+++ b/spec/mqtt/integrations/qos2_spec.cr
@@ -1,0 +1,155 @@
+require "../spec_helper.cr"
+
+module MqttSpecs
+  extend MqttHelpers
+  extend MqttMatchers
+
+  describe "qos2 as receiver" do
+    it "completes the QoS 2 handshake for an inbound publish [MQTT-4.3.3-1]" do
+      with_server do |server|
+        with_client_io(server) do |sub_io|
+          connect(sub_io, client_id: "subscriber")
+          subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher")
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
+            pubrel(io, 7u16)
+            read_packet(io).should be_a(MQTT::Protocol::PubComp)
+            disconnect(io)
+          end
+
+          pub = read_publish(sub_io)
+          String.new(pub.payload).should eq "1"
+          read_packet(sub_io).should be_nil
+
+          disconnect(sub_io)
+        end
+      end
+    end
+
+    it "delivers a re-sent QoS 2 publish only once [MQTT-4.3.3-1]" do
+      with_server do |server|
+        with_client_io(server) do |sub_io|
+          connect(sub_io, client_id: "subscriber")
+          # QoS 0 subscription, so the outbound handshake plays no part here.
+          subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher")
+            # The same packet id twice, never released by a PUBREL. Both are
+            # answered with PUBREC, only the first is delivered onward.
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16, dup: true)
+            disconnect(io)
+          end
+
+          String.new(read_publish(sub_io).payload).should eq "1"
+          read_packet(sub_io).should be_nil
+
+          disconnect(sub_io)
+        end
+      end
+    end
+
+    it "treats a repeat of a released packet id as a new message" do
+      with_server do |server|
+        with_client_io(server) do |sub_io|
+          connect(sub_io, client_id: "subscriber")
+          subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher")
+            publish_qos2(io, 7u16, topic: "a/b", payload: "1".to_slice)
+            # The PUBREL above released id 7, so it is free to name a second
+            # message rather than being deduped against the first.
+            publish_qos2(io, 7u16, topic: "a/b", payload: "2".to_slice)
+            disconnect(io)
+          end
+
+          String.new(read_publish(sub_io).payload).should eq "1"
+          String.new(read_publish(sub_io).payload).should eq "2"
+
+          disconnect(sub_io)
+        end
+      end
+    end
+
+    it "answers PUBCOMP to a PUBREL for an unknown packet id" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io, client_id: "publisher")
+
+          pubrel(io, 99u16)
+          read_packet(io).should be_a(MQTT::Protocol::PubComp)
+          # Still usable: an unknown id must not be treated as a protocol error,
+          # since nothing about the held ids survives a broker restart.
+          io.should be_drained
+
+          disconnect(io)
+        end
+      end
+    end
+
+    it "keeps inbound QoS 2 state across a persistent reconnect [MQTT-4.4.0-1]" do
+      with_server do |server|
+        with_client_io(server) do |sub_io|
+          connect(sub_io, client_id: "subscriber")
+          subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+
+          # A persistent session that subscribes, so it survives the disconnect
+          # below and can still be resumed.
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher", clean_session: false)
+            subscribe(io, topic_filters: mk_topic_filters({"unused", 0u8}))
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
+            # Gone without releasing the id.
+          end
+
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher", clean_session: false)
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16, dup: true)
+            pubrel(io, 7u16)
+            read_packet(io).should be_a(MQTT::Protocol::PubComp)
+            disconnect(io)
+          end
+
+          String.new(read_publish(sub_io).payload).should eq "1"
+          read_packet(sub_io).should be_nil
+
+          disconnect(sub_io)
+        end
+      end
+    end
+
+    it "drops inbound QoS 2 state on a clean session [MQTT-3.1.2-6]" do
+      with_server do |server|
+        with_client_io(server) do |sub_io|
+          connect(sub_io, client_id: "subscriber")
+          subscribe(sub_io, topic_filters: mk_topic_filters({"a/b", 0u8}))
+
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher", clean_session: false)
+            subscribe(io, topic_filters: mk_topic_filters({"unused", 0u8}))
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16)
+          end
+
+          # A clean CONNECT discards the held id, so the re-send is a new message
+          # and is delivered a second time. The mirror of the spec above.
+          with_client_io(server) do |io|
+            connect(io, client_id: "publisher", clean_session: true)
+            publish(io, topic: "a/b", payload: "1".to_slice, qos: 2u8, packet_id: 7u16, dup: true)
+            pubrel(io, 7u16)
+            read_packet(io).should be_a(MQTT::Protocol::PubComp)
+            disconnect(io)
+          end
+
+          String.new(read_publish(sub_io).payload).should eq "1"
+          String.new(read_publish(sub_io).payload).should eq "1"
+
+          disconnect(sub_io)
+        end
+      end
+    end
+  end
+end

--- a/spec/mqtt/integrations/session_resume_spec.cr
+++ b/spec/mqtt/integrations/session_resume_spec.cr
@@ -347,8 +347,10 @@ module MqttSpecs
           resent = read_publishes(io, 2)
           resent.map { |p| String.new(p.payload) }.should eq ["0", "1"]
           resent.first.packet_id.should eq first_id
-          # Both still booked, under different ids. `wait_for` because
-          # `@unacked[id] = sp` is written after the yielding send.
+          # Both still booked, under different ids. The booking now precedes the
+          # yielding send, so this holds by the time the client has the packets;
+          # `wait_for` is kept because it costs nothing and does not depend on
+          # that ordering.
           resent.last.packet_id.should_not eq first_id
           wait_for { session.@unacked.size == 2 }
 

--- a/spec/mqtt/integrations/session_stats_spec.cr
+++ b/spec/mqtt/integrations/session_stats_spec.cr
@@ -61,7 +61,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 
@@ -87,7 +87,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 
@@ -115,7 +115,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 
@@ -138,7 +138,7 @@ module MqttSpecs
 
           with_client_io(server) do |pub_io|
             connect(pub_io, client_id: "publisher")
-            publish(pub_io, topic: "a/b", qos: 0u8)
+            publish(pub_io, topic: "a/b", qos: 1u8)
             disconnect(pub_io)
           end
 

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -132,35 +132,45 @@ module MqttSpecs
       end
     end
 
-    it "grants qos1 for a qos2 subscription [LavinMQ non-normative]" do
+    it "grants qos2 for a qos2 subscription [MQTT-3.9.3-1]" do
       with_server do |server|
         with_client_io(server) do |io|
           connect(io)
 
-          # LavinMQ doesn't support qos2, so a qos2 subscription is downgraded to
-          # qos1. The SubAck return code must show the granted maximum qos, not the
-          # requested one [MQTT-3.9.3-1].
+          # The SubAck return code must show the granted maximum qos.
           topic_filters = mk_topic_filters({"a/b", 2})
           suback = subscribe(io, topic_filters: topic_filters)
           suback.should be_a(MQTT::Protocol::SubAck)
           suback = suback.as(MQTT::Protocol::SubAck)
-          suback.return_codes.should eq([MQTT::Protocol::SubAck::ReturnCode::QoS1])
+          suback.return_codes.should eq([MQTT::Protocol::SubAck::ReturnCode::QoS2])
 
-          # Publish something to the topic we're subscribed to...
-          publish(io, topic: "a/b", payload: "a".to_slice, qos: 1u8)
-          # ... consume it...
-          packet = read_packet(io).as(MQTT::Protocol::Publish)
-          # ... and verify it be qos1, i.e. the downgrade is real and not just
-          # reported in the SubAck
-          packet.qos.should eq(1u8)
-          packet.packet_id.should_not be_nil
+          # Published at qos 2 from a second connection, so that the grant is
+          # what decides the delivery qos rather than the publish capping it
+          # [MQTT-3.3.5-1], and so the publisher's PUBREC does not interleave
+          # with the delivery on this socket.
+          with_client_io(server) do |pub_io|
+            connect(pub_io, client_id: "publisher")
+            publish(pub_io, topic: "a/b", payload: "a".to_slice, qos: 2u8, packet_id: 1u16)
+            pubrel(pub_io, 1u16)
+            read_packet(pub_io).should be_a(MQTT::Protocol::PubComp)
+            disconnect(pub_io)
+          end
+
+          # The grant is real and not just reported in the SubAck.
+          packet = read_publish(io)
+          packet.qos.should eq(2u8)
+          id = packet.packet_id.not_nil!
+
+          pubrec(io, id)
+          read_packet(io).should be_a(MQTT::Protocol::PubRel)
+          pubcomp(io, id)
 
           io.should be_drained
         end
       end
     end
 
-    it "binds a qos2 subscription as qos1" do
+    it "binds a qos2 subscription as qos2" do
       with_server do |server|
         exchange = server.vhosts["/"].exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
         with_client_io(server) do |io|
@@ -168,12 +178,12 @@ module MqttSpecs
           subscribe(io, topic_filters: mk_topic_filters({"a/b", 2}))
 
           binding = exchange.bindings_details.first
-          binding.binding_key.qos.should eq 1u8
-          binding.arguments.should eq LavinMQ::MQTT::QOS1_ARGUMENTS
+          binding.binding_key.qos.should eq 2u8
+          binding.arguments.should eq LavinMQ::MQTT::QOS2_ARGUMENTS
 
           # A follow up subscribe with the qos we granted is the same
           # subscription, so it must not add a second binding
-          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1}))
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 2}))
           exchange.bindings_details.size.should eq 1
           exchange.binding_count.should eq 1
 

--- a/spec/mqtt/integrations/subscribe_spec.cr
+++ b/spec/mqtt/integrations/subscribe_spec.cr
@@ -170,6 +170,31 @@ module MqttSpecs
       end
     end
 
+    it "rebinds when a resubscribe changes the granted qos" do
+      with_server do |server|
+        exchange = server.vhosts["/"].exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1}))
+          exchange.bindings_details.first.binding_key.qos.should eq 1u8
+
+          # The unbind-and-rebind path. Unreachable for 1 -> 2 until QoS 2
+          # stopped collapsing onto QOS1_ARGUMENTS, which made the arguments
+          # compare equal and take the early return instead.
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 2}))
+          exchange.bindings_details.size.should eq 1
+          exchange.bindings_details.first.binding_key.qos.should eq 2u8
+
+          # And back down again.
+          subscribe(io, topic_filters: mk_topic_filters({"a/b", 1}))
+          exchange.bindings_details.size.should eq 1
+          exchange.bindings_details.first.binding_key.qos.should eq 1u8
+
+          disconnect(io)
+        end
+      end
+    end
+
     it "binds a qos2 subscription as qos2" do
       with_server do |server|
         exchange = server.vhosts["/"].exchange(LavinMQ::MQTT::EXCHANGE).as(LavinMQ::MQTT::Exchange)

--- a/spec/mqtt/integrations/unsubscribe_spec.cr
+++ b/spec/mqtt/integrations/unsubscribe_spec.cr
@@ -55,7 +55,7 @@ module MqttSpecs
           end
 
           # Publish messages that will be stored for the subscriber
-          2.times { |i| publish(pubio, topic: "a/b", payload: i.to_s.to_slice, qos: 0u8) }
+          2.times { |i| publish(pubio, topic: "a/b", payload: i.to_s.to_slice, qos: 1u8) }
 
           # Let the subscriber connect and read the messages, but don't ack. Then unsubscribe.
           # We must read the Publish packets before unsubscribe, else the "suback" will be stuck.
@@ -72,7 +72,7 @@ module MqttSpecs
           end
 
           # Publish more messages
-          2.times { |i| publish(pubio, topic: "a/b", payload: (2 + i).to_s.to_slice, qos: 0u8) }
+          2.times { |i| publish(pubio, topic: "a/b", payload: (2 + i).to_s.to_slice, qos: 1u8) }
 
           # Now, if unsubscribed worked, the last two publish packets shouldn't be held for the
           # session. Read the two we expect, then test that there is nothing more to read.

--- a/spec/mqtt/integrations/various_spec.cr
+++ b/spec/mqtt/integrations/various_spec.cr
@@ -15,7 +15,7 @@ module MqttSpecs
 
         with_client_io(server) do |io|
           connect(io, clean_session: false, client_id: "pub")
-          publish(io, topic: "a/b/c", qos: 0u8)
+          publish(io, topic: "a/b/c", qos: 1u8)
         end
 
         with_client_io(server) do |io|

--- a/spec/mqtt/integrations/will_spec.cr
+++ b/spec/mqtt/integrations/will_spec.cr
@@ -31,6 +31,34 @@ module MqttSpecs
       end
     end
 
+    it "is not delivered when a PUBREL arrives for an unknown packet id" do
+      with_server do |server|
+        with_client_io(server) do |io|
+          connect(io)
+          subscribe(io, topic_filters: mk_topic_filters({"will/t", 0}))
+
+          with_client_io(server) do |io2|
+            will = MQTT::Protocol::Will.new(
+              topic: "will/t", payload: "dead".to_slice, qos: 0u8, retain: false)
+            connect(io2, client_id: "will_client", will: will, keepalive: 30u16)
+
+            # A PUBREL naming an id the broker is not holding is ordinary: the
+            # held ids do not survive a restart, so every resuming QoS 2
+            # publisher sends one. If it raised, read_loop would treat it as a
+            # lost connection and publish this client's will [MQTT-3.1.2-8].
+            pubrel(io2, 99u16)
+            read_packet(io2).should be_a(MQTT::Protocol::PubComp)
+            pingpong(io2)
+            disconnect(io2)
+          end
+
+          read_packet(io).should be_nil
+
+          disconnect(io)
+        end
+      end
+    end
+
     describe "is delivered on ungraceful disconnect" do
       it "when client unexpected closes tcp connection" do
         with_server do |server|

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -181,6 +181,8 @@ module MqttHelpers
     pub = read_packet(io).should be_a(MQTT::Protocol::Publish)
     if pub.qos.positive?
       pub.packet_id.should_not be_nil
+      # [MQTT-2.3.1-1]. Free teeth for every delivery spec in the suite.
+      pub.packet_id.should_not eq 0u16
     else
       pub.packet_id.should be_nil
     end

--- a/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
+++ b/spec/mqtt/spec_helper/mqtt_helpers_spec.cr
@@ -115,12 +115,40 @@ module MqttHelpers
   def publish(io, expect_response = true, **args)
     packet = publish_packet(**args)
     packet.to_io(io)
-    MQTT::Protocol::PubAck.from_io(io) if packet.qos.positive? && expect_response
+    return unless expect_response
+    # QoS 2 is answered with PUBREC, not PUBACK, so decoding blindly as a
+    # PubAck would fail on the flags rather than on the assertion.
+    case packet.qos
+    when 1u8 then read_packet(io).should be_a(MQTT::Protocol::PubAck)
+    when 2u8 then read_packet(io).should be_a(MQTT::Protocol::PubRec)
+    end
   end
 
   def puback(io, packet_id : UInt16?)
     return if packet_id.nil?
     MQTT::Protocol::PubAck.new(packet_id).to_io(io)
+  end
+
+  def pubrec(io, packet_id : UInt16)
+    MQTT::Protocol::PubRec.new(packet_id).to_io(io)
+  end
+
+  def pubrel(io, packet_id : UInt16)
+    MQTT::Protocol::PubRel.new(packet_id).to_io(io)
+  end
+
+  def pubcomp(io, packet_id : UInt16)
+    MQTT::Protocol::PubComp.new(packet_id).to_io(io)
+  end
+
+  # The receiver half of the QoS 2 flow: PUBLISH, PUBREC, PUBREL, PUBCOMP.
+  #
+  # Takes an explicit `packet_id` rather than using `next_packet_id`, because
+  # `GENERATOR` starts at 0 and packet id 0 is illegal [MQTT-2.3.1-5].
+  def publish_qos2(io, packet_id : UInt16, **args)
+    publish(io, **{packet_id: packet_id, qos: 2u8}.merge(args))
+    pubrel(io, packet_id)
+    read_packet(io).should be_a(MQTT::Protocol::PubComp)
   end
 
   def ping(io)

--- a/spec/mqtt/subscription_key_spec.cr
+++ b/spec/mqtt/subscription_key_spec.cr
@@ -12,9 +12,9 @@ describe LavinMQ::MQTT::SubscriptionKey do
         .should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
     end
 
-    it "returns the QoS 1 constant for QoS 2" do
+    it "returns the QoS 2 constant for QoS 2" do
       LavinMQ::MQTT::SubscriptionKey.new("a/b", 2u8).arguments
-        .should be(LavinMQ::MQTT::QOS1_ARGUMENTS)
+        .should be(LavinMQ::MQTT::QOS2_ARGUMENTS)
     end
   end
 

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -30,6 +30,47 @@ module LavinMQ
         @exchange = @vhost.mqtt_exchange
       end
 
+      # Packet ids of QoS 2 PUBLISHes answered with PUBREC and not yet released
+      # by a PUBREL, per client_id. Holding the id is the whole of the
+      # exactly-once guarantee on this side: a re-sent PUBLISH carrying one is
+      # answered with another PUBREC and not delivered onward a second time
+      # [MQTT-4.3.3-1].
+      #
+      # Here rather than on `Session`, because a publish-only client never gets
+      # one - `Sessions#declare` is only reached from `#subscribe`. And not on
+      # `Client`, because a reconnect would forget it, which is the exact
+      # duplicate QoS 2 exists to prevent. In memory only, like the outbound
+      # packet ids in `SessionMessageStore`.
+      @qos2_received = Hash(String, Set(UInt16)).new
+
+      # Records `packet_id` as an incomplete QoS 2 delivery. False if it was
+      # already recorded, i.e. this PUBLISH is a re-send of one already
+      # delivered onward.
+      def qos2_publish_received?(client_id : String, packet_id : UInt16) : Bool
+        ids = @qos2_received[client_id] ||= Set(UInt16).new
+        # A conformant client cannot hold more unreleased ids than its own
+        # in-flight window, so past the server's window this is a client
+        # holding ids open to make us allocate. PacketDecode lands in
+        # `read_loop`'s decode-error arm and closes the connection.
+        if ids.size >= Config.instance.max_inflight_messages && !ids.includes?(packet_id)
+          Log.warn { "client_id=#{client_id} holds #{ids.size} unreleased QoS 2 packet ids" }
+          raise Protocol::Error::PacketDecode.new("too many unreleased QoS 2 packet ids")
+        end
+        ids.add?(packet_id)
+      end
+
+      # Releases `packet_id` on PUBREL. False if we were not holding it.
+      def qos2_release(client_id : String, packet_id : UInt16) : Bool
+        ids = @qos2_received[client_id]? || return false
+        released = ids.delete(packet_id)
+        @qos2_received.delete(client_id) if ids.empty?
+        released
+      end
+
+      private def forget_qos2(client_id : String) : Nil
+        @qos2_received.delete(client_id)
+      end
+
       def session_present?(client_id : String, clean_session) : Bool
         return false if clean_session
         session = sessions[client_id]? || return false
@@ -62,6 +103,9 @@ module LavinMQ
           packet.will)
         if client.clean_session?
           sessions[client.client_id]?.try &.delete
+          # A clean session starts with no state of any kind [MQTT-3.1.2-6],
+          # including the ids of QoS 2 publishes its predecessor never released.
+          forget_qos2(client.client_id)
         else
           # If an existing session exists, reuse it. If no session exists
           # it will be created on first subscribe
@@ -87,8 +131,21 @@ module LavinMQ
         if session = sessions[client_id]?
           if session.client.nil? || (session.client == client)
             session.client = nil
-            session.delete if session.clean_session?
+            if session.clean_session?
+              session.delete
+              forget_qos2(client_id)
+            end
           end
+        else
+          # No session to resume into, so there is nothing for the dedupe to
+          # protect: the next CONNECT for this client_id is answered
+          # session_present=false, which entitles the client to reset its own
+          # half. This is also what bounds the map - without it, a client can
+          # connect non-clean, publish one QoS 2 message, vanish, and repeat
+          # with a fresh client_id forever. Live entries are now bounded by
+          # connected clients plus persistent sessions, and those are bounded
+          # by max-queues.
+          forget_qos2(client_id)
         end
         @clients.delete(client_id) if @clients[client_id]? == client
         @vhost.rm_connection(client)

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -30,32 +30,22 @@ module LavinMQ
         @exchange = @vhost.mqtt_exchange
       end
 
-      # Packet ids of QoS 2 PUBLISHes answered with PUBREC and not yet released
-      # by a PUBREL, per client_id. Holding the id is the whole of the
-      # exactly-once guarantee on this side: a re-sent PUBLISH carrying one is
-      # answered with another PUBREC and not delivered onward a second time
+      # Packet ids of QoS 2 PUBLISHes answered with PUBREC and not yet released,
+      # per client_id. Holding the id is the whole of the guarantee: a re-sent
+      # PUBLISH carrying one is answered again and not routed twice
       # [MQTT-4.3.3-1].
       #
-      # Here rather than on `Session`, because a publish-only client never gets
-      # one - `Sessions#declare` is only reached from `#subscribe`. And not on
-      # `Client`, because a reconnect would forget it, which is the exact
-      # duplicate QoS 2 exists to prevent. In memory only, like the outbound
-      # packet ids in `SessionMessageStore`.
+      # Not on `Session`, which a publish-only client never gets, and not on
+      # `Client`, which would forget it on the reconnect it exists to survive.
       @qos2_received = Hash(String, Set(UInt16)).new
 
-      # Records `packet_id` as an incomplete QoS 2 delivery. False if it was
-      # already recorded, i.e. this PUBLISH is a re-send of one already
-      # delivered onward.
+      # Records `packet_id`, returning false if it was already held, i.e. this
+      # PUBLISH is a re-send of one already routed.
+      #
+      # Uncapped on purpose: ids are `UInt16` so one client holds at most 65535,
+      # and rejecting past a cap would have to raise, which publishes the will.
       def qos2_publish_received?(client_id : String, packet_id : UInt16) : Bool
         ids = @qos2_received[client_id] ||= Set(UInt16).new
-        # A conformant client cannot hold more unreleased ids than its own
-        # in-flight window, so past the server's window this is a client
-        # holding ids open to make us allocate. PacketDecode lands in
-        # `read_loop`'s decode-error arm and closes the connection.
-        if ids.size >= Config.instance.max_inflight_messages && !ids.includes?(packet_id)
-          Log.warn { "client_id=#{client_id} holds #{ids.size} unreleased QoS 2 packet ids" }
-          raise Protocol::Error::PacketDecode.new("too many unreleased QoS 2 packet ids")
-        end
         ids.add?(packet_id)
       end
 
@@ -103,8 +93,7 @@ module LavinMQ
           packet.will)
         if client.clean_session?
           sessions[client.client_id]?.try &.delete
-          # A clean session starts with no state of any kind [MQTT-3.1.2-6],
-          # including the ids of QoS 2 publishes its predecessor never released.
+          # A clean session starts with no state at all [MQTT-3.1.2-6].
           forget_qos2(client.client_id)
         else
           # If an existing session exists, reuse it. If no session exists
@@ -137,15 +126,14 @@ module LavinMQ
             end
           end
         else
-          # No session to resume into, so there is nothing for the dedupe to
-          # protect: the next CONNECT for this client_id is answered
-          # session_present=false, which entitles the client to reset its own
-          # half. This is also what bounds the map - without it, a client can
-          # connect non-clean, publish one QoS 2 message, vanish, and repeat
-          # with a fresh client_id forever. Live entries are now bounded by
-          # connected clients plus persistent sessions, and those are bounded
-          # by max-queues.
-          forget_qos2(client_id)
+          # Nothing to resume into, and the next CONNECT is answered
+          # session_present=false. A client with a session keeps its ids
+          # instead, because they have to outlive the connection to dedupe a
+          # re-send; those entries are bounded by the session count, and
+          # `qos2_release` drops the set as soon as it empties. Guarded like
+          # the line below: a displaced connection's ensure runs after its
+          # replacement is installed.
+          forget_qos2(client_id) if @clients[client_id]? == client
         end
         @clients.delete(client_id) if @clients[client_id]? == client
         @vhost.rm_connection(client)

--- a/src/lavinmq/mqtt/broker.cr
+++ b/src/lavinmq/mqtt/broker.cr
@@ -164,7 +164,8 @@ module LavinMQ
         end
         headers = AMQP::Table.new({RETAIN_HEADER => true})
         topics.map do |tf|
-          qos = tf.qos.zero? ? 0u8 : 1u8 # downgrade to 1 if > 1
+          # `Subscribe.from_io` has already rejected anything above 2.
+          qos = tf.qos
           session.subscribe(tf.topic, qos)
           ts = RoughTime.unix_ms
           @retain_store.each(tf.topic) do |topic, body_io, body_bytesize|

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -149,6 +149,7 @@ module LavinMQ
         case packet
         when Protocol::Publish     then recieve_publish(packet)
         when Protocol::PubAck      then recieve_puback(packet)
+        when Protocol::PubRel      then recieve_pubrel(packet)
         when Protocol::Subscribe   then recieve_subscribe(packet)
         when Protocol::Unsubscribe then recieve_unsubscribe(packet)
         when Protocol::PingReq     then receive_pingreq(packet)
@@ -173,7 +174,8 @@ module LavinMQ
             vhost.event_tick(EventType::ClientDeliverNoAck) if packet.qos == 0
             vhost.event_tick(EventType::ClientDeliver) if packet.qos > 0
           end
-        when Protocol::PubAck
+        when Protocol::PubAck, Protocol::PubRec
+          # One confirm per inbound publish, whichever acknowledgement it takes.
           vhost.event_tick(EventType::ClientPublishConfirm)
         end
       end
@@ -188,12 +190,43 @@ module LavinMQ
           close_socket
           return
         end
+        packet_id = packet.packet_id
+        if packet.qos == 2 && packet_id
+          # Figure 4.3: the receiver stores the packet id and initiates onward
+          # delivery before answering PUBREC. Dedupe is by packet id alone -
+          # `dup` is never consulted, since a first send may carry dup=1 after
+          # the client's own reconnect and a re-send may carry dup=0
+          # [MQTT-3.3.1-3].
+          if @broker.qos2_publish_received?(@client_id, packet_id)
+            @broker.publish(packet)
+            vhost.event_tick(EventType::ClientPublish)
+          end
+          # Answered on both paths: a re-sent PUBLISH means our first PUBREC was
+          # lost, and re-answering is the only way the client can move on.
+          send(Protocol::PubRec.new(packet_id))
+          return
+        end
         @broker.publish(packet)
         vhost.event_tick(EventType::ClientPublish)
         # Ok to not send anything if qos = 0 (fire and forget)
-        if packet.qos > 0 && (packet_id = packet.packet_id)
+        if packet.qos > 0 && packet_id
           send(Protocol::PubAck.new(packet_id))
         end
+      end
+
+      def recieve_pubrel(packet : Protocol::PubRel)
+        id = packet.packet_id
+        unless @broker.qos2_release(@client_id, id)
+          # MQTT 3.1.1 leaves the answer to an unknown id implementation
+          # defined, and PUBCOMP is the only one that lets the client release
+          # the id at all. An unknown id here is ordinary rather than
+          # exceptional: `@qos2_received` does not survive a broker restart, so
+          # every resuming QoS 2 publisher arrives with one. Raising would take
+          # that through `read_loop`'s rescue and publish the will of every such
+          # publisher in the vhost.
+          @log.debug { "PUBREL for unknown packet id '#{id}', answering PUBCOMP anyway" }
+        end
+        send(Protocol::PubComp.new(id))
       end
 
       def recieve_puback(packet : Protocol::PubAck)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -149,7 +149,9 @@ module LavinMQ
         case packet
         when Protocol::Publish     then recieve_publish(packet)
         when Protocol::PubAck      then recieve_puback(packet)
+        when Protocol::PubRec      then recieve_pubrec(packet)
         when Protocol::PubRel      then recieve_pubrel(packet)
+        when Protocol::PubComp     then recieve_pubcomp(packet)
         when Protocol::Subscribe   then recieve_subscribe(packet)
         when Protocol::Unsubscribe then recieve_unsubscribe(packet)
         when Protocol::PingReq     then receive_pingreq(packet)
@@ -212,6 +214,27 @@ module LavinMQ
         if packet.qos > 0 && packet_id
           send(Protocol::PubAck.new(packet_id))
         end
+      end
+
+      # PUBREC and PUBCOMP acknowledge something we sent, so without a session
+      # there is nothing they can refer to. Logged and dropped rather than
+      # closed: `recieve_puback`'s `close_socket` below also publishes the will,
+      # because the read loop's next read then raises into the IO::Error arm.
+      # The asymmetry is deliberate - see `Session#pubrec`.
+      def recieve_pubrec(packet : Protocol::PubRec)
+        unless session = @broker.sessions[@client_id]?
+          @log.warn { "Received PubRec from client without a session" }
+          return
+        end
+        vhost.event_tick(EventType::ClientAck) if session.pubrec(packet)
+      end
+
+      def recieve_pubcomp(packet : Protocol::PubComp)
+        unless session = @broker.sessions[@client_id]?
+          @log.warn { "Received PubComp from client without a session" }
+          return
+        end
+        session.pubcomp(packet)
       end
 
       def recieve_pubrel(packet : Protocol::PubRel)

--- a/src/lavinmq/mqtt/client.cr
+++ b/src/lavinmq/mqtt/client.cr
@@ -112,6 +112,12 @@ module LavinMQ
             break
           end
         end
+      rescue ex : Session::ProtocolViolation
+        # The Will publishes from here as it does on every other close without a
+        # DISCONNECT [MQTT-3.1.2-8]; 3.1.2.5 names a server close on a protocol
+        # error as one of those situations.
+        @log.warn { "Protocol violation: #{ex.message}" }
+        publish_will
       rescue ex : Protocol::Error::PacketDecode
         @log.warn(exception: ex) { "Packet decode error" }
         publish_will
@@ -177,7 +183,6 @@ module LavinMQ
             vhost.event_tick(EventType::ClientDeliver) if packet.qos > 0
           end
         when Protocol::PubAck, Protocol::PubRec
-          # One confirm per inbound publish, whichever acknowledgement it takes.
           vhost.event_tick(EventType::ClientPublishConfirm)
         end
       end
@@ -194,17 +199,20 @@ module LavinMQ
         end
         packet_id = packet.packet_id
         if packet.qos == 2 && packet_id
-          # Figure 4.3: the receiver stores the packet id and initiates onward
-          # delivery before answering PUBREC. Dedupe is by packet id alone -
-          # `dup` is never consulted, since a first send may carry dup=1 after
-          # the client's own reconnect and a re-send may carry dup=0
-          # [MQTT-3.3.1-3].
+          # Figure 4.3: store the id, route, then answer PUBREC. Dedupe is by
+          # id alone; `dup` is unreliable in both directions [MQTT-3.3.1-3].
           if @broker.qos2_publish_received?(@client_id, packet_id)
-            @broker.publish(packet)
+            begin
+              @broker.publish(packet)
+            rescue ex
+              # An id left behind by a routing failure would dedupe away the
+              # client's re-send, turning a duplicate into silent loss.
+              @broker.qos2_release(@client_id, packet_id)
+              raise ex
+            end
             vhost.event_tick(EventType::ClientPublish)
           end
-          # Answered on both paths: a re-sent PUBLISH means our first PUBREC was
-          # lost, and re-answering is the only way the client can move on.
+          # Answered on both paths: a re-send means our first PUBREC was lost.
           send(Protocol::PubRec.new(packet_id))
           return
         end
@@ -216,11 +224,9 @@ module LavinMQ
         end
       end
 
-      # PUBREC and PUBCOMP acknowledge something we sent, so without a session
-      # there is nothing they can refer to. Logged and dropped rather than
-      # closed: `recieve_puback`'s `close_socket` below also publishes the will,
-      # because the read loop's next read then raises into the IO::Error arm.
-      # The asymmetry is deliberate - see `Session#pubrec`.
+      # Without a session there is nothing these can refer to. Dropped rather
+      # than closed, unlike `recieve_puback` below, whose `close_socket` also
+      # publishes the will - see `Session#pubrec`.
       def recieve_pubrec(packet : Protocol::PubRec)
         unless session = @broker.sessions[@client_id]?
           @log.warn { "Received PubRec from client without a session" }
@@ -240,13 +246,9 @@ module LavinMQ
       def recieve_pubrel(packet : Protocol::PubRel)
         id = packet.packet_id
         unless @broker.qos2_release(@client_id, id)
-          # MQTT 3.1.1 leaves the answer to an unknown id implementation
-          # defined, and PUBCOMP is the only one that lets the client release
-          # the id at all. An unknown id here is ordinary rather than
-          # exceptional: `@qos2_received` does not survive a broker restart, so
-          # every resuming QoS 2 publisher arrives with one. Raising would take
-          # that through `read_loop`'s rescue and publish the will of every such
-          # publisher in the vhost.
+          # PUBCOMP is the only answer that lets the client release the id, and
+          # an unknown id is ordinary: the held ids do not survive a restart, so
+          # raising would publish the will of every resuming QoS 2 publisher.
           @log.debug { "PUBREL for unknown packet id '#{id}', answering PUBCOMP anyway" }
         end
         send(Protocol::PubComp.new(id))

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -8,13 +8,18 @@ module LavinMQ
 
     QOS0_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 0u8})
     QOS1_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 1u8})
+    QOS2_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 2u8})
 
-    # The binding arguments that carry the given QoS, as one of the two shared,
+    # The binding arguments that carry the given QoS, as one of the three shared,
     # treat-as-read-only constants above, so no table is allocated per subscription.
-    # QoS 2 isn't supported and is granted as QoS 1, hence anything above 0 maps to
-    # QOS1_ARGUMENTS.
+    # The `else` arm keeps it total: `Subscribe.from_io` rejects a QoS above 2,
+    # so only a definitions file can reach it.
     def self.qos_arguments(qos : UInt8) : AMQP::Table
-      qos.zero? ? QOS0_ARGUMENTS : QOS1_ARGUMENTS
+      case qos
+      when 0u8 then QOS0_ARGUMENTS
+      when 1u8 then QOS1_ARGUMENTS
+      else          QOS2_ARGUMENTS
+      end
     end
 
     # The QoS carried in binding arguments, the inverse of `qos_arguments`.
@@ -22,11 +27,12 @@ module LavinMQ
     # Any integer type is accepted: bindings made over the HTTP API or imported
     # from a definitions file don't go through the MQTT protocol parser, so the
     # header isn't necessarily a `UInt8`. The value is granted as the closest
-    # supported QoS, never higher than what we can deliver: QoS 2 as QoS 1
-    # [MQTT-3.9.3-1], a missing, negative or non-integer value as QoS 0.
+    # supported QoS, never higher than what we can deliver: anything above 2 as
+    # QoS 2 - the ceiling MQTT 3.1.1 defines, not one LavinMQ imposes - and a
+    # missing, negative or non-integer value as QoS 0.
     def self.qos(arguments : AMQP::Table?) : UInt8
       qos = arguments.try { |args| args[QOS_HEADER]?.as?(Int) } || 0
-      qos.clamp(0, 1).to_u8
+      qos.clamp(0, 2).to_u8
     end
   end
 end

--- a/src/lavinmq/mqtt/consts.cr
+++ b/src/lavinmq/mqtt/consts.cr
@@ -11,9 +11,9 @@ module LavinMQ
     QOS2_ARGUMENTS = AMQP::Table.new({QOS_HEADER => 2u8})
 
     # The binding arguments that carry the given QoS, as one of the three shared,
-    # treat-as-read-only constants above, so no table is allocated per subscription.
-    # The `else` arm keeps it total: `Subscribe.from_io` rejects a QoS above 2,
-    # so only a definitions file can reach it.
+    # treat-as-read-only constants above, so no table is allocated per
+    # subscription. Callers clamp to 0..2 first, so the `else` arm is only ever
+    # reached with 2.
     def self.qos_arguments(qos : UInt8) : AMQP::Table
       case qos
       when 0u8 then QOS0_ARGUMENTS
@@ -26,10 +26,8 @@ module LavinMQ
     #
     # Any integer type is accepted: bindings made over the HTTP API or imported
     # from a definitions file don't go through the MQTT protocol parser, so the
-    # header isn't necessarily a `UInt8`. The value is granted as the closest
-    # supported QoS, never higher than what we can deliver: anything above 2 as
-    # QoS 2 - the ceiling MQTT 3.1.1 defines, not one LavinMQ imposes - and a
-    # missing, negative or non-integer value as QoS 0.
+    # header isn't necessarily a `UInt8`. Anything above 2 is granted as QoS 2,
+    # the ceiling MQTT 3.1.1 defines; a missing or non-integer value as QoS 0.
     def self.qos(arguments : AMQP::Table?) : UInt8
       qos = arguments.try { |args| args[QOS_HEADER]?.as?(Int) } || 0
       qos.clamp(0, 2).to_u8

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -30,8 +30,12 @@ module LavinMQ
 
         msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
         count = 0u32
+        publish_qos = packet.qos
         @tree.each_entry(packet.topic) do |queue, qos, _filter|
-          msg.properties.delivery_mode = qos
+          # The effective QoS is the lower of the publish and the subscription
+          # [MQTT-3.3.5-1]. Read from a local, since the loop overwrites the
+          # property for every subscriber.
+          msg.properties.delivery_mode = Math.min(publish_qos, qos)
           if queue.publish(msg)
             count += 1
             msg.body_io.rewind

--- a/src/lavinmq/mqtt/exchange.cr
+++ b/src/lavinmq/mqtt/exchange.cr
@@ -30,12 +30,9 @@ module LavinMQ
 
         msg = Message.new(timestamp, EXCHANGE, packet.topic, properties, bodysize, body)
         count = 0u32
-        publish_qos = packet.qos
         @tree.each_entry(packet.topic) do |queue, qos, _filter|
-          # The effective QoS is the lower of the publish and the subscription
-          # [MQTT-3.3.5-1]. Read from a local, since the loop overwrites the
-          # property for every subscriber.
-          msg.properties.delivery_mode = Math.min(publish_qos, qos)
+          # The lower of the publish and the subscription QoS [MQTT-3.3.5-1].
+          msg.properties.delivery_mode = Math.min(packet.qos, qos)
           if queue.publish(msg)
             count += 1
             msg.body_io.rewind

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -16,6 +16,11 @@ module LavinMQ
     class Session
       class ClosedError < MQTT::Error; end
 
+      # A known packet id acknowledged with the wrong packet type. The client
+      # must be disconnected [MQTT-4.8.0-1]; an unknown id is not this, because
+      # the window does not survive a restart.
+      class ProtocolViolation < MQTT::Error; end
+
       include SortableJSON
       include PolicyTarget
       include AMQP::QueueStats
@@ -24,8 +29,9 @@ module LavinMQ
       ARGUMENTS      = AMQP::Table.new({"x-queue-type" => "mqtt"})
       EFFECTIVE_ARGS = {"x-queue-type"}
 
-      # A packet id the client has been handed and has not finished
-      # acknowledging, and the message it was issued for.
+      # A packet id handed to the client and not yet settled. `sp` is nil only
+      # for a QoS 2 id past PUBREC, where the message is gone and the id is held
+      # for the PUBREL/PUBCOMP exchange alone.
       struct Inflight
         getter qos : UInt8
         getter sp : SegmentPosition?
@@ -118,8 +124,10 @@ module LavinMQ
         delivered_bytes = 0_i32
         loop do
           break if closed?
-          next @msg_store.empty.when_false.receive? if @msg_store.empty?
+          # Above every `next`: `loop` is inlined, so a raise from a guard below
+          # would leave the rescue holding the previous iteration's connection.
           client = @client
+          next @msg_store.empty.when_false.receive? if @msg_store.empty?
           next @has_client.when_true.receive? if client.nil?
           next @has_capacity.when_true.receive? unless @has_capacity.value
           get_packet do |pub_packet, bytesize|
@@ -132,8 +140,11 @@ module LavinMQ
           end
         rescue ex
           @log.error(exception: ex) { "Failed to deliver message in deliver_loop" }
-          @client.try &.close("Server force closed client")
-          self.client = nil
+          # Sending yields, so a write can fail after the session was
+          # reattached. Close the connection it was written to, not whichever
+          # happens to be current.
+          client.try &.close("Server force closed client")
+          self.client = nil if @client == client
         end
       end
 
@@ -158,16 +169,19 @@ module LavinMQ
         @has_capacity.swap(@unacked.size < Config.instance.max_inflight_messages)
       end
 
+      # Whether `id` still names this exact delivery. Sending yields, so
+      # `client=`, `ack` or `pubrec` can have moved it in the meantime.
+      private def booked?(id : UInt16, sp : SegmentPosition) : Bool
+        @unacked[id]?.try(&.sp) == sp
+      end
+
       def client : MQTT::Client?
         @client
       end
 
-      # Reading `@unacked` here is safe against the connection being replaced:
-      # `Client#close` joins its read fiber on a waitgroup before
-      # `Broker#add_client` reaches this, and `run_client`'s ensure runs on that
-      # same fiber afterwards, so no `ack`/`pubrec`/`pubcomp` can be in flight.
-      # QoS 2 makes that load-bearing rather than merely tidy - a `pubrec`
-      # racing the loop below would delete an sp it has just requeued.
+      # `Client#close` usually joins the read fiber before `Broker#add_client`
+      # reaches this, so an `ack`/`pubrec` is rarely in flight while `@unacked`
+      # is walked - but a second `close` returns without waiting, so it can be.
       def client=(client : MQTT::Client?)
         return if closed?
         @last_get_time = RoughTime.instant
@@ -195,24 +209,19 @@ module LavinMQ
         @unacked_count.set(0, :release)
         @unacked_bytesize.set(0, :release)
 
-        # Re-booked whether or not anyone is attached. This also runs on the
-        # detach path (`client = nil` from `Broker#remove_client`), and booking
-        # only when a client is present would drop the obligation on exactly the
-        # disconnect the replay exists to survive. No delivery can be issued one
-        # of these ids, because nothing else runs before the re-booking.
+        # Re-booked even when detaching: doing it only for an attached client
+        # would drop the obligation on the disconnect it exists to survive.
         pubcomp_pending.each { |id| @unacked[id] = Inflight.new(2u8, nil) }
         refresh_capacity
 
+        # Assigned before the writes below, which yield: `Session#publish`
+        # drops a QoS 0 message while it is nil.
         @client = client
         if client
           @log.info { "resending #{pubcomp_pending.size} PUBREL" } unless pubcomp_pending.empty?
-          # Before `@has_client` opens the gate, so every PUBREL precedes the
-          # replayed PUBLISHes: `@has_client` is what unparks the deliver_loop,
-          # and `client.send` can yield on a full socket buffer. `pubcomp_pending`
-          # is a private array built above and never mutated, so it needs no
-          # further snapshotting. A failed write leaves the id booked and the
-          # next attach tries again.
-          pubcomp_pending.each { |id| send_pubrel(id) }
+          # Before `@has_client` opens the gate, so these tend to precede the
+          # replayed PUBLISHes. [MQTT-4.4.0-1] does not order the two kinds.
+          pubcomp_pending.each { |id| send_pubrel(id, client) }
         end
         @has_client.set(!client.nil?)
 
@@ -266,63 +275,14 @@ module LavinMQ
         loop do
           env = @msg_store_lock.synchronize { @msg_store.shift? } || break
           sp = env.segment_position
-          no_ack = env.message.properties.delivery_mode == 0
-          if no_ack
-            begin
-              packet = build_packet(env, nil)
-              yield packet, sp.bytesize
-              if env.redelivered
-                @redeliver_count.add(1, :relaxed)
-              else
-                @deliver_no_ack_count.add(1, :relaxed)
-                @deliver_get_count.add(1, :relaxed)
-              end
-            rescue ex # requeue failed delivery
-              @msg_store_lock.synchronize { @msg_store.requeue(sp) }
-              raise ex
-            end
-            delete_message(sp)
+          # `nil` counts as QoS 0: `build_packet` maps it to 0, so booking an
+          # id would leak the slot. Nothing produces a nil today.
+          delivery_mode = env.message.properties.delivery_mode
+          if delivery_mode.nil? || delivery_mode.zero?
+            deliver_no_ack(env, sp) { |packet, bytesize| yield packet, bytesize }
           else
-            begin
-              id = delivery_id(sp)
-              unless id
-                @msg_store_lock.synchronize { @msg_store.requeue(sp) }
-                # Without this the deliver_loop spins: the store is non-empty and
-                # capacity still reads true. Recomputed rather than closed
-                # outright, since an ack can free a slot while the requeue above
-                # waits on a contended @msg_store_lock.
-                refresh_capacity
-                return false
-              end
-              packet = build_packet(env, id)
-              # Booked before the send, which yields: the client can answer
-              # before we return. An acknowledgement that finds no entry raises
-              # out of `ack` and publishes the client's will, and for QoS 2 it
-              # is worse than that - `pubrec` drops it, so the message is never
-              # deleted and the client waits for a PUBREL that never comes.
-              @unacked[id] = Inflight.new(packet.qos, sp)
-              @unacked_count.add(1, :relaxed)
-              @unacked_bytesize.add(sp.bytesize, :relaxed)
-              yield packet, sp.bytesize
-              if env.redelivered
-                @redeliver_count.add(1, :relaxed)
-              else
-                @deliver_count.add(1, :relaxed)
-                @deliver_get_count.add(1, :relaxed)
-              end
-              @msg_store.forget_packet_id(sp)
-              refresh_capacity
-            rescue ex # requeue failed delivery
-              @msg_store_lock.synchronize { @msg_store.requeue(sp) }
-              # Unbook through the hash: a delete that removes nothing means the
-              # client already acknowledged it, so the counters are settled and
-              # must not be rolled back twice.
-              if @unacked.delete(id)
-                @unacked_count.sub(1, :relaxed)
-                @unacked_bytesize.sub(sp.bytesize, :relaxed)
-              end
-              raise ex
-            end
+            delivered = deliver_acked(env, sp) { |packet, bytesize| yield packet, bytesize }
+            return false unless delivered
           end
           return true
         end
@@ -333,15 +293,83 @@ module LavinMQ
         raise ClosedError.new(cause: ex)
       end
 
+      private def deliver_no_ack(env, sp : SegmentPosition, & : Protocol::Publish, UInt32 -> Nil) : Nil
+        begin
+          yield build_packet(env, nil), sp.bytesize
+          if env.redelivered
+            @redeliver_count.add(1, :relaxed)
+          else
+            @deliver_no_ack_count.add(1, :relaxed)
+            @deliver_get_count.add(1, :relaxed)
+          end
+        rescue ex # requeue failed delivery
+          @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+          raise ex
+        end
+        delete_message(sp)
+      end
+
+      # False when no packet id was available, which leaves the message
+      # requeued for the next attempt.
+      private def deliver_acked(env, sp : SegmentPosition, & : Protocol::Publish, UInt32 -> Nil) : Bool
+        id = delivery_id(sp)
+        unless id
+          @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+          # Without this the deliver_loop spins: the store is non-empty and
+          # capacity still reads true. Recomputed rather than closed
+          # outright, since an ack can free a slot while the requeue above
+          # waits on a contended @msg_store_lock.
+          refresh_capacity
+          return false
+        end
+        # Raises before anything is booked, which the rescue below would not
+        # roll back. Unreachable today, but being wrong loses the message.
+        packet = begin
+          build_packet(env, id)
+        rescue ex
+          @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+          raise ex
+        end
+        begin
+          # Booked before the send, which yields: the client can acknowledge
+          # before we return, and an acknowledgement finding no entry is either
+          # fatal (`ack`) or silently dropped (`pubrec`).
+          @unacked[id] = Inflight.new(packet.qos, sp)
+          @unacked_count.add(1, :relaxed)
+          @unacked_bytesize.add(sp.bytesize, :relaxed)
+          yield packet, sp.bytesize
+          if env.redelivered
+            @redeliver_count.add(1, :relaxed)
+          else
+            @deliver_count.add(1, :relaxed)
+            @deliver_get_count.add(1, :relaxed)
+          end
+          # `client=` may have requeued `sp` and remembered `id` during the
+          # send; forgetting then costs the redelivery its id [MQTT-4.4.0-1].
+          @msg_store.forget_packet_id(sp) if booked?(id, sp)
+          refresh_capacity
+        rescue ex # requeue failed delivery
+          # Roll back only what is still ours: requeueing an entry `client=`
+          # already requeued hands the message out twice.
+          if booked?(id, sp)
+            @unacked.delete(id)
+            # Before the lock, which can park: `client=` zeroes both counters,
+            # and a `sub` after that wraps an unsigned atomic.
+            @unacked_count.sub(1, :relaxed)
+            @unacked_bytesize.sub(sp.bytesize, :relaxed)
+            @msg_store_lock.synchronize { @msg_store.requeue(sp) }
+          end
+          raise ex
+        end
+        true
+      end
+
       def build_packet(env, packet_id) : Protocol::Publish
         msg = env.message
         retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
         qos = msg.properties.delivery_mode || 0u8
-        # Not dead code now that `MQTT.qos` clamps to 2: `delivery_mode` is read
-        # off disk with nothing validating it, and `Publish.new` raises above
-        # QoS 2. That raise happens inside `get_packet`, which requeues and
-        # force-closes the client, so one bad byte would be a poison message the
-        # session retries on every reconnect.
+        # `delivery_mode` is read off disk unvalidated and `Publish.new` raises
+        # above QoS 2, which would make one bad byte a poison message.
         qos = 2u8 if qos > 2
         dup = qos.zero? ? false : env.redelivered
         Protocol::Publish.new(
@@ -380,11 +408,11 @@ module LavinMQ
         inflight = @unacked[id]?
         raise ::IO::Error.new("No message inflight for id '#{id}'") if inflight.nil?
         sp = inflight.sp
-        # A QoS 2 delivery is settled by PUBREC, never PUBACK. Checked before
-        # the delete, so acknowledging with the wrong packet type cannot drop an
-        # obligation the session still owes.
+        # A QoS 2 delivery is settled by PUBREC [MQTT-4.3.3-2], so a PUBACK for
+        # one is a protocol violation. Checked before the delete, so it cannot
+        # drop an obligation the session still owes.
         if sp.nil? || inflight.qos != 1u8
-          raise ::IO::Error.new("Packet id '#{id}' is not awaiting a PUBACK")
+          raise ProtocolViolation.new("PUBACK for packet id '#{id}', which is awaiting a QoS 2 acknowledgement")
         end
         @unacked.delete(id)
         begin
@@ -399,16 +427,12 @@ module LavinMQ
         end
       end
 
-      # PUBREC: the receiver has taken ownership of the message [MQTT-4.3.3-1],
-      # so it is deleted here rather than at PUBCOMP - re-sending a PUBLISH once
-      # the receiver owns it is what exactly-once forbids. The packet id stays
-      # booked, now without a message, until PUBCOMP releases it.
+      # The receiver owns the message from PUBREC on [MQTT-4.3.3-1], so it is
+      # deleted here, not at PUBCOMP; the id stays booked until then.
       #
-      # Never raises, unlike `ack`. An id we have no record of is the ordinary
-      # case rather than the exceptional one: nothing in the window survives a
-      # broker restart, so a client resuming a QoS 2 exchange across one always
-      # arrives with ids we have never seen. Raising would take that through
-      # `read_loop`'s rescue and publish the client's will.
+      # Returns rather than raises for an unknown id: nothing in the window
+      # survives a restart, so a client resuming across one always brings ids we
+      # have never seen, and raising would publish its will.
       def pubrec(packet : Protocol::PubRec) : Bool
         id = packet.packet_id
         unless inflight = @unacked[id]?
@@ -422,25 +446,21 @@ module LavinMQ
           return false
         end
         unless inflight.qos == 2u8
-          @log.warn { "PUBREC for QoS #{inflight.qos} packet id '#{id}'" }
-          return false
+          raise ProtocolViolation.new("PUBREC for QoS #{inflight.qos} packet id '#{id}'")
         end
-        # State transition and delete before the send: if the write fails, this
-        # is still the correct post-PUBREC state and `client=` re-sends the
-        # PUBREL on the next attach.
+        # Before the send: a failed write still leaves the correct state, and
+        # `client=` re-sends the PUBREL.
         @unacked[id] = Inflight.new(2u8, nil)
         @ack_count.add(1, :relaxed)
         @unacked_count.sub(1, :relaxed)
         @unacked_bytesize.sub(sp.bytesize, :relaxed)
         delete_message(sp)
         send_pubrel(id)
-        # No `refresh_capacity`: the id is still booked, so `@unacked.size` has
-        # not moved. That is the point of the second phase.
+        # No `refresh_capacity`: the id is still booked, so the window is
+        # unchanged.
         true
       end
 
-      # PUBCOMP releases the packet id and completes the exchange
-      # [MQTT-4.3.3-1]. Nothing else is owed, the message went at PUBREC.
       def pubcomp(packet : Protocol::PubComp) : Bool
         id = packet.packet_id
         unless inflight = @unacked[id]?
@@ -448,8 +468,7 @@ module LavinMQ
           return false
         end
         unless inflight.sp.nil?
-          @log.warn { "PUBCOMP for packet id '#{id}' that has not been PUBRECed" }
-          return false
+          raise ProtocolViolation.new("PUBCOMP for packet id '#{id}' that has not been PUBRECed")
         end
         @unacked.delete(id)
         # Load-bearing: for a window full of ids awaiting PUBCOMP, this is the
@@ -458,13 +477,10 @@ module LavinMQ
         true
       end
 
-      # Leaves the id booked whether or not the write lands, so `client=`
-      # re-sends it on the next attach [MQTT-4.4.0-1]. Errors are swallowed
-      # because the two callers cannot usefully fail over a write the reconnect
-      # path already covers: `pubrec` runs on the client's read fiber, and
-      # `client=` runs inside `Broker#add_client`.
-      private def send_pubrel(id : UInt16) : Bool
-        client = @client
+      # Errors are swallowed: the id stays booked either way, so the next
+      # attach re-sends it [MQTT-4.4.0-1].
+      private def send_pubrel(id : UInt16, client : MQTT::Client? = nil) : Bool
+        client ||= @client
         return false if client.nil?
         client.send(Protocol::PubRel.new(id))
         true
@@ -474,12 +490,15 @@ module LavinMQ
       end
 
       private def next_id : UInt16?
-        # `>=` rather than `==`: the limit is mutable at runtime and the window
-        # now has a second entry point in `pubcomp`, so exact equality is not
-        # something to rely on.
+        # `>=` not `==`: the limit is mutable at runtime, so the window can
+        # already be over it.
         return if @unacked.size >= Config.instance.max_inflight_messages
         start_id = @count
         next_id : UInt16 = start_id &+ 1_u16
+        # `@count` at 65535 wraps this to 0, which the loop below never
+        # corrects because 0 is never booked. Packet id 0 is illegal
+        # [MQTT-2.3.1-1].
+        next_id = 1u16 if next_id == 0
         while @unacked.has_key?(next_id)
           next_id &+= 1u16
           next_id = 1u16 if next_id == 0

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -337,7 +337,12 @@ module LavinMQ
         msg = env.message
         retained = msg.properties.try &.headers.try &.["mqtt.retain"]? == true
         qos = msg.properties.delivery_mode || 0u8
-        qos = 1u8 if qos > 1
+        # Not dead code now that `MQTT.qos` clamps to 2: `delivery_mode` is read
+        # off disk with nothing validating it, and `Publish.new` raises above
+        # QoS 2. That raise happens inside `get_packet`, which requeues and
+        # force-closes the client, so one bad byte would be a poison message the
+        # session retries on every reconnect.
+        qos = 2u8 if qos > 2
         dup = qos.zero? ? false : env.redelivered
         Protocol::Publish.new(
           packet_id: packet_id,

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -266,6 +266,12 @@ module LavinMQ
                 return false
               end
               packet = build_packet(env, id)
+              # Booked before the send, which yields: the client can answer
+              # before we return. An acknowledgement that finds no entry raises
+              # out of `ack` and publishes the client's will, and for QoS 2 it
+              # is worse than that - `pubrec` drops it, so the message is never
+              # deleted and the client waits for a PUBREL that never comes.
+              @unacked[id] = Inflight.new(packet.qos, sp)
               @unacked_count.add(1, :relaxed)
               @unacked_bytesize.add(sp.bytesize, :relaxed)
               yield packet, sp.bytesize
@@ -275,13 +281,17 @@ module LavinMQ
                 @deliver_count.add(1, :relaxed)
                 @deliver_get_count.add(1, :relaxed)
               end
-              @unacked[id] = Inflight.new(packet.qos, sp)
               @msg_store.forget_packet_id(sp)
               refresh_capacity
             rescue ex # requeue failed delivery
               @msg_store_lock.synchronize { @msg_store.requeue(sp) }
-              @unacked_count.sub(1, :relaxed)
-              @unacked_bytesize.sub(sp.bytesize, :relaxed)
+              # Unbook through the hash: a delete that removes nothing means the
+              # client already acknowledged it, so the counters are settled and
+              # must not be rolled back twice.
+              if @unacked.delete(id)
+                @unacked_count.sub(1, :relaxed)
+                @unacked_bytesize.sub(sp.bytesize, :relaxed)
+              end
               raise ex
             end
           end

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -162,9 +162,18 @@ module LavinMQ
         @client
       end
 
+      # Reading `@unacked` here is safe against the connection being replaced:
+      # `Client#close` joins its read fiber on a waitgroup before
+      # `Broker#add_client` reaches this, and `run_client`'s ensure runs on that
+      # same fiber afterwards, so no `ack`/`pubrec`/`pubcomp` can be in flight.
+      # QoS 2 makes that load-bearing rather than merely tidy - a `pubrec`
+      # racing the loop below would delete an sp it has just requeued.
       def client=(client : MQTT::Client?)
         return if closed?
         @last_get_time = RoughTime.instant
+
+        # Ids past PUBREC, which owe a PUBREL rather than a message.
+        pubcomp_pending = Array(UInt16).new
 
         # A clean session carries nothing between connections [MQTT-3.1.2-6]. A
         # persistent one requeues what it owes and remembers the packet ids, to
@@ -172,9 +181,12 @@ module LavinMQ
         unless clean_session?
           @msg_store_lock.synchronize do
             @unacked.each do |packet_id, inflight|
-              next unless sp = inflight.sp
-              @msg_store.remember_packet_id(sp, packet_id)
-              @msg_store.requeue(sp)
+              if sp = inflight.sp
+                @msg_store.remember_packet_id(sp, packet_id)
+                @msg_store.requeue(sp)
+              else
+                pubcomp_pending << packet_id
+              end
             end
           end
         end
@@ -182,9 +194,26 @@ module LavinMQ
         @unacked.clear
         @unacked_count.set(0, :release)
         @unacked_bytesize.set(0, :release)
+
+        # Re-booked whether or not anyone is attached. This also runs on the
+        # detach path (`client = nil` from `Broker#remove_client`), and booking
+        # only when a client is present would drop the obligation on exactly the
+        # disconnect the replay exists to survive. No delivery can be issued one
+        # of these ids, because nothing else runs before the re-booking.
+        pubcomp_pending.each { |id| @unacked[id] = Inflight.new(2u8, nil) }
         refresh_capacity
 
         @client = client
+        if client
+          @log.info { "resending #{pubcomp_pending.size} PUBREL" } unless pubcomp_pending.empty?
+          # Before `@has_client` opens the gate, so every PUBREL precedes the
+          # replayed PUBLISHes: `@has_client` is what unparks the deliver_loop,
+          # and `client.send` can yield on a full socket buffer. `pubcomp_pending`
+          # is a private array built above and never mutated, so it needs no
+          # further snapshotting. A failed write leaves the id booked and the
+          # next attach tries again.
+          pubcomp_pending.each { |id| send_pubrel(id) }
+        end
         @has_client.set(!client.nil?)
 
         @log.debug { "client set to '#{client.try &.name}'" }

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -343,24 +343,107 @@ module LavinMQ
 
       def ack(packet : Protocol::PubAck) : Nil
         id = packet.packet_id
-        if sp = @unacked.delete(id).try &.sp
-          begin
-            @ack_count.add(1, :relaxed)
-            @unacked_count.sub(1, :relaxed)
-            @unacked_bytesize.sub(sp.bytesize, :relaxed)
-            delete_message(sp)
-          rescue ex
-            raise ::IO::Error.new("Could not acknowledge packet with id '#{id}'", ex)
-          ensure
-            refresh_capacity
-          end
-        else
-          raise ::IO::Error.new("No message inflight for id '#{id}'")
+        inflight = @unacked[id]?
+        raise ::IO::Error.new("No message inflight for id '#{id}'") if inflight.nil?
+        sp = inflight.sp
+        # A QoS 2 delivery is settled by PUBREC, never PUBACK. Checked before
+        # the delete, so acknowledging with the wrong packet type cannot drop an
+        # obligation the session still owes.
+        if sp.nil? || inflight.qos != 1u8
+          raise ::IO::Error.new("Packet id '#{id}' is not awaiting a PUBACK")
+        end
+        @unacked.delete(id)
+        begin
+          @ack_count.add(1, :relaxed)
+          @unacked_count.sub(1, :relaxed)
+          @unacked_bytesize.sub(sp.bytesize, :relaxed)
+          delete_message(sp)
+        rescue ex
+          raise ::IO::Error.new("Could not acknowledge packet with id '#{id}'", ex)
+        ensure
+          refresh_capacity
         end
       end
 
+      # PUBREC: the receiver has taken ownership of the message [MQTT-4.3.3-1],
+      # so it is deleted here rather than at PUBCOMP - re-sending a PUBLISH once
+      # the receiver owns it is what exactly-once forbids. The packet id stays
+      # booked, now without a message, until PUBCOMP releases it.
+      #
+      # Never raises, unlike `ack`. An id we have no record of is the ordinary
+      # case rather than the exceptional one: nothing in the window survives a
+      # broker restart, so a client resuming a QoS 2 exchange across one always
+      # arrives with ids we have never seen. Raising would take that through
+      # `read_loop`'s rescue and publish the client's will.
+      def pubrec(packet : Protocol::PubRec) : Bool
+        id = packet.packet_id
+        unless inflight = @unacked[id]?
+          @log.warn { "PUBREC for unknown packet id '#{id}'" }
+          return false
+        end
+        unless sp = inflight.sp
+          # A repeat of a PUBREC we already answered, so our PUBREL was lost.
+          # Answering again is the only way the client can release the id.
+          send_pubrel(id)
+          return false
+        end
+        unless inflight.qos == 2u8
+          @log.warn { "PUBREC for QoS #{inflight.qos} packet id '#{id}'" }
+          return false
+        end
+        # State transition and delete before the send: if the write fails, this
+        # is still the correct post-PUBREC state and `client=` re-sends the
+        # PUBREL on the next attach.
+        @unacked[id] = Inflight.new(2u8, nil)
+        @ack_count.add(1, :relaxed)
+        @unacked_count.sub(1, :relaxed)
+        @unacked_bytesize.sub(sp.bytesize, :relaxed)
+        delete_message(sp)
+        send_pubrel(id)
+        # No `refresh_capacity`: the id is still booked, so `@unacked.size` has
+        # not moved. That is the point of the second phase.
+        true
+      end
+
+      # PUBCOMP releases the packet id and completes the exchange
+      # [MQTT-4.3.3-1]. Nothing else is owed, the message went at PUBREC.
+      def pubcomp(packet : Protocol::PubComp) : Bool
+        id = packet.packet_id
+        unless inflight = @unacked[id]?
+          @log.warn { "PUBCOMP for unknown packet id '#{id}'" }
+          return false
+        end
+        unless inflight.sp.nil?
+          @log.warn { "PUBCOMP for packet id '#{id}' that has not been PUBRECed" }
+          return false
+        end
+        @unacked.delete(id)
+        # Load-bearing: for a window full of ids awaiting PUBCOMP, this is the
+        # only event that can reopen the capacity gate.
+        refresh_capacity
+        true
+      end
+
+      # Leaves the id booked whether or not the write lands, so `client=`
+      # re-sends it on the next attach [MQTT-4.4.0-1]. Errors are swallowed
+      # because the two callers cannot usefully fail over a write the reconnect
+      # path already covers: `pubrec` runs on the client's read fiber, and
+      # `client=` runs inside `Broker#add_client`.
+      private def send_pubrel(id : UInt16) : Bool
+        client = @client
+        return false if client.nil?
+        client.send(Protocol::PubRel.new(id))
+        true
+      rescue ex
+        @log.debug { "Failed to send PUBREL for id '#{id}': #{ex.message}" }
+        false
+      end
+
       private def next_id : UInt16?
-        return if @unacked.size == Config.instance.max_inflight_messages
+        # `>=` rather than `==`: the limit is mutable at runtime and the window
+        # now has a second entry point in `pubcomp`, so exact equality is not
+        # something to rely on.
+        return if @unacked.size >= Config.instance.max_inflight_messages
         start_id = @count
         next_id : UInt16 = start_id &+ 1_u16
         while @unacked.has_key?(next_id)

--- a/src/lavinmq/mqtt/session.cr
+++ b/src/lavinmq/mqtt/session.cr
@@ -24,6 +24,16 @@ module LavinMQ
       ARGUMENTS      = AMQP::Table.new({"x-queue-type" => "mqtt"})
       EFFECTIVE_ARGS = {"x-queue-type"}
 
+      # A packet id the client has been handed and has not finished
+      # acknowledging, and the message it was issued for.
+      struct Inflight
+        getter qos : UInt8
+        getter sp : SegmentPosition?
+
+        def initialize(@qos : UInt8, @sp : SegmentPosition?)
+        end
+      end
+
       getter name : String
       getter vhost : VHost
       getter? auto_delete
@@ -44,7 +54,7 @@ module LavinMQ
                                @auto_delete = false,
                                arguments : ::AMQ::Protocol::Table = AMQP::Table.new)
         @count = 0u16
-        @unacked = Hash(UInt16, SegmentPosition).new
+        @unacked = Hash(UInt16, Inflight).new
 
         @metadata = ::Log::Metadata.new(nil, {queue: @name, vhost: @vhost.name})
         data_dir = File.join(
@@ -161,7 +171,8 @@ module LavinMQ
         # resend under the ids the client already knows [MQTT-4.4.0-1].
         unless clean_session?
           @msg_store_lock.synchronize do
-            @unacked.each do |packet_id, sp|
+            @unacked.each do |packet_id, inflight|
+              next unless sp = inflight.sp
               @msg_store.remember_packet_id(sp, packet_id)
               @msg_store.requeue(sp)
             end
@@ -264,7 +275,7 @@ module LavinMQ
                 @deliver_count.add(1, :relaxed)
                 @deliver_get_count.add(1, :relaxed)
               end
-              @unacked[id] = sp
+              @unacked[id] = Inflight.new(packet.qos, sp)
               @msg_store.forget_packet_id(sp)
               refresh_capacity
             rescue ex # requeue failed delivery
@@ -322,7 +333,7 @@ module LavinMQ
 
       def ack(packet : Protocol::PubAck) : Nil
         id = packet.packet_id
-        if sp = @unacked.delete(id)
+        if sp = @unacked.delete(id).try &.sp
           begin
             @ack_count.add(1, :relaxed)
             @unacked_count.sub(1, :relaxed)

--- a/src/lavinmq/mqtt/session_message_store.cr
+++ b/src/lavinmq/mqtt/session_message_store.cr
@@ -6,6 +6,10 @@ module LavinMQ
     # the session owes a resuming client. The ids live here so that a message
     # leaving the store takes its id with it, whichever path removed it.
     class SessionMessageStore < LavinMQ::MessageStore
+      # Not guarded by the session's `@msg_store_lock`, unlike the rest of this
+      # object: every access is a single `Hash` operation, which cannot yield.
+      # Same shape as `Session#@unacked`, and the same caveat under
+      # multi-threading, tracked in #2067.
       @packet_ids = Hash(SegmentPosition, UInt16).new
 
       def remember_packet_id(sp : SegmentPosition, packet_id : UInt16) : Nil


### PR DESCRIPTION
## What

MQTT QoS 2 (exactly once) support, in both directions.

- The full `PUBLISH`/`PUBREC`/`PUBREL`/`PUBCOMP` handshake as receiver and as sender.
- QoS 2 subscriptions are granted rather than downgraded to QoS 1.
- An unfinished outbound exchange is resumed on reconnect, re-sending `PUBREL`
  under its original packet ID [MQTT-4.4.0-1].
- Delivery is at the lower of the publish and the subscription QoS [MQTT-3.3.5-1].
- A packet ID handed out past `PUBREC` stays booked, without a message, until
  `PUBCOMP`. `max_inflight_messages` therefore bounds outstanding packet IDs
  rather than outstanding messages.
- Acknowledging a delivery with the wrong packet type (`PUBACK` for a QoS 2
  delivery, `PUBREC` for a QoS 1 one, `PUBCOMP` before `PUBREC`) closes the
  connection [MQTT-4.8.0-1] and publishes the Will. An acknowledgement for an ID
  the session never issued is logged and ignored instead, because the in-flight
  window does not survive a broker restart.
- `next_id` no longer hands out packet ID 0 once `@count` wraps past 65535
  [MQTT-2.3.1-1].

`docs/mqtt.md` covers the semantics and the limitations.

## Verification

- [x] `make test TAGS=~slow` - 2181 examples, 0 failures
- [x] `make lint` - 405 inspected, 0 failures
- [x] `crystal tool format --check` - clean
- [x] mosquitto 2.0.11 (`mosquitto_pub`/`mosquitto_sub`): QoS 2 both directions,
      offline messages replayed to a persistent session, downgrade to a QoS 1 and
      a QoS 0 subscription
- [x] Raw-socket conformance script, every byte hand-built to MQTT 3.1.1 rather
      than encoded by the shard: both handshake directions, the `PUBREL` replay
      across an ungraceful drop, `PUBCOMP` carrying reserved flags `0000`, an
      unknown `PUBREL` not firing the Will, and the protocol-violation close
- [x] Unknown packet ID per acknowledgement type: `PUBREC`, `PUBCOMP` and
      `PUBREL` ignored with the connection intact, `PUBACK` closing it
- [x] Packet ID wraparound: 70000 QoS 2 deliveries through one session, all
      payloads unique and complete, IDs spanning `1..65535` and never 0. Fails
      with one ID 0 against the same build without the `next_id` fix
- [ ] Tested against a multi-node cluster

The scripts behind the last three are not committed.

Not covered by specs: the `booked?` and `forget_qos2` guards (both need a blocked
socket write), the `qos2_release` rollback in `recieve_publish` (unreachable while
an AMQP exchange cannot bind an MQTT session), and the unknown-`PUBACK` close.

## Merge order

1. `84codes/mqtt-protocol.cr#15` (`PUBCOMP` reserved flags), released as a tag.
   Without the fix a subscriber's Will fires on every QoS 2 delivery
   (`Packet decode error / invalid flags: 0000`). The fix should also be carried
   into that shard's v1.0.0 (mqtt5) work.
2. Swap this PR's `shard.yml` from the commit pin to a version constraint. The
   shard repo squash/rebase-merges and deletes branches on merge, so neither the
   branch ref nor commit `935a1bcb` survives step 1. **This blocks undrafting.**
3. #2233, which this branch is based on rather than `main`.
4. This PR.

## Future considerations

- **Persist QoS 2 state across restart and failover.** The outbound window, the
  remembered packet IDs and the inbound dedupe set are all in memory and none are
  replicated. An un-`PUBREL`ed inbound publish is routed a second time and
  degrades to at-least-once; an outbound delivery past `PUBREC` leaves the
  subscriber holding a packet ID for the life of the session, because
  [MQTT-4.4.0-1] has clients re-send only `PUBLISH` and `PUBREL`, never `PUBREC`.
- The inbound dedupe set does not survive a reconnect for a publish-only client,
  which has no session. Retaining it would be unbounded in client IDs.
- Retained messages replay at the subscription's QoS, ignoring the publish QoS,
  because `RetainStore` persists only topic and payload. Needs a retain index
  format change.
- `next_id`'s scan never tests `@count` itself, so it can return nil with one slot
  free.
- Packet ID 0 is accepted inbound on both the QoS 1 and QoS 2 paths.
- Nothing calls `forget_qos2` when a session's queue is deleted out of band (HTTP
  API, vhost deletion), so that entry outlives its bound until the client ID
  reconnects clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
